### PR TITLE
fix(i18n): remove vanished tags, restore translations and add missing strings

### DIFF
--- a/translations/client_da.ts
+++ b/translations/client_da.ts
@@ -1,2580 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="da_DK">
+<TS language="da_DK" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Om</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">LUK</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Version %1. For mere information besøg &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribueret af %1 og licenseret under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoet er registrerede varemærker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Bygget fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekode&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke åbne mappen %1.</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Om</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>LUK</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Version %1. For mere information besøg &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribueret af %1 og licenseret under &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoet er registrerede varemærker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Bygget fra &lt;a style="color: #489EF3" href="%1"&gt;Git-kildekode&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke åbne mappen %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke åbne mappestien %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke åbne mappestien %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Synkronisering starter, og du vil kunne tilføje filer til din %1-mappe.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Din kDrive er klar!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ÅBEN MAPPE</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">INDSTILLINGER</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Synkroniser et andet drev</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Synkronisering starter, og du vil kunne tilføje filer til din %1-mappe.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Din kDrive er klar!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ÅBEN MAPPE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>INDSTILLINGER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synkroniser et andet drev</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuller</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">NÆSTE</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Vælg den kDrive, du vil synkronisere</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Få kDrive gratis</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Gem dine billeder, dokumenter og e-mails i Schweiz hos et uafhængigt selskab, der respekterer privatlivets fred. Læs mere</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Test gratis</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>NÆSTE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Vælg den kDrive, du vil synkronisere</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Få kDrive gratis</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Gem dine billeder, dokumenter og e-mails i Schweiz hos et uafhængigt selskab, der respekterer privatlivets fred. Læs mere</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Test gratis</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Vil du aktivere Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Vil du aktivere Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synkroniserer alle dine filer uden at bruge plads på din computer. Du kan gennemse filerne i din kDrive og downloade dem lokalt, når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Bevar plads på din computer</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Beslut, hvilke filer der skal være tilgængelige online eller lokalt</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">SENERE</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Vil du aktivere Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Vil du aktivere Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synkroniserer alle dine filer uden at bruge plads på din computer. Du kan gennemse filerne i din kDrive og downloade dem lokalt, når du vil. &lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Bevar plads på din computer</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Beslut, hvilke filer der skal være tilgængelige online eller lokalt</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>SENERE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Placering af din %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Rediger mappe</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Du vil finde alle dine filer i denne mappe, når konfigurationen er afsluttet. Du kan placere nye filer der for at synkronisere dem til din kDrive.</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">AFSLUT</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÆT</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Indholdet af mappen &lt;b&gt;%1&lt;/b&gt; vil blive synkroniseret i din kDrive</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Placering af din %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Rediger mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Du vil finde alle dine filer i denne mappe, når konfigurationen er afsluttet. Du kan placere nye filer der for at synkronisere dem til din kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>AFSLUT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>FORTSÆT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Indholdet af mappen &lt;b&gt;%1&lt;/b&gt; vil blive synkroniseret i din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt; 
 Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Vælg mappe</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Vælg mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Log ind fra din browser</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Din browser bør åbne automatisk for at fuldføre forbindelsen. Når du er forbundet, vender du automatisk tilbage til kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Åbn login-siden</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Der opstod en fejl under godkendelsen. Luk loginvinduet og prøv igen.&lt;br&gt;Kontakt vores supportteam, hvis fejlen fortsætter.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Login mislykkedes: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Kunne ikke åbne login-siden i din webbrowser</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Log ind fra din browser</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Din browser bør åbne automatisk for at fuldføre forbindelsen. Når du er forbundet, vender du automatisk tilbage til kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Åbn login-siden</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Der opstod en fejl under godkendelsen. Luk loginvinduet og prøv igen.&lt;br&gt;Kontakt vores supportteam, hvis fejlen fortsætter.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Login mislykkedes: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Kunne ikke åbne login-siden i din webbrowser</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Vælg kDrive-mapper til synkronisering på din computer</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÆT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Tilgængeligt plads på din computer: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Der opstod en fejl under indlæsning af listen over undermapper.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Kan ikke indlæse listen over undermapper. Din kDrive er muligvis i vedligeholdelsestilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Vælg kDrive-mapper til synkronisering på din computer</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>FORTSÆT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Tilgængeligt plads på din computer: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Kan ikke indlæse listen over undermapper. Din kDrive er muligvis i vedligeholdelsestilstand.&lt;br&gt;Log venligst ind på &lt;a style="%1" href="%2"&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Kunne ikke oprette lokal mappe %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Kunne ikke oprette ny synkronisering</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">kDrive %1 er allerede synkroniseret på denne computer. Fortsæt alligevel?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Kunne ikke oprette lokal mappe %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Kunne ikke oprette ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>kDrive %1 er allerede synkroniseret på denne computer. Fortsæt alligevel?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-klienten kører med forkerte parametre!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">kDrive-klienten kører allerede!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Brugeren %1 er ikke tilsluttet. Log venligst ind igen.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-klienten kører med forkerte parametre!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>kDrive-klienten kører allerede!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Brugeren %1 er ikke tilsluttet. Log venligst ind igen.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Delingslink kopieret til udklipsholderen</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n anden fil er blevet fjernet.</numerusform>
-            <numerusform>%1 og %n andre filer er blevet fjernet.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er blevet fjernet.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n anden fil er blevet tilføjet.</numerusform>
-            <numerusform>%1 og %n andre filer er blevet tilføjet.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er blevet tilføjet.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n anden fil er blevet opdateret.</numerusform>
-            <numerusform>%1 og %n andre filer er blevet opdateret.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er blevet opdateret.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 er blevet flyttet til %2 og %n anden fil er blevet flyttet.</numerusform>
-            <numerusform>%1 er blevet flyttet til %2 og %n andre filer er blevet flyttet.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 er blevet flyttet til %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synkroniseringsaktivitet</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Delingslink kopieret til udklipsholderen</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 og %n anden fil er blevet fjernet.</numerusform>
+<numerusform>%1 og %n andre filer er blevet fjernet.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er blevet fjernet.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 og %n anden fil er blevet tilføjet.</numerusform>
+<numerusform>%1 og %n andre filer er blevet tilføjet.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er blevet tilføjet.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 og %n anden fil er blevet opdateret.</numerusform>
+<numerusform>%1 og %n andre filer er blevet opdateret.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er blevet opdateret.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 er blevet flyttet til %2 og %n anden fil er blevet flyttet.</numerusform>
+<numerusform>%1 er blevet flyttet til %2 og %n andre filer er blevet flyttet.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 er blevet flyttet til %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synkroniseringsaktivitet</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Ingen undermapper på serveren i øjeblikket.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Ingen undermapper på serveren i øjeblikket.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Forlad betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Tilmeld betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Få tidlig adgang til nye versioner af applikationen, før de udgives til offentligheden, og deltag i forbedringen af applikationen ved at sende os dine kommentarer.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Nyd godt af applikationens beta-opdateringer</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Nej</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Offentlig betaversion</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Intern betaversion</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Testversion</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Jeg forstår</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Er du sikker på, at du vil forlade betaprogrammet?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Gem</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuller</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Din nuværende version af applikationen er måske for ny. Dit valg træder i kraft, når den næste opdatering er tilgængelig.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Betaversioner kan afsluttes uventet eller forårsage ustabilitet.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Forlad betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Tilmeld betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Få tidlig adgang til nye versioner af applikationen, før de udgives til offentligheden, og deltag i forbedringen af applikationen ved at sende os dine kommentarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Nyd godt af applikationens beta-opdateringer</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Offentlig betaversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Intern betaversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Testversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Jeg forstår</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Er du sikker på, at du vil forlade betaprogrammet?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Gem</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Din nuværende version af applikationen er måske for ny. Dit valg træder i kraft, når den næste opdatering er tilgængelig.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Betaversioner kan afsluttes uventet eller forårsage ustabilitet.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Kan ikke initialisere kDrive-klienten</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Kunne ikke løse konflikt(er) på %1 element(er) i synkroniseringsmappen: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Log venligst ind</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synkronisering er sat på pause</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Mappe %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Der er ingen synkroniseringsmapper konfigureret.</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Udefineret tilstand.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Venter på at starte synkroniseringen.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synkronisering kører.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synkronisering lykkedes, uløste konflikter.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Seneste synkronisering lykkedes.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Bruger afbrød.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synkronisering er sat på pause.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synkronisering er sat på pause)</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke åbne mappestien %1.</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vil du virkelig fjerne synkroniseringerne for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">FJERN ALLE SYNKRONISERINGER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 elementer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. For at undgå utilsigtede sletninger er synkroniseringen sat på pause.&lt;br&gt;Vil du overføre disse sletninger til dit kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Flere filer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Slettede filer findes i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papirkurv&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Vis ikke igen</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Oversigt</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Indstillinger</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Afslut</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Kunne ikke starte synkroniseringer!</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Kan ikke initialisere kDrive-klienten</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Kunne ikke løse konflikt(er) på %1 element(er) i synkroniseringsmappen: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Log venligst ind</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synkronisering er sat på pause</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Mappe %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Der er ingen synkroniseringsmapper konfigureret.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Udefineret tilstand.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Venter på at starte synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synkronisering kører.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synkronisering lykkedes, uløste konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Seneste synkronisering lykkedes.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Bruger afbrød.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synkronisering er sat på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synkronisering er sat på pause)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke åbne mappestien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vil du virkelig fjerne synkroniseringerne for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>FJERN ALLE SYNKRONISERINGER</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 elementer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. For at undgå utilsigtede sletninger er synkroniseringen sat på pause.&lt;br&gt;Vil du overføre disse sletninger til dit kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Flere filer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Slettede filer findes i kDrives &lt;a style="%1" href="%3"&gt;papirkurv&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Vis ikke igen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Oversigt</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Indstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Afslut</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Kunne ikke starte synkroniseringer!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Resumé af din lokale mappesynkronisering</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Indholdet af mappen på din computer vil blive synkroniseret til mappen på den valgte kDrive og omvendt.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNKRONISER</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Resumé af din lokale mappesynkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Indholdet af mappen på din computer vil blive synkroniseret til mappen på den valgte kDrive og omvendt.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNKRONISER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Inden du afslutter</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Udfør følgende trin for at sikre, at Lite Sync fungerer korrekt på din computer og for at fuldføre konfigurationen af kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åbn din Macs &lt;b&gt;Generelle indstillinger&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åbn din Macs &lt;b&gt;Indstillinger for Privatliv og sikkerhed&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åbn din Macs &lt;b&gt;Indstillinger for Sikkerhed og privatliv&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Gå til sektionen &lt;b&gt;&quot;Login-emner og udvidelser&quot;&lt;/b&gt; og derefter til &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Godkend kDrive-applikationen</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Gå til sektionen &lt;b&gt;&quot;Sikkerhed&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Godkend kDrive-applikationen i boksen, der angiver, at kDrive er blevet blokeret</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Lås hængelåsen op &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkend kDrive-applikationen</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Gå til sektionen &lt;b&gt;&quot;Privatliv og sikkerhed&quot;&lt;/b&gt; og klik på &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Stadig i indstillingerne for Sikkerhed og privatliv, åbn fanen &lt;b&gt;&quot;Privatliv&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Markér boksen &quot;kDrive LiteSync Extension&quot; og derefter boksen &quot;kDrive.app&quot; (hvis den ikke allerede er markeret)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">En genstart af appen kan blive foreslået. I så fald accepter den</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Markér boksen &quot;kDrive LiteSync Extension&quot; (og &quot;kDrive.app&quot; hvis den findes) under &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">TRIN 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Udført)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">TRIN 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">UDFØRTE TRIN</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">AFSLUT</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Inden du afslutter</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Udfør følgende trin for at sikre, at Lite Sync fungerer korrekt på din computer og for at fuldføre konfigurationen af kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åbn din Macs &lt;b&gt;Generelle indstillinger&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åbn din Macs &lt;b&gt;Indstillinger for Privatliv og sikkerhed&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åbn din Macs &lt;b&gt;Indstillinger for Sikkerhed og privatliv&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Gå til sektionen &lt;b&gt;"Login-emner og udvidelser"&lt;/b&gt; og derefter til &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Godkend kDrive-applikationen</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Gå til sektionen &lt;b&gt;"Sikkerhed"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Godkend kDrive-applikationen i boksen, der angiver, at kDrive er blevet blokeret</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Lås hængelåsen op &lt;img src=":/client/resources/icons/actions/lock.png"&gt; og godkend kDrive-applikationen</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Gå til sektionen &lt;b&gt;"Privatliv og sikkerhed"&lt;/b&gt; og klik på &lt;b&gt;"Fuld diskadgang"&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Stadig i indstillingerne for Sikkerhed og privatliv, åbn fanen &lt;b&gt;"Privatliv"&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Markér boksen "kDrive LiteSync Extension" og derefter boksen "kDrive.app" (hvis den ikke allerede er markeret)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>En genstart af appen kan blive foreslået. I så fald accepter den</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Markér boksen "kDrive LiteSync Extension" (og "kDrive.app" hvis den findes) under &lt;b&gt;"Fuld diskadgang"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>TRIN 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Udført)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>TRIN 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>UDFØRTE TRIN</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>AFSLUT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NEJ</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NEJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Sender fejlretningsoplysninger</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuller</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Sender fejlretningsoplysninger</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Fejlretning</translation>
-    </message>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Info</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Advarsel</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fejl</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Kritisk</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Fejlretningsindstillinger</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Gem fejlretningsoplysninger i en mappe på min computer (Anbefalet)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Disse oplysninger giver IT-support mulighed for at fastslå kilden til en hændelse.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Fejlretningsniveau</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Sporingsniveauet lader dig vælge omfanget af de registrerede fejlretningsoplysninger</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Den udvidede fulde log indsamler en detaljeret historik, der kan bruges til fejlretning. Aktivering af den kan bremse kDrive-applikationen.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Udvidet fuld log</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Slet logfiler ældre end %1 dage</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Del fejlretningsmappen med Infomaniak support.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Den seneste session er perioden siden den seneste kDrive-start.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Del kun den seneste kDrive-session</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Indlæser</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuller</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GEM</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Deling mislykkedes</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Kontroller, at du er logget ind &lt;br&gt;2. Kontroller, at du har konfigureret mindst én kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Forbindelsen afbrudt)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Del mappen med SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Vi komprimerede automatisk din log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Del linket med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Seneste upload den %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Deling er annulleret</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Den udvidede fulde log aktiveres via miljøvariablen KDRIVE_FORCE_EXTENDED_LOG. Indstil den til 0 for at deaktivere den.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 kl. %4h%5m og %6s</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du gemme dine ændringer?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke åbne mappen %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Del</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Deler | trin 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Deler | trin 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Annullerer...</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Hele mappen er stor (&gt; 100 MB) og kan tage noget tid at dele. For at reducere delingstiden anbefaler vi, at du kun deler den seneste kDrive-session.</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Fejlretning</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Advarsel</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Fejl</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Kritisk</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Fejlretningsindstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Gem fejlretningsoplysninger i en mappe på min computer (Anbefalet)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Disse oplysninger giver IT-support mulighed for at fastslå kilden til en hændelse.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Fejlretningsniveau</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Sporingsniveauet lader dig vælge omfanget af de registrerede fejlretningsoplysninger</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Den udvidede fulde log indsamler en detaljeret historik, der kan bruges til fejlretning. Aktivering af den kan bremse kDrive-applikationen.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Udvidet fuld log</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Slet logfiler ældre end %1 dage</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Del fejlretningsmappen med Infomaniak support.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Den seneste session er perioden siden den seneste kDrive-start.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Del kun den seneste kDrive-session</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Indlæser</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>GEM</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Deling mislykkedes</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Kontroller, at du er logget ind &lt;br&gt;2. Kontroller, at du har konfigureret mindst én kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Forbindelsen afbrudt)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Vi komprimerede automatisk din log &lt;a style="%1" href="%2"&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Overfør arkivet med &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Del linket med &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Seneste upload den %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Deling er annulleret</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Den udvidede fulde log aktiveres via miljøvariablen KDRIVE_FORCE_EXTENDED_LOG. Indstil den til 0 for at deaktivere den.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 kl. %4h%5m og %6s</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du gemme dine ændringer?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke åbne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Del</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Deler | trin 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Deler | trin 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Annullerer...</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Hele mappen er stor (&gt; 100 MB) og kan tage noget tid at dele. For at reducere delingstiden anbefaler vi, at du kun deler den seneste kDrive-session.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synkroniseringsfejl og information.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Synkroniser en lokal mappe</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Vil du virkelig aktivere Lite Sync?</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Denne handling kan tage fra et par sekunder til et par minutter afhængigt af mappens størrelse.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKRÆFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Vil du virkelig deaktivere Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Du har ikke nok plads til at synkronisere alle filerne på din kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, skal du vælge, hvilke mapper der skal synkroniseres på din computer. I mellemtiden sættes synkroniseringen af din kDrive på pause.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Hvis du deaktiverer Lite Sync, vil alle filer blive downloadet til din computer.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Kunne ikke oprette ny synkronisering</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Ny lokal mappesynkronisering mislykkedes!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync aktiveret.</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Aktivering af Lite Sync mislykkedes.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync deaktiveret.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Deaktivering af Lite Sync mislykkedes.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Dette drev slettes.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Kan ikke åbne elementet %1</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vil du virkelig stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">FJERN MAPPESYNKRONISERINGSFORBINDELSEN</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Kunne ikke stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Der opstod en fejl under indlæsning af listen over undermapper.</translation>
-    </message>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Mapper</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Meddelelser</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Aktivér meddelelser for denne kDrive</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">En meddelelse vises, så snart en ny mappe er synkroniseret eller ændret</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Forbundet med</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Fjern alle synkroniseringer</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Søg i din kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Søg</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synkroniseringsfejl og information.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synkroniser en lokal mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Vil du virkelig aktivere Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Denne handling kan tage fra et par sekunder til et par minutter afhængigt af mappens størrelse.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>BEKRÆFT</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Vil du virkelig deaktivere Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Du har ikke nok plads til at synkronisere alle filerne på din kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, skal du vælge, hvilke mapper der skal synkroniseres på din computer. I mellemtiden sættes synkroniseringen af din kDrive på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Hvis du deaktiverer Lite Sync, vil alle filer blive downloadet til din computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Kunne ikke oprette ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Ny lokal mappesynkronisering mislykkedes!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync aktiveret.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Aktivering af Lite Sync mislykkedes.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync deaktiveret.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Deaktivering af Lite Sync mislykkedes.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Dette drev slettes.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Kan ikke åbne elementet %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vil du virkelig stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>FJERN MAPPESYNKRONISERINGSFORBINDELSEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Kunne ikke stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Mapper</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Meddelelser</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Aktivér meddelelser for denne kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>En meddelelse vises, så snart en ny mappe er synkroniseret eller ændret</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Forbundet med</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Fjern alle synkroniseringer</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Søg i din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Søg</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Tilføj en kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Synkroniser en kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Tilføj en kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synkroniser en kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Ryd historik</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Skal løses</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">problem(er) opdaget</translation>
-    </message>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Løs</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Konfliktende element(er)</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Element(er) med ikke-understøttede tegn</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Automatisk løst</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problem(er) løst</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Ryd historik</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Skal løses</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>problem(er) opdaget</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Løs</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Konfliktende element(er)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Element(er) med ikke-understøttede tegn</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Automatisk løst</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problem(er) løst</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synkroniseringskonflikter eller fejl</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Fejl</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Tilbage til indstillinger</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synkroniseringskonflikter eller fejl</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Fejl</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Tilbage til indstillinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Nogle filer kunne ikke synkroniseres på følgende kDrive(s):</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 fejl)</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 information(er))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 fejl og %2 information(er))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Generiske fejl (%n advarsel eller fejl)</numerusform>
-            <numerusform>Generiske fejl (%n advarsler eller fejl)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Nogle filer kunne ikke synkroniseres på følgende kDrive(s):</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 fejl)</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 information(er))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 fejl og %2 information(er))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Generiske fejl (%n advarsel eller fejl)</numerusform>
+<numerusform>Generiske fejl (%n advarsler eller fejl)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Ekskluderede filer</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Tilføj filer eller mapper, der ikke synkroniseres på din computer.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Tilføj</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAVN</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">ADVARSEL</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GEM</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du gemme dine ændringer?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Eksklusionsskabelon eksisterer allerede!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vil du virkelig slette?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Kan ikke gemme ændringer!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Ekskluderede filer</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Tilføj filer eller mapper, der ikke synkroniseres på din computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Tilføj</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NAVN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>ADVARSEL</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>GEM</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du gemme dine ændringer?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Eksklusionsskabelon eksisterer allerede!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Vil du virkelig slette?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Kan ikke gemme ændringer!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">GODKEND</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>GODKEND</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Løs konflikt(er)</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Hvad vil du gøre med de %1 konfliktende element(er)?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Gem mine ændringer og erstat andre brugeres versioner.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Fortryd mine ændringer og behold andre brugeres versioner.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Dine ændringer kan blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Dine ændringer vil blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Vis element(er)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">GODKEND</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Disse filer er blevet ændret af flere brugere på flere steder (online på kDrive, en computer eller en mobilenhed). Mapper, der indeholder disse filer, kan også være blevet slettet.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Den lokale version af dit element &lt;b&gt;er ikke synkroniseret&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Løs konflikt(er)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Hvad vil du gøre med de %1 konfliktende element(er)?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Gem mine ændringer og erstat andre brugeres versioner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Fortryd mine ændringer og behold andre brugeres versioner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Dine ændringer kan blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Dine ændringer vil blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Vis element(er)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>GODKEND</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Disse filer er blevet ændret af flere brugere på flere steder (online på kDrive, en computer eller en mobilenhed). Mapper, der indeholder disse filer, kan også være blevet slettet.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Den lokale version af dit element &lt;b&gt;er ikke synkroniseret&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synkroniseret i &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Aktivér Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Aktivér Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Deaktivér Lite Sync</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Sæt synkronisering på pause</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Genoptag synkronisering</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Fjern synkronisering</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Ikke-valgte mapper flyttes til papirkurven, forudsat at de indeholder offline-elementer. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Ikke-valgte mapper flyttes til papirkurven. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Ikke-valgte mapper vil blive &lt;b&gt;permanent&lt;/b&gt; slettet fra computeren. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuller</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">GODKEND</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synkroniseret i &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Aktivér Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Aktivér Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Deaktivér Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Sæt synkronisering på pause</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Genoptag synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Fjern synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Ikke-valgte mapper flyttes til papirkurven, forudsat at de indeholder offline-elementer. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Ikke-valgte mapper flyttes til papirkurven. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Ikke-valgte mapper vil blive &lt;b&gt;permanent&lt;/b&gt; slettet fra computeren. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Annuller</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>GODKEND</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke åbne mappestien %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke åbne mappestien %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Applikations-id</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Applikationsnavn</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">GODKEND</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Applikations-id</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Applikationsnavn</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>GODKEND</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Nogle apps (sikkerhedskopiering, antivirus...) tilgår dine filer, hvilket fører til, at de downloades, når de er &quot;online&quot;. Tilføj dem i listen nedenfor for at undgå dette.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Tilføj</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">APPLIKATIONS-ID</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAVN</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GEM</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du gemme dine ændringer?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vil du virkelig slette?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Kan ikke gemme ændringer!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Nogle apps (sikkerhedskopiering, antivirus...) tilgår dine filer, hvilket fører til, at de downloades, når de er "online". Tilføj dem i listen nedenfor for at undgå dette.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Tilføj</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>APPLIKATIONS-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NAVN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>GEM</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du gemme dine ændringer?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Vil du virkelig slette?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Kan ikke gemme ændringer!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Hvilken mappe på din computer vil du&lt;br&gt;synkronisere?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Indholdet af denne mappe vil blive synkroniseret på kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Vælg en mappe</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Rediger mappe</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÆT</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Hvilken mappe på din computer vil du&lt;br&gt;synkronisere?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Indholdet af denne mappe vil blive synkroniseret på kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Vælg en mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Rediger mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>FORTSÆT</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt;
 Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Vælg mappe</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Vælg mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fejl</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Filen &apos;%1&apos;&lt;br/&gt;kan ikke åbnes til skrivning.&lt;br/&gt;&lt;br/&gt;Logoutputtet kan &lt;b&gt;ikke&lt;/b&gt; gemmes!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Fejl</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Filen '%1'&lt;br/&gt;kan ikke åbnes til skrivning.&lt;br/&gt;&lt;br/&gt;Logoutputtet kan &lt;b&gt;ikke&lt;/b&gt; gemmes!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Indstillinger</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Hjælp</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Indstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Hjælp</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive skal have skriveadgang til din computers midlertidige mappe.&lt;br&gt;Genstart venligst kDrive-appen for at løse dette problem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Det ser ud til, at din netværksforbindelse er konfigureret med en for lav timeout til, at applikationen kan fungere korrekt (fejl %1).&lt;br&gt;Kontroller venligst din netværkskonfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Kan ikke oprette forbindelse til kDrive-serveren (fejl %1).&lt;br&gt;Forsøger at genoprette forbindelsen. Kontroller venligst din internetforbindelse og firewall.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Log venligst ind igen, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>En ny version af applikationen er tilgængelig.&lt;br&gt;Opdater venligst applikationen for at fortsætte med at bruge den.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Log-upload mislykkedes (fejl %1).&lt;br&gt;Prøv venligst igen senere.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkroniseringsmappen er ikke længere tilgængelig (fejl %1).&lt;br&gt;Synkronisering genoptages, så snart mappen er tilgængelig.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Drevet, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet (fejl %1).&lt;br&gt;Tilslut det venligst igen for at genoptage synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Synkronisering er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Der er ikke nok hukommelse tilbage på din maskine.&lt;br&gt;Synkronisering er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Antallet af inotify-overvågninger er utilstrækkeligt (fejl %1).&lt;br&gt;Du kan hæve dette antal ved at redigere &apos;/etc/sysctl.conf&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;Du skal tillade:&lt;br&gt;- kDrive i Systemindstillinger &gt;&gt; Generelt &gt;&gt; Login-emner og udvidelser &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension i Systemindstillinger &gt;&gt; Privatliv og sikkerhed &gt;&gt; Fuld diskadgang.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;LiteSyncExt-processen kører ikke i øjeblikket. Synkronisering genoptages, så snart den er startet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen er installeret, og at Windows Search-tjenesten er aktiveret.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen har de korrekte tilladelser og kører.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>En fil eller mappe inde i din synkroniseringsmappe ser ud til at være beskadiget.&lt;br&gt;Synkronisering er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive er i vedligeholdelsestilstand.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive er blokeret.&lt;br&gt;Forny venligst kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive er blokeret.&lt;br&gt;Kontakt venligst en administrator for at forny kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive vågner.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på webversionen for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Du har ikke adgang til denne kDrive.&lt;br&gt;Synkronisering er sat på pause. Kontakt venligst en administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Netværksforbindelserne er blevet afbrudt af kernen (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Desværre kunne din gamle konfiguration ikke migreres.&lt;br&gt;Applikationen vil bruge en tom konfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Desværre kunne din gamle proxykonfiguration ikke migreres, SOCKS5-proxyer understøttes ikke i øjeblikket.&lt;br&gt;Applikationen vil i stedet bruge systemets proxyindstillinger.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkroniseringsmappen er blevet erstattet eller flyttet på en måde, der forhindrer synkronisering (fejl %1).&lt;br&gt;Dette kan ske efter kopiering, flytning eller gendannelse af mappen.&lt;br&gt;For at løse dette, opret venligst en ny synkronisering med en ny mappe.&lt;br&gt;Bemærk: Hvis du har usynkroniserede ændringer i den gamle mappe, skal du kopiere dem manuelt til den nye.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering er genstartet. Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Der er opstået en fejl ved adgang til synkroniseringsdatabasen (fejl %1).&lt;br&gt;Synkronisering er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Token er ugyldigt eller tilbagekaldt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Indlejrede synkroniseringer er forbudte (fejl %1).&lt;br&gt;Du bør kun beholde synkroniseringer, hvis mapper ikke er indlejrede.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Synkroniseringsmappen på den fjernliggende kDrive eksisterer ikke længere eller er ikke længere tilgængelig (fejl %1).&lt;br&gt;Du skal gendanne den eller give den adgangsrettigheder tilbage eller slette/genoprette synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Filnavnfejl ved parsing (fejl %1).&lt;br&gt;Specialtegn som anførselstegn, omvendte skråstreger eller linjeskift kan forårsage parsing-fejl.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Dette element er blevet flyttet et andet sted hen.&lt;br&gt;Den lokale handling er annulleret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Den lokale handling er annulleret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Det lokale element er omdøbt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Filen blev ændret på samme tid af en anden bruger.&lt;br&gt;Dine ændringer er gemt i en kopi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>En anden bruger har flyttet en overordnet mappe til destinationen.&lt;br&gt;Den lokale handling er annulleret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Et eksisterende element har et identisk navn med de samme store og små bogstaver.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementnavnet indeholder et ikke-understøttet tegn.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementnavnet afsluttes med et mellemrum, hvilket er forbudt på dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Dette elementnavn er reserveret af dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementnavnet er for langt.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Elementstien er for lang.&lt;br&gt;Det er ignoreret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Elementnavnet indeholder et nyere UNICODE-tegn, der endnu ikke understøttes af dit filsystem.&lt;br&gt;Det er udelukket fra synkronisering.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementnavnet indeholder kun mellemrum.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Du har enten ikke tilladelse til at oprette et element, eller der findes allerede et andet element med samme navn. Elementet er blevet ignoreret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Du har ikke tilladelse til at redigere elementet.&lt;br&gt;Filen med dine ændringer er omdøbt og udelukket fra synkronisering.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Du har ikke tilladelse til at omdøbe elementet.&lt;br&gt;Det vil blive gendannet med sit originale navn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Du har ikke tilladelse til at flytte elementet til &quot;%1&quot;.&lt;br&gt;Det vil blive gendannet i sin originale overordnede mappe.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Du har ikke tilladelse til at slette elementet.&lt;br&gt;Det vil blive gendannet på sin originale placering.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Kunne ikke flytte dette element til papirkurven, det er sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Kunne ikke synkronisere dette element. Det er midlertidigt sortlistet.&lt;br&gt;Et nyt forsøg på at synkronisere det vil blive foretaget om en time eller ved næste opstart af applikationen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Dette element er udelukket fra synkronisering af en brugerdefineret skabelon.&lt;br&gt;Du kan deaktivere denne type meddelelse fra Indstillinger</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Dette element er udelukket fra synkronisering, fordi det er et hårdt link.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Filen er blevet ændret lokalt, mens den er blevet slettet på den fjernliggende kDrive.&lt;br&gt;Den lokale kopi er gemt i redningmappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Handlingen udført på elementet er forbudt.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Handlingen udført på dette element mislykkedes.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Filen er for stor til at blive uploadet. Den er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Du har overskredet din kvota. Øg din pladskvota for at genaktivere filuploads.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Kan ikke downloade filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Dette element er i øjeblikket låst af en anden bruger online.&lt;br&gt;Vi vil forsøge at uploade dine ændringer igen senere.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Synkroniseringsfejl.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Kan ikke tilgå elementet.&lt;br&gt;Ret venligst læse- og skrivetilladelserne.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Downloaden er annulleret.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Kan ikke oprette filen %1, fordi den ikke understøttes af dit filsystem.&lt;br&gt;Den er udelukket fra synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Systemfejl.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementet eksisterer allerede på den anden side.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Kan ikke åbne mappestien %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Transmission gennemført!&lt;br&gt;Referer venligst til id&apos;et &lt;b&gt;%1&lt;/b&gt; i fejlrapporter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Transmission mislykkedes!
-Brug venligst følgende link til at sende loggene til support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Ingen kDrive konfigureret!</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive skal have skriveadgang til din computers midlertidige mappe.&lt;br&gt;Genstart venligst kDrive-appen for at løse dette problem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Der er opstået en teknisk fejl.&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Det ser ud til, at din netværksforbindelse er konfigureret med en for lav timeout til, at applikationen kan fungere korrekt (fejl %1).&lt;br&gt;Kontroller venligst din netværkskonfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Kan ikke oprette forbindelse til kDrive-serveren (fejl %1).&lt;br&gt;Forsøger at genoprette forbindelsen. Kontroller venligst din internetforbindelse og firewall.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Log venligst ind igen, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>En ny version af applikationen er tilgængelig.&lt;br&gt;Opdater venligst applikationen for at fortsætte med at bruge den.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Log-upload mislykkedes (fejl %1).&lt;br&gt;Prøv venligst igen senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Synkroniseringsmappen er ikke længere tilgængelig (fejl %1).&lt;br&gt;Synkronisering genoptages, så snart mappen er tilgængelig.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Drevet, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet (fejl %1).&lt;br&gt;Tilslut det venligst igen for at genoptage synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Synkronisering er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Der er ikke nok hukommelse tilbage på din maskine.&lt;br&gt;Synkronisering er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Antallet af inotify-overvågninger er utilstrækkeligt (fejl %1).&lt;br&gt;Du kan hæve dette antal ved at redigere '/etc/sysctl.conf'.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;Du skal tillade:&lt;br&gt;- kDrive i Systemindstillinger &gt;&gt; Generelt &gt;&gt; Login-emner og udvidelser &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension i Systemindstillinger &gt;&gt; Privatliv og sikkerhed &gt;&gt; Fuld diskadgang.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;LiteSyncExt-processen kører ikke i øjeblikket. Synkronisering genoptages, så snart den er startet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen er installeret, og at Windows Search-tjenesten er aktiveret.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen har de korrekte tilladelser og kører.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>En fil eller mappe inde i din synkroniseringsmappe ser ud til at være beskadiget.&lt;br&gt;Synkronisering er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive er i vedligeholdelsestilstand.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive er blokeret.&lt;br&gt;Forny venligst kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive er blokeret.&lt;br&gt;Kontakt venligst en administrator for at forny kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive vågner.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på &lt;a style="%1" href="%2"&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på webversionen for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Du har ikke adgang til denne kDrive.&lt;br&gt;Synkronisering er sat på pause. Kontakt venligst en administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Netværksforbindelserne er blevet afbrudt af kernen (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Desværre kunne din gamle konfiguration ikke migreres.&lt;br&gt;Applikationen vil bruge en tom konfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Desværre kunne din gamle proxykonfiguration ikke migreres, SOCKS5-proxyer understøttes ikke i øjeblikket.&lt;br&gt;Applikationen vil i stedet bruge systemets proxyindstillinger.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Synkroniseringsmappen er blevet erstattet eller flyttet på en måde, der forhindrer synkronisering (fejl %1).&lt;br&gt;Dette kan ske efter kopiering, flytning eller gendannelse af mappen.&lt;br&gt;For at løse dette, opret venligst en ny synkronisering med en ny mappe.&lt;br&gt;Bemærk: Hvis du har usynkroniserede ændringer i den gamle mappe, skal du kopiere dem manuelt til den nye.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering er genstartet. Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Der er opstået en fejl ved adgang til synkroniseringsdatabasen (fejl %1).&lt;br&gt;Synkronisering er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Token er ugyldigt eller tilbagekaldt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Indlejrede synkroniseringer er forbudte (fejl %1).&lt;br&gt;Du bør kun beholde synkroniseringer, hvis mapper ikke er indlejrede.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Synkroniseringsmappen på den fjernliggende kDrive eksisterer ikke længere eller er ikke længere tilgængelig (fejl %1).&lt;br&gt;Du skal gendanne den eller give den adgangsrettigheder tilbage eller slette/genoprette synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Filnavnfejl ved parsing (fejl %1).&lt;br&gt;Specialtegn som anførselstegn, omvendte skråstreger eller linjeskift kan forårsage parsing-fejl.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Dette element er blevet flyttet et andet sted hen.&lt;br&gt;Den lokale handling er annulleret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Den lokale handling er annulleret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Det lokale element er omdøbt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Filen blev ændret på samme tid af en anden bruger.&lt;br&gt;Dine ændringer er gemt i en kopi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>En anden bruger har flyttet en overordnet mappe til destinationen.&lt;br&gt;Den lokale handling er annulleret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Et eksisterende element har et identisk navn med de samme store og små bogstaver.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementnavnet indeholder et ikke-understøttet tegn.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementnavnet afsluttes med et mellemrum, hvilket er forbudt på dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Dette elementnavn er reserveret af dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementnavnet er for langt.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Elementstien er for lang.&lt;br&gt;Det er ignoreret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Elementnavnet indeholder et nyere UNICODE-tegn, der endnu ikke understøttes af dit filsystem.&lt;br&gt;Det er udelukket fra synkronisering.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementnavnet indeholder kun mellemrum.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Du har enten ikke tilladelse til at oprette et element, eller der findes allerede et andet element med samme navn. Elementet er blevet ignoreret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Du har ikke tilladelse til at redigere elementet.&lt;br&gt;Filen med dine ændringer er omdøbt og udelukket fra synkronisering.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Du har ikke tilladelse til at omdøbe elementet.&lt;br&gt;Det vil blive gendannet med sit originale navn.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Du har ikke tilladelse til at flytte elementet til "%1".&lt;br&gt;Det vil blive gendannet i sin originale overordnede mappe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Du har ikke tilladelse til at slette elementet.&lt;br&gt;Det vil blive gendannet på sin originale placering.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Kunne ikke flytte dette element til papirkurven, det er sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Kunne ikke synkronisere dette element. Det er midlertidigt sortlistet.&lt;br&gt;Et nyt forsøg på at synkronisere det vil blive foretaget om en time eller ved næste opstart af applikationen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Dette element er udelukket fra synkronisering af en brugerdefineret skabelon.&lt;br&gt;Du kan deaktivere denne type meddelelse fra Indstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Dette element er udelukket fra synkronisering, fordi det er et hårdt link.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Filen er blevet ændret lokalt, mens den er blevet slettet på den fjernliggende kDrive.&lt;br&gt;Den lokale kopi er gemt i redningmappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Handlingen udført på elementet er forbudt.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Handlingen udført på dette element mislykkedes.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Filen er for stor til at blive uploadet. Den er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Du har overskredet din kvota. Øg din pladskvota for at genaktivere filuploads.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Kan ikke downloade filen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Dette element er i øjeblikket låst af en anden bruger online.&lt;br&gt;Vi vil forsøge at uploade dine ændringer igen senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Synkroniseringsfejl.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Kan ikke tilgå elementet.&lt;br&gt;Ret venligst læse- og skrivetilladelserne.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Downloaden er annulleret.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Det er ikke muligt at oprette filen »%1«, da den ikke understøttes af dit filsystem.&lt;br&gt;Den er blevet udelukket fra synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Systemfejl.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementet eksisterer allerede på den anden side.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Der er opstået en teknisk fejl.&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke åbne mappestien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Transmission gennemført!&lt;br&gt;Referer venligst til id'et &lt;b&gt;%1&lt;/b&gt; i fejlrapporter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Transmission mislykkedes!
+Brug venligst følgende link til at sende loggene til support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Ingen kDrive konfigureret!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Denne synkronisering slettes.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Denne synkronisering slettes.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Tilbage til drevlisten</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Indstillinger</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Tilbage til drevlisten</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Indstillinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke åbne mappen %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ugyldigt link %1.</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Nogle processer kunne ikke køre.</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Generelt</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Aktivér mørkt tema</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Aktivér monokrome ikoner</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Start kDrive ved opstart</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Sprog</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Flyt slettede filer til min computers papirkurv</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Nogle filer eller mapper kan måske ikke flyttes til computerens papirkurv.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Du kan altid hente allerede synkroniserede filer fra kDrive-webapplikationens papirkurv.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Standard</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Engelsk</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Fransk</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Tysk</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Spansk</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italiensk</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Svensk</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugisisk</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polsk</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norsk</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finsk</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Dansk</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Græsk</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Nederlandsk</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avanceret</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Fejlretningsoplysninger</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Filer der skal ekskluderes</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke åbne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Ugyldigt link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Nogle processer kunne ikke køre.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Generelt</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Aktivér mørkt tema</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Aktivér monokrome ikoner</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Start kDrive ved opstart</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Sprog</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Flyt slettede filer til min computers papirkurv</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Nogle filer eller mapper kan måske ikke flyttes til computerens papirkurv.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Du kan altid hente allerede synkroniserede filer fra kDrive-webapplikationens papirkurv.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Standard</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Engelsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Fransk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Tysk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Spansk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italiensk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Svensk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugisisk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Dansk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Græsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Nederlandsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avanceret</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Fejlretningsoplysninger</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Filer der skal ekskluderes</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 i brug</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 i brug</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S)-proxy</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Ingen proxyserver</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Brug systemparametre</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Angiv en proxy manuelt</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Port</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Adresse på proxyserveren</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Godkendelse krævet</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Bruger</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Adgangskode</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GEM</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du gemme dine ændringer?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Kan ikke gemme, ikke alle obligatoriske felter er udfyldt!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy ikke fundet, gem alligevel?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S)-proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ingen proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Brug systemparametre</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Angiv en proxy manuelt</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Port</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Adresse på proxyserveren</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Godkendelse krævet</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Bruger</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Adgangskode</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>GEM</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du gemme dine ændringer?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Kan ikke gemme, ikke alle obligatoriske felter er udfyldt!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy ikke fundet, gem alligevel?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Ressourcemanager</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Maksimal tilladt CPU-brug</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GEM</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du gemme dine ændringer?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Ressourcemanager</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Maksimal tilladt CPU-brug</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>GEM</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du gemme dine ændringer?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Vælg en mappe på din kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Indholdet af den valgte mappe vil blive synkroniseret i mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÆT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Tilgængeligt plads på din computer til den aktuelle mappe: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Denne mappe synkroniseres allerede.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKRÆFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLER</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Vælg en mappe på din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Indholdet af den valgte mappe vil blive synkroniseret i mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>FORTSÆT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Tilgængeligt plads på din computer til den aktuelle mappe: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Denne mappe synkroniseres allerede.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>BEKRÆFT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ANNULLER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; indeholder undermapper,&lt;br&gt; vælg dem, du vil synkronisere</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÆT</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Ingen undermapper på serveren i øjeblikket.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; indeholder undermapper,&lt;br&gt; vælg dem, du vil synkronisere</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>FORTSÆT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Ingen undermapper på serveren i øjeblikket.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Genoptag synkronisering af kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Genoptag synkronisering</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Genoptag synkronisering af alle kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Sæt synkronisering af kDrive &quot;%1&quot; på pause</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Sæt synkronisering på pause</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Sæt synkronisering af alle kDrives på pause</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Genoptag synkronisering af kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Genoptag synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Genoptag synkronisering af alle kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Sæt synkronisering af kDrive "%1" på pause</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Sæt synkronisering på pause</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Sæt synkronisering af alle kDrives på pause</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Åbn</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Føj til favoritter</translation>
-    </message>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Kopiér delingslink</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Vis på kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Vis i mappe</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Åbn</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Føj til favoritter</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Kopiér delingslink</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Vis på kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Vis i mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kan ikke åbne mappen-url %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Åbn i mappe</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Åbn %1 webversion</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Drevindstillinger</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Meddelelser deaktiveret indtil %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Deaktivér meddelelser</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Applikationsindstillinger</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Brug for hjælp</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Send feedback</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Afslut kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Kan ikke tilgå webstedet %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Vis fejl og information</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Vis information</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Aldrig</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">I 1 time</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Til i morgen kl. 8:00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">I 3 dage</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">I 1 uge</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Altid</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">I 1 time mere</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">I 3 dage mere</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">I 1 uge mere</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kan ikke åbne mappen-url %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Åbn i mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Åbn %1 webversion</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Drevindstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Meddelelser deaktiveret indtil %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Deaktivér meddelelser</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Applikationsindstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Brug for hjælp</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Send feedback</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Afslut kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Kan ikke tilgå webstedet %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Vis fejl og information</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Vis information</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Aldrig</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>I 1 time</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Til i morgen kl. 8:00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>I 3 dage</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>I 1 uge</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Altid</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>I 1 time mere</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>I 3 dage mere</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>I 1 uge mere</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synkroniseret</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoritter</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Aktivitet</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kan ikke åbne mappen-url %1.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Opdater</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Opdateringsdownload i gang</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Søger efter opdatering...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Manuel opdatering</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Ikke tilgængelig</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Ikke implementeret!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke åbne linket %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ugyldigt link %1.</translation>
-    </message>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Opdater kDrive-appen</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Denne version af kDrive-appen understøttes ikke længere. For at få adgang til de nyeste funktioner og forbedringer, opdater venligst.</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klik her for at downloade manuelt&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Download venligst den nyeste version på webstedet.</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Ingen synkroniseret mappe for dette drev!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Ingen kDrive konfigureret!</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra din computer&lt;/a&gt; eller på &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synkroniseret</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoritter</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Aktivitet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kan ikke åbne mappen-url %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Opdater</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Opdateringsdownload i gang</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Søger efter opdatering...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Manuel opdatering</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Ikke tilgængelig</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Ikke implementeret!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke åbne linket %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Ugyldigt link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Opdater kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Denne version af kDrive-appen understøttes ikke længere. For at få adgang til de nyeste funktioner og forbedringer, opdater venligst.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klik her for at downloade manuelt&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Download venligst den nyeste version på webstedet.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Ingen synkroniseret mappe for dette drev!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Ingen kDrive konfigureret!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Du kan synkronisere filer &lt;a style="%1" href="%2"&gt;fra din computer&lt;/a&gt; eller på &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Den nye version &lt;b&gt;%1&lt;/b&gt; af %2-klienten er tilgængelig og er downloadet.&lt;/p&gt;&lt;p&gt;Den installerede version er %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Spring denne version over</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Påmind mig senere</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installer opdatering</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Den nye version &lt;b&gt;%1&lt;/b&gt; af %2-klienten er tilgængelig og er downloadet.&lt;/p&gt;&lt;p&gt;Den installerede version er %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Spring denne version over</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Påmind mig senere</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installer opdatering</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Ny opdatering tilgængelig.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Version %1 er tilgængelig til download.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Ny opdatering tilgængelig.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Version %1 er tilgængelig til download.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Tilføj en konto</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Tilføj en konto</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis frigivelsesbemærkninger&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Version</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">OPDATER</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 er opdateret!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Søger efter opdatering på serveren...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">En opdatering er tilgængelig: %1.&lt;br&gt;Download den venligst fra &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">En opdatering er tilgængelig: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Downloader %1. Vent venligst...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Kunne ikke søge efter nye opdateringer.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Der opstod en fejl under opdateringen.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Kunne ikke downloade opdateringen.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Opdatering deaktiveret.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Betaprogram</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Få tidlig adgang til nye versioner af applikationen</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Tilmeld</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Rediger</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Afslut</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Vis frigivelsesbemærkninger&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Version</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>OPDATER</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 er opdateret!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Søger efter opdatering på serveren...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>En opdatering er tilgængelig: %1.&lt;br&gt;Download den venligst fra &lt;a style="%2" href="%3"&gt;her&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>En opdatering er tilgængelig: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Downloader %1. Vent venligst...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Kunne ikke søge efter nye opdateringer.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Der opstod en fejl under opdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Kunne ikke downloade opdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Opdatering deaktiveret.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Betaprogram</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Få tidlig adgang til nye versioner af applikationen</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Tilmeld</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Rediger</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Afslut</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync (Beta) er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync (Beta) er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Kan ikke gemme parametre. Prøv venligst igen senere.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Kan ikke gemme parametre!</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Gør tilgængeligt lokalt</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Frigør lokal plads</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Annuller frigørelse af lokal plads</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Annuller gør tilgængeligt lokalt</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Gendeling af denne fil er ikke tilladt</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Gendeling af denne mappe er ikke tilladt</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Kopiér offentligt delingslink</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Kopiér privat delingslink</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Åbn i browser</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Den overordnede mappe er en synkroniseringsmappe eller er indeholdt i en</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Kan ikke finde en gyldig sti</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Ingen gyldig mappe valgt!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Den valgte sti eksisterer ikke!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Den valgte sti er ikke en mappe!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Du har ikke tilladelse til at skrive til den valgte mappe!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappe %1 indeholder en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappe %1 er indeholdt i en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappe %1 er allerede synkroniseret. Vælg venligst en anden!</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync (Beta) er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync (Beta) er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Kan ikke gemme parametre. Prøv venligst igen senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Kan ikke gemme parametre!</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Gør tilgængeligt lokalt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Frigør lokal plads</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Annuller frigørelse af lokal plads</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Annuller gør tilgængeligt lokalt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Gendeling af denne fil er ikke tilladt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Gendeling af denne mappe er ikke tilladt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Kopiér offentligt delingslink</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Kopiér privat delingslink</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Åbn i browser</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Den overordnede mappe er en synkroniseringsmappe eller er indeholdt i en</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Kan ikke finde en gyldig sti</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Ingen gyldig mappe valgt!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Den valgte sti eksisterer ikke!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Den valgte sti er ikke en mappe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Du har ikke tilladelse til at skrive til den valgte mappe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Den lokale mappe %1 indeholder en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Den lokale mappe %1 er indeholdt i en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Den lokale mappe %1 er allerede synkroniseret. Vælg venligst en anden!</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">kDrive-applikationen lukker på grund af en kritisk fejl.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>kDrive-applikationen lukker på grund af en kritisk fejl.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n år</numerusform>
-            <numerusform>%n år</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n måned</numerusform>
-            <numerusform>%n måneder</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n dag</numerusform>
-            <numerusform>%n dage</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n time</numerusform>
-            <numerusform>%n timer</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minut</numerusform>
-            <numerusform>%n minutter</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n sekund</numerusform>
-            <numerusform>%n sekunder</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
+<name>Utility</name>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n år</numerusform>
+<numerusform>%n år</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n måned</numerusform>
+<numerusform>%n måneder</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n dag</numerusform>
+<numerusform>%n dage</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n time</numerusform>
+<numerusform>%n timer</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minut</numerusform>
+<numerusform>%n minutter</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekund</numerusform>
+<numerusform>%n sekunder</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Systembakken er ikke tilgængelig</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 kræver en fungerende systembakke. Kører du XFCE, følg venligst &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;disse instruktioner&lt;/a&gt;. Ellers skal du installere et systembakkeprogram som &apos;trayer&apos; og prøve igen.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Systembakken er ikke tilgængelig</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 kræver en fungerende systembakke. Kører du XFCE, følg venligst &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;disse instruktioner&lt;/a&gt;. Ellers skal du installere et systembakkeprogram som 'trayer' og prøve igen.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Kunne ikke åbne browser</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Der opstod en fejl ved åbning af browseren for at gå til URL %1. Måske er der ikke konfigureret en standardbrowser?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Kunne ikke åbne e-mailklient</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Der opstod en fejl ved åbning af e-mailklienten for at oprette en ny besked. Måske er der ikke konfigureret en standard e-mailklient?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Du er ikke længere forbundet. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log ind&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Kunne ikke åbne browser</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Der opstod en fejl ved åbning af browseren for at gå til URL %1. Måske er der ikke konfigureret en standardbrowser?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Kunne ikke åbne e-mailklient</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Der opstod en fejl ved åbning af e-mailklienten for at oprette en ny besked. Måske er der ikke konfigureret en standard e-mailklient?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Du er ikke længere forbundet. &lt;a style="%1" href="%2"&gt;Log ind&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Ingen mappe at synkronisere
+<translation>Ingen mappe at synkronisere
 Du kan tilføje en fra kDrive-indstillingerne.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synkronisering i gang (%1 af %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synkronisering i gang (%1 af %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synkronisering i gang (%1 af %2)
+<translation>Synkronisering i gang (%1 af %2)
 %3 tilbage...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synkronisering i gang (Trin %1/%2).</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Synkronisering starter</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synkronisering i gang.</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Du er opdateret, uløste konflikter.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Du er opdateret!</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Nogle filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synkronisering sætter på pause...</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synkronisering sat på pause.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi en anden synkronisering bruger samme mappe.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den indeholder den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den er indeholdt i den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe. Foreslået mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Du har ekskluderet mere end %1 mapper. Bemærk, at dette vil påvirke synkroniseringsydelsen.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Du kan ikke ekskludere mere end %1 mapper. Fravælg venligst mapper på højere niveau.</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synkronisering i gang (Trin %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synkronisering starter</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synkronisering i gang.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Du er opdateret, uløste konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Du er opdateret!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Nogle filer kunne ikke synkroniseres. &lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synkronisering sætter på pause...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synkronisering sat på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi en anden synkronisering bruger samme mappe.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den indeholder den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den er indeholdt i den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe. Foreslået mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Du har ekskluderet mere end %1 mapper. Bemærk, at dette vil påvirke synkroniseringsydelsen.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Du kan ikke ekskludere mere end %1 mapper. Fravælg venligst mapper på højere niveau.</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_da.ts
+++ b/translations/client_da.ts
@@ -1,3095 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="da_DK" version="2.1">
+<TS version="2.1" language="da_DK">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Om</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>LUK</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Version %1. For mere information besøg &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribueret af %1 og licenseret under &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoet er registrerede varemærker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Bygget fra &lt;a style="color: #489EF3" href="%1"&gt;Git-kildekode&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke åbne mappen %1.</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>LUK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Version %1. For mere information besøg &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribueret af %1 og licenseret under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoet er registrerede varemærker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Bygget fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekode&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke åbne mappen %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke åbne mappestien %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Synkronisering starter, og du vil kunne tilføje filer til din %1-mappe.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Din kDrive er klar!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ÅBEN MAPPE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>INDSTILLINGER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synkroniser et andet drev</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkronisering starter, og du vil kunne tilføje filer til din %1-mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Din kDrive er klar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ÅBEN MAPPE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>INDSTILLINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkroniser et andet drev</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Annuller</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>NÆSTE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Vælg den kDrive, du vil synkronisere</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Få kDrive gratis</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Gem dine billeder, dokumenter og e-mails i Schweiz hos et uafhængigt selskab, der respekterer privatlivets fred. Læs mere</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Test gratis</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>NÆSTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Vælg den kDrive, du vil synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Få kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Gem dine billeder, dokumenter og e-mails i Schweiz hos et uafhængigt selskab, der respekterer privatlivets fred. Læs mere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Test gratis</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Vil du aktivere Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Vil du aktivere Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synkroniserer alle dine filer uden at bruge plads på din computer. Du kan gennemse filerne i din kDrive og downloade dem lokalt, når du vil. &lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Bevar plads på din computer</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Beslut, hvilke filer der skal være tilgængelige online eller lokalt</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>SENERE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Vil du aktivere Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Vil du aktivere Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkroniserer alle dine filer uden at bruge plads på din computer. Du kan gennemse filerne i din kDrive og downloade dem lokalt, når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Bevar plads på din computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Beslut, hvilke filer der skal være tilgængelige online eller lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>SENERE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Placering af din %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Rediger mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Du vil finde alle dine filer i denne mappe, når konfigurationen er afsluttet. Du kan placere nye filer der for at synkronisere dem til din kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>AFSLUT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>FORTSÆT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Indholdet af mappen &lt;b&gt;%1&lt;/b&gt; vil blive synkroniseret i din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Placering af din %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Du vil finde alle dine filer i denne mappe, når konfigurationen er afsluttet. Du kan placere nye filer der for at synkronisere dem til din kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>AFSLUT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Indholdet af mappen &lt;b&gt;%1&lt;/b&gt; vil blive synkroniseret i din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt; 
 Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Vælg mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Vælg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Log ind fra din browser</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Din browser bør åbne automatisk for at fuldføre forbindelsen. Når du er forbundet, vender du automatisk tilbage til kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Åbn login-siden</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Der opstod en fejl under godkendelsen. Luk loginvinduet og prøv igen.&lt;br&gt;Kontakt vores supportteam, hvis fejlen fortsætter.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Login mislykkedes: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Kunne ikke åbne login-siden i din webbrowser</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Log ind fra din browser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Din browser bør åbne automatisk for at fuldføre forbindelsen. Når du er forbundet, vender du automatisk tilbage til kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Åbn login-siden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Der opstod en fejl under godkendelsen. Luk loginvinduet og prøv igen.&lt;br&gt;Kontakt vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Login mislykkedes: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Kunne ikke åbne login-siden i din webbrowser</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Vælg kDrive-mapper til synkronisering på din computer</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>FORTSÆT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Tilgængeligt plads på din computer: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Kan ikke indlæse listen over undermapper. Din kDrive er muligvis i vedligeholdelsestilstand.&lt;br&gt;Log venligst ind på &lt;a style="%1" href="%2"&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Vælg kDrive-mapper til synkronisering på din computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Tilgængeligt plads på din computer: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Kan ikke indlæse listen over undermapper. Din kDrive er muligvis i vedligeholdelsestilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Kunne ikke oprette lokal mappe %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Kunne ikke oprette ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>kDrive %1 er allerede synkroniseret på denne computer. Fortsæt alligevel?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Kunne ikke oprette lokal mappe %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Kunne ikke oprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 er allerede synkroniseret på denne computer. Fortsæt alligevel?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-klienten kører med forkerte parametre!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>kDrive-klienten kører allerede!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Brugeren %1 er ikke tilsluttet. Log venligst ind igen.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-klienten kører med forkerte parametre!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-klienten kører allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Brugeren %1 er ikke tilsluttet. Log venligst ind igen.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Delingslink kopieret til udklipsholderen</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 og %n anden fil er blevet fjernet.</numerusform>
-<numerusform>%1 og %n andre filer er blevet fjernet.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er blevet fjernet.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 og %n anden fil er blevet tilføjet.</numerusform>
-<numerusform>%1 og %n andre filer er blevet tilføjet.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er blevet tilføjet.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 og %n anden fil er blevet opdateret.</numerusform>
-<numerusform>%1 og %n andre filer er blevet opdateret.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er blevet opdateret.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 er blevet flyttet til %2 og %n anden fil er blevet flyttet.</numerusform>
-<numerusform>%1 er blevet flyttet til %2 og %n andre filer er blevet flyttet.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 er blevet flyttet til %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synkroniseringsaktivitet</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Delingslink kopieret til udklipsholderen</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 og %n anden fil er blevet fjernet.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet fjernet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er blevet fjernet.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 og %n anden fil er blevet tilføjet.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet tilføjet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er blevet tilføjet.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 og %n anden fil er blevet opdateret.</numerusform>
+            <numerusform>%1 og %n andre filer er blevet opdateret.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er blevet opdateret.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 er blevet flyttet til %2 og %n anden fil er blevet flyttet.</numerusform>
+            <numerusform>%1 er blevet flyttet til %2 og %n andre filer er blevet flyttet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 er blevet flyttet til %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synkroniseringsaktivitet</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Ingen undermapper på serveren i øjeblikket.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Ingen undermapper på serveren i øjeblikket.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Forlad betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Tilmeld betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Få tidlig adgang til nye versioner af applikationen, før de udgives til offentligheden, og deltag i forbedringen af applikationen ved at sende os dine kommentarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Nyd godt af applikationens beta-opdateringer</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Nej</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Offentlig betaversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Intern betaversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Testversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Jeg forstår</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Er du sikker på, at du vil forlade betaprogrammet?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Gem</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Annuller</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Din nuværende version af applikationen er måske for ny. Dit valg træder i kraft, når den næste opdatering er tilgængelig.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Betaversioner kan afsluttes uventet eller forårsage ustabilitet.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Forlad betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Tilmeld betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Få tidlig adgang til nye versioner af applikationen, før de udgives til offentligheden, og deltag i forbedringen af applikationen ved at sende os dine kommentarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Nyd godt af applikationens beta-opdateringer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Nej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Offentlig betaversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Intern betaversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Testversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Jeg forstår</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Er du sikker på, at du vil forlade betaprogrammet?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Gem</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Din nuværende version af applikationen er måske for ny. Dit valg træder i kraft, når den næste opdatering er tilgængelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Betaversioner kan afsluttes uventet eller forårsage ustabilitet.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Kan ikke initialisere kDrive-klienten</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Kunne ikke løse konflikt(er) på %1 element(er) i synkroniseringsmappen: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Log venligst ind</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synkronisering er sat på pause</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Mappe %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Der er ingen synkroniseringsmapper konfigureret.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Udefineret tilstand.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Venter på at starte synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synkronisering kører.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synkronisering lykkedes, uløste konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Seneste synkronisering lykkedes.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Bruger afbrød.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synkronisering er sat på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synkronisering er sat på pause)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke åbne mappestien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vil du virkelig fjerne synkroniseringerne for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>FJERN ALLE SYNKRONISERINGER</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 elementer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. For at undgå utilsigtede sletninger er synkroniseringen sat på pause.&lt;br&gt;Vil du overføre disse sletninger til dit kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Flere filer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Slettede filer findes i kDrives &lt;a style="%1" href="%3"&gt;papirkurv&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Vis ikke igen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Oversigt</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Indstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Afslut</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Kunne ikke starte synkroniseringer!</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Kan ikke initialisere kDrive-klienten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Kunne ikke løse konflikt(er) på %1 element(er) i synkroniseringsmappen: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Log venligst ind</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkronisering er sat på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Mappe %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Der er ingen synkroniseringsmapper konfigureret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Udefineret tilstand.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Venter på at starte synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synkronisering kører.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkronisering lykkedes, uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Seneste synkronisering lykkedes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Bruger afbrød.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synkronisering er sat på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkronisering er sat på pause)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig fjerne synkroniseringerne for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>FJERN ALLE SYNKRONISERINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 elementer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. For at undgå utilsigtede sletninger er synkroniseringen sat på pause.&lt;br&gt;Vil du overføre disse sletninger til dit kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Flere filer er blevet slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Slettede filer findes i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papirkurv&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Vis ikke igen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Oversigt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Indstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Kunne ikke starte synkroniseringer!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Resumé af din lokale mappesynkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Indholdet af mappen på din computer vil blive synkroniseret til mappen på den valgte kDrive og omvendt.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNKRONISER</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Resumé af din lokale mappesynkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Indholdet af mappen på din computer vil blive synkroniseret til mappen på den valgte kDrive og omvendt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONISER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Inden du afslutter</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Udfør følgende trin for at sikre, at Lite Sync fungerer korrekt på din computer og for at fuldføre konfigurationen af kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åbn din Macs &lt;b&gt;Generelle indstillinger&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åbn din Macs &lt;b&gt;Indstillinger for Privatliv og sikkerhed&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åbn din Macs &lt;b&gt;Indstillinger for Sikkerhed og privatliv&lt;/b&gt; eller  &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Gå til sektionen &lt;b&gt;"Login-emner og udvidelser"&lt;/b&gt; og derefter til &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Godkend kDrive-applikationen</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Gå til sektionen &lt;b&gt;"Sikkerhed"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Godkend kDrive-applikationen i boksen, der angiver, at kDrive er blevet blokeret</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Lås hængelåsen op &lt;img src=":/client/resources/icons/actions/lock.png"&gt; og godkend kDrive-applikationen</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Gå til sektionen &lt;b&gt;"Privatliv og sikkerhed"&lt;/b&gt; og klik på &lt;b&gt;"Fuld diskadgang"&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Stadig i indstillingerne for Sikkerhed og privatliv, åbn fanen &lt;b&gt;"Privatliv"&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klik her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Markér boksen "kDrive LiteSync Extension" og derefter boksen "kDrive.app" (hvis den ikke allerede er markeret)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>En genstart af appen kan blive foreslået. I så fald accepter den</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Markér boksen "kDrive LiteSync Extension" (og "kDrive.app" hvis den findes) under &lt;b&gt;"Fuld diskadgang"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>TRIN 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Udført)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>TRIN 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>UDFØRTE TRIN</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>AFSLUT</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Inden du afslutter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Udfør følgende trin for at sikre, at Lite Sync fungerer korrekt på din computer og for at fuldføre konfigurationen af kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åbn din Macs &lt;b&gt;Generelle indstillinger&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åbn din Macs &lt;b&gt;Indstillinger for Privatliv og sikkerhed&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åbn din Macs &lt;b&gt;Indstillinger for Sikkerhed og privatliv&lt;/b&gt; eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Login-emner og udvidelser&quot;&lt;/b&gt; og derefter til &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Godkend kDrive-applikationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Sikkerhed&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Godkend kDrive-applikationen i boksen, der angiver, at kDrive er blevet blokeret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Lås hængelåsen op &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkend kDrive-applikationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Gå til sektionen &lt;b&gt;&quot;Privatliv og sikkerhed&quot;&lt;/b&gt; og klik på &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Stadig i indstillingerne for Sikkerhed og privatliv, åbn fanen &lt;b&gt;&quot;Privatliv&quot;&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Markér boksen &quot;kDrive LiteSync Extension&quot; og derefter boksen &quot;kDrive.app&quot; (hvis den ikke allerede er markeret)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>En genstart af appen kan blive foreslået. I så fald accepter den</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Markér boksen &quot;kDrive LiteSync Extension&quot; (og &quot;kDrive.app&quot; hvis den findes) under &lt;b&gt;&quot;Fuld diskadgang&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>TRIN 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Udført)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>TRIN 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>UDFØRTE TRIN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>AFSLUT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NEJ</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NEJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Sender fejlretningsoplysninger</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Annuller</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Sender fejlretningsoplysninger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Fejlretning</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Info</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Advarsel</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Fejl</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Kritisk</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Fejlretningsindstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Gem fejlretningsoplysninger i en mappe på min computer (Anbefalet)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Disse oplysninger giver IT-support mulighed for at fastslå kilden til en hændelse.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Fejlretningsniveau</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Sporingsniveauet lader dig vælge omfanget af de registrerede fejlretningsoplysninger</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Den udvidede fulde log indsamler en detaljeret historik, der kan bruges til fejlretning. Aktivering af den kan bremse kDrive-applikationen.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Udvidet fuld log</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Slet logfiler ældre end %1 dage</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Del fejlretningsmappen med Infomaniak support.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Den seneste session er perioden siden den seneste kDrive-start.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Del kun den seneste kDrive-session</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Indlæser</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Annuller</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>GEM</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Deling mislykkedes</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Kontroller, at du er logget ind &lt;br&gt;2. Kontroller, at du har konfigureret mindst én kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Forbindelsen afbrudt)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Vi komprimerede automatisk din log &lt;a style="%1" href="%2"&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Overfør arkivet med &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Del linket med &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Seneste upload den %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Deling er annulleret</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Den udvidede fulde log aktiveres via miljøvariablen KDRIVE_FORCE_EXTENDED_LOG. Indstil den til 0 for at deaktivere den.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 kl. %4h%5m og %6s</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du gemme dine ændringer?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke åbne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Del</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Deler | trin 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Deler | trin 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Annullerer...</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Hele mappen er stor (&gt; 100 MB) og kan tage noget tid at dele. For at reducere delingstiden anbefaler vi, at du kun deler den seneste kDrive-session.</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Fejlretning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Kritisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Fejlretningsindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Gem fejlretningsoplysninger i en mappe på min computer (Anbefalet)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Disse oplysninger giver IT-support mulighed for at fastslå kilden til en hændelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Fejlretningsniveau</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Sporingsniveauet lader dig vælge omfanget af de registrerede fejlretningsoplysninger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Den udvidede fulde log indsamler en detaljeret historik, der kan bruges til fejlretning. Aktivering af den kan bremse kDrive-applikationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Udvidet fuld log</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Slet logfiler ældre end %1 dage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Del fejlretningsmappen med Infomaniak support.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Den seneste session er perioden siden den seneste kDrive-start.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Del kun den seneste kDrive-session</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Indlæser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>GEM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Deling mislykkedes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Kontroller, at du er logget ind &lt;br&gt;2. Kontroller, at du har konfigureret mindst én kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Forbindelsen afbrudt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Vi komprimerede automatisk din log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Del linket med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Seneste upload den %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Deling er annulleret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Den udvidede fulde log aktiveres via miljøvariablen KDRIVE_FORCE_EXTENDED_LOG. Indstil den til 0 for at deaktivere den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 kl. %4h%5m og %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du gemme dine ændringer?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke åbne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Del</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Deler | trin 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Deler | trin 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Annullerer...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Hele mappen er stor (&gt; 100 MB) og kan tage noget tid at dele. For at reducere delingstiden anbefaler vi, at du kun deler den seneste kDrive-session.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synkroniseringsfejl og information.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synkroniser en lokal mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Vil du virkelig aktivere Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Denne handling kan tage fra et par sekunder til et par minutter afhængigt af mappens størrelse.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>BEKRÆFT</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Vil du virkelig deaktivere Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Du har ikke nok plads til at synkronisere alle filerne på din kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, skal du vælge, hvilke mapper der skal synkroniseres på din computer. I mellemtiden sættes synkroniseringen af din kDrive på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Hvis du deaktiverer Lite Sync, vil alle filer blive downloadet til din computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Kunne ikke oprette ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Ny lokal mappesynkronisering mislykkedes!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync aktiveret.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Aktivering af Lite Sync mislykkedes.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync deaktiveret.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Deaktivering af Lite Sync mislykkedes.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Dette drev slettes.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Kan ikke åbne elementet %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vil du virkelig stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>FJERN MAPPESYNKRONISERINGSFORBINDELSEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Kunne ikke stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Mapper</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Meddelelser</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Aktivér meddelelser for denne kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>En meddelelse vises, så snart en ny mappe er synkroniseret eller ændret</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Forbundet med</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Fjern alle synkroniseringer</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Søg i din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Søg</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkroniseringsfejl og information.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkroniser en lokal mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Vil du virkelig aktivere Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Denne handling kan tage fra et par sekunder til et par minutter afhængigt af mappens størrelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEKRÆFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Vil du virkelig deaktivere Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Du har ikke nok plads til at synkronisere alle filerne på din kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, skal du vælge, hvilke mapper der skal synkroniseres på din computer. I mellemtiden sættes synkroniseringen af din kDrive på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Hvis du deaktiverer Lite Sync, vil alle filer blive downloadet til din computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Kunne ikke oprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Ny lokal mappesynkronisering mislykkedes!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync aktiveret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktivering af Lite Sync mislykkedes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync deaktiveret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Deaktivering af Lite Sync mislykkedes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Dette drev slettes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Kan ikke åbne elementet %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Bemærk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette nogen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>FJERN MAPPESYNKRONISERINGSFORBINDELSEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Kunne ikke stoppe synkroniseringen af mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Der opstod en fejl under indlæsning af listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Meddelelser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Aktivér meddelelser for denne kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>En meddelelse vises, så snart en ny mappe er synkroniseret eller ændret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Forbundet med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Fjern alle synkroniseringer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Søg i din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Søg</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Tilføj en kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synkroniser en kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Tilføj en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkroniser en kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Ryd historik</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Skal løses</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>problem(er) opdaget</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Løs</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Konfliktende element(er)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Element(er) med ikke-understøttede tegn</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Automatisk løst</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problem(er) løst</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Ryd historik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Skal løses</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>problem(er) opdaget</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Løs</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Konfliktende element(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Element(er) med ikke-understøttede tegn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automatisk løst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problem(er) løst</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synkroniseringskonflikter eller fejl</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Fejl</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Tilbage til indstillinger</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkroniseringskonflikter eller fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Tilbage til indstillinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Nogle filer kunne ikke synkroniseres på følgende kDrive(s):</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 fejl)</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 information(er))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 fejl og %2 information(er))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Generiske fejl (%n advarsel eller fejl)</numerusform>
-<numerusform>Generiske fejl (%n advarsler eller fejl)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Nogle filer kunne ikke synkroniseres på følgende kDrive(s):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 fejl)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 information(er))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 fejl og %2 information(er))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Generiske fejl (%n advarsel eller fejl)</numerusform>
+            <numerusform>Generiske fejl (%n advarsler eller fejl)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Ekskluderede filer</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Tilføj filer eller mapper, der ikke synkroniseres på din computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Tilføj</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NAVN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>ADVARSEL</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>GEM</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du gemme dine ændringer?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Eksklusionsskabelon eksisterer allerede!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Vil du virkelig slette?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Kan ikke gemme ændringer!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ekskluderede filer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Tilføj filer eller mapper, der ikke synkroniseres på din computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Tilføj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>ADVARSEL</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>GEM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du gemme dine ændringer?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Eksklusionsskabelon eksisterer allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke gemme ændringer!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>GODKEND</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>GODKEND</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Løs konflikt(er)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Hvad vil du gøre med de %1 konfliktende element(er)?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Gem mine ændringer og erstat andre brugeres versioner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Fortryd mine ændringer og behold andre brugeres versioner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Dine ændringer kan blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Dine ændringer vil blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Vis element(er)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>GODKEND</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Disse filer er blevet ændret af flere brugere på flere steder (online på kDrive, en computer eller en mobilenhed). Mapper, der indeholder disse filer, kan også være blevet slettet.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Den lokale version af dit element &lt;b&gt;er ikke synkroniseret&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Løs konflikt(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Hvad vil du gøre med de %1 konfliktende element(er)?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Gem mine ændringer og erstat andre brugeres versioner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Fortryd mine ændringer og behold andre brugeres versioner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Dine ændringer kan blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Dine ændringer vil blive slettet permanent. De kan ikke gendannes fra kDrive-webapplikationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Vis element(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>GODKEND</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Disse filer er blevet ændret af flere brugere på flere steder (online på kDrive, en computer eller en mobilenhed). Mapper, der indeholder disse filer, kan også være blevet slettet.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den lokale version af dit element &lt;b&gt;er ikke synkroniseret&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synkroniseret i &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Aktivér Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Aktivér Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Deaktivér Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Sæt synkronisering på pause</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Genoptag synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Fjern synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Ikke-valgte mapper flyttes til papirkurven, forudsat at de indeholder offline-elementer. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Ikke-valgte mapper flyttes til papirkurven. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Ikke-valgte mapper vil blive &lt;b&gt;permanent&lt;/b&gt; slettet fra computeren. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Annuller</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>GODKEND</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkroniseret i &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Aktivér Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Aktivér Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Deaktivér Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Sæt synkronisering på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Genoptag synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Fjern synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper flyttes til papirkurven, forudsat at de indeholder offline-elementer. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper flyttes til papirkurven. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Ikke-valgte mapper vil blive &lt;b&gt;permanent&lt;/b&gt; slettet fra computeren. Mapper synkroniseret til kDrive forbliver tilgængelige online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Annuller</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>GODKEND</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke åbne mappestien %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Applikations-id</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Applikationsnavn</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>GODKEND</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Applikations-id</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Applikationsnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>GODKEND</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Nogle apps (sikkerhedskopiering, antivirus...) tilgår dine filer, hvilket fører til, at de downloades, når de er "online". Tilføj dem i listen nedenfor for at undgå dette.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Tilføj</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>APPLIKATIONS-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NAVN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>GEM</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du gemme dine ændringer?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Vil du virkelig slette?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Kan ikke gemme ændringer!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Nogle apps (sikkerhedskopiering, antivirus...) tilgår dine filer, hvilket fører til, at de downloades, når de er &quot;online&quot;. Tilføj dem i listen nedenfor for at undgå dette.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Tilføj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>APPLIKATIONS-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>GEM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du gemme dine ændringer?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke gemme ændringer!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Hvilken mappe på din computer vil du&lt;br&gt;synkronisere?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Indholdet af denne mappe vil blive synkroniseret på kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Vælg en mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Rediger mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>FORTSÆT</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Hvilken mappe på din computer vil du&lt;br&gt;synkronisere?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Indholdet af denne mappe vil blive synkroniseret på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Vælg en mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappe er ikke kompatibel med Lite Sync.&lt;br&gt;
 Vælg venligst en anden mappe. Hvis du fortsætter, deaktiveres Lite Sync.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Vælg mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Vælg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Fejl</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Filen '%1'&lt;br/&gt;kan ikke åbnes til skrivning.&lt;br/&gt;&lt;br/&gt;Logoutputtet kan &lt;b&gt;ikke&lt;/b&gt; gemmes!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Fejl</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Filen &apos;%1&apos;&lt;br/&gt;kan ikke åbnes til skrivning.&lt;br/&gt;&lt;br/&gt;Logoutputtet kan &lt;b&gt;ikke&lt;/b&gt; gemmes!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Indstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Hjælp</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Indstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hjælp</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive skal have skriveadgang til din computers midlertidige mappe.&lt;br&gt;Genstart venligst kDrive-appen for at løse dette problem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Der er opstået en teknisk fejl.&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Det ser ud til, at din netværksforbindelse er konfigureret med en for lav timeout til, at applikationen kan fungere korrekt (fejl %1).&lt;br&gt;Kontroller venligst din netværkskonfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Kan ikke oprette forbindelse til kDrive-serveren (fejl %1).&lt;br&gt;Forsøger at genoprette forbindelsen. Kontroller venligst din internetforbindelse og firewall.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Log venligst ind igen, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>En ny version af applikationen er tilgængelig.&lt;br&gt;Opdater venligst applikationen for at fortsætte med at bruge den.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Log-upload mislykkedes (fejl %1).&lt;br&gt;Prøv venligst igen senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Synkroniseringsmappen er ikke længere tilgængelig (fejl %1).&lt;br&gt;Synkronisering genoptages, så snart mappen er tilgængelig.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Drevet, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet (fejl %1).&lt;br&gt;Tilslut det venligst igen for at genoptage synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Synkronisering er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Der er ikke nok hukommelse tilbage på din maskine.&lt;br&gt;Synkronisering er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Antallet af inotify-overvågninger er utilstrækkeligt (fejl %1).&lt;br&gt;Du kan hæve dette antal ved at redigere '/etc/sysctl.conf'.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;Du skal tillade:&lt;br&gt;- kDrive i Systemindstillinger &gt;&gt; Generelt &gt;&gt; Login-emner og udvidelser &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension i Systemindstillinger &gt;&gt; Privatliv og sikkerhed &gt;&gt; Fuld diskadgang.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;LiteSyncExt-processen kører ikke i øjeblikket. Synkronisering genoptages, så snart den er startet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen er installeret, og at Windows Search-tjenesten er aktiveret.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen har de korrekte tilladelser og kører.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>En fil eller mappe inde i din synkroniseringsmappe ser ud til at være beskadiget.&lt;br&gt;Synkronisering er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive er i vedligeholdelsestilstand.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive er blokeret.&lt;br&gt;Forny venligst kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive er blokeret.&lt;br&gt;Kontakt venligst en administrator for at forny kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive vågner.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på &lt;a style="%1" href="%2"&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på webversionen for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Du har ikke adgang til denne kDrive.&lt;br&gt;Synkronisering er sat på pause. Kontakt venligst en administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Netværksforbindelserne er blevet afbrudt af kernen (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Desværre kunne din gamle konfiguration ikke migreres.&lt;br&gt;Applikationen vil bruge en tom konfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Desværre kunne din gamle proxykonfiguration ikke migreres, SOCKS5-proxyer understøttes ikke i øjeblikket.&lt;br&gt;Applikationen vil i stedet bruge systemets proxyindstillinger.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Synkroniseringsmappen er blevet erstattet eller flyttet på en måde, der forhindrer synkronisering (fejl %1).&lt;br&gt;Dette kan ske efter kopiering, flytning eller gendannelse af mappen.&lt;br&gt;For at løse dette, opret venligst en ny synkronisering med en ny mappe.&lt;br&gt;Bemærk: Hvis du har usynkroniserede ændringer i den gamle mappe, skal du kopiere dem manuelt til den nye.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering er genstartet. Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Der er opstået en fejl ved adgang til synkroniseringsdatabasen (fejl %1).&lt;br&gt;Synkronisering er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Token er ugyldigt eller tilbagekaldt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Indlejrede synkroniseringer er forbudte (fejl %1).&lt;br&gt;Du bør kun beholde synkroniseringer, hvis mapper ikke er indlejrede.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Synkroniseringsmappen på den fjernliggende kDrive eksisterer ikke længere eller er ikke længere tilgængelig (fejl %1).&lt;br&gt;Du skal gendanne den eller give den adgangsrettigheder tilbage eller slette/genoprette synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Filnavnfejl ved parsing (fejl %1).&lt;br&gt;Specialtegn som anførselstegn, omvendte skråstreger eller linjeskift kan forårsage parsing-fejl.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Dette element er blevet flyttet et andet sted hen.&lt;br&gt;Den lokale handling er annulleret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Den lokale handling er annulleret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Det lokale element er omdøbt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Filen blev ændret på samme tid af en anden bruger.&lt;br&gt;Dine ændringer er gemt i en kopi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>En anden bruger har flyttet en overordnet mappe til destinationen.&lt;br&gt;Den lokale handling er annulleret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Et eksisterende element har et identisk navn med de samme store og små bogstaver.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementnavnet indeholder et ikke-understøttet tegn.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementnavnet afsluttes med et mellemrum, hvilket er forbudt på dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Dette elementnavn er reserveret af dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementnavnet er for langt.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Elementstien er for lang.&lt;br&gt;Det er ignoreret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Elementnavnet indeholder et nyere UNICODE-tegn, der endnu ikke understøttes af dit filsystem.&lt;br&gt;Det er udelukket fra synkronisering.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementnavnet indeholder kun mellemrum.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Du har enten ikke tilladelse til at oprette et element, eller der findes allerede et andet element med samme navn. Elementet er blevet ignoreret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Du har ikke tilladelse til at redigere elementet.&lt;br&gt;Filen med dine ændringer er omdøbt og udelukket fra synkronisering.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Du har ikke tilladelse til at omdøbe elementet.&lt;br&gt;Det vil blive gendannet med sit originale navn.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Du har ikke tilladelse til at flytte elementet til "%1".&lt;br&gt;Det vil blive gendannet i sin originale overordnede mappe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Du har ikke tilladelse til at slette elementet.&lt;br&gt;Det vil blive gendannet på sin originale placering.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Kunne ikke flytte dette element til papirkurven, det er sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Kunne ikke synkronisere dette element. Det er midlertidigt sortlistet.&lt;br&gt;Et nyt forsøg på at synkronisere det vil blive foretaget om en time eller ved næste opstart af applikationen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Dette element er udelukket fra synkronisering af en brugerdefineret skabelon.&lt;br&gt;Du kan deaktivere denne type meddelelse fra Indstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Dette element er udelukket fra synkronisering, fordi det er et hårdt link.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Filen er blevet ændret lokalt, mens den er blevet slettet på den fjernliggende kDrive.&lt;br&gt;Den lokale kopi er gemt i redningmappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Handlingen udført på elementet er forbudt.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Handlingen udført på dette element mislykkedes.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Filen er for stor til at blive uploadet. Den er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Du har overskredet din kvota. Øg din pladskvota for at genaktivere filuploads.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Kan ikke downloade filen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Dette element er i øjeblikket låst af en anden bruger online.&lt;br&gt;Vi vil forsøge at uploade dine ændringer igen senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Synkroniseringsfejl.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Kan ikke tilgå elementet.&lt;br&gt;Ret venligst læse- og skrivetilladelserne.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Downloaden er annulleret.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Det er ikke muligt at oprette filen »%1«, da den ikke understøttes af dit filsystem.&lt;br&gt;Den er blevet udelukket fra synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Systemfejl.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementet eksisterer allerede på den anden side.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Der er opstået en teknisk fejl.&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke åbne mappestien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Transmission gennemført!&lt;br&gt;Referer venligst til id'et &lt;b&gt;%1&lt;/b&gt; i fejlrapporter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Transmission mislykkedes!
-Brug venligst følgende link til at sende loggene til support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Ingen kDrive konfigureret!</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive skal have skriveadgang til din computers midlertidige mappe.&lt;br&gt;Genstart venligst kDrive-appen for at løse dette problem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Det ser ud til, at din netværksforbindelse er konfigureret med en for lav timeout til, at applikationen kan fungere korrekt (fejl %1).&lt;br&gt;Kontroller venligst din netværkskonfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Kan ikke oprette forbindelse til kDrive-serveren (fejl %1).&lt;br&gt;Forsøger at genoprette forbindelsen. Kontroller venligst din internetforbindelse og firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Log venligst ind igen, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>En ny version af applikationen er tilgængelig.&lt;br&gt;Opdater venligst applikationen for at fortsætte med at bruge den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Log-upload mislykkedes (fejl %1).&lt;br&gt;Prøv venligst igen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkroniseringsmappen er ikke længere tilgængelig (fejl %1).&lt;br&gt;Synkronisering genoptages, så snart mappen er tilgængelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Drevet, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet (fejl %1).&lt;br&gt;Tilslut det venligst igen for at genoptage synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Der er ikke nok hukommelse tilbage på din maskine.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Antallet af inotify-overvågninger er utilstrækkeligt (fejl %1).&lt;br&gt;Du kan hæve dette antal ved at redigere &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;Du skal tillade:&lt;br&gt;- kDrive i Systemindstillinger &gt;&gt; Generelt &gt;&gt; Login-emner og udvidelser &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension i Systemindstillinger &gt;&gt; Privatliv og sikkerhed &gt;&gt; Fuld diskadgang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Kan ikke starte synkronisering (fejl %1).&lt;br&gt;LiteSyncExt-processen kører ikke i øjeblikket. Synkronisering genoptages, så snart den er startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen er installeret, og at Windows Search-tjenesten er aktiveret.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Kontroller, at Lite Sync-udvidelsen har de korrekte tilladelser og kører.&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Kan ikke starte Lite Sync-plugin (fejl %1).&lt;br&gt;Ryd venligst historikken, genstart, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>En fil eller mappe inde i din synkroniseringsmappe ser ud til at være beskadiget.&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i vedligeholdelsestilstand.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokeret.&lt;br&gt;Forny venligst kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokeret.&lt;br&gt;Kontakt venligst en administrator for at forny kDrive. Hvis der ikke handles, vil dataene blive slettet permanent og det vil være umuligt at gendanne dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive vågner.&lt;br&gt;Synkronisering begynder igen hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversionen&lt;/a&gt; for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er i dvaletilstand.&lt;br&gt;Log venligst ind på webversionen for at kontrollere din kDrive-status, eller kontakt din administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Du har ikke adgang til denne kDrive.&lt;br&gt;Synkronisering er sat på pause. Kontakt venligst en administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering genoptages hurtigst muligt. Kontakt venligst vores supportteam, hvis fejlen fortsætter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Netværksforbindelserne er blevet afbrudt af kernen (fejl %1).&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Desværre kunne din gamle konfiguration ikke migreres.&lt;br&gt;Applikationen vil bruge en tom konfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Desværre kunne din gamle proxykonfiguration ikke migreres, SOCKS5-proxyer understøttes ikke i øjeblikket.&lt;br&gt;Applikationen vil i stedet bruge systemets proxyindstillinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkroniseringsmappen er blevet erstattet eller flyttet på en måde, der forhindrer synkronisering (fejl %1).&lt;br&gt;Dette kan ske efter kopiering, flytning eller gendannelse af mappen.&lt;br&gt;For at løse dette, opret venligst en ny synkronisering med en ny mappe.&lt;br&gt;Bemærk: Hvis du har usynkroniserede ændringer i den gamle mappe, skal du kopiere dem manuelt til den nye.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Der er opstået en teknisk fejl (fejl %1).&lt;br&gt;Synkronisering er genstartet. Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Der er opstået en fejl ved adgang til synkroniseringsdatabasen (fejl %1).&lt;br&gt;Synkronisering er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Der er opstået et loginproblem (fejl %1).&lt;br&gt;Token er ugyldigt eller tilbagekaldt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Indlejrede synkroniseringer er forbudte (fejl %1).&lt;br&gt;Du bør kun beholde synkroniseringer, hvis mapper ikke er indlejrede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Synkroniseringsmappen på den fjernliggende kDrive eksisterer ikke længere eller er ikke længere tilgængelig (fejl %1).&lt;br&gt;Du skal gendanne den eller give den adgangsrettigheder tilbage eller slette/genoprette synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Filnavnfejl ved parsing (fejl %1).&lt;br&gt;Specialtegn som anførselstegn, omvendte skråstreger eller linjeskift kan forårsage parsing-fejl.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dette element er blevet flyttet et andet sted hen.&lt;br&gt;Den lokale handling er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Den lokale handling er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Et element med samme navn eksisterer allerede på denne placering.&lt;br&gt;Det lokale element er omdøbt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Filen blev ændret på samme tid af en anden bruger.&lt;br&gt;Dine ændringer er gemt i en kopi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>En anden bruger har flyttet en overordnet mappe til destinationen.&lt;br&gt;Den lokale handling er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Et eksisterende element har et identisk navn med de samme store og små bogstaver.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementnavnet indeholder et ikke-understøttet tegn.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementnavnet afsluttes med et mellemrum, hvilket er forbudt på dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Dette elementnavn er reserveret af dit operativsystem.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementnavnet er for langt.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Elementstien er for lang.&lt;br&gt;Det er ignoreret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Elementnavnet indeholder et nyere UNICODE-tegn, der endnu ikke understøttes af dit filsystem.&lt;br&gt;Det er udelukket fra synkronisering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementnavnet indeholder kun mellemrum.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Du har enten ikke tilladelse til at oprette et element, eller der findes allerede et andet element med samme navn. Elementet er blevet ignoreret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Du har ikke tilladelse til at redigere elementet.&lt;br&gt;Filen med dine ændringer er omdøbt og udelukket fra synkronisering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Du har ikke tilladelse til at omdøbe elementet.&lt;br&gt;Det vil blive gendannet med sit originale navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Du har ikke tilladelse til at flytte elementet til &quot;%1&quot;.&lt;br&gt;Det vil blive gendannet i sin originale overordnede mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Du har ikke tilladelse til at slette elementet.&lt;br&gt;Det vil blive gendannet på sin originale placering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Kunne ikke flytte dette element til papirkurven, det er sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Kunne ikke synkronisere dette element. Det er midlertidigt sortlistet.&lt;br&gt;Et nyt forsøg på at synkronisere det vil blive foretaget om en time eller ved næste opstart af applikationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Dette element er udelukket fra synkronisering af en brugerdefineret skabelon.&lt;br&gt;Du kan deaktivere denne type meddelelse fra Indstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Dette element er udelukket fra synkronisering, fordi det er et hårdt link.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Filen er blevet ændret lokalt, mens den er blevet slettet på den fjernliggende kDrive.&lt;br&gt;Den lokale kopi er gemt i redningmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen udført på elementet er forbudt.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen udført på dette element mislykkedes.&lt;br&gt;Elementet er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Filen er for stor til at blive uploadet. Den er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Du har overskredet din kvota. Øg din pladskvota for at genaktivere filuploads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Kan ikke downloade filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Dette element er i øjeblikket låst af en anden bruger online.&lt;br&gt;Vi vil forsøge at uploade dine ændringer igen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Synkroniseringsfejl.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kan ikke tilgå elementet.&lt;br&gt;Ret venligst læse- og skrivetilladelserne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Der er ikke nok plads tilbage på din computer.&lt;br&gt;Downloaden er annulleret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Det er ikke muligt at oprette filen »%1«, da den ikke understøttes af dit filsystem.&lt;br&gt;Den er blevet udelukket fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Systemfejl.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementet eksisterer allerede på den anden side.&lt;br&gt;Det er midlertidigt sortlistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Der er opstået en teknisk fejl.&lt;br&gt;Ryd venligst historikken, og hvis fejlen fortsætter, kontakt vores supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke åbne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Transmission gennemført!&lt;br&gt;Referer venligst til id&apos;et &lt;b&gt;%1&lt;/b&gt; i fejlrapporter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Transmission mislykkedes!
+Brug venligst følgende link til at sende loggene til support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Ingen kDrive konfigureret!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Denne synkronisering slettes.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Denne synkronisering slettes.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Tilbage til drevlisten</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Indstillinger</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Tilbage til drevlisten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Indstillinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke åbne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Ugyldigt link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Nogle processer kunne ikke køre.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Generelt</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Aktivér mørkt tema</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Aktivér monokrome ikoner</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Start kDrive ved opstart</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Sprog</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Flyt slettede filer til min computers papirkurv</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Nogle filer eller mapper kan måske ikke flyttes til computerens papirkurv.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Du kan altid hente allerede synkroniserede filer fra kDrive-webapplikationens papirkurv.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Standard</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Engelsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Fransk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Tysk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Spansk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italiensk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Svensk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugisisk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Dansk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Græsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Nederlandsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avanceret</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Fejlretningsoplysninger</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Filer der skal ekskluderes</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke åbne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldigt link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Nogle processer kunne ikke køre.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Generelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Aktivér mørkt tema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Aktivér monokrome ikoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Start kDrive ved opstart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Sprog</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Flyt slettede filer til min computers papirkurv</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Nogle filer eller mapper kan måske ikke flyttes til computerens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Du kan altid hente allerede synkroniserede filer fra kDrive-webapplikationens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Engelsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Fransk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Tysk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Spansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italiensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Svensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugisisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Dansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Græsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Nederlandsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avanceret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Fejlretningsoplysninger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åbn fejlretningsmappe&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Filer der skal ekskluderes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 i brug</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 i brug</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S)-proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ingen proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Brug systemparametre</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Angiv en proxy manuelt</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Port</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Adresse på proxyserveren</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Godkendelse krævet</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Bruger</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Adgangskode</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>GEM</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du gemme dine ændringer?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Kan ikke gemme, ikke alle obligatoriske felter er udfyldt!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy ikke fundet, gem alligevel?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ingen proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Brug systemparametre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Angiv en proxy manuelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adresse på proxyserveren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Godkendelse krævet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Bruger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Adgangskode</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>GEM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du gemme dine ændringer?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Kan ikke gemme, ikke alle obligatoriske felter er udfyldt!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy ikke fundet, gem alligevel?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Ressourcemanager</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Maksimal tilladt CPU-brug</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>GEM</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du gemme dine ændringer?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Ressourcemanager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maksimal tilladt CPU-brug</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>GEM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du gemme dine ændringer?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Vælg en mappe på din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Indholdet af den valgte mappe vil blive synkroniseret i mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>FORTSÆT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Tilgængeligt plads på din computer til den aktuelle mappe: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Denne mappe synkroniseres allerede.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>BEKRÆFT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ANNULLER</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Vælg en mappe på din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Indholdet af den valgte mappe vil blive synkroniseret i mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Tilgængeligt plads på din computer til den aktuelle mappe: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Denne mappe synkroniseres allerede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BEKRÆFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANNULLER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; indeholder undermapper,&lt;br&gt; vælg dem, du vil synkronisere</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>FORTSÆT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Ingen undermapper på serveren i øjeblikket.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; indeholder undermapper,&lt;br&gt; vælg dem, du vil synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÆT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Ingen undermapper på serveren i øjeblikket.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Genoptag synkronisering af kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Genoptag synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Genoptag synkronisering af alle kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Sæt synkronisering af kDrive "%1" på pause</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Sæt synkronisering på pause</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Sæt synkronisering af alle kDrives på pause</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Genoptag synkronisering af kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Genoptag synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Genoptag synkronisering af alle kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Sæt synkronisering af kDrive &quot;%1&quot; på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Sæt synkronisering på pause</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Sæt synkronisering af alle kDrives på pause</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Åbn</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Føj til favoritter</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Kopiér delingslink</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Vis på kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Vis i mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Åbn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Føj til favoritter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopiér delingslink</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Vis på kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Vis i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kan ikke åbne mappen-url %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Åbn i mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Åbn %1 webversion</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Drevindstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Meddelelser deaktiveret indtil %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Deaktivér meddelelser</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Applikationsindstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Brug for hjælp</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Send feedback</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Afslut kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Kan ikke tilgå webstedet %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Vis fejl og information</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Vis information</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Aldrig</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>I 1 time</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Til i morgen kl. 8:00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>I 3 dage</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>I 1 uge</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Altid</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>I 1 time mere</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>I 3 dage mere</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>I 1 uge mere</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan ikke åbne mappen-url %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Åbn i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Åbn %1 webversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drevindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Meddelelser deaktiveret indtil %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Deaktivér meddelelser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Applikationsindstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Brug for hjælp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Send feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Afslut kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Kan ikke tilgå webstedet %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Vis fejl og information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Vis information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Aldrig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>I 1 time</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Til i morgen kl. 8:00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>I 3 dage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>I 1 uge</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Altid</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>I 1 time mere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>I 3 dage mere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>I 1 uge mere</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synkroniseret</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoritter</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Aktivitet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kan ikke åbne mappen-url %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Opdater</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Opdateringsdownload i gang</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Søger efter opdatering...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Manuel opdatering</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Ikke tilgængelig</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Ikke implementeret!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke åbne linket %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Ugyldigt link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Opdater kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Denne version af kDrive-appen understøttes ikke længere. For at få adgang til de nyeste funktioner og forbedringer, opdater venligst.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klik her for at downloade manuelt&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Download venligst den nyeste version på webstedet.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Ingen synkroniseret mappe for dette drev!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Ingen kDrive konfigureret!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Du kan synkronisere filer &lt;a style="%1" href="%2"&gt;fra din computer&lt;/a&gt; eller på &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synkroniseret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoritter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kan ikke åbne mappen-url %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Opdater</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Opdateringsdownload i gang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Søger efter opdatering...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Manuel opdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Ikke tilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Ikke implementeret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke åbne linket %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldigt link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Opdater kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Denne version af kDrive-appen understøttes ikke længere. For at få adgang til de nyeste funktioner og forbedringer, opdater venligst.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klik her for at downloade manuelt&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Download venligst den nyeste version på webstedet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Ingen synkroniseret mappe for dette drev!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Ingen kDrive konfigureret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra din computer&lt;/a&gt; eller på &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Den nye version &lt;b&gt;%1&lt;/b&gt; af %2-klienten er tilgængelig og er downloadet.&lt;/p&gt;&lt;p&gt;Den installerede version er %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Spring denne version over</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Påmind mig senere</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installer opdatering</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Den nye version &lt;b&gt;%1&lt;/b&gt; af %2-klienten er tilgængelig og er downloadet.&lt;/p&gt;&lt;p&gt;Den installerede version er %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Spring denne version over</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Påmind mig senere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installer opdatering</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Ny opdatering tilgængelig.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Version %1 er tilgængelig til download.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Ny opdatering tilgængelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Version %1 er tilgængelig til download.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Tilføj en konto</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Tilføj en konto</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Vis frigivelsesbemærkninger&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Version</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>OPDATER</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 er opdateret!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Søger efter opdatering på serveren...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>En opdatering er tilgængelig: %1.&lt;br&gt;Download den venligst fra &lt;a style="%2" href="%3"&gt;her&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>En opdatering er tilgængelig: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Downloader %1. Vent venligst...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Kunne ikke søge efter nye opdateringer.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Der opstod en fejl under opdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Kunne ikke downloade opdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Opdatering deaktiveret.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Betaprogram</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Få tidlig adgang til nye versioner af applikationen</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Tilmeld</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Rediger</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Afslut</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis frigivelsesbemærkninger&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>OPDATER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 er opdateret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Søger efter opdatering på serveren...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>En opdatering er tilgængelig: %1.&lt;br&gt;Download den venligst fra &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>En opdatering er tilgængelig: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Downloader %1. Vent venligst...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Kunne ikke søge efter nye opdateringer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Der opstod en fejl under opdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Kunne ikke downloade opdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Opdatering deaktiveret.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Betaprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Få tidlig adgang til nye versioner af applikationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Tilmeld</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Rediger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Afslut</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync (Beta) er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync (Beta) er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Kan ikke gemme parametre. Prøv venligst igen senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Kan ikke gemme parametre!</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Gør tilgængeligt lokalt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Frigør lokal plads</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Annuller frigørelse af lokal plads</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Annuller gør tilgængeligt lokalt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Gendeling af denne fil er ikke tilladt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Gendeling af denne mappe er ikke tilladt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Kopiér offentligt delingslink</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Kopiér privat delingslink</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Åbn i browser</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Den overordnede mappe er en synkroniseringsmappe eller er indeholdt i en</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Kan ikke finde en gyldig sti</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Ingen gyldig mappe valgt!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Den valgte sti eksisterer ikke!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Den valgte sti er ikke en mappe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Du har ikke tilladelse til at skrive til den valgte mappe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Den lokale mappe %1 indeholder en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Den lokale mappe %1 er indeholdt i en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Den lokale mappe %1 er allerede synkroniseret. Vælg venligst en anden!</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync (Beta) er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync (Beta) er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync er aktiveret. Filer fra kDrive forbliver i skyen og bruger ikke din computers lagerplads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync er deaktiveret. kDrive-filerne bruger din computers lagerplads.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Kan ikke gemme parametre. Prøv venligst igen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Kan ikke gemme parametre!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Gør tilgængeligt lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Frigør lokal plads</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Annuller frigørelse af lokal plads</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Annuller gør tilgængeligt lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Gendeling af denne fil er ikke tilladt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Gendeling af denne mappe er ikke tilladt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Kopiér offentligt delingslink</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Kopiér privat delingslink</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Åbn i browser</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Den overordnede mappe er en synkroniseringsmappe eller er indeholdt i en</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kan ikke finde en gyldig sti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Ingen gyldig mappe valgt!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Den valgte sti eksisterer ikke!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Den valgte sti er ikke en mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Du har ikke tilladelse til at skrive til den valgte mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 indeholder en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 er indeholdt i en mappe, der allerede er synkroniseret. Vælg venligst en anden!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Den lokale mappe %1 er allerede synkroniseret. Vælg venligst en anden!</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>kDrive-applikationen lukker på grund af en kritisk fejl.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-applikationen lukker på grund af en kritisk fejl.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n år</numerusform>
-<numerusform>%n år</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n måned</numerusform>
-<numerusform>%n måneder</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n dag</numerusform>
-<numerusform>%n dage</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n time</numerusform>
-<numerusform>%n timer</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minut</numerusform>
-<numerusform>%n minutter</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekund</numerusform>
-<numerusform>%n sekunder</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
+    <name>Utility</name>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n måned</numerusform>
+            <numerusform>%n måneder</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dage</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minutter</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Systembakken er ikke tilgængelig</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 kræver en fungerende systembakke. Kører du XFCE, følg venligst &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;disse instruktioner&lt;/a&gt;. Ellers skal du installere et systembakkeprogram som 'trayer' og prøve igen.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Systembakken er ikke tilgængelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 kræver en fungerende systembakke. Kører du XFCE, følg venligst &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;disse instruktioner&lt;/a&gt;. Ellers skal du installere et systembakkeprogram som &apos;trayer&apos; og prøve igen.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Kunne ikke åbne browser</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Der opstod en fejl ved åbning af browseren for at gå til URL %1. Måske er der ikke konfigureret en standardbrowser?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Kunne ikke åbne e-mailklient</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Der opstod en fejl ved åbning af e-mailklienten for at oprette en ny besked. Måske er der ikke konfigureret en standard e-mailklient?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Du er ikke længere forbundet. &lt;a style="%1" href="%2"&gt;Log ind&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Kunne ikke åbne browser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Der opstod en fejl ved åbning af browseren for at gå til URL %1. Måske er der ikke konfigureret en standardbrowser?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Kunne ikke åbne e-mailklient</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Der opstod en fejl ved åbning af e-mailklienten for at oprette en ny besked. Måske er der ikke konfigureret en standard e-mailklient?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Du er ikke længere forbundet. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log ind&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Ingen mappe at synkronisere
+        <translation>Ingen mappe at synkronisere
 Du kan tilføje en fra kDrive-indstillingerne.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synkronisering i gang (%1 af %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronisering i gang (%1 af %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synkronisering i gang (%1 af %2)
+        <translation>Synkronisering i gang (%1 af %2)
 %3 tilbage...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synkronisering i gang (Trin %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synkronisering starter</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synkronisering i gang.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Du er opdateret, uløste konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Du er opdateret!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Nogle filer kunne ikke synkroniseres. &lt;a style="%1" href="%2"&gt;Læs mere&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synkronisering sætter på pause...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synkronisering sat på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi en anden synkronisering bruger samme mappe.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den indeholder den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den er indeholdt i den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe. Foreslået mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Du har ekskluderet mere end %1 mapper. Bemærk, at dette vil påvirke synkroniseringsydelsen.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Du kan ikke ekskludere mere end %1 mapper. Fravælg venligst mapper på højere niveau.</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronisering i gang (Trin %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronisering starter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronisering i gang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Du er opdateret, uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Du er opdateret!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Nogle filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Læs mere&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronisering sætter på pause...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkronisering sat på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi en anden synkronisering bruger samme mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den indeholder den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges, fordi den er indeholdt i den synkroniserede mappe &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke vælges som synkroniseringsmappe. Vælg venligst en anden mappe. Foreslået mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Du har ekskluderet mere end %1 mapper. Bemærk, at dette vil påvirke synkroniseringsydelsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Du kan ikke ekskludere mere end %1 mapper. Fravælg venligst mapper på højere niveau.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -1,3097 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="de_DE" version="2.1">
+<TS version="2.1" language="de_DE">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Über</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>SCHLIESSEN</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Version %1. Weitere Informationen unter &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Vertrieb durch %1 und lizenziert unter &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 und das %2-Logo sind eingetragene Marken von %1. &lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Ordner %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Erstellt aus &lt;a style="color: #489EF3" href="%1"&gt;Git-Quellen&lt;/a&gt; am %2 um %3 mit Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Über</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>SCHLIESSEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Version %1. Weitere Informationen unter &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Vertrieb durch %1 und lizenziert unter &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 und das %2-Logo sind eingetragene Marken von %1. &lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Ordner %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Erstellt aus &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-Quellen&lt;/a&gt; am %2 um %3 mit Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Die Synchronisierung beginnt, und Sie können Dateien zu Ihrem %1 Ordner hinzufügen.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Ihr kDrive ist bereit!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ORDNER ÖFFNEN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>EINSTELLUNGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Weiteres Laufwerk synchronisieren</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Die Synchronisierung beginnt, und Sie können Dateien zu Ihrem %1 Ordner hinzufügen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Ihr kDrive ist bereit!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ORDNER ÖFFNEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>EINSTELLUNGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Weiteres Laufwerk synchronisieren</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Abbrechen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>WEITER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Wählen Sie den zu synchronisierenden kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>kDrive kostenlos herunterladen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Speichern Sie Ihre Bilder, Dokumente und E-Mails in der Schweiz bei einem unabhängigen Unternehmen mit Achtung der Privatsphäre. Mehr erfahren</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Kostenlos testen</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>WEITER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Wählen Sie den zu synchronisierenden kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>kDrive kostenlos herunterladen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Speichern Sie Ihre Bilder, Dokumente und E-Mails in der Schweiz bei einem unabhängigen Unternehmen mit Achtung der Privatsphäre. Mehr erfahren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Kostenlos testen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Bewahren Sie Ihren Rechnerspeicherplatz</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Entscheiden Sie, welche Dateien online oder lokal verfügbar sein sollen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>SPÄTER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synchronisiert alle Ihre Dateien, ohne Ihren Rechnerspeicherplatz zu nutzen. Sie können die Dateien in Ihrem kDrive durchsuchen und jederzeit lokal herunterladen. &lt;a style="%1" href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Möchten Sie Lite Sync aktivieren (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Möchten Sie Lite Sync aktivieren?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Bewahren Sie Ihren Rechnerspeicherplatz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Entscheiden Sie, welche Dateien online oder lokal verfügbar sein sollen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>SPÄTER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synchronisiert alle Ihre Dateien, ohne Ihren Rechnerspeicherplatz zu nutzen. Sie können die Dateien in Ihrem kDrive durchsuchen und jederzeit lokal herunterladen. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Möchten Sie Lite Sync aktivieren (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Möchten Sie Lite Sync aktivieren?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Ort Ihres %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Ordner bearbeiten</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>ABSCHLIESSEN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Ordner auswählen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Der Inhalt des &lt;b&gt;%1&lt;/b&gt;-Ordners wird in Ihrem kDrive synchronisiert</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Alle Ihre Dateien befinden sich in diesem Ordner, sobald die Einrichtung abgeschlossen ist. Sie können dort neue Dateien ablegen und mit Ihrem kDrive synchronisieren.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Ort Ihres %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Ordner bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>ABSCHLIESSEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Ordner auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Der Inhalt des &lt;b&gt;%1&lt;/b&gt;-Ordners wird in Ihrem kDrive synchronisiert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Alle Ihre Dateien befinden sich in diesem Ordner, sobald die Einrichtung abgeschlossen ist. Sie können dort neue Dateien ablegen und mit Ihrem kDrive synchronisieren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
 Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deaktiviert.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Weitere Informationen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>FORTFAHREN</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTFAHREN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Melden Sie sich über Ihren Browser an.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Ihr Browser sollte sich automatisch öffnen, um die Verbindung herzustellen. Sobald die Verbindung hergestellt ist, kehren Sie automatisch zu kDrive zurück.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Öffnen Sie die Anmeldeseite</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Login fehlgeschlagen: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Die Anmeldeseite konnte in Ihrem Webbrowser nicht geöffnet werden</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Melden Sie sich über Ihren Browser an.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Ihr Browser sollte sich automatisch öffnen, um die Verbindung herzustellen. Sobald die Verbindung hergestellt ist, kehren Sie automatisch zu kDrive zurück.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Öffnen Sie die Anmeldeseite</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Login fehlgeschlagen: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Die Anmeldeseite konnte in Ihrem Webbrowser nicht geöffnet werden</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>kDrive-Ordner für die Synchronisierung auf Ihrem Desktop wählen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>FORTFAHREN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Auf Ihrem Rechner verfügbarer Speicherplatz: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Impossibile caricare l’elenco delle sottocartelle. Il tuo kDrive potrebbe essere in manutenzione.&lt;br&gt;Accedi alla &lt;a style="%1" href="%2"&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>kDrive-Ordner für die Synchronisierung auf Ihrem Desktop wählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>FORTFAHREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Auf Ihrem Rechner verfügbarer Speicherplatz: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Impossibile caricare l’elenco delle sottocartelle. Il tuo kDrive potrebbe essere in manutenzione.&lt;br&gt;Accedi alla &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Lokaler Ordner %1 konnte nicht erstellt werden</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>Der kDrive %1 wurde bereits auf diesem Computer synchronisiert. Trotzdem fortfahren?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Lokaler Ordner %1 konnte nicht erstellt werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Der kDrive %1 wurde bereits auf diesem Computer synchronisiert. Trotzdem fortfahren?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-Client wird mit falschen Parametern ausgeführt!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>Der kDrive Client läuft bereits!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Der Benutzer %1 ist nicht angemeldet. Bitte melden Sie sich erneut an.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-Client wird mit falschen Parametern ausgeführt!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Der kDrive Client läuft bereits!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Der Benutzer %1 ist nicht angemeldet. Bitte melden Sie sich erneut an.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Freigabelink in die Zwischenablage kopiert</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
-<numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 wurde gelöscht.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
-<numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 wurde hinzugefügt.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
-<numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 wurde aktualisiert.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
-<numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 wurde zu %2 verschoben.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synchronisierungsaktivität</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Freigabelink in die Zwischenablage kopiert</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 wurde gelöscht.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 wurde hinzugefügt.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
+            <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 wurde aktualisiert.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
+            <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 wurde zu %2 verschoben.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synchronisierungsaktivität</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Beenden Sie das Beta-Programm</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Nehmen Sie am Beta-Programm teil</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Erhalten Sie frühzeitigen Zugang zu neuen Versionen der Anwendung, bevor sie für die Allgemeinheit freigegeben werden, und beteiligen Sie sich an der Verbesserung der Anwendung, indem Sie uns Ihre Kommentare schicken.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Profitieren Sie von Beta-Updates für Anwendungen</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Nein</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Öffentliche Beta-Version</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Interne Betaversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Testversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Ich verstehe</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Sind Sie sicher, dass Sie das Beta-Programm verlassen wollen?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Speichern</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Abbrechen</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Ihre aktuelle Version der Anwendung ist möglicherweise zu aktuell. Ihre Auswahl wird ab dem nächsten verfügbaren Update wirksam.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Beta-Versionen können unerwartet verlassen werden oder Instabilitäten verursachen.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Beenden Sie das Beta-Programm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Nehmen Sie am Beta-Programm teil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Erhalten Sie frühzeitigen Zugang zu neuen Versionen der Anwendung, bevor sie für die Allgemeinheit freigegeben werden, und beteiligen Sie sich an der Verbesserung der Anwendung, indem Sie uns Ihre Kommentare schicken.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Profitieren Sie von Beta-Updates für Anwendungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Nein</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Öffentliche Beta-Version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Interne Betaversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Testversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Ich verstehe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Sind Sie sicher, dass Sie das Beta-Programm verlassen wollen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Speichern</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Ihre aktuelle Version der Anwendung ist möglicherweise zu aktuell. Ihre Auswahl wird ab dem nächsten verfügbaren Update wirksam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Beta-Versionen können unerwartet verlassen werden oder Instabilitäten verursachen.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Bitte melden Sie sich an</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Ordner %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Es wurden keine Synchronisierungsordner konfiguriert.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Synthese</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Einstellungen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Beenden</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Undefinierter Zustand.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Synchronisierung ausstehend.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synchronisierung läuft.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synchronisierung war erfolgreich, ungelöste Konflikte.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Die letzte Synchronisierung war erfolgreich.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Benutzer-Abbruch.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synchronisierung wurde angehalten.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synchronisierung wurde angehalten)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>ALLE SYNC. ENTFERNEN</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 Elemente wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt; gelöscht. Um unbeabsichtigte Löschungen zu vermeiden, wurde die Synchronisierung pausiert.&lt;br&gt;Möchten Sie diese Löschungen auf Ihr kDrive übertragen?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Mehrere Dateien wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt; gelöscht. Gelöschte Dateien finden Sie im &lt;a style="%1" href="%3"&gt;Papierkorb&lt;/a&gt; von kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Nicht mehr anzeigen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Synchronisierungen konnten nicht gestartet werden!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Der kDrive-Client kann nicht initialisiert werden</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Konflikt(e) bei %1 Element(en) im Synchronisierungsordner %2 konnten nicht behoben werden</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synchronisierung wird angehalten</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Bitte melden Sie sich an</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Ordner %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Es wurden keine Synchronisierungsordner konfiguriert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Synthese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Beenden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Undefinierter Zustand.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Synchronisierung ausstehend.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synchronisierung läuft.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synchronisierung war erfolgreich, ungelöste Konflikte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Die letzte Synchronisierung war erfolgreich.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Benutzer-Abbruch.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synchronisierung wurde angehalten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synchronisierung wurde angehalten)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>ALLE SYNC. ENTFERNEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 Elemente wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt; gelöscht. Um unbeabsichtigte Löschungen zu vermeiden, wurde die Synchronisierung pausiert.&lt;br&gt;Möchten Sie diese Löschungen auf Ihr kDrive übertragen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Mehrere Dateien wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt; gelöscht. Gelöschte Dateien finden Sie im &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;Papierkorb&lt;/a&gt; von kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Nicht mehr anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Synchronisierungen konnten nicht gestartet werden!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Der kDrive-Client kann nicht initialisiert werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Konflikt(e) bei %1 Element(en) im Synchronisierungsordner %2 konnten nicht behoben werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synchronisierung wird angehalten</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Zusammenfassung der Synchronisierung Ihrer lokalen Ordner</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Die Inhalte des Ordners auf Ihrem Rechner werden mit dem Ordner des ausgewählten kDrive synchronisiert und umgekehrt.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNCHRONISIEREN</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Zusammenfassung der Synchronisierung Ihrer lokalen Ordner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Die Inhalte des Ordners auf Ihrem Rechner werden mit dem Ordner des ausgewählten kDrive synchronisiert und umgekehrt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNCHRONISIEREN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Vor der Fertigstellung</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Stellen Sie mit den nächsten Schritten sicher, dass Lite Sync auf Ihrem Rechner ordnungsgemäss funktioniert, und schliessen Sie die Einrichtung des kDrive ab.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öffnen Sie die &lt;b&gt;Allgemeinen Einstellungen&lt;/b&gt; Ihres Macs oder &lt;a style=%1 href=%2&gt;klicken Sie hier&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öffnen Sie die &lt;b&gt;Datenschutz- und Sicherheitseinstellungen&lt;/b&gt; Ihres Mac oder &lt;a style="%1" href="%2"&gt;klicken Sie hier&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Gehen Sie zum Abschnitt &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; und dann zu &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Autorisieren Sie die kDrive-Anwendung</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Gehen Sie zum Bereich &lt;b&gt;"Sicherheit"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Autorisieren Sie die kDrive-Anwendung in dem Feld, in dem angezeigt wird, dass kDrive blockiert wurde</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Öffnen Sie das Vorhängeschloss &lt;img src=":/client/resources/icons/actions/lock.png"&gt; und autorisieren Sie die kDrive-Anwendung</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Gehen Sie zum Abschnitt &lt;b&gt;Datenschutz und Sicherheit"&lt;/b&gt; und klicken Sie auf &lt;b&gt;Voller Festplattenzugriff"&lt;/b&gt; oder &lt;a style=%1 href=%2&gt;hier klicken&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öffnen Sie in den Einstellungen Sicherheit und Datenschutz den Reiter &lt;b&gt;"Datenschutz"&lt;/b&gt; oder &lt;a style="%1" href="%2"&gt;klicken Sie hier&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Setzen Sie ein Häkchen bei "kDrive LiteSync Extension" und dann bei "kDrive.app" (sofern noch nicht erfolgt)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Gegebenenfalls kann ein Neustart der App vorgeschlagen werden, bitte führen Sie diesen durch</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Setzen Sie das Häkchen bei "kDrive LiteSync Extension"(und bei "kDrive.app" sofern vorhanden) unter &lt;b&gt;"Vollständiger Festplattenzgang"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>SCHRITT 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Erledigt)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>SCHRITT 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>DURCHGEFÜHRTE SCHRITTE</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>ENDE</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Vor der Fertigstellung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Stellen Sie mit den nächsten Schritten sicher, dass Lite Sync auf Ihrem Rechner ordnungsgemäss funktioniert, und schliessen Sie die Einrichtung des kDrive ab.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öffnen Sie die &lt;b&gt;Allgemeinen Einstellungen&lt;/b&gt; Ihres Macs oder &lt;a style=%1 href=%2&gt;klicken Sie hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öffnen Sie die &lt;b&gt;Datenschutz- und Sicherheitseinstellungen&lt;/b&gt; Ihres Mac oder &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicken Sie hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Gehen Sie zum Abschnitt &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; und dann zu &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autorisieren Sie die kDrive-Anwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Gehen Sie zum Bereich &lt;b&gt;&quot;Sicherheit&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autorisieren Sie die kDrive-Anwendung in dem Feld, in dem angezeigt wird, dass kDrive blockiert wurde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Öffnen Sie das Vorhängeschloss &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; und autorisieren Sie die kDrive-Anwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Gehen Sie zum Abschnitt &lt;b&gt;Datenschutz und Sicherheit&quot;&lt;/b&gt; und klicken Sie auf &lt;b&gt;Voller Festplattenzugriff&quot;&lt;/b&gt; oder &lt;a style=%1 href=%2&gt;hier klicken&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öffnen Sie in den Einstellungen Sicherheit und Datenschutz den Reiter &lt;b&gt;&quot;Datenschutz&quot;&lt;/b&gt; oder &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicken Sie hier&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Setzen Sie ein Häkchen bei &quot;kDrive LiteSync Extension&quot; und dann bei &quot;kDrive.app&quot; (sofern noch nicht erfolgt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Gegebenenfalls kann ein Neustart der App vorgeschlagen werden, bitte führen Sie diesen durch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Setzen Sie das Häkchen bei &quot;kDrive LiteSync Extension&quot;(und bei &quot;kDrive.app&quot; sofern vorhanden) unter &lt;b&gt;&quot;Vollständiger Festplattenzgang&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>SCHRITT 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Erledigt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>SCHRITT 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>DURCHGEFÜHRTE SCHRITTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>ENDE</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NEIN</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NEIN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Debugging-Informationen werden versendet</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Abbrechen</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Debugging-Informationen werden versendet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Info</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Debuggen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Warnung</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Fehler</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Schwer</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Debugging-Einstellungen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Debugging-Informationen in einem Ordner auf meinem Computer speichern (empfohlen)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Mithilfe dieser Informationen kann der IT-Support den Ursprung eines Vorfalls ermitteln.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Debug level</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Mit der Trace-Ebene können Sie den Umfang der aufgezeichneten Debugging-Informationen auswählen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Das erweiterte vollständige Protokoll erfasst einen detaillierten Verlauf, der zum Debuggen verwendet werden kann. Die Aktivierung kann die kDrive-Anwendung verlangsamen.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Erweitertes vollständiges Protokoll</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Protokolle löschen, die älter als %1 Tage sind</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Geben Sie den Debug-Ordner für den Infomaniak-Support frei.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Die letzte Sitzung ist der Zeitraum seit dem letzten kDrive-Start.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Teilen Sie nur die letzte kDrive-Sitzung</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Wird geladen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Abbrechen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>SPEICHERN</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Teilen fehlgeschlagen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Überprüfen Sie, ob Sie angemeldet sind &lt;br&gt;2. Überprüfen Sie, ob Sie mindestens ein kDrive konfiguriert haben</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Verbindung unterbrochen)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Teilen Sie den Ordner mit SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Wir haben Ihr Protokoll &lt;a style="%1" href="%2"&gt;hier&lt;/a&gt; automatisch komprimiert.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Übertragen Sie das Archiv mit &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Teilen Sie den Link mit &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translatorcomment>Letzte Hochladung am %1</translatorcomment>
-<translation>Letztes Hochladen von %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Die Freigabe wurde abgebrochen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Das erweiterte vollständige Protokoll wird über die Umgebungsvariable KDRIVE_FORCE_EXTENDED_LOG aktiviert. Setzen Sie sie auf 0, um es zu deaktivieren.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Der gesamte Ordner ist groß (&gt; 100 MB) und kann einige Zeit für die Freigabe benötigen. Um die Freigabezeit zu reduzieren, empfehlen wir, nur die letzte kDrive-Sitzung freizugeben.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translatorcomment>ie: Letzte Hochladung am 29.01.24 um 13:04:06 Uhr</translatorcomment>
-<translation>%2.%1.%3 um %4:%5:%6 Uhr</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Wollen Sie Ihre Änderungen speichern?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Ordner %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Teilen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Teilen | Schritt 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Teilen | Schritt 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Stornieren...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Debuggen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Warnung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Schwer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Debugging-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Debugging-Informationen in einem Ordner auf meinem Computer speichern (empfohlen)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Mithilfe dieser Informationen kann der IT-Support den Ursprung eines Vorfalls ermitteln.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Debug level</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Mit der Trace-Ebene können Sie den Umfang der aufgezeichneten Debugging-Informationen auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Das erweiterte vollständige Protokoll erfasst einen detaillierten Verlauf, der zum Debuggen verwendet werden kann. Die Aktivierung kann die kDrive-Anwendung verlangsamen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Erweitertes vollständiges Protokoll</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Protokolle löschen, die älter als %1 Tage sind</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Geben Sie den Debug-Ordner für den Infomaniak-Support frei.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Die letzte Sitzung ist der Zeitraum seit dem letzten kDrive-Start.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Teilen Sie nur die letzte kDrive-Sitzung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Wird geladen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Teilen fehlgeschlagen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Überprüfen Sie, ob Sie angemeldet sind &lt;br&gt;2. Überprüfen Sie, ob Sie mindestens ein kDrive konfiguriert haben</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Verbindung unterbrochen)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Teilen Sie den Ordner mit SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Wir haben Ihr Protokoll &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt; automatisch komprimiert.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Übertragen Sie das Archiv mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Teilen Sie den Link mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translatorcomment>Letzte Hochladung am %1</translatorcomment>
+        <translation>Letztes Hochladen von %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Die Freigabe wurde abgebrochen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Das erweiterte vollständige Protokoll wird über die Umgebungsvariable KDRIVE_FORCE_EXTENDED_LOG aktiviert. Setzen Sie sie auf 0, um es zu deaktivieren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Der gesamte Ordner ist groß (&gt; 100 MB) und kann einige Zeit für die Freigabe benötigen. Um die Freigabezeit zu reduzieren, empfehlen wir, nur die letzte kDrive-Sitzung freizugeben.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translatorcomment>ie: Letzte Hochladung am 29.01.24 um 13:04:06 Uhr</translatorcomment>
+        <translation>%2.%1.%3 um %4:%5:%6 Uhr</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wollen Sie Ihre Änderungen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Ordner %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Teilen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Teilen | Schritt 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Teilen | Schritt 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Stornieren...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Ordner</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Benachrichtigungen</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Es wird eine Benachrichtigung angezeigt, sobald ein neuer Ordner synchronisiert oder geändert wurde</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Verbunden mit</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Wollen Sie die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt;wirklich beenden?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Hierdurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Dieser Vorgang kann je nach Größe des Ordners zwischen einigen Sekunden und einigen Minuten dauern.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Neue Synchronisierung des lokalen Ordners fehlgeschlagen!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Lite Sync-Aktivierung fehlgeschlagen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Lite Sync-Deaktivierung fehlgeschlagen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>VERBINDUNG FÜR ORDNERSYNC. ENTFERNEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Benachrichtigungen für diesen kDrive aktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synchronisierungsfehler und Informationen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Lokalen Ordner synchronisieren</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Wollen Sie Lite Sync wirklich einschalten?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Wollen Sie Lite Sync wirklich ausschalten?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Sie haben nicht genug Speicherplatz, um alle Dateien auf Ihrem kDrive (%1 fehlt) zu synchronisieren. Wenn Sie Lite Sync ausschalten, müssen Sie die auf Ihrem Rechner zu synchronisierenden Ordner auswählen. Bis dahin wird die Synchronisierung Ihres kDrive ausgesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Wenn Sie Lite Sync deaktivieren, werden alle Dateien auf Ihren Computer heruntergeladen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync aktiviert.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync ist deaktiviert.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Dieses Laufwerk wird gelöscht.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Element %1 kann nicht geöffnet werden</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt; konnte nicht beendet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Entfernen Sie alle Synchronisierungen</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Suchen Sie in Ihrem kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Suche</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Ordner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Benachrichtigungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Es wird eine Benachrichtigung angezeigt, sobald ein neuer Ordner synchronisiert oder geändert wurde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Verbunden mit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Wollen Sie die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt;wirklich beenden?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Hierdurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Dieser Vorgang kann je nach Größe des Ordners zwischen einigen Sekunden und einigen Minuten dauern.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Neue Synchronisierung des lokalen Ordners fehlgeschlagen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Lite Sync-Aktivierung fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Lite Sync-Deaktivierung fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>VERBINDUNG FÜR ORDNERSYNC. ENTFERNEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Benachrichtigungen für diesen kDrive aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synchronisierungsfehler und Informationen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Lokalen Ordner synchronisieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Wollen Sie Lite Sync wirklich einschalten?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Wollen Sie Lite Sync wirklich ausschalten?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Sie haben nicht genug Speicherplatz, um alle Dateien auf Ihrem kDrive (%1 fehlt) zu synchronisieren. Wenn Sie Lite Sync ausschalten, müssen Sie die auf Ihrem Rechner zu synchronisierenden Ordner auswählen. Bis dahin wird die Synchronisierung Ihres kDrive ausgesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Wenn Sie Lite Sync deaktivieren, werden alle Dateien auf Ihren Computer heruntergeladen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync aktiviert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync ist deaktiviert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Dieses Laufwerk wird gelöscht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Element %1 kann nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt; konnte nicht beendet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Entfernen Sie alle Synchronisierungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Suchen Sie in Ihrem kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Suche</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Einen kDrive synchronisieren</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>kDrive hinzufügen</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Einen kDrive synchronisieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>kDrive hinzufügen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Lösen</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>In Konflikt stehende(s) Element(e)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Artikel mit nicht unterstützten Zeichen</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Verlauf löschen</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Zu lösen</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Automatisch gelöst</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>Problem(e) gelöst</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>Problem(e) erkannt</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Lösen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>In Konflikt stehende(s) Element(e)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Artikel mit nicht unterstützten Zeichen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Verlauf löschen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Zu lösen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automatisch gelöst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>Problem(e) gelöst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>Problem(e) erkannt</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synchronisierungskonflikte oder Fehler</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Fehler</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Zurück zu den Einstellungen</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synchronisierungskonflikte oder Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Zurück zu den Einstellungen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Einige Dateien auf dem / den folgenden kDrive(s) konnten nicht synchronisiert werden:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 Fehler)</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 Informationen(n))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 Fehler und %2 Informationen)</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
-<numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Einige Dateien auf dem / den folgenden kDrive(s) konnten nicht synchronisiert werden:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 Fehler)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 Informationen(n))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 Fehler und %2 Informationen)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
+            <numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Ausgeschlossene Dateien</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Fügen Sie Dateien oder Ordner hinzu, die auf Ihrem Rechner nicht synchronisiert werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Hinzufügen</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NAME</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>WARNUNG</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>SPEICHERN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Wollen Sie Ihre Änderungen speichern?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Ausschlussvorlage existiert bereits!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Möchten Sie wirklich löschen?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Änderungen können nicht gespeichert werden!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ausgeschlossene Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Fügen Sie Dateien oder Ordner hinzu, die auf Ihrem Rechner nicht synchronisiert werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>WARNUNG</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wollen Sie Ihre Änderungen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Ausschlussvorlage existiert bereits!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Möchten Sie wirklich löschen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Änderungen können nicht gespeichert werden!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Konflikt(e) lösen</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Was möchten Sie mit %1 in Konflikt stehenden Elementen tun?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Meine Änderungen speichern und die Versionen anderer Benutzer ersetzen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Meine Änderungen rückgängig machen und die Versionen anderer Benutzer behalten.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Ihre Änderungen können unwiederbringlich gelöscht werden. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Ihre Änderungen werden dauerhaft gelöscht. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Artikel anzeigen</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>An diesen Dateien wurden von mehreren Benutzern an mehreren Orten (online auf kDrive, auf einem Computer oder einem Mobiltelefon) Änderungen vorgenommen. Ordner, die diese Dateien enthalten, wurden möglicherweise auch gelöscht.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Die lokale Version Ihres Artikels ist &lt;b&gt;nicht mit kDrive synchronisiert&lt;/b&gt;. &lt;a style="color: #489EF3" href="%1"&gt;Weitere Informationen&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Konflikt(e) lösen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Was möchten Sie mit %1 in Konflikt stehenden Elementen tun?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Meine Änderungen speichern und die Versionen anderer Benutzer ersetzen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Meine Änderungen rückgängig machen und die Versionen anderer Benutzer behalten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Ihre Änderungen können unwiederbringlich gelöscht werden. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Ihre Änderungen werden dauerhaft gelöscht. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Artikel anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>An diesen Dateien wurden von mehreren Benutzern an mehreren Orten (online auf kDrive, auf einem Computer oder einem Mobiltelefon) Änderungen vorgenommen. Ordner, die diese Dateien enthalten, wurden möglicherweise auch gelöscht.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Die lokale Version Ihres Artikels ist &lt;b&gt;nicht mit kDrive synchronisiert&lt;/b&gt;. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Weitere Aktionen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synchronisiert in &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Lite Sync aktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Lite Sync aktivieren (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben, sofern sie Offline-Elemente enthalten. Mit kDrive synchronisierte Ordner bleiben online verfügbar.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben. Mit kDrive synchronisierte Ordner bleiben weiterhin online verfügbar.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Nicht ausgewählte Ordner werden &lt;b&gt;permanent&lt;/b&gt; vom Computer gelöscht. Ordner, die mit kDrive synchronisiert wurden, bleiben online verfügbar.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Abbrechen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Synchronisierung anhalten</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Lite Sync deaktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Synchronisierung fortsetzen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Synchronisierung entfernen</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Weitere Aktionen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synchronisiert in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Lite Sync aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Lite Sync aktivieren (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben, sofern sie Offline-Elemente enthalten. Mit kDrive synchronisierte Ordner bleiben online verfügbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben. Mit kDrive synchronisierte Ordner bleiben weiterhin online verfügbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Nicht ausgewählte Ordner werden &lt;b&gt;permanent&lt;/b&gt; vom Computer gelöscht. Ordner, die mit kDrive synchronisiert wurden, bleiben online verfügbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Synchronisierung anhalten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Lite Sync deaktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Synchronisierung fortsetzen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Synchronisierung entfernen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Anwendungs-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Name der Anwendung</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Anwendungs-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Name der Anwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Einige Anwendungen wie Backup, Anti-Virus usw. greifen auf Ihre Dateien zu, sodass diese heruntergeladen werden, wenn sie "online" sind. Fügen Sie sie zur nachfolgenden Liste hinzu, um dieses Verhalten zu vermeiden.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Hinzufügen</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ANWENDUNGS-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NAME</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>SPEICHERN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Wollen Sie Ihre Änderungen speichern?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Möchten Sie wirklich löschen?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Änderungen können nicht gespeichert werden!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Einige Anwendungen wie Backup, Anti-Virus usw. greifen auf Ihre Dateien zu, sodass diese heruntergeladen werden, wenn sie &quot;online&quot; sind. Fügen Sie sie zur nachfolgenden Liste hinzu, um dieses Verhalten zu vermeiden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ANWENDUNGS-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wollen Sie Ihre Änderungen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Möchten Sie wirklich löschen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Änderungen können nicht gespeichert werden!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Welchen Ordner auf Ihrem Rechner möchten Sie&lt;br&gt;synchronisieren?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Der Inhalt dieses Ordners wird auf dem kDrive synchronisiert</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Ordner auswählen</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Ordner bearbeiten</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>FORTFAHREN</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Welchen Ordner auf Ihrem Rechner möchten Sie&lt;br&gt;synchronisieren?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Der Inhalt dieses Ordners wird auf dem kDrive synchronisiert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Ordner auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Ordner bearbeiten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>FORTFAHREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
 Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deaktiviert.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Weitere Informationen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Ordner auswählen</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Ordner auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Fehler</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;File '%1'&lt;br/&gt;kann nicht zum Schreiben geöffnet werden.&lt;br/&gt;&lt;br/&gt;Die Log-Datei kann &lt;b&gt;nicht&lt;/b&gt; gespeichert werden!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Fehler</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;kann nicht zum Schreiben geöffnet werden.&lt;br/&gt;&lt;br/&gt;Die Log-Datei kann &lt;b&gt;nicht&lt;/b&gt; gespeichert werden!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Einstellungen</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Hilfe</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hilfe</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Übertragung abgeschlossen!&lt;br&gt;Weitere Einzelheiten enthält der Identifier &lt;b&gt;%1&lt;/b&gt; in den Fehlerberichten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Übertragung fehlgeschlagen!
-Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu senden: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Kein kDrive eingerichtet!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Ein technischer Fehler ist aufgetreten (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf und kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Es scheint, dass Ihre Netzwerkverbindung mit einem zu niedrigen Timeout konfiguriert ist, als dass die Anwendung ordnungsgemäß funktionieren könnte (Fehler %1).&lt;br&gt;Bitte überprüfen Sie Ihre Netzwerkkonfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Es kann keine Verbindung zum kDrive-Server hergestellt werden (Fehler %1).&lt;br&gt;Es wird versucht, die Verbindung wiederherzustellen. Bitte überprüfen Sie Ihre Internetverbindung und Ihre Firewall.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Bitte melden Sie sich erneut an. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Eine neue Version der Anwendung ist verfügbar.&lt;br&gt;Bitte aktualisieren Sie die Anwendung, um sie weiterhin verwenden zu können.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Das Hochladen des Protokolls ist fehlgeschlagen (Fehler %1).&lt;br&gt;Bitte versuchen Sie es später erneut.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Auf den Synchronisierungsordner kann nicht mehr zugegriffen werden (Fehler %1).&lt;br&gt;Die Synchronisierung wird fortgesetzt, sobald auf den Ordner zugegriffen werden kann.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Der Synchronisationsordner wurde ersetzt oder verschoben, so dass die Synchronisation nicht mehr möglich ist (Fehler %1).&lt;br&gt; Dies kann nach dem Kopieren, Verschieben oder Wiederherstellen des Ordners passieren.&lt;br&gt; Um das Problem zu beheben, erstellen Sie bitte eine neue Synchronisation mit einem neuen Ordner.&lt;br&gt;Hinweis: Wenn Sie nicht synchronisierte Änderungen im alten Ordner haben, müssen Sie diese manuell in den neuen Ordner kopieren.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Auf Ihrem Computer ist nicht mehr genügend Speicher vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive benötigt Schreibzugriff auf das temporäre Verzeichnis Ihres Computers. &lt;br&gt;Bitte starten Sie die kDrive-App neu, um dieses Problem zu beheben.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Es ist ein technischer Fehler aufgetreten. Die Synchronisierung wird so schnell wie möglich fortgesetzt. Bitte kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Die Anzahl der inotify-Überwachungen ist unzureichend (Fehler %1).&lt;br&gt;Sie können diese Anzahl erhöhen, indem Sie '/etc/sysctl.conf' bearbeiten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Synchronisierung kann nicht gestartet werden (Fehler %1).&lt;br&gt;Sie müssen Folgendes zulassen:&lt;br&gt;- kDrive in den Systemeinstellungen &gt;&gt; Allgemein &gt;&gt; Anmeldeobjekte und Erweiterungen &gt;&gt; Endpoint Security-Erweiterungen&lt;br&gt;- kDrive LiteSync-Erweiterung in den Systemeinstellungen &gt;&gt; Datenschutz und Sicherheit &gt;&gt; Vollständiger Festplattenzugriff.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Das Lite Sync-Plugin kann nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung installiert und der Windows-Suchdienst aktiviert ist.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung über die richtigen Berechtigungen verfügt und ausgeführt wird.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und kontaktieren Sie unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Der kDrive befindet sich im Wartungsmodus. Die &lt;br/&gt;Synchronisierung wird schnellstmöglich wieder aufgenommen. Bitte wenden Sie sich an unseren Support, sofern der Fehler weiterhin auftritt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte verlängern Sie kDrive. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte wenden Sie sich an einen Administrator, um den kDrive zu verlängern. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive wird gerade gestartet.&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der &lt;a style="%1" href="%2"&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der Webversion an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Sie sind nicht berechtigt, auf dieses kDrive zuzugreifen.&lt;br&gt;Die Synchronisierung wurde angehalten. Bitte wenden Sie sich an einen Administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Es ist ein technischer Fehler aufgetreten (Fehler %1).&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Die Netzwerkverbindungen wurden vom Kernel unterbrochen (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Leider konnte Ihre alte Konfiguration nicht migriert werden. &lt;br/&gt;Das Programm verwendet eine leere Konfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Leider konnte Ihre alte Proxy-Konfiguration nicht migriert werden, SOCKS5-Proxies werden derzeit nicht unterstützt. Stattdessen werden &lt;br/&gt;die System-Proxyeinstellungen verwendet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Ein technischer Fehler (Fehler %1) ist aufgetreten. Die &lt;br/&gt;Synchronisierung wurde neu gestartet. Bitte leeren Sie den Verlauf; sollte der Fehler weiterhin auftreten, dann wenden Sie sich an unseren Support.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Beim Zugriff auf die Synchronisierungsdatenbank ist ein Fehler aufgetreten (Fehler %1). Die &lt;br/&gt;Synchronisierung wurde angehalten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Token ungültig oder widerrufen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Verschachtelte Synchronisierungen sind verboten (Fehler %1).&lt;br&gt;Sie sollten nur Synchronisierungen behalten, deren Ordner nicht verschachtelt sind.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Der Synchronisationsordner auf dem entfernten kDrive existiert nicht mehr oder ist nicht mehr zugänglich (Fehler %1).&lt;br&gt;Sie müssen ihn wiederherstellen oder ihm wieder Zugriffsrechte geben oder die Synchronisation löschen/neu erstellen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Fehler beim Parsen des Dateinamens (Fehler %1).&lt;br&gt;Sonderzeichen wie doppelte Anführungszeichen, umgekehrte Schrägstriche oder Zeilenumbrüche können zu Parsingfehlern führen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Sie sind entweder nicht berechtigt, ein Element zu erstellen, oder es existiert bereits ein anderes Element mit demselben Namen. Das Element wurde ignoriert.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Es ist Ihnen nicht erlaubt, das Element nach "%1" zu verschieben.&lt;br&gt;Es wird in seinen ursprünglichen übergeordneten Ordner wiederhergestellt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Der Speicherplatz auf Ihrem Computer reicht nicht mehr aus.&lt;br&gt;Der Download wurde abgebrochen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Die Datei „%1“ kann nicht erstellt werden, da sie von Ihrem Dateisystem nicht unterstützt wird.&lt;br&gt;Sie wurde von der Synchronisierung ausgeschlossen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Dieses Element wurde an einen anderen Ort verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Das lokale Element wurde umbenannt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Auf Ihrem Computer ist nicht mehr genügend Speicherplatz vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Die Datei wurde zur gleichen Zeit von einem anderen Benutzer geändert. &lt;br/&gt;Ihre Änderungen wurden in einer Kopie gespeichert.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Ein anderer Benutzer hat einen übergeordneten Ordner des Ziels verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Der Name des Elements enthält nur Leerzeichen.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Sie dürfen keine Elemente bearbeiten. &lt;br/&gt;Die Datei mit Ihren Änderungen wurde umbenannt und von der Synchronisierung ausgeschlossen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Sie dürfen das Element nicht umbenennen. &lt;br/&gt;Es wird mit seinem ursprünglichen Namen wiederhergestellt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Sie dürfen das Element nicht löschen. &lt;br/&gt;Es wird an seinem ursprünglichen Ort wiederhergestellt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Dieses Objekt konnte nicht in den Papierkorb verschoben werden, es wurde auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Die Datei wurde lokal geändert, während sie im entfernten kDrive gelöscht wurde.&lt;br&gt;Eine lokale Kopie wurde im Rettungsordner gespeichert (rescue folder).</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Der Vorgang, der mit dem Artikel durchgeführt wurde, ist verboten.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Der für diesen Artikel durchgeführte Vorgang ist fehlgeschlagen.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Die Datei ist zu groß, um hochgeladen zu werden. Sie wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Es ist nicht möglich, die Datei herunterzuladen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Sie haben Ihr Kontingent überschritten. Erhöhen Sie Ihr Speicherplatzkontingent, um den Datei-Upload wieder zu aktivieren.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Das Laufwerk mit Ihrem Synchronisationsordner ist nicht mehr verbunden (Fehler %1).&lt;br&gt;Bitte verbinden Sie es erneut, um die Synchronisierung fortzusetzen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Synchronisierung konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Der LiteSyncExt-Prozess wird derzeit nicht ausgeführt. Die Synchronisierung wird fortgesetzt, sobald er gestartet ist.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Ein vorhandenes Element hat einen identischen Namen mit derselben Groß- und Kleinschreibung (dieselbe Groß- und Kleinschreibung).&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Der Artikelname enthält ein nicht unterstütztes Zeichen.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Der Name des Elements endet mit einem Leerzeichen, was auf Ihrem Betriebssystem verboten ist.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Dieser Elementname ist von Ihrem Betriebssystem reserviert.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Der Artikelname ist zu lang.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Der Elementpfad ist zu lang.&lt;br&gt;Er wurde ignoriert.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Der Elementname enthält ein neues UNICODE-Zeichen, das von Ihrem Dateisystem noch nicht unterstützt wird.&lt;br&gt;Es wurde von der Synchronisierung ausgeschlossen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Synchronisierung dieses Elements fehlgeschlagen. Es wurde vorübergehend auf die Blacklist gesetzt.&lt;br&gt;Ein weiterer Versuch zur Synchronisierung wird in einer Stunde oder beim nächsten Start der Anwendung durchgeführt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Dieser Artikel wurde durch eine benutzerdefinierte Vorlage vom Sync ausgeschlossen. Sie können diese Art von Benachrichtigung in den Einstellungen deaktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Dieses Element wurde von der Synchronisierung ausgeschlossen, da es sich um einen Hardlink handelt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Dieser Artikel ist derzeit von einem anderen Benutzer online gesperrt.&lt;br&gt;Wir werden später erneut versuchen, Ihre Änderungen hochzuladen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Synchronisierungsfehler.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Zugriff auf Element nicht möglich.&lt;br&gt;Bitte korrigieren Sie die Lese- und Schreibberechtigungen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Systemfehler.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Das Element existiert bereits auf der anderen Seite.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Es ist ein technischer Fehler aufgetreten.&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Übertragung abgeschlossen!&lt;br&gt;Weitere Einzelheiten enthält der Identifier &lt;b&gt;%1&lt;/b&gt; in den Fehlerberichten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Übertragung fehlgeschlagen!
+Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu senden: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Kein kDrive eingerichtet!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ein technischer Fehler ist aufgetreten (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf und kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Es scheint, dass Ihre Netzwerkverbindung mit einem zu niedrigen Timeout konfiguriert ist, als dass die Anwendung ordnungsgemäß funktionieren könnte (Fehler %1).&lt;br&gt;Bitte überprüfen Sie Ihre Netzwerkkonfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Es kann keine Verbindung zum kDrive-Server hergestellt werden (Fehler %1).&lt;br&gt;Es wird versucht, die Verbindung wiederherzustellen. Bitte überprüfen Sie Ihre Internetverbindung und Ihre Firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Bitte melden Sie sich erneut an. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Eine neue Version der Anwendung ist verfügbar.&lt;br&gt;Bitte aktualisieren Sie die Anwendung, um sie weiterhin verwenden zu können.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Das Hochladen des Protokolls ist fehlgeschlagen (Fehler %1).&lt;br&gt;Bitte versuchen Sie es später erneut.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Auf den Synchronisierungsordner kann nicht mehr zugegriffen werden (Fehler %1).&lt;br&gt;Die Synchronisierung wird fortgesetzt, sobald auf den Ordner zugegriffen werden kann.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Der Synchronisationsordner wurde ersetzt oder verschoben, so dass die Synchronisation nicht mehr möglich ist (Fehler %1).&lt;br&gt; Dies kann nach dem Kopieren, Verschieben oder Wiederherstellen des Ordners passieren.&lt;br&gt; Um das Problem zu beheben, erstellen Sie bitte eine neue Synchronisation mit einem neuen Ordner.&lt;br&gt;Hinweis: Wenn Sie nicht synchronisierte Änderungen im alten Ordner haben, müssen Sie diese manuell in den neuen Ordner kopieren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Auf Ihrem Computer ist nicht mehr genügend Speicher vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive benötigt Schreibzugriff auf das temporäre Verzeichnis Ihres Computers. &lt;br&gt;Bitte starten Sie die kDrive-App neu, um dieses Problem zu beheben.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Es ist ein technischer Fehler aufgetreten. Die Synchronisierung wird so schnell wie möglich fortgesetzt. Bitte kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Die Anzahl der inotify-Überwachungen ist unzureichend (Fehler %1).&lt;br&gt;Sie können diese Anzahl erhöhen, indem Sie &apos;/etc/sysctl.conf&apos; bearbeiten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Synchronisierung kann nicht gestartet werden (Fehler %1).&lt;br&gt;Sie müssen Folgendes zulassen:&lt;br&gt;- kDrive in den Systemeinstellungen &gt;&gt; Allgemein &gt;&gt; Anmeldeobjekte und Erweiterungen &gt;&gt; Endpoint Security-Erweiterungen&lt;br&gt;- kDrive LiteSync-Erweiterung in den Systemeinstellungen &gt;&gt; Datenschutz und Sicherheit &gt;&gt; Vollständiger Festplattenzugriff.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Das Lite Sync-Plugin kann nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung installiert und der Windows-Suchdienst aktiviert ist.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung über die richtigen Berechtigungen verfügt und ausgeführt wird.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und kontaktieren Sie unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Der kDrive befindet sich im Wartungsmodus. Die &lt;br/&gt;Synchronisierung wird schnellstmöglich wieder aufgenommen. Bitte wenden Sie sich an unseren Support, sofern der Fehler weiterhin auftritt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte verlängern Sie kDrive. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte wenden Sie sich an einen Administrator, um den kDrive zu verlängern. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive wird gerade gestartet.&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der Webversion an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Sie sind nicht berechtigt, auf dieses kDrive zuzugreifen.&lt;br&gt;Die Synchronisierung wurde angehalten. Bitte wenden Sie sich an einen Administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Es ist ein technischer Fehler aufgetreten (Fehler %1).&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Die Netzwerkverbindungen wurden vom Kernel unterbrochen (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Leider konnte Ihre alte Konfiguration nicht migriert werden. &lt;br/&gt;Das Programm verwendet eine leere Konfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Leider konnte Ihre alte Proxy-Konfiguration nicht migriert werden, SOCKS5-Proxies werden derzeit nicht unterstützt. Stattdessen werden &lt;br/&gt;die System-Proxyeinstellungen verwendet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Ein technischer Fehler (Fehler %1) ist aufgetreten. Die &lt;br/&gt;Synchronisierung wurde neu gestartet. Bitte leeren Sie den Verlauf; sollte der Fehler weiterhin auftreten, dann wenden Sie sich an unseren Support.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Beim Zugriff auf die Synchronisierungsdatenbank ist ein Fehler aufgetreten (Fehler %1). Die &lt;br/&gt;Synchronisierung wurde angehalten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Token ungültig oder widerrufen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Verschachtelte Synchronisierungen sind verboten (Fehler %1).&lt;br&gt;Sie sollten nur Synchronisierungen behalten, deren Ordner nicht verschachtelt sind.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Der Synchronisationsordner auf dem entfernten kDrive existiert nicht mehr oder ist nicht mehr zugänglich (Fehler %1).&lt;br&gt;Sie müssen ihn wiederherstellen oder ihm wieder Zugriffsrechte geben oder die Synchronisation löschen/neu erstellen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Fehler beim Parsen des Dateinamens (Fehler %1).&lt;br&gt;Sonderzeichen wie doppelte Anführungszeichen, umgekehrte Schrägstriche oder Zeilenumbrüche können zu Parsingfehlern führen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Sie sind entweder nicht berechtigt, ein Element zu erstellen, oder es existiert bereits ein anderes Element mit demselben Namen. Das Element wurde ignoriert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Es ist Ihnen nicht erlaubt, das Element nach &quot;%1&quot; zu verschieben.&lt;br&gt;Es wird in seinen ursprünglichen übergeordneten Ordner wiederhergestellt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Der Speicherplatz auf Ihrem Computer reicht nicht mehr aus.&lt;br&gt;Der Download wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Die Datei „%1“ kann nicht erstellt werden, da sie von Ihrem Dateisystem nicht unterstützt wird.&lt;br&gt;Sie wurde von der Synchronisierung ausgeschlossen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dieses Element wurde an einen anderen Ort verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Das lokale Element wurde umbenannt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Auf Ihrem Computer ist nicht mehr genügend Speicherplatz vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Die Datei wurde zur gleichen Zeit von einem anderen Benutzer geändert. &lt;br/&gt;Ihre Änderungen wurden in einer Kopie gespeichert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Ein anderer Benutzer hat einen übergeordneten Ordner des Ziels verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Der Name des Elements enthält nur Leerzeichen.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Sie dürfen keine Elemente bearbeiten. &lt;br/&gt;Die Datei mit Ihren Änderungen wurde umbenannt und von der Synchronisierung ausgeschlossen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Sie dürfen das Element nicht umbenennen. &lt;br/&gt;Es wird mit seinem ursprünglichen Namen wiederhergestellt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Sie dürfen das Element nicht löschen. &lt;br/&gt;Es wird an seinem ursprünglichen Ort wiederhergestellt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Dieses Objekt konnte nicht in den Papierkorb verschoben werden, es wurde auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Die Datei wurde lokal geändert, während sie im entfernten kDrive gelöscht wurde.&lt;br&gt;Eine lokale Kopie wurde im Rettungsordner gespeichert (rescue folder).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Der Vorgang, der mit dem Artikel durchgeführt wurde, ist verboten.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Der für diesen Artikel durchgeführte Vorgang ist fehlgeschlagen.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Die Datei ist zu groß, um hochgeladen zu werden. Sie wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Es ist nicht möglich, die Datei herunterzuladen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Sie haben Ihr Kontingent überschritten. Erhöhen Sie Ihr Speicherplatzkontingent, um den Datei-Upload wieder zu aktivieren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Das Laufwerk mit Ihrem Synchronisationsordner ist nicht mehr verbunden (Fehler %1).&lt;br&gt;Bitte verbinden Sie es erneut, um die Synchronisierung fortzusetzen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Synchronisierung konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Der LiteSyncExt-Prozess wird derzeit nicht ausgeführt. Die Synchronisierung wird fortgesetzt, sobald er gestartet ist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ein vorhandenes Element hat einen identischen Namen mit derselben Groß- und Kleinschreibung (dieselbe Groß- und Kleinschreibung).&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Der Artikelname enthält ein nicht unterstütztes Zeichen.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Der Name des Elements endet mit einem Leerzeichen, was auf Ihrem Betriebssystem verboten ist.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Dieser Elementname ist von Ihrem Betriebssystem reserviert.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Der Artikelname ist zu lang.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Der Elementpfad ist zu lang.&lt;br&gt;Er wurde ignoriert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Der Elementname enthält ein neues UNICODE-Zeichen, das von Ihrem Dateisystem noch nicht unterstützt wird.&lt;br&gt;Es wurde von der Synchronisierung ausgeschlossen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Synchronisierung dieses Elements fehlgeschlagen. Es wurde vorübergehend auf die Blacklist gesetzt.&lt;br&gt;Ein weiterer Versuch zur Synchronisierung wird in einer Stunde oder beim nächsten Start der Anwendung durchgeführt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Dieser Artikel wurde durch eine benutzerdefinierte Vorlage vom Sync ausgeschlossen. Sie können diese Art von Benachrichtigung in den Einstellungen deaktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Dieses Element wurde von der Synchronisierung ausgeschlossen, da es sich um einen Hardlink handelt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Dieser Artikel ist derzeit von einem anderen Benutzer online gesperrt.&lt;br&gt;Wir werden später erneut versuchen, Ihre Änderungen hochzuladen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Synchronisierungsfehler.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Zugriff auf Element nicht möglich.&lt;br&gt;Bitte korrigieren Sie die Lese- und Schreibberechtigungen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Systemfehler.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Das Element existiert bereits auf der anderen Seite.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Es ist ein technischer Fehler aufgetreten.&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Diese Synchronisierung wird gelöscht.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Diese Synchronisierung wird gelöscht.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Zurück zur Laufwerksliste</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Einstellungen</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Zurück zur Laufwerksliste</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Einstellungen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Allgemein</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Dunkles Thema aktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Einfarbige Schaltflächen aktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>kDrive beim Start öffnen</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finnisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Niederländisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Erweitert</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Debugging-Informationen</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Auszuschliessende Dateien</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Proxy-Server</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Schwedisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugiesisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polnisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norwegisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Dänisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Griechisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Ordner %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Ungültiger Link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Sprache</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Ein Prozess ist fehlgeschlagen.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Gelöschte Dateien in den Papierkorb meines Computers verschieben</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Einige Dateien oder Ordner werden möglicherweise nicht in den Papierkorb des Computers verschoben.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Sie können bereits synchronisierte Dateien jederzeit aus dem Papierkorb der kDrive-Webanwendung abrufen.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Englisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Französisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Deutsch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Spanisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italienisch</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Standard</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Allgemein</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Dunkles Thema aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Einfarbige Schaltflächen aktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>kDrive beim Start öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finnisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Niederländisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Erweitert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Debugging-Informationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Auszuschliessende Dateien</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Proxy-Server</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Schwedisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugiesisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polnisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norwegisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Dänisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Griechisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Ordner %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Ungültiger Link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Sprache</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Ein Prozess ist fehlgeschlagen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Gelöschte Dateien in den Papierkorb meines Computers verschieben</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Einige Dateien oder Ordner werden möglicherweise nicht in den Papierkorb des Computers verschoben.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Sie können bereits synchronisierte Dateien jederzeit aus dem Papierkorb der kDrive-Webanwendung abrufen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Englisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Französisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Deutsch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Spanisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italienisch</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 wird verwendet</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 wird verwendet</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S) Proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Proxy-Server</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Kein Proxy-Server</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Systemeinstellungen verwenden</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Proxy-Server manuell eingeben</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Port</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Adresse des Proxy-Servers</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Authentifizierung erforderlich</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Benutzer</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Kennwort</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>SPEICHERN</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Wollen Sie Ihre Änderungen speichern?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Speichern nicht möglich, es wurden nicht alle Pflichtfelder ausgefüllt!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy-Server nicht gefunden – trotzdem speichern?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S) Proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxy-Server</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Kein Proxy-Server</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Systemeinstellungen verwenden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Proxy-Server manuell eingeben</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adresse des Proxy-Servers</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Authentifizierung erforderlich</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Benutzer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Kennwort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wollen Sie Ihre Änderungen speichern?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Speichern nicht möglich, es wurden nicht alle Pflichtfelder ausgefüllt!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy-Server nicht gefunden – trotzdem speichern?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Ressourcenmanager</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Maximal zulässige CPU-Auslastung</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>SPEICHERN</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Wollen Sie Ihre Änderungen speichern?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Ressourcenmanager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maximal zulässige CPU-Auslastung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>SPEICHERN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Wollen Sie Ihre Änderungen speichern?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Ordner auf Ihrem kDrive auswählen</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Der Inhalt des ausgewählten Ordners wird in dem &lt;b&gt;%1&lt;/b&gt; Ordner synchronisiert.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>FORTFAHREN</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Auf Ihrem Rechner für den aktuellen Ordner verfügbarer Speicherplatz: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Dieser Ordner wird bereits synchronisiert.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>BESTÄTIGEN</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ABBRECHEN</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Ordner auf Ihrem kDrive auswählen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Der Inhalt des ausgewählten Ordners wird in dem &lt;b&gt;%1&lt;/b&gt; Ordner synchronisiert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>FORTFAHREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Auf Ihrem Rechner für den aktuellen Ordner verfügbarer Speicherplatz: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Dieser Ordner wird bereits synchronisiert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BESTÄTIGEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ABBRECHEN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Der &lt;b&gt;%1&lt;/b&gt; Ordner enthält Unterordner,&lt;br&gt; wählen Sie diejenigen aus, die Sie synchronisieren möchten</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>FORTFAHREN</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Der &lt;b&gt;%1&lt;/b&gt; Ordner enthält Unterordner,&lt;br&gt; wählen Sie diejenigen aus, die Sie synchronisieren möchten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>FORTFAHREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Setzen Sie die Synchronisierung von kDrive „%1“ fort</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Setzen Sie die Synchronisierung aller kDrives fort</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Unterbrechen Sie die Synchronisierung von kDrive „%1“</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Synchronisierung anhalten</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Unterbrechen Sie die Synchronisierung aller kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Synchronisierung fortsetzen</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Setzen Sie die Synchronisierung von kDrive „%1“ fort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Setzen Sie die Synchronisierung aller kDrives fort</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Unterbrechen Sie die Synchronisierung von kDrive „%1“</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Synchronisierung anhalten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Unterbrechen Sie die Synchronisierung aller kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Synchronisierung fortsetzen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Link zur Freigabe kopieren</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Anzeigen auf kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>In Ordner anzeigen</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Weitere Aktionen</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Öffnen</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Zu Favoriten hinzufügen</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Link zur Freigabe kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Anzeigen auf kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>In Ordner anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Weitere Aktionen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Zu Favoriten hinzufügen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Nie</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>1 Stunde lang</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Bis morgen 8 Uhr</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>3 Tage lang</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>1 Woche lang</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Immer</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Für 1 weitere Stunde</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Für weitere 3 Tage</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Für 1 weitere Woche</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Im Ordner öffnen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Webversion %1 öffnen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Drive-Einstellungen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Benachrichtigungen deaktiviert bis %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Benachrichtigungen deaktivieren</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Anwendungseinstellungen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Hilfe benötigt</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Senden Sie Feedback</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>kDrive beenden</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Zugang zu Website %1 nicht möglich.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Fehler und Informationen anzeigen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Informationen anzeigen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Weitere Aktionen</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>1 Stunde lang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Bis morgen 8 Uhr</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>3 Tage lang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>1 Woche lang</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Immer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Für 1 weitere Stunde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Für weitere 3 Tage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Für 1 weitere Woche</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Im Ordner öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Webversion %1 öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drive-Einstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Benachrichtigungen deaktiviert bis %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Benachrichtigungen deaktivieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Anwendungseinstellungen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Hilfe benötigt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Senden Sie Feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>kDrive beenden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Zugang zu Website %1 nicht möglich.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Fehler und Informationen anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Informationen anzeigen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Weitere Aktionen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Aktualisieren Sie die kDrive-App</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Diese kDrive-App-Version wird nicht mehr unterstützt. Um auf die neuesten Funktionen und Verbesserungen zuzugreifen, aktualisieren Sie bitte.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Aktualisieren</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Bitte laden Sie die neueste Version auf der Website herunter.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Update-Download läuft</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Auf der Suche nach Updates...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Manuelles Update</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Nicht verfügbar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Sie können Dateien &lt;a style="%1" href="%2"&gt;von Ihrem Computer&lt;/a&gt; oder von &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt; synchronisieren.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synchronisiert</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoriten</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Aktivität</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Nicht implementiert!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/de/anwendungen/kdrive-herunterladen"&gt;Klicken Sie hier, um manuell herunterzuladen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Kein synchronisierter Ordner für diesen kDrive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Kein kDrive eingerichtet!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Link %1 kann nicht geöffnet werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Ungültiger Link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Aktualisieren Sie die kDrive-App</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Diese kDrive-App-Version wird nicht mehr unterstützt. Um auf die neuesten Funktionen und Verbesserungen zuzugreifen, aktualisieren Sie bitte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Aktualisieren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Bitte laden Sie die neueste Version auf der Website herunter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Update-Download läuft</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Auf der Suche nach Updates...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Manuelles Update</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Nicht verfügbar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Sie können Dateien &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;von Ihrem Computer&lt;/a&gt; oder von &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt; synchronisieren.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synchronisiert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoriten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Aktivität</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Nicht implementiert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/de/anwendungen/kdrive-herunterladen&quot;&gt;Klicken Sie hier, um manuell herunterzuladen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Kein synchronisierter Ordner für diesen kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Kein kDrive eingerichtet!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Link %1 kann nicht geöffnet werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Ungültiger Link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Die neue Version &lt;b&gt;%1&lt;/b&gt; des %2 Clients ist verfügbar und wurde heruntergeladen.&lt;/p&gt;&lt;p&gt;Die installierte Version ist %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Diese Version auslassen</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Später erinnern</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installieren</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Die neue Version &lt;b&gt;%1&lt;/b&gt; des %2 Clients ist verfügbar und wurde heruntergeladen.&lt;/p&gt;&lt;p&gt;Die installierte Version ist %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Diese Version auslassen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Später erinnern</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installieren</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Neues Update verfügbar.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Version %1 ist zum Download verfügbar.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Neues Update verfügbar.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Version %1 ist zum Download verfügbar.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Konto hinzufügen</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Konto hinzufügen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Versionshinweis anzeigen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Version</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>AKTUALISIEREN</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 ist auf dem neuesten Stand!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Überprüfe Update auf dem Server...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Ein Update ist verfügbar: %1.&lt;br&gt;Bitte laden Sie es &lt;a style="%2" href="%3"&gt;hier&lt;/a&gt; herunter.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Ein Update ist verfügbar: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Herunterladen von %1. Bitte warten…</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Es konnte nicht nach neuen Updates gesucht werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Während der Aktualisierung ist ein Fehler aufgetreten.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Das Update konnte nicht heruntergeladen werden.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Update deaktiviert.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Beta-Programm</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Frühzeitiger Zugang zu neuen Versionen der Anwendung</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Beitreten</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Ändern Sie</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Beenden</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Versionshinweis anzeigen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>AKTUALISIEREN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 ist auf dem neuesten Stand!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Überprüfe Update auf dem Server...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Ein Update ist verfügbar: %1.&lt;br&gt;Bitte laden Sie es &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt; herunter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Ein Update ist verfügbar: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Herunterladen von %1. Bitte warten…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Es konnte nicht nach neuen Updates gesucht werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Während der Aktualisierung ist ein Fehler aufgetreten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Das Update konnte nicht heruntergeladen werden.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Update deaktiviert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Beta-Programm</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Frühzeitiger Zugang zu neuen Versionen der Anwendung</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Beitreten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Ändern Sie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Beenden</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Die Parameter konnten nicht gespeichert werden. Bitte versuchen Sie es später noch einmal.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Einstellungen können nicht gespeichert werden!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Der übergeordnete Ordner ist ein Sync-Ordner oder befindet sich in einem / einer</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Kann keinen gültigen Pfad finden</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Kein gültiger Ordner ausgewählt!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Der ausgewählte Pfad existiert nicht!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Der ausgewählte Pfad ist kein Ordner!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Der lokale Ordner %1 ist bereits synchronisiert. Bitte wählen Sie einen anderen!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync (Beta) ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync (Beta) ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Lokal verfügbar machen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Lokalen Speicherplatz freigeben</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Lokalen Speicherplatz freigeben abbrechen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Lokal verfügbar machen abbrechen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Öffentlichen Freigabelink kopieren</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Link zur privaten Freigabe kopieren</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Im Browser öffnen</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Die Parameter konnten nicht gespeichert werden. Bitte versuchen Sie es später noch einmal.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Einstellungen können nicht gespeichert werden!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Der übergeordnete Ordner ist ein Sync-Ordner oder befindet sich in einem / einer</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kann keinen gültigen Pfad finden</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Kein gültiger Ordner ausgewählt!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Der ausgewählte Pfad existiert nicht!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Der ausgewählte Pfad ist kein Ordner!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Der lokale Ordner %1 ist bereits synchronisiert. Bitte wählen Sie einen anderen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync (Beta) ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync (Beta) ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Lokal verfügbar machen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Lokalen Speicherplatz freigeben</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Lokalen Speicherplatz freigeben abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Lokal verfügbar machen abbrechen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Öffentlichen Freigabelink kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Link zur privaten Freigabe kopieren</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Im Browser öffnen</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>Die kDrive-Anwendung wird aufgrund eines schwerwiegenden Fehlers geschlossen.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>Die kDrive-Anwendung wird aufgrund eines schwerwiegenden Fehlers geschlossen.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n Jahr(e)</numerusform>
-<numerusform>%n Jahr(e)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n Monat(e)</numerusform>
-<numerusform>%n Monat(e)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n Tag(e)</numerusform>
-<numerusform>%n Tag(e)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n Stunde(n)</numerusform>
-<numerusform>%n Stunde(n)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n Minute(n)</numerusform>
-<numerusform>%n Minute(n)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n Sekunde(n)</numerusform>
-<numerusform>%n Sekunde(n)</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n Jahr(e)</numerusform>
+            <numerusform>%n Jahr(e)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n Monat(e)</numerusform>
+            <numerusform>%n Monat(e)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n Tag(e)</numerusform>
+            <numerusform>%n Tag(e)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n Stunde(n)</numerusform>
+            <numerusform>%n Stunde(n)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n Minute(n)</numerusform>
+            <numerusform>%n Minute(n)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n Sekunde(n)</numerusform>
+            <numerusform>%n Sekunde(n)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Systemleiste nicht verfügbar</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer“ und versuchen Sie es erneut.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Systemleiste nicht verfügbar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer“ und versuchen Sie es erneut.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Konnte Browser nicht öffnen</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Die URL %1 konnte aufgrund eines Fehlers nicht aufgerufen werden. Ist vielleicht kein Standard-Browser konfiguriert?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Die E-Mail-Anwendung konnte nicht geöffnet werden</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Beim Öffnen der E-Mail-Anwendung für das Erstellen einer neuen Nachricht ist ein Fehler aufgetreten. Ist vielleicht keine E-Mail-Anwendung konfiguriert?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Sie sind nicht mehr verbunden. &lt;a style="%1" href="%2"&gt;Einloggen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Konnte Browser nicht öffnen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Die URL %1 konnte aufgrund eines Fehlers nicht aufgerufen werden. Ist vielleicht kein Standard-Browser konfiguriert?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Die E-Mail-Anwendung konnte nicht geöffnet werden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Beim Öffnen der E-Mail-Anwendung für das Erstellen einer neuen Nachricht ist ein Fehler aufgetreten. Ist vielleicht keine E-Mail-Anwendung konfiguriert?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Sie sind nicht mehr verbunden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Einloggen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Kein Ordner zum Synchronisieren
+        <translation>Kein Ordner zum Synchronisieren
 Sie können eines über die kDrive-Einstellungen hinzufügen.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synchronisierung läuft (%1 von %2)
+        <translation>Synchronisierung läuft (%1 von %2)
 %3 übrig...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synchronisierung läuft (Schritt %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synchronisierung läuft.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Einige Dateien konnten nicht synchronisiert werden. &lt;a style="%1" href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synchronisierung angehalten…</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da eine andere Synchronisierung denselben Ordner verwendet.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er den synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthält.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er im synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthalten ist.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisierungsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner aus.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synchronisierung beginnt</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synchronisierung angehalten.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synchronisierung läuft (%1 von %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Sie sind auf dem neuesten Stand, ungelöste Konflikte.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Sie sind auf dem neuesten Stand!</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synchronisierung läuft (Schritt %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synchronisierung läuft.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Einige Dateien konnten nicht synchronisiert werden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synchronisierung angehalten…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da eine andere Synchronisierung denselben Ordner verwendet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er den synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthält.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er im synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthalten ist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisierungsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner aus.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synchronisierung beginnt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synchronisierung angehalten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synchronisierung läuft (%1 von %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Sie sind auf dem neuesten Stand, ungelöste Konflikte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Sie sind auf dem neuesten Stand!</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_de.ts
+++ b/translations/client_de.ts
@@ -1,2582 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="de_DE">
+<TS language="de_DE" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Über</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">SCHLIESSEN</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Version %1. Weitere Informationen unter &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Vertrieb durch %1 und lizenziert unter &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 und das %2-Logo sind eingetragene Marken von %1. &lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Ordner %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Erstellt aus &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-Quellen&lt;/a&gt; am %2 um %3 mit Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Über</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>SCHLIESSEN</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Version %1. Weitere Informationen unter &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Vertrieb durch %1 und lizenziert unter &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 und das %2-Logo sind eingetragene Marken von %1. &lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Ordner %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Erstellt aus &lt;a style="color: #489EF3" href="%1"&gt;Git-Quellen&lt;/a&gt; am %2 um %3 mit Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Die Synchronisierung beginnt, und Sie können Dateien zu Ihrem %1 Ordner hinzufügen.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Ihr kDrive ist bereit!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ORDNER ÖFFNEN</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">EINSTELLUNGEN</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Weiteres Laufwerk synchronisieren</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Die Synchronisierung beginnt, und Sie können Dateien zu Ihrem %1 Ordner hinzufügen.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Ihr kDrive ist bereit!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ORDNER ÖFFNEN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>EINSTELLUNGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Weiteres Laufwerk synchronisieren</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">WEITER</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Wählen Sie den zu synchronisierenden kDrive</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">kDrive kostenlos herunterladen</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Speichern Sie Ihre Bilder, Dokumente und E-Mails in der Schweiz bei einem unabhängigen Unternehmen mit Achtung der Privatsphäre. Mehr erfahren</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Kostenlos testen</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>WEITER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Wählen Sie den zu synchronisierenden kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>kDrive kostenlos herunterladen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Speichern Sie Ihre Bilder, Dokumente und E-Mails in der Schweiz bei einem unabhängigen Unternehmen mit Achtung der Privatsphäre. Mehr erfahren</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Kostenlos testen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Bewahren Sie Ihren Rechnerspeicherplatz</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Entscheiden Sie, welche Dateien online oder lokal verfügbar sein sollen</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">SPÄTER</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synchronisiert alle Ihre Dateien, ohne Ihren Rechnerspeicherplatz zu nutzen. Sie können die Dateien in Ihrem kDrive durchsuchen und jederzeit lokal herunterladen. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Möchten Sie Lite Sync aktivieren (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Möchten Sie Lite Sync aktivieren?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Bewahren Sie Ihren Rechnerspeicherplatz</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Entscheiden Sie, welche Dateien online oder lokal verfügbar sein sollen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>SPÄTER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synchronisiert alle Ihre Dateien, ohne Ihren Rechnerspeicherplatz zu nutzen. Sie können die Dateien in Ihrem kDrive durchsuchen und jederzeit lokal herunterladen. &lt;a style="%1" href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Möchten Sie Lite Sync aktivieren (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Möchten Sie Lite Sync aktivieren?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Ort Ihres %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Ordner bearbeiten</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ABSCHLIESSEN</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Ordner auswählen</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Der Inhalt des &lt;b&gt;%1&lt;/b&gt;-Ordners wird in Ihrem kDrive synchronisiert</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Alle Ihre Dateien befinden sich in diesem Ordner, sobald die Einrichtung abgeschlossen ist. Sie können dort neue Dateien ablegen und mit Ihrem kDrive synchronisieren.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Ort Ihres %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Ordner bearbeiten</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>ABSCHLIESSEN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Ordner auswählen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Der Inhalt des &lt;b&gt;%1&lt;/b&gt;-Ordners wird in Ihrem kDrive synchronisiert</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Alle Ihre Dateien befinden sich in diesem Ordner, sobald die Einrichtung abgeschlossen ist. Sie können dort neue Dateien ablegen und mit Ihrem kDrive synchronisieren.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
 Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deaktiviert.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTFAHREN</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Weitere Informationen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>FORTFAHREN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Melden Sie sich über Ihren Browser an.</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Ihr Browser sollte sich automatisch öffnen, um die Verbindung herzustellen. Sobald die Verbindung hergestellt ist, kehren Sie automatisch zu kDrive zurück.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Öffnen Sie die Anmeldeseite</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Login fehlgeschlagen: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Die Anmeldeseite konnte in Ihrem Webbrowser nicht geöffnet werden</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Melden Sie sich über Ihren Browser an.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Ihr Browser sollte sich automatisch öffnen, um die Verbindung herzustellen. Sobald die Verbindung hergestellt ist, kehren Sie automatisch zu kDrive zurück.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Öffnen Sie die Anmeldeseite</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Bei der Authentifizierung ist ein Fehler aufgetreten. Bitte schließen Sie das Anmeldefenster und versuchen Sie es erneut.&lt;br&gt;Wenn der Fehler weiterhin auftritt, kontaktieren Sie unser Support-Team.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Login fehlgeschlagen: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Die Anmeldeseite konnte in Ihrem Webbrowser nicht geöffnet werden</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">kDrive-Ordner für die Synchronisierung auf Ihrem Desktop wählen</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTFAHREN</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Auf Ihrem Rechner verfügbarer Speicherplatz: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Impossibile caricare l’elenco delle sottocartelle. Il tuo kDrive potrebbe essere in manutenzione.&lt;br&gt;Accedi alla &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>kDrive-Ordner für die Synchronisierung auf Ihrem Desktop wählen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>FORTFAHREN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Auf Ihrem Rechner verfügbarer Speicherplatz: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Impossibile caricare l’elenco delle sottocartelle. Il tuo kDrive potrebbe essere in manutenzione.&lt;br&gt;Accedi alla &lt;a style="%1" href="%2"&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Lokaler Ordner %1 konnte nicht erstellt werden</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Neue Synchronisierung konnte nicht erstellt werden</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">Der kDrive %1 wurde bereits auf diesem Computer synchronisiert. Trotzdem fortfahren?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Lokaler Ordner %1 konnte nicht erstellt werden</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>Der kDrive %1 wurde bereits auf diesem Computer synchronisiert. Trotzdem fortfahren?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-Client wird mit falschen Parametern ausgeführt!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">Der kDrive Client läuft bereits!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Der Benutzer %1 ist nicht angemeldet. Bitte melden Sie sich erneut an.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-Client wird mit falschen Parametern ausgeführt!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>Der kDrive Client läuft bereits!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Der Benutzer %1 ist nicht angemeldet. Bitte melden Sie sich erneut an.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Freigabelink in die Zwischenablage kopiert</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
-            <numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 wurde gelöscht.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
-            <numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 wurde hinzugefügt.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
-            <numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 wurde aktualisiert.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
-            <numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 wurde zu %2 verschoben.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synchronisierungsaktivität</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Freigabelink in die Zwischenablage kopiert</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
+<numerusform>%1 und %n andere Datei(en) wurde(n) gelöscht.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 wurde gelöscht.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
+<numerusform>%1 und %n andere Datei(en) wurde(n) hinzugefügt.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 wurde hinzugefügt.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
+<numerusform>%1 und %n andere Datei(en) wurde(n) aktualisiert.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 wurde aktualisiert.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
+<numerusform>%1 wurde zu %2 verschoben und %n andere Datei(en) wurde(n) verschoben.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 wurde zu %2 verschoben.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synchronisierungsaktivität</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Aktuell befinden sich keine Unterordner auf dem Server.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Beenden Sie das Beta-Programm</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Nehmen Sie am Beta-Programm teil</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Erhalten Sie frühzeitigen Zugang zu neuen Versionen der Anwendung, bevor sie für die Allgemeinheit freigegeben werden, und beteiligen Sie sich an der Verbesserung der Anwendung, indem Sie uns Ihre Kommentare schicken.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Profitieren Sie von Beta-Updates für Anwendungen</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Nein</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Öffentliche Beta-Version</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Interne Betaversion</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Testversion</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Ich verstehe</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Sind Sie sicher, dass Sie das Beta-Programm verlassen wollen?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Speichern</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Ihre aktuelle Version der Anwendung ist möglicherweise zu aktuell. Ihre Auswahl wird ab dem nächsten verfügbaren Update wirksam.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Beta-Versionen können unerwartet verlassen werden oder Instabilitäten verursachen.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Beenden Sie das Beta-Programm</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Nehmen Sie am Beta-Programm teil</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Erhalten Sie frühzeitigen Zugang zu neuen Versionen der Anwendung, bevor sie für die Allgemeinheit freigegeben werden, und beteiligen Sie sich an der Verbesserung der Anwendung, indem Sie uns Ihre Kommentare schicken.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Profitieren Sie von Beta-Updates für Anwendungen</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Nein</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Öffentliche Beta-Version</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Interne Betaversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Testversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Ich verstehe</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Sind Sie sicher, dass Sie das Beta-Programm verlassen wollen?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Speichern</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Ihre aktuelle Version der Anwendung ist möglicherweise zu aktuell. Ihre Auswahl wird ab dem nächsten verfügbaren Update wirksam.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Beta-Versionen können unerwartet verlassen werden oder Instabilitäten verursachen.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Bitte melden Sie sich an</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Ordner %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Es wurden keine Synchronisierungsordner konfiguriert.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Synthese</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Einstellungen</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Beenden</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Undefinierter Zustand.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Synchronisierung ausstehend.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synchronisierung läuft.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synchronisierung war erfolgreich, ungelöste Konflikte.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Die letzte Synchronisierung war erfolgreich.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Benutzer-Abbruch.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synchronisierung wurde angehalten.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synchronisierung wurde angehalten)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">ALLE SYNC. ENTFERNEN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 Elemente wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt; gelöscht. Um unbeabsichtigte Löschungen zu vermeiden, wurde die Synchronisierung pausiert.&lt;br&gt;Möchten Sie diese Löschungen auf Ihr kDrive übertragen?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Mehrere Dateien wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt; gelöscht. Gelöschte Dateien finden Sie im &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;Papierkorb&lt;/a&gt; von kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Nicht mehr anzeigen</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Synchronisierungen konnten nicht gestartet werden!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Der kDrive-Client kann nicht initialisiert werden</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Konflikt(e) bei %1 Element(en) im Synchronisierungsordner %2 konnten nicht behoben werden</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synchronisierung wird angehalten</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Bitte melden Sie sich an</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Ordner %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Es wurden keine Synchronisierungsordner konfiguriert.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Synthese</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Einstellungen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Beenden</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Undefinierter Zustand.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Synchronisierung ausstehend.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synchronisierung läuft.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synchronisierung war erfolgreich, ungelöste Konflikte.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Die letzte Synchronisierung war erfolgreich.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Benutzer-Abbruch.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synchronisierung wurde angehalten.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synchronisierung wurde angehalten)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Möchten Sie die Synchronisierungen des Kontos &lt;i&gt;%1&lt;/i&gt; wirklich entfernen?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Dadurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>ALLE SYNC. ENTFERNEN</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 Elemente wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt; gelöscht. Um unbeabsichtigte Löschungen zu vermeiden, wurde die Synchronisierung pausiert.&lt;br&gt;Möchten Sie diese Löschungen auf Ihr kDrive übertragen?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Mehrere Dateien wurden aus Ihrem lokalen Synchronisierungsordner &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt; gelöscht. Gelöschte Dateien finden Sie im &lt;a style="%1" href="%3"&gt;Papierkorb&lt;/a&gt; von kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Nicht mehr anzeigen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Synchronisierungen konnten nicht gestartet werden!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Der kDrive-Client kann nicht initialisiert werden</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Konflikt(e) bei %1 Element(en) im Synchronisierungsordner %2 konnten nicht behoben werden</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synchronisierung wird angehalten</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Zusammenfassung der Synchronisierung Ihrer lokalen Ordner</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Die Inhalte des Ordners auf Ihrem Rechner werden mit dem Ordner des ausgewählten kDrive synchronisiert und umgekehrt.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNCHRONISIEREN</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Zusammenfassung der Synchronisierung Ihrer lokalen Ordner</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Die Inhalte des Ordners auf Ihrem Rechner werden mit dem Ordner des ausgewählten kDrive synchronisiert und umgekehrt.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNCHRONISIEREN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Vor der Fertigstellung</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Stellen Sie mit den nächsten Schritten sicher, dass Lite Sync auf Ihrem Rechner ordnungsgemäss funktioniert, und schliessen Sie die Einrichtung des kDrive ab.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öffnen Sie die &lt;b&gt;Allgemeinen Einstellungen&lt;/b&gt; Ihres Macs oder &lt;a style=%1 href=%2&gt;klicken Sie hier&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öffnen Sie die &lt;b&gt;Datenschutz- und Sicherheitseinstellungen&lt;/b&gt; Ihres Mac oder &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicken Sie hier&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Gehen Sie zum Abschnitt &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; und dann zu &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Autorisieren Sie die kDrive-Anwendung</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Gehen Sie zum Bereich &lt;b&gt;&quot;Sicherheit&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Autorisieren Sie die kDrive-Anwendung in dem Feld, in dem angezeigt wird, dass kDrive blockiert wurde</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Öffnen Sie das Vorhängeschloss &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; und autorisieren Sie die kDrive-Anwendung</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Gehen Sie zum Abschnitt &lt;b&gt;Datenschutz und Sicherheit&quot;&lt;/b&gt; und klicken Sie auf &lt;b&gt;Voller Festplattenzugriff&quot;&lt;/b&gt; oder &lt;a style=%1 href=%2&gt;hier klicken&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öffnen Sie in den Einstellungen Sicherheit und Datenschutz den Reiter &lt;b&gt;&quot;Datenschutz&quot;&lt;/b&gt; oder &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicken Sie hier&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Setzen Sie ein Häkchen bei &quot;kDrive LiteSync Extension&quot; und dann bei &quot;kDrive.app&quot; (sofern noch nicht erfolgt)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Gegebenenfalls kann ein Neustart der App vorgeschlagen werden, bitte führen Sie diesen durch</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Setzen Sie das Häkchen bei &quot;kDrive LiteSync Extension&quot;(und bei &quot;kDrive.app&quot; sofern vorhanden) unter &lt;b&gt;&quot;Vollständiger Festplattenzgang&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">SCHRITT 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Erledigt)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">SCHRITT 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">DURCHGEFÜHRTE SCHRITTE</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ENDE</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Vor der Fertigstellung</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Stellen Sie mit den nächsten Schritten sicher, dass Lite Sync auf Ihrem Rechner ordnungsgemäss funktioniert, und schliessen Sie die Einrichtung des kDrive ab.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öffnen Sie die &lt;b&gt;Allgemeinen Einstellungen&lt;/b&gt; Ihres Macs oder &lt;a style=%1 href=%2&gt;klicken Sie hier&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öffnen Sie die &lt;b&gt;Datenschutz- und Sicherheitseinstellungen&lt;/b&gt; Ihres Mac oder &lt;a style="%1" href="%2"&gt;klicken Sie hier&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Gehen Sie zum Abschnitt &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; und dann zu &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Autorisieren Sie die kDrive-Anwendung</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Gehen Sie zum Bereich &lt;b&gt;"Sicherheit"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Autorisieren Sie die kDrive-Anwendung in dem Feld, in dem angezeigt wird, dass kDrive blockiert wurde</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Öffnen Sie das Vorhängeschloss &lt;img src=":/client/resources/icons/actions/lock.png"&gt; und autorisieren Sie die kDrive-Anwendung</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Gehen Sie zum Abschnitt &lt;b&gt;Datenschutz und Sicherheit"&lt;/b&gt; und klicken Sie auf &lt;b&gt;Voller Festplattenzugriff"&lt;/b&gt; oder &lt;a style=%1 href=%2&gt;hier klicken&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öffnen Sie in den Einstellungen Sicherheit und Datenschutz den Reiter &lt;b&gt;"Datenschutz"&lt;/b&gt; oder &lt;a style="%1" href="%2"&gt;klicken Sie hier&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Setzen Sie ein Häkchen bei "kDrive LiteSync Extension" und dann bei "kDrive.app" (sofern noch nicht erfolgt)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Gegebenenfalls kann ein Neustart der App vorgeschlagen werden, bitte führen Sie diesen durch</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Setzen Sie das Häkchen bei "kDrive LiteSync Extension"(und bei "kDrive.app" sofern vorhanden) unter &lt;b&gt;"Vollständiger Festplattenzgang"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>SCHRITT 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Erledigt)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>SCHRITT 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>DURCHGEFÜHRTE SCHRITTE</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>ENDE</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NEIN</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NEIN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Debugging-Informationen werden versendet</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Debugging-Informationen werden versendet</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Info</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Debuggen</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Warnung</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fehler</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Schwer</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Debugging-Einstellungen</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Debugging-Informationen in einem Ordner auf meinem Computer speichern (empfohlen)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Mithilfe dieser Informationen kann der IT-Support den Ursprung eines Vorfalls ermitteln.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Debug level</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Mit der Trace-Ebene können Sie den Umfang der aufgezeichneten Debugging-Informationen auswählen</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Das erweiterte vollständige Protokoll erfasst einen detaillierten Verlauf, der zum Debuggen verwendet werden kann. Die Aktivierung kann die kDrive-Anwendung verlangsamen.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Erweitertes vollständiges Protokoll</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Protokolle löschen, die älter als %1 Tage sind</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Geben Sie den Debug-Ordner für den Infomaniak-Support frei.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Die letzte Sitzung ist der Zeitraum seit dem letzten kDrive-Start.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Teilen Sie nur die letzte kDrive-Sitzung</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Wird geladen</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPEICHERN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Teilen fehlgeschlagen</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Überprüfen Sie, ob Sie angemeldet sind &lt;br&gt;2. Überprüfen Sie, ob Sie mindestens ein kDrive konfiguriert haben</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Verbindung unterbrochen)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Teilen Sie den Ordner mit SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Wir haben Ihr Protokoll &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt; automatisch komprimiert.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Übertragen Sie das Archiv mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Teilen Sie den Link mit &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translatorcomment>Letzte Hochladung am %1</translatorcomment>
-        <translation type="vanished">Letztes Hochladen von %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Die Freigabe wurde abgebrochen</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Das erweiterte vollständige Protokoll wird über die Umgebungsvariable KDRIVE_FORCE_EXTENDED_LOG aktiviert. Setzen Sie sie auf 0, um es zu deaktivieren.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Der gesamte Ordner ist groß (&gt; 100 MB) und kann einige Zeit für die Freigabe benötigen. Um die Freigabezeit zu reduzieren, empfehlen wir, nur die letzte kDrive-Sitzung freizugeben.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translatorcomment>ie: Letzte Hochladung am 29.01.24 um 13:04:06 Uhr</translatorcomment>
-        <translation type="vanished">%2.%1.%3 um %4:%5:%6 Uhr</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wollen Sie Ihre Änderungen speichern?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Ordner %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Teilen</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Teilen | Schritt 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Teilen | Schritt 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Stornieren...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Debuggen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Warnung</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Fehler</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Schwer</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Debugging-Einstellungen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Debugging-Informationen in einem Ordner auf meinem Computer speichern (empfohlen)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Mithilfe dieser Informationen kann der IT-Support den Ursprung eines Vorfalls ermitteln.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Debug level</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Mit der Trace-Ebene können Sie den Umfang der aufgezeichneten Debugging-Informationen auswählen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Das erweiterte vollständige Protokoll erfasst einen detaillierten Verlauf, der zum Debuggen verwendet werden kann. Die Aktivierung kann die kDrive-Anwendung verlangsamen.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Erweitertes vollständiges Protokoll</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Protokolle löschen, die älter als %1 Tage sind</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Geben Sie den Debug-Ordner für den Infomaniak-Support frei.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Die letzte Sitzung ist der Zeitraum seit dem letzten kDrive-Start.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Teilen Sie nur die letzte kDrive-Sitzung</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Wird geladen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>SPEICHERN</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Teilen fehlgeschlagen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Überprüfen Sie, ob Sie angemeldet sind &lt;br&gt;2. Überprüfen Sie, ob Sie mindestens ein kDrive konfiguriert haben</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Verbindung unterbrochen)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Teilen Sie den Ordner mit SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Wir haben Ihr Protokoll &lt;a style="%1" href="%2"&gt;hier&lt;/a&gt; automatisch komprimiert.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Übertragen Sie das Archiv mit &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Teilen Sie den Link mit &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translatorcomment>Letzte Hochladung am %1</translatorcomment>
+<translation>Letztes Hochladen von %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Die Freigabe wurde abgebrochen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Das erweiterte vollständige Protokoll wird über die Umgebungsvariable KDRIVE_FORCE_EXTENDED_LOG aktiviert. Setzen Sie sie auf 0, um es zu deaktivieren.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Der gesamte Ordner ist groß (&gt; 100 MB) und kann einige Zeit für die Freigabe benötigen. Um die Freigabezeit zu reduzieren, empfehlen wir, nur die letzte kDrive-Sitzung freizugeben.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translatorcomment>ie: Letzte Hochladung am 29.01.24 um 13:04:06 Uhr</translatorcomment>
+<translation>%2.%1.%3 um %4:%5:%6 Uhr</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Wollen Sie Ihre Änderungen speichern?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Ordner %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Teilen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Teilen | Schritt 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Teilen | Schritt 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Stornieren...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Ordner</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Benachrichtigungen</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Es wird eine Benachrichtigung angezeigt, sobald ein neuer Ordner synchronisiert oder geändert wurde</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Verbunden mit</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Wollen Sie die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt;wirklich beenden?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Hierdurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Dieser Vorgang kann je nach Größe des Ordners zwischen einigen Sekunden und einigen Minuten dauern.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Neue Synchronisierung des lokalen Ordners fehlgeschlagen!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Lite Sync-Aktivierung fehlgeschlagen.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Lite Sync-Deaktivierung fehlgeschlagen.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">VERBINDUNG FÜR ORDNERSYNC. ENTFERNEN</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Benachrichtigungen für diesen kDrive aktivieren</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synchronisierungsfehler und Informationen.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Lokalen Ordner synchronisieren</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Wollen Sie Lite Sync wirklich einschalten?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Wollen Sie Lite Sync wirklich ausschalten?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Sie haben nicht genug Speicherplatz, um alle Dateien auf Ihrem kDrive (%1 fehlt) zu synchronisieren. Wenn Sie Lite Sync ausschalten, müssen Sie die auf Ihrem Rechner zu synchronisierenden Ordner auswählen. Bis dahin wird die Synchronisierung Ihres kDrive ausgesetzt.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Wenn Sie Lite Sync deaktivieren, werden alle Dateien auf Ihren Computer heruntergeladen.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Neue Synchronisierung konnte nicht erstellt werden</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync aktiviert.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync ist deaktiviert.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Dieses Laufwerk wird gelöscht.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Element %1 kann nicht geöffnet werden</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt; konnte nicht beendet werden.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Entfernen Sie alle Synchronisierungen</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Suchen Sie in Ihrem kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Suche</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Ordner</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Benachrichtigungen</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Es wird eine Benachrichtigung angezeigt, sobald ein neuer Ordner synchronisiert oder geändert wurde</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Verbunden mit</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Wollen Sie die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt;wirklich beenden?&lt;br&gt;&lt;b&gt;Hinweis:&lt;/b&gt; Hierdurch werden &lt;b&gt;keine&lt;/b&gt; Dateien gelöscht.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Dieser Vorgang kann je nach Größe des Ordners zwischen einigen Sekunden und einigen Minuten dauern.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Neue Synchronisierung des lokalen Ordners fehlgeschlagen!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Lite Sync-Aktivierung fehlgeschlagen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Lite Sync-Deaktivierung fehlgeschlagen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>VERBINDUNG FÜR ORDNERSYNC. ENTFERNEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Beim Laden der Liste der Unterordner ist ein Fehler aufgetreten.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Benachrichtigungen für diesen kDrive aktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synchronisierungsfehler und Informationen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Lokalen Ordner synchronisieren</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Wollen Sie Lite Sync wirklich einschalten?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Wollen Sie Lite Sync wirklich ausschalten?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Sie haben nicht genug Speicherplatz, um alle Dateien auf Ihrem kDrive (%1 fehlt) zu synchronisieren. Wenn Sie Lite Sync ausschalten, müssen Sie die auf Ihrem Rechner zu synchronisierenden Ordner auswählen. Bis dahin wird die Synchronisierung Ihres kDrive ausgesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Wenn Sie Lite Sync deaktivieren, werden alle Dateien auf Ihren Computer heruntergeladen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Neue Synchronisierung konnte nicht erstellt werden</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync aktiviert.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync ist deaktiviert.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Dieses Laufwerk wird gelöscht.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Element %1 kann nicht geöffnet werden</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Die Synchronisierung des Ordners &lt;i&gt;%1&lt;/i&gt; konnte nicht beendet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Entfernen Sie alle Synchronisierungen</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Suchen Sie in Ihrem kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Suche</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Einen kDrive synchronisieren</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">kDrive hinzufügen</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Einen kDrive synchronisieren</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>kDrive hinzufügen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Lösen</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">In Konflikt stehende(s) Element(e)</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Artikel mit nicht unterstützten Zeichen</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Verlauf löschen</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Zu lösen</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Automatisch gelöst</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">Problem(e) gelöst</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">Problem(e) erkannt</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Lösen</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>In Konflikt stehende(s) Element(e)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Artikel mit nicht unterstützten Zeichen</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Verlauf löschen</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Zu lösen</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Automatisch gelöst</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>Problem(e) gelöst</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>Problem(e) erkannt</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synchronisierungskonflikte oder Fehler</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Fehler</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Zurück zu den Einstellungen</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synchronisierungskonflikte oder Fehler</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Fehler</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Zurück zu den Einstellungen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Einige Dateien auf dem / den folgenden kDrive(s) konnten nicht synchronisiert werden:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 Fehler)</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 Informationen(n))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 Fehler und %2 Informationen)</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
-            <numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Einige Dateien auf dem / den folgenden kDrive(s) konnten nicht synchronisiert werden:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 Fehler)</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 Informationen(n))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 Fehler und %2 Informationen)</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
+<numerusform>Generische Fehler (%n Warnung(en) oder Fehler)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Ausgeschlossene Dateien</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Fügen Sie Dateien oder Ordner hinzu, die auf Ihrem Rechner nicht synchronisiert werden.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Hinzufügen</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAME</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">WARNUNG</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPEICHERN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wollen Sie Ihre Änderungen speichern?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Ausschlussvorlage existiert bereits!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Möchten Sie wirklich löschen?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Änderungen können nicht gespeichert werden!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Ausgeschlossene Dateien</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Fügen Sie Dateien oder Ordner hinzu, die auf Ihrem Rechner nicht synchronisiert werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Hinzufügen</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NAME</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>WARNUNG</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>SPEICHERN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Wollen Sie Ihre Änderungen speichern?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Ausschlussvorlage existiert bereits!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Möchten Sie wirklich löschen?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Änderungen können nicht gespeichert werden!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Konflikt(e) lösen</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Was möchten Sie mit %1 in Konflikt stehenden Elementen tun?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Meine Änderungen speichern und die Versionen anderer Benutzer ersetzen.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Meine Änderungen rückgängig machen und die Versionen anderer Benutzer behalten.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Ihre Änderungen können unwiederbringlich gelöscht werden. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Ihre Änderungen werden dauerhaft gelöscht. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Artikel anzeigen</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">An diesen Dateien wurden von mehreren Benutzern an mehreren Orten (online auf kDrive, auf einem Computer oder einem Mobiltelefon) Änderungen vorgenommen. Ordner, die diese Dateien enthalten, wurden möglicherweise auch gelöscht.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Die lokale Version Ihres Artikels ist &lt;b&gt;nicht mit kDrive synchronisiert&lt;/b&gt;. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Konflikt(e) lösen</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Was möchten Sie mit %1 in Konflikt stehenden Elementen tun?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Meine Änderungen speichern und die Versionen anderer Benutzer ersetzen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Meine Änderungen rückgängig machen und die Versionen anderer Benutzer behalten.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Ihre Änderungen können unwiederbringlich gelöscht werden. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Ihre Änderungen werden dauerhaft gelöscht. Sie können über die kDrive-Webanwendung nicht wiederhergestellt werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Artikel anzeigen</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>An diesen Dateien wurden von mehreren Benutzern an mehreren Orten (online auf kDrive, auf einem Computer oder einem Mobiltelefon) Änderungen vorgenommen. Ordner, die diese Dateien enthalten, wurden möglicherweise auch gelöscht.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Die lokale Version Ihres Artikels ist &lt;b&gt;nicht mit kDrive synchronisiert&lt;/b&gt;. &lt;a style="color: #489EF3" href="%1"&gt;Weitere Informationen&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Weitere Aktionen</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synchronisiert in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Lite Sync aktivieren</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Lite Sync aktivieren (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Nicht ausgewählte Ordner werden in den Papierkorb verschoben, sofern sie Offline-Elemente enthalten. Mit kDrive synchronisierte Ordner bleiben online verfügbar.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Nicht ausgewählte Ordner werden in den Papierkorb verschoben. Mit kDrive synchronisierte Ordner bleiben weiterhin online verfügbar.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Nicht ausgewählte Ordner werden &lt;b&gt;permanent&lt;/b&gt; vom Computer gelöscht. Ordner, die mit kDrive synchronisiert wurden, bleiben online verfügbar.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Abbrechen</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Synchronisierung anhalten</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Lite Sync deaktivieren</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Synchronisierung fortsetzen</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Synchronisierung entfernen</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Weitere Aktionen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synchronisiert in &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Lite Sync aktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Lite Sync aktivieren (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben, sofern sie Offline-Elemente enthalten. Mit kDrive synchronisierte Ordner bleiben online verfügbar.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Nicht ausgewählte Ordner werden in den Papierkorb verschoben. Mit kDrive synchronisierte Ordner bleiben weiterhin online verfügbar.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Nicht ausgewählte Ordner werden &lt;b&gt;permanent&lt;/b&gt; vom Computer gelöscht. Ordner, die mit kDrive synchronisiert wurden, bleiben online verfügbar.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Abbrechen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Synchronisierung anhalten</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Lite Sync deaktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Synchronisierung fortsetzen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Synchronisierung entfernen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Anwendungs-ID</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Name der Anwendung</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Anwendungs-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Name der Anwendung</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Einige Anwendungen wie Backup, Anti-Virus usw. greifen auf Ihre Dateien zu, sodass diese heruntergeladen werden, wenn sie &quot;online&quot; sind. Fügen Sie sie zur nachfolgenden Liste hinzu, um dieses Verhalten zu vermeiden.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Hinzufügen</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ANWENDUNGS-ID</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAME</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPEICHERN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wollen Sie Ihre Änderungen speichern?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Möchten Sie wirklich löschen?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Änderungen können nicht gespeichert werden!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Einige Anwendungen wie Backup, Anti-Virus usw. greifen auf Ihre Dateien zu, sodass diese heruntergeladen werden, wenn sie "online" sind. Fügen Sie sie zur nachfolgenden Liste hinzu, um dieses Verhalten zu vermeiden.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Hinzufügen</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ANWENDUNGS-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NAME</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>SPEICHERN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Wollen Sie Ihre Änderungen speichern?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Möchten Sie wirklich löschen?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Änderungen können nicht gespeichert werden!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Welchen Ordner auf Ihrem Rechner möchten Sie&lt;br&gt;synchronisieren?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Der Inhalt dieses Ordners wird auf dem kDrive synchronisiert</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Ordner auswählen</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Ordner bearbeiten</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTFAHREN</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Welchen Ordner auf Ihrem Rechner möchten Sie&lt;br&gt;synchronisieren?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Der Inhalt dieses Ordners wird auf dem kDrive synchronisiert</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Ordner auswählen</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Ordner bearbeiten</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>FORTFAHREN</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Dieser Ordner ist nicht mit Lite Sync kompatibel.&lt;br&gt;
 Bitte wählen Sie einen anderen Ordner. Wenn Sie fortfahren, wird Lite Sync deaktiviert.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Weitere Informationen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Ordner auswählen</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Weitere Informationen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Ordner auswählen</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fehler</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;kann nicht zum Schreiben geöffnet werden.&lt;br/&gt;&lt;br/&gt;Die Log-Datei kann &lt;b&gt;nicht&lt;/b&gt; gespeichert werden!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Fehler</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;File '%1'&lt;br/&gt;kann nicht zum Schreiben geöffnet werden.&lt;br/&gt;&lt;br/&gt;Die Log-Datei kann &lt;b&gt;nicht&lt;/b&gt; gespeichert werden!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Einstellungen</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Hilfe</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Einstellungen</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Hilfe</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Übertragung abgeschlossen!&lt;br&gt;Weitere Einzelheiten enthält der Identifier &lt;b&gt;%1&lt;/b&gt; in den Fehlerberichten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Übertragung fehlgeschlagen!
-Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu senden: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Kein kDrive eingerichtet!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ein technischer Fehler ist aufgetreten (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf und kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Es scheint, dass Ihre Netzwerkverbindung mit einem zu niedrigen Timeout konfiguriert ist, als dass die Anwendung ordnungsgemäß funktionieren könnte (Fehler %1).&lt;br&gt;Bitte überprüfen Sie Ihre Netzwerkkonfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Es kann keine Verbindung zum kDrive-Server hergestellt werden (Fehler %1).&lt;br&gt;Es wird versucht, die Verbindung wiederherzustellen. Bitte überprüfen Sie Ihre Internetverbindung und Ihre Firewall.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Bitte melden Sie sich erneut an. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Eine neue Version der Anwendung ist verfügbar.&lt;br&gt;Bitte aktualisieren Sie die Anwendung, um sie weiterhin verwenden zu können.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Das Hochladen des Protokolls ist fehlgeschlagen (Fehler %1).&lt;br&gt;Bitte versuchen Sie es später erneut.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Auf den Synchronisierungsordner kann nicht mehr zugegriffen werden (Fehler %1).&lt;br&gt;Die Synchronisierung wird fortgesetzt, sobald auf den Ordner zugegriffen werden kann.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Der Synchronisationsordner wurde ersetzt oder verschoben, so dass die Synchronisation nicht mehr möglich ist (Fehler %1).&lt;br&gt; Dies kann nach dem Kopieren, Verschieben oder Wiederherstellen des Ordners passieren.&lt;br&gt; Um das Problem zu beheben, erstellen Sie bitte eine neue Synchronisation mit einem neuen Ordner.&lt;br&gt;Hinweis: Wenn Sie nicht synchronisierte Änderungen im alten Ordner haben, müssen Sie diese manuell in den neuen Ordner kopieren.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Auf Ihrem Computer ist nicht mehr genügend Speicher vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive benötigt Schreibzugriff auf das temporäre Verzeichnis Ihres Computers. &lt;br&gt;Bitte starten Sie die kDrive-App neu, um dieses Problem zu beheben.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Es ist ein technischer Fehler aufgetreten. Die Synchronisierung wird so schnell wie möglich fortgesetzt. Bitte kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Die Anzahl der inotify-Überwachungen ist unzureichend (Fehler %1).&lt;br&gt;Sie können diese Anzahl erhöhen, indem Sie &apos;/etc/sysctl.conf&apos; bearbeiten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Synchronisierung kann nicht gestartet werden (Fehler %1).&lt;br&gt;Sie müssen Folgendes zulassen:&lt;br&gt;- kDrive in den Systemeinstellungen &gt;&gt; Allgemein &gt;&gt; Anmeldeobjekte und Erweiterungen &gt;&gt; Endpoint Security-Erweiterungen&lt;br&gt;- kDrive LiteSync-Erweiterung in den Systemeinstellungen &gt;&gt; Datenschutz und Sicherheit &gt;&gt; Vollständiger Festplattenzugriff.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Das Lite Sync-Plugin kann nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung installiert und der Windows-Suchdienst aktiviert ist.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung über die richtigen Berechtigungen verfügt und ausgeführt wird.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und kontaktieren Sie unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Der kDrive befindet sich im Wartungsmodus. Die &lt;br/&gt;Synchronisierung wird schnellstmöglich wieder aufgenommen. Bitte wenden Sie sich an unseren Support, sofern der Fehler weiterhin auftritt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte verlängern Sie kDrive. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte wenden Sie sich an einen Administrator, um den kDrive zu verlängern. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive wird gerade gestartet.&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der Webversion an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Sie sind nicht berechtigt, auf dieses kDrive zuzugreifen.&lt;br&gt;Die Synchronisierung wurde angehalten. Bitte wenden Sie sich an einen Administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Es ist ein technischer Fehler aufgetreten (Fehler %1).&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Die Netzwerkverbindungen wurden vom Kernel unterbrochen (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Leider konnte Ihre alte Konfiguration nicht migriert werden. &lt;br/&gt;Das Programm verwendet eine leere Konfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Leider konnte Ihre alte Proxy-Konfiguration nicht migriert werden, SOCKS5-Proxies werden derzeit nicht unterstützt. Stattdessen werden &lt;br/&gt;die System-Proxyeinstellungen verwendet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Ein technischer Fehler (Fehler %1) ist aufgetreten. Die &lt;br/&gt;Synchronisierung wurde neu gestartet. Bitte leeren Sie den Verlauf; sollte der Fehler weiterhin auftreten, dann wenden Sie sich an unseren Support.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Beim Zugriff auf die Synchronisierungsdatenbank ist ein Fehler aufgetreten (Fehler %1). Die &lt;br/&gt;Synchronisierung wurde angehalten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Token ungültig oder widerrufen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Verschachtelte Synchronisierungen sind verboten (Fehler %1).&lt;br&gt;Sie sollten nur Synchronisierungen behalten, deren Ordner nicht verschachtelt sind.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Der Synchronisationsordner auf dem entfernten kDrive existiert nicht mehr oder ist nicht mehr zugänglich (Fehler %1).&lt;br&gt;Sie müssen ihn wiederherstellen oder ihm wieder Zugriffsrechte geben oder die Synchronisation löschen/neu erstellen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Fehler beim Parsen des Dateinamens (Fehler %1).&lt;br&gt;Sonderzeichen wie doppelte Anführungszeichen, umgekehrte Schrägstriche oder Zeilenumbrüche können zu Parsingfehlern führen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Sie sind entweder nicht berechtigt, ein Element zu erstellen, oder es existiert bereits ein anderes Element mit demselben Namen. Das Element wurde ignoriert.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Es ist Ihnen nicht erlaubt, das Element nach &quot;%1&quot; zu verschieben.&lt;br&gt;Es wird in seinen ursprünglichen übergeordneten Ordner wiederhergestellt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Der Speicherplatz auf Ihrem Computer reicht nicht mehr aus.&lt;br&gt;Der Download wurde abgebrochen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Dieses Element wurde an einen anderen Ort verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Das lokale Element wurde umbenannt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Auf Ihrem Computer ist nicht mehr genügend Speicherplatz vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Die Datei wurde zur gleichen Zeit von einem anderen Benutzer geändert. &lt;br/&gt;Ihre Änderungen wurden in einer Kopie gespeichert.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Ein anderer Benutzer hat einen übergeordneten Ordner des Ziels verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Der Name des Elements enthält nur Leerzeichen.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Sie dürfen keine Elemente bearbeiten. &lt;br/&gt;Die Datei mit Ihren Änderungen wurde umbenannt und von der Synchronisierung ausgeschlossen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Sie dürfen das Element nicht umbenennen. &lt;br/&gt;Es wird mit seinem ursprünglichen Namen wiederhergestellt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Sie dürfen das Element nicht löschen. &lt;br/&gt;Es wird an seinem ursprünglichen Ort wiederhergestellt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Dieses Objekt konnte nicht in den Papierkorb verschoben werden, es wurde auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Die Datei wurde lokal geändert, während sie im entfernten kDrive gelöscht wurde.&lt;br&gt;Eine lokale Kopie wurde im Rettungsordner gespeichert (rescue folder).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Der Vorgang, der mit dem Artikel durchgeführt wurde, ist verboten.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Der für diesen Artikel durchgeführte Vorgang ist fehlgeschlagen.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Die Datei ist zu groß, um hochgeladen zu werden. Sie wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Es ist nicht möglich, die Datei herunterzuladen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Sie haben Ihr Kontingent überschritten. Erhöhen Sie Ihr Speicherplatzkontingent, um den Datei-Upload wieder zu aktivieren.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Das Laufwerk mit Ihrem Synchronisationsordner ist nicht mehr verbunden (Fehler %1).&lt;br&gt;Bitte verbinden Sie es erneut, um die Synchronisierung fortzusetzen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Synchronisierung konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Der LiteSyncExt-Prozess wird derzeit nicht ausgeführt. Die Synchronisierung wird fortgesetzt, sobald er gestartet ist.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ein vorhandenes Element hat einen identischen Namen mit derselben Groß- und Kleinschreibung (dieselbe Groß- und Kleinschreibung).&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Der Artikelname enthält ein nicht unterstütztes Zeichen.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Der Name des Elements endet mit einem Leerzeichen, was auf Ihrem Betriebssystem verboten ist.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Dieser Elementname ist von Ihrem Betriebssystem reserviert.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Der Artikelname ist zu lang.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Der Elementpfad ist zu lang.&lt;br&gt;Er wurde ignoriert.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Der Elementname enthält ein neues UNICODE-Zeichen, das von Ihrem Dateisystem noch nicht unterstützt wird.&lt;br&gt;Es wurde von der Synchronisierung ausgeschlossen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Synchronisierung dieses Elements fehlgeschlagen. Es wurde vorübergehend auf die Blacklist gesetzt.&lt;br&gt;Ein weiterer Versuch zur Synchronisierung wird in einer Stunde oder beim nächsten Start der Anwendung durchgeführt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Dieser Artikel wurde durch eine benutzerdefinierte Vorlage vom Sync ausgeschlossen. Sie können diese Art von Benachrichtigung in den Einstellungen deaktivieren</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Dieses Element wurde von der Synchronisierung ausgeschlossen, da es sich um einen Hardlink handelt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Dieser Artikel ist derzeit von einem anderen Benutzer online gesperrt.&lt;br&gt;Wir werden später erneut versuchen, Ihre Änderungen hochzuladen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Synchronisierungsfehler.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Zugriff auf Element nicht möglich.&lt;br&gt;Bitte korrigieren Sie die Lese- und Schreibberechtigungen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Datei %1 kann nicht erstellt werden, da sie von Ihrem Dateisystem nicht unterstützt wird.&lt;br&gt;Sie wurde von der Synchronisation ausgeschlossen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Systemfehler.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Das Element existiert bereits auf der anderen Seite.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Es ist ein technischer Fehler aufgetreten.&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Ordnerpfad %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Übertragung abgeschlossen!&lt;br&gt;Weitere Einzelheiten enthält der Identifier &lt;b&gt;%1&lt;/b&gt; in den Fehlerberichten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Übertragung fehlgeschlagen!
+Bitte verwenden Sie den folgenden Link, um die Protokolle an den Support zu senden: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Kein kDrive eingerichtet!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Ein technischer Fehler ist aufgetreten (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf und kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Es scheint, dass Ihre Netzwerkverbindung mit einem zu niedrigen Timeout konfiguriert ist, als dass die Anwendung ordnungsgemäß funktionieren könnte (Fehler %1).&lt;br&gt;Bitte überprüfen Sie Ihre Netzwerkkonfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Es kann keine Verbindung zum kDrive-Server hergestellt werden (Fehler %1).&lt;br&gt;Es wird versucht, die Verbindung wiederherzustellen. Bitte überprüfen Sie Ihre Internetverbindung und Ihre Firewall.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Bitte melden Sie sich erneut an. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Eine neue Version der Anwendung ist verfügbar.&lt;br&gt;Bitte aktualisieren Sie die Anwendung, um sie weiterhin verwenden zu können.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Das Hochladen des Protokolls ist fehlgeschlagen (Fehler %1).&lt;br&gt;Bitte versuchen Sie es später erneut.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Auf den Synchronisierungsordner kann nicht mehr zugegriffen werden (Fehler %1).&lt;br&gt;Die Synchronisierung wird fortgesetzt, sobald auf den Ordner zugegriffen werden kann.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Der Synchronisationsordner wurde ersetzt oder verschoben, so dass die Synchronisation nicht mehr möglich ist (Fehler %1).&lt;br&gt; Dies kann nach dem Kopieren, Verschieben oder Wiederherstellen des Ordners passieren.&lt;br&gt; Um das Problem zu beheben, erstellen Sie bitte eine neue Synchronisation mit einem neuen Ordner.&lt;br&gt;Hinweis: Wenn Sie nicht synchronisierte Änderungen im alten Ordner haben, müssen Sie diese manuell in den neuen Ordner kopieren.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Auf Ihrem Computer ist nicht mehr genügend Speicher vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive benötigt Schreibzugriff auf das temporäre Verzeichnis Ihres Computers. &lt;br&gt;Bitte starten Sie die kDrive-App neu, um dieses Problem zu beheben.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Es ist ein technischer Fehler aufgetreten. Die Synchronisierung wird so schnell wie möglich fortgesetzt. Bitte kontaktieren Sie unser Support-Team, falls der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Die Anzahl der inotify-Überwachungen ist unzureichend (Fehler %1).&lt;br&gt;Sie können diese Anzahl erhöhen, indem Sie '/etc/sysctl.conf' bearbeiten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Synchronisierung kann nicht gestartet werden (Fehler %1).&lt;br&gt;Sie müssen Folgendes zulassen:&lt;br&gt;- kDrive in den Systemeinstellungen &gt;&gt; Allgemein &gt;&gt; Anmeldeobjekte und Erweiterungen &gt;&gt; Endpoint Security-Erweiterungen&lt;br&gt;- kDrive LiteSync-Erweiterung in den Systemeinstellungen &gt;&gt; Datenschutz und Sicherheit &gt;&gt; Vollständiger Festplattenzugriff.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Das Lite Sync-Plugin kann nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung installiert und der Windows-Suchdienst aktiviert ist.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Überprüfen Sie, ob die Lite Sync-Erweiterung über die richtigen Berechtigungen verfügt und ausgeführt wird.&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Das Lite Sync-Plugin konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf, starten Sie neu und kontaktieren Sie unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Eine Datei oder ein Ordner in Ihrem Synchronisationsordner scheint beschädigt zu sein.&lt;br&gt;Die Synchronisation wurde gestoppt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Der kDrive befindet sich im Wartungsmodus. Die &lt;br/&gt;Synchronisierung wird schnellstmöglich wieder aufgenommen. Bitte wenden Sie sich an unseren Support, sofern der Fehler weiterhin auftritt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte verlängern Sie kDrive. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Der kDrive ist gesperrt. &lt;br/&gt;Bitte wenden Sie sich an einen Administrator, um den kDrive zu verlängern. Wenn keine Massnahmen ergriffen werden, werden die Daten dauerhaft gelöscht und können nicht wiederhergestellt werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive wird gerade gestartet.&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der &lt;a style="%1" href="%2"&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive befindet sich im Ruhemodus.&lt;br&gt;Melden Sie sich bei der Webversion an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Sie sind nicht berechtigt, auf dieses kDrive zuzugreifen.&lt;br&gt;Die Synchronisierung wurde angehalten. Bitte wenden Sie sich an einen Administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Es ist ein technischer Fehler aufgetreten (Fehler %1).&lt;br&gt;Die Synchronisierung wird so bald wie möglich fortgesetzt. Bitte wenden Sie sich an unser Support-Team, wenn der Fehler weiterhin besteht.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Die Netzwerkverbindungen wurden vom Kernel unterbrochen (Fehler %1).&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Leider konnte Ihre alte Konfiguration nicht migriert werden. &lt;br/&gt;Das Programm verwendet eine leere Konfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Leider konnte Ihre alte Proxy-Konfiguration nicht migriert werden, SOCKS5-Proxies werden derzeit nicht unterstützt. Stattdessen werden &lt;br/&gt;die System-Proxyeinstellungen verwendet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Ein technischer Fehler (Fehler %1) ist aufgetreten. Die &lt;br/&gt;Synchronisierung wurde neu gestartet. Bitte leeren Sie den Verlauf; sollte der Fehler weiterhin auftreten, dann wenden Sie sich an unseren Support.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Beim Zugriff auf die Synchronisierungsdatenbank ist ein Fehler aufgetreten (Fehler %1). Die &lt;br/&gt;Synchronisierung wurde angehalten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Es ist ein Anmeldeproblem aufgetreten (Fehler %1).&lt;br&gt;Token ungültig oder widerrufen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Verschachtelte Synchronisierungen sind verboten (Fehler %1).&lt;br&gt;Sie sollten nur Synchronisierungen behalten, deren Ordner nicht verschachtelt sind.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Der Synchronisationsordner auf dem entfernten kDrive existiert nicht mehr oder ist nicht mehr zugänglich (Fehler %1).&lt;br&gt;Sie müssen ihn wiederherstellen oder ihm wieder Zugriffsrechte geben oder die Synchronisation löschen/neu erstellen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Fehler beim Parsen des Dateinamens (Fehler %1).&lt;br&gt;Sonderzeichen wie doppelte Anführungszeichen, umgekehrte Schrägstriche oder Zeilenumbrüche können zu Parsingfehlern führen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Sie sind entweder nicht berechtigt, ein Element zu erstellen, oder es existiert bereits ein anderes Element mit demselben Namen. Das Element wurde ignoriert.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Es ist Ihnen nicht erlaubt, das Element nach "%1" zu verschieben.&lt;br&gt;Es wird in seinen ursprünglichen übergeordneten Ordner wiederhergestellt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Der Speicherplatz auf Ihrem Computer reicht nicht mehr aus.&lt;br&gt;Der Download wurde abgebrochen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Die Datei „%1“ kann nicht erstellt werden, da sie von Ihrem Dateisystem nicht unterstützt wird.&lt;br&gt;Sie wurde von der Synchronisierung ausgeschlossen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Dieses Element wurde an einen anderen Ort verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Das lokale Element wurde umbenannt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>An diesem Ort besteht bereits ein Element mit dem gleichen Namen. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Auf Ihrem Computer ist nicht mehr genügend Speicherplatz vorhanden.&lt;br&gt;Die Synchronisierung wurde gestoppt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Die Datei wurde zur gleichen Zeit von einem anderen Benutzer geändert. &lt;br/&gt;Ihre Änderungen wurden in einer Kopie gespeichert.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Ein anderer Benutzer hat einen übergeordneten Ordner des Ziels verschoben. &lt;br/&gt;Der lokale Vorgang wurde abgebrochen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Der Name des Elements enthält nur Leerzeichen.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Sie dürfen keine Elemente bearbeiten. &lt;br/&gt;Die Datei mit Ihren Änderungen wurde umbenannt und von der Synchronisierung ausgeschlossen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Sie dürfen das Element nicht umbenennen. &lt;br/&gt;Es wird mit seinem ursprünglichen Namen wiederhergestellt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Sie dürfen das Element nicht löschen. &lt;br/&gt;Es wird an seinem ursprünglichen Ort wiederhergestellt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Dieses Objekt konnte nicht in den Papierkorb verschoben werden, es wurde auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Die Datei wurde lokal geändert, während sie im entfernten kDrive gelöscht wurde.&lt;br&gt;Eine lokale Kopie wurde im Rettungsordner gespeichert (rescue folder).</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Der Vorgang, der mit dem Artikel durchgeführt wurde, ist verboten.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Der für diesen Artikel durchgeführte Vorgang ist fehlgeschlagen.&lt;br&gt;Der Artikel wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Die Datei ist zu groß, um hochgeladen zu werden. Sie wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Es ist nicht möglich, die Datei herunterzuladen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Sie haben Ihr Kontingent überschritten. Erhöhen Sie Ihr Speicherplatzkontingent, um den Datei-Upload wieder zu aktivieren.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Das Laufwerk mit Ihrem Synchronisationsordner ist nicht mehr verbunden (Fehler %1).&lt;br&gt;Bitte verbinden Sie es erneut, um die Synchronisierung fortzusetzen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Synchronisierung konnte nicht gestartet werden (Fehler %1).&lt;br&gt;Der LiteSyncExt-Prozess wird derzeit nicht ausgeführt. Die Synchronisierung wird fortgesetzt, sobald er gestartet ist.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Ein vorhandenes Element hat einen identischen Namen mit derselben Groß- und Kleinschreibung (dieselbe Groß- und Kleinschreibung).&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Der Artikelname enthält ein nicht unterstütztes Zeichen.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Der Name des Elements endet mit einem Leerzeichen, was auf Ihrem Betriebssystem verboten ist.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Dieser Elementname ist von Ihrem Betriebssystem reserviert.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Der Artikelname ist zu lang.&lt;br&gt;Er wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Der Elementpfad ist zu lang.&lt;br&gt;Er wurde ignoriert.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Der Elementname enthält ein neues UNICODE-Zeichen, das von Ihrem Dateisystem noch nicht unterstützt wird.&lt;br&gt;Es wurde von der Synchronisierung ausgeschlossen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Synchronisierung dieses Elements fehlgeschlagen. Es wurde vorübergehend auf die Blacklist gesetzt.&lt;br&gt;Ein weiterer Versuch zur Synchronisierung wird in einer Stunde oder beim nächsten Start der Anwendung durchgeführt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Dieser Artikel wurde durch eine benutzerdefinierte Vorlage vom Sync ausgeschlossen. Sie können diese Art von Benachrichtigung in den Einstellungen deaktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Dieses Element wurde von der Synchronisierung ausgeschlossen, da es sich um einen Hardlink handelt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Dieser Artikel ist derzeit von einem anderen Benutzer online gesperrt.&lt;br&gt;Wir werden später erneut versuchen, Ihre Änderungen hochzuladen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Synchronisierungsfehler.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Zugriff auf Element nicht möglich.&lt;br&gt;Bitte korrigieren Sie die Lese- und Schreibberechtigungen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Systemfehler.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Das Element existiert bereits auf der anderen Seite.&lt;br&gt;Es wurde vorübergehend auf die schwarze Liste gesetzt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Es ist ein technischer Fehler aufgetreten.&lt;br&gt;Bitte leeren Sie den Verlauf. Wenn der Fehler weiterhin besteht, wenden Sie sich an unser Support-Team.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Diese Synchronisierung wird gelöscht.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Diese Synchronisierung wird gelöscht.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Zurück zur Laufwerksliste</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Einstellungen</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Zurück zur Laufwerksliste</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Einstellungen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Allgemein</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Dunkles Thema aktivieren</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Einfarbige Schaltflächen aktivieren</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">kDrive beim Start öffnen</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finnisch</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Niederländisch</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Erweitert</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Debugging-Informationen</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Auszuschliessende Dateien</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxy-Server</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Schwedisch</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugiesisch</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polnisch</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norwegisch</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Dänisch</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Griechisch</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Ordner %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ungültiger Link %1.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Sprache</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Ein Prozess ist fehlgeschlagen.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Gelöschte Dateien in den Papierkorb meines Computers verschieben</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Einige Dateien oder Ordner werden möglicherweise nicht in den Papierkorb des Computers verschoben.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Sie können bereits synchronisierte Dateien jederzeit aus dem Papierkorb der kDrive-Webanwendung abrufen.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Englisch</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Französisch</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Deutsch</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Spanisch</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italienisch</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Standard</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Allgemein</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Dunkles Thema aktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Einfarbige Schaltflächen aktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>kDrive beim Start öffnen</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finnisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Niederländisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Erweitert</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Debugging-Informationen</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Debugging-Ordner öffnen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Auszuschliessende Dateien</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Proxy-Server</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Schwedisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugiesisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polnisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norwegisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Dänisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Griechisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Ordner %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Ungültiger Link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Sprache</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Ein Prozess ist fehlgeschlagen.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Gelöschte Dateien in den Papierkorb meines Computers verschieben</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Einige Dateien oder Ordner werden möglicherweise nicht in den Papierkorb des Computers verschoben.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Sie können bereits synchronisierte Dateien jederzeit aus dem Papierkorb der kDrive-Webanwendung abrufen.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Englisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Französisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Deutsch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Spanisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italienisch</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Standard</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 wird verwendet</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 wird verwendet</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S) Proxy</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxy-Server</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Kein Proxy-Server</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Systemeinstellungen verwenden</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Proxy-Server manuell eingeben</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Port</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Adresse des Proxy-Servers</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Authentifizierung erforderlich</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Benutzer</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Kennwort</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPEICHERN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wollen Sie Ihre Änderungen speichern?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Speichern nicht möglich, es wurden nicht alle Pflichtfelder ausgefüllt!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy-Server nicht gefunden – trotzdem speichern?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S) Proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Proxy-Server</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Kein Proxy-Server</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Systemeinstellungen verwenden</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Proxy-Server manuell eingeben</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Port</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Adresse des Proxy-Servers</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Authentifizierung erforderlich</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Benutzer</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Kennwort</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>SPEICHERN</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Wollen Sie Ihre Änderungen speichern?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Speichern nicht möglich, es wurden nicht alle Pflichtfelder ausgefüllt!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy-Server nicht gefunden – trotzdem speichern?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Ressourcenmanager</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Maximal zulässige CPU-Auslastung</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPEICHERN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wollen Sie Ihre Änderungen speichern?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Ressourcenmanager</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Maximal zulässige CPU-Auslastung</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>SPEICHERN</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Wollen Sie Ihre Änderungen speichern?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Ordner auf Ihrem kDrive auswählen</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Der Inhalt des ausgewählten Ordners wird in dem &lt;b&gt;%1&lt;/b&gt; Ordner synchronisiert.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTFAHREN</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Auf Ihrem Rechner für den aktuellen Ordner verfügbarer Speicherplatz: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Dieser Ordner wird bereits synchronisiert.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BESTÄTIGEN</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ABBRECHEN</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Ordner auf Ihrem kDrive auswählen</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Der Inhalt des ausgewählten Ordners wird in dem &lt;b&gt;%1&lt;/b&gt; Ordner synchronisiert.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>FORTFAHREN</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Auf Ihrem Rechner für den aktuellen Ordner verfügbarer Speicherplatz: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Dieser Ordner wird bereits synchronisiert.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>BESTÄTIGEN</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ABBRECHEN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Der &lt;b&gt;%1&lt;/b&gt; Ordner enthält Unterordner,&lt;br&gt; wählen Sie diejenigen aus, die Sie synchronisieren möchten</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTFAHREN</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Aktuell befinden sich keine Unterordner auf dem Server.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Der &lt;b&gt;%1&lt;/b&gt; Ordner enthält Unterordner,&lt;br&gt; wählen Sie diejenigen aus, die Sie synchronisieren möchten</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>FORTFAHREN</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Aktuell befinden sich keine Unterordner auf dem Server.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Setzen Sie die Synchronisierung von kDrive „%1“ fort</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Setzen Sie die Synchronisierung aller kDrives fort</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Unterbrechen Sie die Synchronisierung von kDrive „%1“</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Synchronisierung anhalten</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Unterbrechen Sie die Synchronisierung aller kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Synchronisierung fortsetzen</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Setzen Sie die Synchronisierung von kDrive „%1“ fort</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Setzen Sie die Synchronisierung aller kDrives fort</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Unterbrechen Sie die Synchronisierung von kDrive „%1“</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Synchronisierung anhalten</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Unterbrechen Sie die Synchronisierung aller kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Synchronisierung fortsetzen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Link zur Freigabe kopieren</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Anzeigen auf kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">In Ordner anzeigen</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Weitere Aktionen</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Öffnen</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Zu Favoriten hinzufügen</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Link zur Freigabe kopieren</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Anzeigen auf kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>In Ordner anzeigen</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Weitere Aktionen</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Öffnen</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Zu Favoriten hinzufügen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Nie</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">1 Stunde lang</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Bis morgen 8 Uhr</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">3 Tage lang</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">1 Woche lang</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Immer</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Für 1 weitere Stunde</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Für weitere 3 Tage</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Für 1 weitere Woche</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Ordner-URL %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Im Ordner öffnen</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Webversion %1 öffnen</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Drive-Einstellungen</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Benachrichtigungen deaktiviert bis %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Benachrichtigungen deaktivieren</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Anwendungseinstellungen</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Hilfe benötigt</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Senden Sie Feedback</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">kDrive beenden</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Zugang zu Website %1 nicht möglich.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Fehler und Informationen anzeigen</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Informationen anzeigen</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Weitere Aktionen</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Nie</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>1 Stunde lang</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Bis morgen 8 Uhr</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>3 Tage lang</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>1 Woche lang</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Immer</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Für 1 weitere Stunde</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Für weitere 3 Tage</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Für 1 weitere Woche</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Im Ordner öffnen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Webversion %1 öffnen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Drive-Einstellungen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Benachrichtigungen deaktiviert bis %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Benachrichtigungen deaktivieren</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Anwendungseinstellungen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Hilfe benötigt</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Senden Sie Feedback</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>kDrive beenden</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Zugang zu Website %1 nicht möglich.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Fehler und Informationen anzeigen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Informationen anzeigen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Weitere Aktionen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Aktualisieren Sie die kDrive-App</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Diese kDrive-App-Version wird nicht mehr unterstützt. Um auf die neuesten Funktionen und Verbesserungen zuzugreifen, aktualisieren Sie bitte.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Aktualisieren</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Bitte laden Sie die neueste Version auf der Website herunter.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Update-Download läuft</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Auf der Suche nach Updates...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Manuelles Update</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Nicht verfügbar</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Sie können Dateien &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;von Ihrem Computer&lt;/a&gt; oder von &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt; synchronisieren.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synchronisiert</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoriten</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Aktivität</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Nicht implementiert!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/de/anwendungen/kdrive-herunterladen&quot;&gt;Klicken Sie hier, um manuell herunterzuladen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Kein synchronisierter Ordner für diesen kDrive!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Kein kDrive eingerichtet!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Link %1 kann nicht geöffnet werden.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ungültiger Link %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Ordner-URL %1 kann nicht geöffnet werden.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Aktualisieren Sie die kDrive-App</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Diese kDrive-App-Version wird nicht mehr unterstützt. Um auf die neuesten Funktionen und Verbesserungen zuzugreifen, aktualisieren Sie bitte.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Aktualisieren</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Bitte laden Sie die neueste Version auf der Website herunter.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Update-Download läuft</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Auf der Suche nach Updates...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Manuelles Update</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Nicht verfügbar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Sie können Dateien &lt;a style="%1" href="%2"&gt;von Ihrem Computer&lt;/a&gt; oder von &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt; synchronisieren.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synchronisiert</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoriten</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Aktivität</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Nicht implementiert!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/de/anwendungen/kdrive-herunterladen"&gt;Klicken Sie hier, um manuell herunterzuladen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Kein synchronisierter Ordner für diesen kDrive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Kein kDrive eingerichtet!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Link %1 kann nicht geöffnet werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Ungültiger Link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Ordner-URL %1 kann nicht geöffnet werden.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Die neue Version &lt;b&gt;%1&lt;/b&gt; des %2 Clients ist verfügbar und wurde heruntergeladen.&lt;/p&gt;&lt;p&gt;Die installierte Version ist %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Diese Version auslassen</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Später erinnern</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installieren</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Die neue Version &lt;b&gt;%1&lt;/b&gt; des %2 Clients ist verfügbar und wurde heruntergeladen.&lt;/p&gt;&lt;p&gt;Die installierte Version ist %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Diese Version auslassen</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Später erinnern</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installieren</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Neues Update verfügbar.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Version %1 ist zum Download verfügbar.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Neues Update verfügbar.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Version %1 ist zum Download verfügbar.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Konto hinzufügen</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Konto hinzufügen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Versionshinweis anzeigen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Version</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">AKTUALISIEREN</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 ist auf dem neuesten Stand!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Überprüfe Update auf dem Server...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Ein Update ist verfügbar: %1.&lt;br&gt;Bitte laden Sie es &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt; herunter.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Ein Update ist verfügbar: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Herunterladen von %1. Bitte warten…</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Es konnte nicht nach neuen Updates gesucht werden.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Während der Aktualisierung ist ein Fehler aufgetreten.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Das Update konnte nicht heruntergeladen werden.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Update deaktiviert.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Beta-Programm</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Frühzeitiger Zugang zu neuen Versionen der Anwendung</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Beitreten</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Ändern Sie</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Beenden</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Versionshinweis anzeigen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Version</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>AKTUALISIEREN</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 ist auf dem neuesten Stand!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Überprüfe Update auf dem Server...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Ein Update ist verfügbar: %1.&lt;br&gt;Bitte laden Sie es &lt;a style="%2" href="%3"&gt;hier&lt;/a&gt; herunter.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Ein Update ist verfügbar: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Herunterladen von %1. Bitte warten…</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Es konnte nicht nach neuen Updates gesucht werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Während der Aktualisierung ist ein Fehler aufgetreten.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Das Update konnte nicht heruntergeladen werden.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Update deaktiviert.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Beta-Programm</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Frühzeitiger Zugang zu neuen Versionen der Anwendung</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Beitreten</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Ändern Sie</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Beenden</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Die Parameter konnten nicht gespeichert werden. Bitte versuchen Sie es später noch einmal.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Einstellungen können nicht gespeichert werden!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Der übergeordnete Ordner ist ein Sync-Ordner oder befindet sich in einem / einer</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Kann keinen gültigen Pfad finden</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Kein gültiger Ordner ausgewählt!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Der ausgewählte Pfad existiert nicht!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Der ausgewählte Pfad ist kein Ordner!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Der lokale Ordner %1 ist bereits synchronisiert. Bitte wählen Sie einen anderen!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync (Beta) ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync (Beta) ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Lokal verfügbar machen</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Lokalen Speicherplatz freigeben</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Lokalen Speicherplatz freigeben abbrechen</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Lokal verfügbar machen abbrechen</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Öffentlichen Freigabelink kopieren</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Link zur privaten Freigabe kopieren</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Im Browser öffnen</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Die Parameter konnten nicht gespeichert werden. Bitte versuchen Sie es später noch einmal.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Einstellungen können nicht gespeichert werden!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Der übergeordnete Ordner ist ein Sync-Ordner oder befindet sich in einem / einer</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Kann keinen gültigen Pfad finden</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Kein gültiger Ordner ausgewählt!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Der ausgewählte Pfad existiert nicht!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Der ausgewählte Pfad ist kein Ordner!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Sie haben keine Schreibberechtigung für den ausgewählten Ordner!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Der lokale Ordner %1 enthält einen bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Der lokale Ordner %1 befindet sich in einem bereits synchronisierten Ordner. Bitte wählen Sie einen anderen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Der lokale Ordner %1 ist bereits synchronisiert. Bitte wählen Sie einen anderen!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync (Beta) ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync (Beta) ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync ist aktiviert. Dateien von kDrive bleiben in der Cloud und nutzen nicht den Speicherplatz Ihres Computers.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync ist deaktiviert. Die kDrive-Dateien nutzen den Speicherplatz Ihres Computers.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Lokal verfügbar machen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Lokalen Speicherplatz freigeben</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Lokalen Speicherplatz freigeben abbrechen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Lokal verfügbar machen abbrechen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Die erneute Freigabe dieser Datei ist nicht erlaubt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Die erneute Freigabe dieses Ordners ist nicht erlaubt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Öffentlichen Freigabelink kopieren</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Link zur privaten Freigabe kopieren</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Im Browser öffnen</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">Die kDrive-Anwendung wird aufgrund eines schwerwiegenden Fehlers geschlossen.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>Die kDrive-Anwendung wird aufgrund eines schwerwiegenden Fehlers geschlossen.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Jahr(e)</numerusform>
-            <numerusform>%n Jahr(e)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Monat(e)</numerusform>
-            <numerusform>%n Monat(e)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Tag(e)</numerusform>
-            <numerusform>%n Tag(e)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Stunde(n)</numerusform>
-            <numerusform>%n Stunde(n)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Minute(n)</numerusform>
-            <numerusform>%n Minute(n)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n Sekunde(n)</numerusform>
-            <numerusform>%n Sekunde(n)</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n Jahr(e)</numerusform>
+<numerusform>%n Jahr(e)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n Monat(e)</numerusform>
+<numerusform>%n Monat(e)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n Tag(e)</numerusform>
+<numerusform>%n Tag(e)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n Stunde(n)</numerusform>
+<numerusform>%n Stunde(n)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n Minute(n)</numerusform>
+<numerusform>%n Minute(n)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n Sekunde(n)</numerusform>
+<numerusform>%n Sekunde(n)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Systemleiste nicht verfügbar</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer“ und versuchen Sie es erneut.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Systemleiste nicht verfügbar</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 benötigt eine funktionierende Systemablage (System Tray). Wenn Sie XFCE verwenden, folgen Sie bitte &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;diesen Anweisungen&lt;/a&gt;. Andernfalls installieren Sie bitte eine System-Tray-Anwendung wie „trayer“ und versuchen Sie es erneut.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Konnte Browser nicht öffnen</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Die URL %1 konnte aufgrund eines Fehlers nicht aufgerufen werden. Ist vielleicht kein Standard-Browser konfiguriert?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Die E-Mail-Anwendung konnte nicht geöffnet werden</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Beim Öffnen der E-Mail-Anwendung für das Erstellen einer neuen Nachricht ist ein Fehler aufgetreten. Ist vielleicht keine E-Mail-Anwendung konfiguriert?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Sie sind nicht mehr verbunden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Einloggen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Konnte Browser nicht öffnen</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Die URL %1 konnte aufgrund eines Fehlers nicht aufgerufen werden. Ist vielleicht kein Standard-Browser konfiguriert?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Die E-Mail-Anwendung konnte nicht geöffnet werden</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Beim Öffnen der E-Mail-Anwendung für das Erstellen einer neuen Nachricht ist ein Fehler aufgetreten. Ist vielleicht keine E-Mail-Anwendung konfiguriert?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Sie sind nicht mehr verbunden. &lt;a style="%1" href="%2"&gt;Einloggen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Kein Ordner zum Synchronisieren
+<translation>Kein Ordner zum Synchronisieren
 Sie können eines über die kDrive-Einstellungen hinzufügen.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synchronisierung läuft (%1 von %2)
+<translation>Synchronisierung läuft (%1 von %2)
 %3 übrig...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synchronisierung läuft (Schritt %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synchronisierung läuft.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Einige Dateien konnten nicht synchronisiert werden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mehr erfahren&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synchronisierung angehalten…</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da eine andere Synchronisierung denselben Ordner verwendet.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er den synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthält.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er im synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthalten ist.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisierungsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner aus.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Synchronisierung beginnt</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synchronisierung angehalten.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synchronisierung läuft (%1 von %2)</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Sie sind auf dem neuesten Stand, ungelöste Konflikte.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Sie sind auf dem neuesten Stand!</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synchronisierung läuft (Schritt %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synchronisierung läuft.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Einige Dateien konnten nicht synchronisiert werden. &lt;a style="%1" href="%2"&gt;Mehr erfahren&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synchronisierung angehalten…</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da eine andere Synchronisierung denselben Ordner verwendet.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er den synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthält.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht ausgewählt werden, da er im synchronisierten Ordner &lt;b&gt;%2&lt;/b&gt; enthalten ist.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisierungsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner aus.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Der Ordner &lt;b&gt;%1&lt;/b&gt; kann nicht als Synchronisationsordner ausgewählt werden. Bitte wählen Sie einen anderen Ordner. Vorgeschlagener Ordner: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Sie haben mehr als %1 Ordner ausgeschlossen. Bitte beachten Sie, dass dies die Synchronisierungsleistung beeinträchtigt.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Sie können maximal %1 Ordner ausschließen. Bitte deaktivieren Sie die übergeordneten Ordner.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synchronisierung beginnt</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synchronisierung angehalten.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synchronisierung läuft (%1 von %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Sie sind auf dem neuesten Stand, ungelöste Konflikte.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Sie sind auf dem neuesten Stand!</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_el.ts
+++ b/translations/client_el.ts
@@ -1,3095 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="el_GR" version="2.1">
+<TS version="2.1" language="el_GR">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Σχετικά</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>ΚΛΕΙΣΙΜΟ</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Έκδοση %1. Για περισσότερες πληροφορίες επισκεφθείτε &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Πνευματικά δικαιώματα 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Διανέμεται από τον %1 και αδειοδοτείται υπό &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;Το %2 και το λογότυπο %2 είναι κατοχυρωμένα εμπορικά σήματα του %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Κατασκευάστηκε από &lt;a style="color: #489EF3" href="%1"&gt;πηγές Git&lt;/a&gt; στις %2, %3 χρησιμοποιώντας Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Σχετικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>ΚΛΕΙΣΙΜΟ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Έκδοση %1. Για περισσότερες πληροφορίες επισκεφθείτε &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Πνευματικά δικαιώματα 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Διανέμεται από τον %1 και αδειοδοτείται υπό &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;Το %2 και το λογότυπο %2 είναι κατοχυρωμένα εμπορικά σήματα του %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Κατασκευάστηκε από &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;πηγές Git&lt;/a&gt; στις %2, %3 χρησιμοποιώντας Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Ο συγχρονισμός θα ξεκινήσει και θα μπορείτε να προσθέσετε αρχεία στον φάκελο %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Το kDrive σας είναι έτοιμο!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ΑΝΟΙΓΜΑ ΦΑΚΕΛΟΥ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>ΠΑΡΑΜΕΤΡΟΙ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Συγχρονισμός άλλης μονάδας</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Ο συγχρονισμός θα ξεκινήσει και θα μπορείτε να προσθέσετε αρχεία στον φάκελο %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Το kDrive σας είναι έτοιμο!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ΑΝΟΙΓΜΑ ΦΑΚΕΛΟΥ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>ΠΑΡΑΜΕΤΡΟΙ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Συγχρονισμός άλλης μονάδας</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Ακύρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>ΕΠΟΜΕΝΟ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Επιλέξτε το kDrive που θέλετε να συγχρονίσετε</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Αποκτήστε kDrive δωρεάν</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Αποθηκεύστε φωτογραφίες, έγγραφα και email στην Ελβετία από ανεξάρτητη εταιρεία που σέβεται την ιδιωτικότητα. Μάθετε περισσότερα</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Δοκιμάστε δωρεάν</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>ΕΠΟΜΕΝΟ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Επιλέξτε το kDrive που θέλετε να συγχρονίσετε</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Αποκτήστε kDrive δωρεάν</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Αποθηκεύστε φωτογραφίες, έγγραφα και email στην Ελβετία από ανεξάρτητη εταιρεία που σέβεται την ιδιωτικότητα. Μάθετε περισσότερα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Δοκιμάστε δωρεάν</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Θέλετε να ενεργοποιήσετε το Lite Sync (Beta);</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Θέλετε να ενεργοποιήσετε το Lite Sync;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Το Lite Sync συγχρονίζει όλα τα αρχεία χωρίς να καταναλώνει χώρο στον υπολογιστή. Μπορείτε να περιηγηθείτε στα αρχεία του kDrive και να τα κατεβάσετε τοπικά όποτε θέλετε. &lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Εξοικονομήστε χώρο στον υπολογιστή</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Αποφασίστε ποια αρχεία θα είναι διαθέσιμα ηλεκτρονικά ή τοπικά</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>ΑΡΓΟΤΕΡΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>ΝΑΙ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Θέλετε να ενεργοποιήσετε το Lite Sync (Beta);</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Θέλετε να ενεργοποιήσετε το Lite Sync;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Το Lite Sync συγχρονίζει όλα τα αρχεία χωρίς να καταναλώνει χώρο στον υπολογιστή. Μπορείτε να περιηγηθείτε στα αρχεία του kDrive και να τα κατεβάσετε τοπικά όποτε θέλετε. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Εξοικονομήστε χώρο στον υπολογιστή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Αποφασίστε ποια αρχεία θα είναι διαθέσιμα ηλεκτρονικά ή τοπικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>ΑΡΓΟΤΕΡΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>ΝΑΙ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Τοποθεσία του kDrive %1 σας</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Επεξεργασία φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Θα βρείτε όλα τα αρχεία σας σε αυτόν τον φάκελο μόλις ολοκληρωθεί η διαμόρφωση. Μπορείτε να προσθέσετε νέα αρχεία για συγχρονισμό με το kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>ΤΕΛΟΣ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>ΣΥΝΕΧΕΙΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Τα περιεχόμενα του φακέλου &lt;b&gt;%1&lt;/b&gt; θα συγχρονιστούν στο kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Τοποθεσία του kDrive %1 σας</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Επεξεργασία φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Θα βρείτε όλα τα αρχεία σας σε αυτόν τον φάκελο μόλις ολοκληρωθεί η διαμόρφωση. Μπορείτε να προσθέσετε νέα αρχεία για συγχρονισμό με το kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>ΤΕΛΟΣ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>ΣΥΝΕΧΕΙΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Τα περιεχόμενα του φακέλου &lt;b&gt;%1&lt;/b&gt; θα συγχρονιστούν στο kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt; 
 Επιλέξτε άλλον φάκελο. Αν συνεχίσετε, το Lite Sync θα απενεργοποιηθεί.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Επιλογή φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Επιλογή φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Σύνδεση μέσω του περιηγητή</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Ο περιηγητής σας θα ανοίξει αυτόματα για να ολοκληρωθεί η σύνδεση. Μόλις συνδεθείτε, θα επιστρέψετε αυτόματα στο kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Άνοιγμα σελίδας σύνδεσης</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Παρουσιάστηκε σφάλμα κατά τον έλεγχο ταυτότητας. Κλείστε το παράθυρο σύνδεσης και δοκιμάστε ξανά.&lt;br&gt;Εάν το σφάλμα επιμένει, επικοινωνήστε με την ομάδα υποστήριξής μας.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Αποτυχία σύνδεσης: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Αποτυχία ανοίγματος σελίδας σύνδεσης στον περιηγητή</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Σύνδεση μέσω του περιηγητή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Ο περιηγητής σας θα ανοίξει αυτόματα για να ολοκληρωθεί η σύνδεση. Μόλις συνδεθείτε, θα επιστρέψετε αυτόματα στο kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Άνοιγμα σελίδας σύνδεσης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά τον έλεγχο ταυτότητας. Κλείστε το παράθυρο σύνδεσης και δοκιμάστε ξανά.&lt;br&gt;Εάν το σφάλμα επιμένει, επικοινωνήστε με την ομάδα υποστήριξής μας.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Αποτυχία σύνδεσης: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Αποτυχία ανοίγματος σελίδας σύνδεσης στον περιηγητή</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Επιλέξτε φακέλους kDrive για συγχρονισμό στον υπολογιστή</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>ΣΥΝΕΧΕΙΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Διαθέσιμος χώρος στον υπολογιστή: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Αδύνατη η φόρτωση της λίστας υποφακέλων. Το kDrive μπορεί να βρίσκεται σε συντήρηση.&lt;br&gt;Συνδεθείτε στην &lt;a style="%1" href="%2"&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Επιλέξτε φακέλους kDrive για συγχρονισμό στον υπολογιστή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>ΣΥΝΕΧΕΙΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Διαθέσιμος χώρος στον υπολογιστή: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Αδύνατη η φόρτωση της λίστας υποφακέλων. Το kDrive μπορεί να βρίσκεται σε συντήρηση.&lt;br&gt;Συνδεθείτε στην &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Αποτυχία δημιουργίας τοπικού φακέλου %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>Το kDrive %1 είναι ήδη συγχρονισμένο σε αυτόν τον υπολογιστή. Θέλετε να συνεχίσετε;</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Αποτυχία δημιουργίας τοπικού φακέλου %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Το kDrive %1 είναι ήδη συγχρονισμένο σε αυτόν τον υπολογιστή. Θέλετε να συνεχίσετε;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>Ο πελάτης kDrive εκτελείται με εσφαλμένες παραμέτρους!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>Ο πελάτης kDrive εκτελείται ήδη!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Ο χρήστης %1 δεν είναι συνδεδεμένος. Παρακαλώ συνδεθείτε ξανά.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>Ο πελάτης kDrive εκτελείται με εσφαλμένες παραμέτρους!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Ο πελάτης kDrive εκτελείται ήδη!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Ο χρήστης %1 δεν είναι συνδεδεμένος. Παρακαλώ συνδεθείτε ξανά.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Ο σύνδεσμος κοινοποίησης αντιγράφηκε στο πρόχειρο</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 και %n άλλο αρχείο αφαιρέθηκαν.</numerusform>
-<numerusform>%1 και %n άλλα αρχεία αφαιρέθηκαν.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>Το %1 αφαιρέθηκε.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 και %n άλλο αρχείο προστέθηκαν.</numerusform>
-<numerusform>%1 και %n άλλα αρχεία προστέθηκαν.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>Το %1 προστέθηκε.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 και %n άλλο αρχείο ενημερώθηκαν.</numerusform>
-<numerusform>%1 και %n άλλα αρχεία ενημερώθηκαν.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>Το %1 ενημερώθηκε.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλο αρχείο μετακινήθηκε.</numerusform>
-<numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλα αρχεία μετακινήθηκαν.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>Το %1 μετακινήθηκε στο %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Δραστηριότητα συγχρονισμού</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Ο σύνδεσμος κοινοποίησης αντιγράφηκε στο πρόχειρο</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 και %n άλλο αρχείο αφαιρέθηκαν.</numerusform>
+            <numerusform>%1 και %n άλλα αρχεία αφαιρέθηκαν.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>Το %1 αφαιρέθηκε.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 και %n άλλο αρχείο προστέθηκαν.</numerusform>
+            <numerusform>%1 και %n άλλα αρχεία προστέθηκαν.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>Το %1 προστέθηκε.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 και %n άλλο αρχείο ενημερώθηκαν.</numerusform>
+            <numerusform>%1 και %n άλλα αρχεία ενημερώθηκαν.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>Το %1 ενημερώθηκε.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλο αρχείο μετακινήθηκε.</numerusform>
+            <numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλα αρχεία μετακινήθηκαν.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>Το %1 μετακινήθηκε στο %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Δραστηριότητα συγχρονισμού</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Αποχώρηση από το πρόγραμμα beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Συμμετοχή στο πρόγραμμα beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής πριν κυκλοφορήσουν στο ευρύ κοινό και συμμετάσχετε στη βελτίωσή της αποστέλλοντας τα σχόλιά σας.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Επωφεληθείτε από τις ενημερώσεις beta της εφαρμογής</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Όχι</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Δημόσια έκδοση beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Εσωτερική έκδοση beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Δοκιμαστική έκδοση</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Κατανοώ</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Είστε βέβαιοι ότι θέλετε να αποχωρήσετε από το πρόγραμμα beta;</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Αποθήκευση</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Ακύρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Η τρέχουσα έκδοση της εφαρμογής μπορεί να είναι πολύ πρόσφατη. Η επιλογή σας θα ισχύσει με την επόμενη διαθέσιμη ενημέρωση.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Οι εκδόσεις beta ενδέχεται να διακοπούν απροσδόκητα ή να προκαλέσουν αστάθειες.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Αποχώρηση από το πρόγραμμα beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Συμμετοχή στο πρόγραμμα beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής πριν κυκλοφορήσουν στο ευρύ κοινό και συμμετάσχετε στη βελτίωσή της αποστέλλοντας τα σχόλιά σας.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Επωφεληθείτε από τις ενημερώσεις beta της εφαρμογής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Όχι</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Δημόσια έκδοση beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Εσωτερική έκδοση beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Δοκιμαστική έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Κατανοώ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Είστε βέβαιοι ότι θέλετε να αποχωρήσετε από το πρόγραμμα beta;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Αποθήκευση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Η τρέχουσα έκδοση της εφαρμογής μπορεί να είναι πολύ πρόσφατη. Η επιλογή σας θα ισχύσει με την επόμενη διαθέσιμη ενημέρωση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Οι εκδόσεις beta ενδέχεται να διακοπούν απροσδόκητα ή να προκαλέσουν αστάθειες.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Δεν είναι δυνατή η αρχικοποίηση του πελάτη kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Αποτυχία επίλυσης %1 σύγκρουση(ων) σε φάκελο συγχρονισμού: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Παρακαλώ συνδεθείτε</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Ο συγχρονισμός έχει τεθεί σε παύση</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Φάκελος %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Δεν έχουν διαμορφωθεί φάκελοι συγχρονισμού.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Απροσδιόριστη κατάσταση.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Αναμονή έναρξης συγχρονισμού.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Ο συγχρονισμός εκτελείται.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Ο συγχρονισμός ήταν επιτυχής, με μη επιλυμένες συγκρούσεις.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Ο τελευταίος συγχρονισμός ήταν επιτυχής.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Ακύρωση από τον χρήστη.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Ο συγχρονισμός είναι σε παύση.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Ο συγχρονισμός είναι σε παύση)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Θέλετε πραγματικά να καταργήσετε τους συγχρονισμούς του λογαριασμού &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>ΚΑΤΑΡΓΗΣΗ ΟΛΩΝ ΤΩΝ ΣΥΓΧΡΟΝΙΣΜΩΝ</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 στοιχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Για να αποφευχθούν ακούσιες διαγραφές, ο συγχρονισμός έχει τεθεί σε παύση.&lt;br&gt;Θέλετε να μεταφέρετε αυτές τις διαγραφές στο kDrive σας;</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Αρκετά αρχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Τα διαγραμμένα αρχεία βρίσκονται στον &lt;a style="%1" href="%3"&gt;κάδο ανακύκλωσης&lt;/a&gt; του kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Να μην εμφανίζεται ξανά</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Σύνοψη</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Προτιμήσεις</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Έξοδος</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Αποτυχία εκκίνησης συγχρονισμών!</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Δεν είναι δυνατή η αρχικοποίηση του πελάτη kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Αποτυχία επίλυσης %1 σύγκρουση(ων) σε φάκελο συγχρονισμού: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Παρακαλώ συνδεθείτε</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Ο συγχρονισμός έχει τεθεί σε παύση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Φάκελος %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Δεν έχουν διαμορφωθεί φάκελοι συγχρονισμού.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Απροσδιόριστη κατάσταση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Αναμονή έναρξης συγχρονισμού.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Ο συγχρονισμός εκτελείται.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Ο συγχρονισμός ήταν επιτυχής, με μη επιλυμένες συγκρούσεις.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Ο τελευταίος συγχρονισμός ήταν επιτυχής.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Ακύρωση από τον χρήστη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Ο συγχρονισμός είναι σε παύση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Ο συγχρονισμός είναι σε παύση)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Θέλετε πραγματικά να καταργήσετε τους συγχρονισμούς του λογαριασμού &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>ΚΑΤΑΡΓΗΣΗ ΟΛΩΝ ΤΩΝ ΣΥΓΧΡΟΝΙΣΜΩΝ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 στοιχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Για να αποφευχθούν ακούσιες διαγραφές, ο συγχρονισμός έχει τεθεί σε παύση.&lt;br&gt;Θέλετε να μεταφέρετε αυτές τις διαγραφές στο kDrive σας;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Αρκετά αρχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Τα διαγραμμένα αρχεία βρίσκονται στον &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;κάδο ανακύκλωσης&lt;/a&gt; του kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Να μην εμφανίζεται ξανά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Σύνοψη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Προτιμήσεις</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Έξοδος</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Αποτυχία εκκίνησης συγχρονισμών!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Σύνοψη συγχρονισμού τοπικού φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Τα περιεχόμενα του φακέλου στον υπολογιστή θα συγχρονιστούν με τον φάκελο του επιλεγμένου kDrive και αντίστροφα.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>ΣΥΓΧΡΟΝΙΣΜΟΣ</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Σύνοψη συγχρονισμού τοπικού φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Τα περιεχόμενα του φακέλου στον υπολογιστή θα συγχρονιστούν με τον φάκελο του επιλεγμένου kDrive και αντίστροφα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>ΣΥΓΧΡΟΝΙΣΜΟΣ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Πριν την ολοκλήρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Ακολουθήστε τα παρακάτω βήματα για να διασφαλίσετε τη σωστή λειτουργία του Lite Sync στον υπολογιστή σας και να ολοκληρώσετε τη διαμόρφωση του kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ανοίξτε τις &lt;b&gt;Γενικές ρυθμίσεις&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Απόρρητο &amp;amp; Ασφάλεια&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Ασφάλεια &amp;amp; Απόρρητο&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις"&lt;/b&gt; και στη συνέχεια στο &lt;b&gt;"Επεκτάσεις ασφαλείας τερματικού"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Εξουσιοδοτήστε την εφαρμογή kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Ασφάλεια"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Εξουσιοδοτήστε την εφαρμογή kDrive στο πλαίσιο που υποδεικνύει ότι το kDrive έχει αποκλειστεί</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Ξεκλειδώστε το λουκέτο &lt;img src=":/client/resources/icons/actions/lock.png"&gt; και εξουσιοδοτήστε την εφαρμογή kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Απόρρητο &amp;amp; Ασφάλεια"&lt;/b&gt; και κάντε κλικ στο &lt;b&gt;"Πλήρης πρόσβαση δίσκου"&lt;/b&gt; ή &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Στις ρυθμίσεις Ασφάλεια &amp;amp; Απόρρητο, ανοίξτε την καρτέλα &lt;b&gt;"Απόρρητο"&lt;/b&gt; ή &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Επιλέξτε το πλαίσιο "kDrive LiteSync Extension" και στη συνέχεια το πλαίσιο "kDrive.app" (αν δεν είναι ήδη επιλεγμένο)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Ενδέχεται να προταθεί επανεκκίνηση της εφαρμογής, σε αυτή την περίπτωση αποδεχτείτε την</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Επιλέξτε το πλαίσιο "kDrive LiteSync Extension" (και "kDrive.app" αν υπάρχει) στην &lt;b&gt;"Πλήρη πρόσβαση δίσκου"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>ΒΗΜΑ 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Ολοκληρώθηκε)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>ΒΗΜΑ 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>ΒΗΜΑΤΑ ΕΚΤΕΛΕΣΤΗΚΑΝ</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>ΤΕΛΟΣ</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Πριν την ολοκλήρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Ακολουθήστε τα παρακάτω βήματα για να διασφαλίσετε τη σωστή λειτουργία του Lite Sync στον υπολογιστή σας και να ολοκληρώσετε τη διαμόρφωση του kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ανοίξτε τις &lt;b&gt;Γενικές ρυθμίσεις&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Απόρρητο &amp;amp; Ασφάλεια&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Ασφάλεια &amp;amp; Απόρρητο&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Μεταβείτε στην ενότητα &lt;b&gt;&quot;Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις&quot;&lt;/b&gt; και στη συνέχεια στο &lt;b&gt;&quot;Επεκτάσεις ασφαλείας τερματικού&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Εξουσιοδοτήστε την εφαρμογή kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Μεταβείτε στην ενότητα &lt;b&gt;&quot;Ασφάλεια&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Εξουσιοδοτήστε την εφαρμογή kDrive στο πλαίσιο που υποδεικνύει ότι το kDrive έχει αποκλειστεί</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Ξεκλειδώστε το λουκέτο &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; και εξουσιοδοτήστε την εφαρμογή kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Μεταβείτε στην ενότητα &lt;b&gt;&quot;Απόρρητο &amp;amp; Ασφάλεια&quot;&lt;/b&gt; και κάντε κλικ στο &lt;b&gt;&quot;Πλήρης πρόσβαση δίσκου&quot;&lt;/b&gt; ή &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Στις ρυθμίσεις Ασφάλεια &amp;amp; Απόρρητο, ανοίξτε την καρτέλα &lt;b&gt;&quot;Απόρρητο&quot;&lt;/b&gt; ή &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Επιλέξτε το πλαίσιο &quot;kDrive LiteSync Extension&quot; και στη συνέχεια το πλαίσιο &quot;kDrive.app&quot; (αν δεν είναι ήδη επιλεγμένο)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Ενδέχεται να προταθεί επανεκκίνηση της εφαρμογής, σε αυτή την περίπτωση αποδεχτείτε την</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Επιλέξτε το πλαίσιο &quot;kDrive LiteSync Extension&quot; (και &quot;kDrive.app&quot; αν υπάρχει) στην &lt;b&gt;&quot;Πλήρη πρόσβαση δίσκου&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>ΒΗΜΑ 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Ολοκληρώθηκε)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>ΒΗΜΑ 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>ΒΗΜΑΤΑ ΕΚΤΕΛΕΣΤΗΚΑΝ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>ΤΕΛΟΣ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>ΟΚ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>ΝΑΙ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>ΟΧΙ</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>ΟΚ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>ΝΑΙ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>ΟΧΙ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Αποστολή πληροφοριών εντοπισμού σφαλμάτων</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Ακύρωση</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Αποστολή πληροφοριών εντοπισμού σφαλμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Εντοπισμός σφαλμάτων</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Πληροφορίες</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Προειδοποίηση</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Σφάλμα</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Κρίσιμο</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Ρυθμίσεις εντοπισμού σφαλμάτων</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Αποθήκευση πληροφοριών εντοπισμού σε φάκελο στον υπολογιστή (Συνιστάται)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Αυτές οι πληροφορίες επιτρέπουν στην τεχνική υποστήριξη να προσδιορίσει την αιτία ενός συμβάντος.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Επίπεδο εντοπισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Το επίπεδο ιχνηλάτησης σάς επιτρέπει να επιλέξετε την έκταση των καταγεγραμμένων πληροφοριών εντοπισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Το εκτεταμένο πλήρες αρχείο καταγραφής συλλέγει λεπτομερές ιστορικό για εντοπισμό σφαλμάτων. Η ενεργοποίησή του μπορεί να επιβραδύνει την εφαρμογή kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Εκτεταμένο πλήρες αρχείο καταγραφής</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Διαγραφή αρχείων καταγραφής παλαιότερων από %1 ημέρες</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Κοινοποίηση του φακέλου εντοπισμού με την υποστήριξη Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Η τελευταία συνεδρία είναι η περίοδος από την τελευταία εκκίνηση του kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Φόρτωση</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Ακύρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Αποτυχία κοινοποίησης</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Βεβαιωθείτε ότι είστε συνδεδεμένοι &lt;br&gt;2. Βεβαιωθείτε ότι έχετε διαμορφώσει τουλάχιστον ένα kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Η σύνδεση διακόπηκε)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Κοινοποίηση του φακέλου μέσω SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Συμπιέσαμε αυτόματα το αρχείο καταγραφής σας &lt;a style="%1" href="%2"&gt;εδώ&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Μεταφέρετε το αρχείο με &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Κοινοποιήστε τον σύνδεσμο στο &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Τελευταία μεταφόρτωση στις %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Η κοινοποίηση ακυρώθηκε</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Το εκτεταμένο πλήρες αρχείο ενεργοποιείται μέσω της μεταβλητής περιβάλλοντος KDRIVE_FORCE_EXTENDED_LOG. Ορίστε το σε 0 για απενεργοποίηση.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 στις %4:%5 και %6 δευτερόλεπτα</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Κοινοποίηση</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Κοινοποίηση | βήμα 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Κοινοποίηση | βήμα 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Ακύρωση...</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Ο φάκελος είναι μεγάλος (&gt; 100 MB) και η κοινοποίησή του ενδέχεται να διαρκέσει. Για μικρότερο χρόνο, συνιστάται η κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive.</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Εντοπισμός σφαλμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Πληροφορίες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Προειδοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Σφάλμα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Κρίσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Ρυθμίσεις εντοπισμού σφαλμάτων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Αποθήκευση πληροφοριών εντοπισμού σε φάκελο στον υπολογιστή (Συνιστάται)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Αυτές οι πληροφορίες επιτρέπουν στην τεχνική υποστήριξη να προσδιορίσει την αιτία ενός συμβάντος.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Επίπεδο εντοπισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Το επίπεδο ιχνηλάτησης σάς επιτρέπει να επιλέξετε την έκταση των καταγεγραμμένων πληροφοριών εντοπισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Το εκτεταμένο πλήρες αρχείο καταγραφής συλλέγει λεπτομερές ιστορικό για εντοπισμό σφαλμάτων. Η ενεργοποίησή του μπορεί να επιβραδύνει την εφαρμογή kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Εκτεταμένο πλήρες αρχείο καταγραφής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Διαγραφή αρχείων καταγραφής παλαιότερων από %1 ημέρες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Κοινοποίηση του φακέλου εντοπισμού με την υποστήριξη Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Η τελευταία συνεδρία είναι η περίοδος από την τελευταία εκκίνηση του kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Φόρτωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Αποτυχία κοινοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Βεβαιωθείτε ότι είστε συνδεδεμένοι &lt;br&gt;2. Βεβαιωθείτε ότι έχετε διαμορφώσει τουλάχιστον ένα kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Η σύνδεση διακόπηκε)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Κοινοποίηση του φακέλου μέσω SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Συμπιέσαμε αυτόματα το αρχείο καταγραφής σας &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;εδώ&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Μεταφέρετε το αρχείο με &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Κοινοποιήστε τον σύνδεσμο στο &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Τελευταία μεταφόρτωση στις %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Η κοινοποίηση ακυρώθηκε</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Το εκτεταμένο πλήρες αρχείο ενεργοποιείται μέσω της μεταβλητής περιβάλλοντος KDRIVE_FORCE_EXTENDED_LOG. Ορίστε το σε 0 για απενεργοποίηση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 στις %4:%5 και %6 δευτερόλεπτα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Κοινοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Κοινοποίηση | βήμα 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Κοινοποίηση | βήμα 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Ακύρωση...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Ο φάκελος είναι μεγάλος (&gt; 100 MB) και η κοινοποίησή του ενδέχεται να διαρκέσει. Για μικρότερο χρόνο, συνιστάται η κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Σφάλματα και πληροφορίες συγχρονισμού.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Συγχρονισμός τοπικού φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Θέλετε πραγματικά να ενεργοποιήσετε το Lite Sync;</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Αυτή η λειτουργία μπορεί να διαρκέσει από λίγα δευτερόλεπτα έως λίγα λεπτά ανάλογα με το μέγεθος του φακέλου.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Θέλετε πραγματικά να απενεργοποιήσετε το Lite Sync;</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Δεν έχετε αρκετό χώρο για να συγχρονίσετε όλα τα αρχεία του kDrive (%1 απαιτούνται). Αν απενεργοποιήσετε το Lite Sync, πρέπει να επιλέξετε ποιους φακέλους θα συγχρονίσετε. Εν τω μεταξύ, ο συγχρονισμός θα τεθεί σε παύση.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Αν απενεργοποιήσετε το Lite Sync, όλα τα αρχεία θα ληφθούν στον υπολογιστή σας.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Αποτυχία συγχρονισμού νέου τοπικού φακέλου!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Το Lite Sync ενεργοποιήθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Αποτυχία ενεργοποίησης Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Το Lite Sync απενεργοποιήθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Αποτυχία απενεργοποίησης Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Αυτή η μονάδα διαγράφεται.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του στοιχείου %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Θέλετε πραγματικά να σταματήσετε τον συγχρονισμό του φακέλου &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>ΚΑΤΑΡΓΗΣΗ ΣΥΝΔΕΣΗΣ ΣΥΓΧΡΟΝΙΣΜΟΥ ΦΑΚΕΛΟΥ</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Αποτυχία διακοπής συγχρονισμού φακέλου &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Φάκελοι</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Ειδοποιήσεις</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Ενεργοποίηση ειδοποιήσεων για αυτό το kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Θα εμφανίζεται ειδοποίηση μόλις συγχρονιστεί ή τροποποιηθεί νέος φάκελος</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Συνδεδεμένος με</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Κατάργηση όλων των συγχρονισμών</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Αναζήτηση στο kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Αναζήτηση</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Σφάλματα και πληροφορίες συγχρονισμού.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Συγχρονισμός τοπικού φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Θέλετε πραγματικά να ενεργοποιήσετε το Lite Sync;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Αυτή η λειτουργία μπορεί να διαρκέσει από λίγα δευτερόλεπτα έως λίγα λεπτά ανάλογα με το μέγεθος του φακέλου.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Θέλετε πραγματικά να απενεργοποιήσετε το Lite Sync;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Δεν έχετε αρκετό χώρο για να συγχρονίσετε όλα τα αρχεία του kDrive (%1 απαιτούνται). Αν απενεργοποιήσετε το Lite Sync, πρέπει να επιλέξετε ποιους φακέλους θα συγχρονίσετε. Εν τω μεταξύ, ο συγχρονισμός θα τεθεί σε παύση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Αν απενεργοποιήσετε το Lite Sync, όλα τα αρχεία θα ληφθούν στον υπολογιστή σας.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Αποτυχία συγχρονισμού νέου τοπικού φακέλου!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Το Lite Sync ενεργοποιήθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Αποτυχία ενεργοποίησης Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Το Lite Sync απενεργοποιήθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Αποτυχία απενεργοποίησης Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Αυτή η μονάδα διαγράφεται.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του στοιχείου %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Θέλετε πραγματικά να σταματήσετε τον συγχρονισμό του φακέλου &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>ΚΑΤΑΡΓΗΣΗ ΣΥΝΔΕΣΗΣ ΣΥΓΧΡΟΝΙΣΜΟΥ ΦΑΚΕΛΟΥ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Αποτυχία διακοπής συγχρονισμού φακέλου &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Φάκελοι</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Ειδοποιήσεις</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Ενεργοποίηση ειδοποιήσεων για αυτό το kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Θα εμφανίζεται ειδοποίηση μόλις συγχρονιστεί ή τροποποιηθεί νέος φάκελος</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Συνδεδεμένος με</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Κατάργηση όλων των συγχρονισμών</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Αναζήτηση στο kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Αναζήτηση</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Προσθήκη kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Συγχρονισμός kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Προσθήκη kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Συγχρονισμός kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Εκκαθάριση ιστορικού</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Προς επίλυση</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>πρόβλημα(τα) εντοπίστηκαν</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Επίλυση</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Στοιχείο(α) με σύγκρουση</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Στοιχείο(α) με μη υποστηριζόμενους χαρακτήρες</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Αυτόματη επίλυση</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>πρόβλημα(τα) επιλύθηκαν</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Εκκαθάριση ιστορικού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Προς επίλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>πρόβλημα(τα) εντοπίστηκαν</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Επίλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Στοιχείο(α) με σύγκρουση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Στοιχείο(α) με μη υποστηριζόμενους χαρακτήρες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Αυτόματη επίλυση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>πρόβλημα(τα) επιλύθηκαν</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Συγκρούσεις ή σφάλματα συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Σφάλματα</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Επιστροφή στις προτιμήσεις</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Συγκρούσεις ή σφάλματα συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Σφάλματα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Επιστροφή στις προτιμήσεις</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν στα ακόλουθα kDrive:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 σφάλμα(τα))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 πληροφορία(ες))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 σφάλμα(τα) και %2 πληροφορία(ες))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Γενικά σφάλματα (%n προειδοποίηση ή σφάλμα)</numerusform>
-<numerusform>Γενικά σφάλματα (%n προειδοποιήσεις ή σφάλματα)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν στα ακόλουθα kDrive:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 σφάλμα(τα))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 πληροφορία(ες))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 σφάλμα(τα) και %2 πληροφορία(ες))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Γενικά σφάλματα (%n προειδοποίηση ή σφάλμα)</numerusform>
+            <numerusform>Γενικά σφάλματα (%n προειδοποιήσεις ή σφάλματα)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Εξαιρεθέντα αρχεία</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Προσθέστε αρχεία ή φακέλους που δεν θα συγχρονιστούν στον υπολογιστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Προσθήκη</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>ΟΝΟΜΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>ΠΡΟΕΙΔΟΠΟΙΗΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Το πρότυπο εξαίρεσης υπάρχει ήδη!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Θέλετε πραγματικά να διαγράψετε;</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Εξαιρεθέντα αρχεία</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Προσθέστε αρχεία ή φακέλους που δεν θα συγχρονιστούν στον υπολογιστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Προσθήκη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>ΟΝΟΜΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>ΠΡΟΕΙΔΟΠΟΙΗΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Το πρότυπο εξαίρεσης υπάρχει ήδη!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Θέλετε πραγματικά να διαγράψετε;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>ΕΠΙΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>ΕΠΙΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Επίλυση σύγκρουσης(εων)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Τι θέλετε να κάνετε με τα %1 στοιχεία με σύγκρουση;&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Αποθήκευση των αλλαγών μου και αντικατάσταση των εκδόσεων άλλων χρηστών.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Αναίρεση των αλλαγών μου και διατήρηση των εκδόσεων άλλων χρηστών.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Οι αλλαγές σας ενδέχεται να διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Οι αλλαγές σας θα διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Εμφάνιση στοιχείων</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>ΕΠΙΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Αυτά τα αρχεία έχουν τροποποιηθεί από πολλούς χρήστες σε πολλά μέρη (ηλεκτρονικά στο kDrive, σε υπολογιστή ή κινητό). Φάκελοι που περιέχουν αυτά τα αρχεία ενδέχεται επίσης να έχουν διαγραφεί.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Η τοπική έκδοση του στοιχείου σας &lt;b&gt;δεν είναι συγχρονισμένη&lt;/b&gt; με το kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Επίλυση σύγκρουσης(εων)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Τι θέλετε να κάνετε με τα %1 στοιχεία με σύγκρουση;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Αποθήκευση των αλλαγών μου και αντικατάσταση των εκδόσεων άλλων χρηστών.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Αναίρεση των αλλαγών μου και διατήρηση των εκδόσεων άλλων χρηστών.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Οι αλλαγές σας ενδέχεται να διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Οι αλλαγές σας θα διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Εμφάνιση στοιχείων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>ΕΠΙΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Αυτά τα αρχεία έχουν τροποποιηθεί από πολλούς χρήστες σε πολλά μέρη (ηλεκτρονικά στο kDrive, σε υπολογιστή ή κινητό). Φάκελοι που περιέχουν αυτά τα αρχεία ενδέχεται επίσης να έχουν διαγραφεί.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Η τοπική έκδοση του στοιχείου σας &lt;b&gt;δεν είναι συγχρονισμένη&lt;/b&gt; με το kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Συγχρονίστηκε στο &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Ενεργοποίηση Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Ενεργοποίηση Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Απενεργοποίηση Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Παύση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Συνέχιση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Κατάργηση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Περισσότερες ενέργειες</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο αν περιέχουν εκτός σύνδεσης στοιχεία. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Οι μη επιλεγμένοι φάκελοι θα διαγραφούν &lt;b&gt;οριστικά&lt;/b&gt; από τον υπολογιστή. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Ακύρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>ΕΠΙΚΥΡΩΣΗ</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Συγχρονίστηκε στο &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Ενεργοποίηση Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Ενεργοποίηση Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Απενεργοποίηση Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Παύση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Συνέχιση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Κατάργηση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Περισσότερες ενέργειες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο αν περιέχουν εκτός σύνδεσης στοιχεία. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Οι μη επιλεγμένοι φάκελοι θα διαγραφούν &lt;b&gt;οριστικά&lt;/b&gt; από τον υπολογιστή. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Ακύρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>ΕΠΙΚΥΡΩΣΗ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Αναγνωριστικό εφαρμογής</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Όνομα εφαρμογής</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>ΕΠΙΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Αναγνωριστικό εφαρμογής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Όνομα εφαρμογής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>ΕΠΙΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Ορισμένες εφαρμογές (αντίγραφα ασφαλείας, antivirus...) έχουν πρόσβαση στα αρχεία σας, προκαλώντας τη λήψη τους όταν είναι "ηλεκτρονικά". Προσθέστε τες παρακάτω για να αποφύγετε αυτή τη συμπεριφορά.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Προσθήκη</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ΑΝΑΓΝΩΡΙΣΤΙΚΟ ΕΦΑΡΜΟΓΗΣ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>ΟΝΟΜΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Θέλετε πραγματικά να διαγράψετε;</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Ορισμένες εφαρμογές (αντίγραφα ασφαλείας, antivirus...) έχουν πρόσβαση στα αρχεία σας, προκαλώντας τη λήψη τους όταν είναι &quot;ηλεκτρονικά&quot;. Προσθέστε τες παρακάτω για να αποφύγετε αυτή τη συμπεριφορά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Προσθήκη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ΑΝΑΓΝΩΡΙΣΤΙΚΟ ΕΦΑΡΜΟΓΗΣ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>ΟΝΟΜΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Θέλετε πραγματικά να διαγράψετε;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Ποιον φάκελο στον υπολογιστή θέλετε να&lt;br&gt;συγχρονίσετε;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Τα περιεχόμενα αυτού του φακέλου θα συγχρονιστούν στο kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Επιλογή φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Επεξεργασία φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>ΣΥΝΕΧΕΙΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Ποιον φάκελο στον υπολογιστή θέλετε να&lt;br&gt;συγχρονίσετε;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Τα περιεχόμενα αυτού του φακέλου θα συγχρονιστούν στο kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Επιλογή φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Επεξεργασία φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>ΣΥΝΕΧΕΙΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt;
 Επιλέξτε άλλον φάκελο. Αν συνεχίσετε, το Lite Sync θα απενεργοποιηθεί.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Επιλογή φακέλου</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Επιλογή φακέλου</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Σφάλμα</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Το αρχείο '%1'&lt;br/&gt;δεν μπορεί να ανοίξει για εγγραφή.&lt;br/&gt;&lt;br/&gt;Η καταγραφή &lt;b&gt;δεν&lt;/b&gt; μπορεί να αποθηκευτεί!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Σφάλμα</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Το αρχείο &apos;%1&apos;&lt;br/&gt;δεν μπορεί να ανοίξει για εγγραφή.&lt;br/&gt;&lt;br/&gt;Η καταγραφή &lt;b&gt;δεν&lt;/b&gt; μπορεί να αποθηκευτεί!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Προτιμήσεις</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Βοήθεια</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Προτιμήσεις</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Βοήθεια</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>Το kDrive χρειάζεται πρόσβαση εγγραφής στον προσωρινό κατάλογο.&lt;br&gt;Κάντε επανεκκίνηση της εφαρμογής kDrive για να επιλυθεί το πρόβλημα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Φαίνεται ότι η σύνδεση δικτύου διαθέτει πολύ μικρό χρονικό όριο για τη σωστή λειτουργία της εφαρμογής (σφάλμα %1).&lt;br&gt;Ελέγξτε τη διαμόρφωση δικτύου.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Αδύνατη η σύνδεση με τον διακομιστή kDrive (σφάλμα %1).&lt;br&gt;Προσπάθεια επανασύνδεσης. Ελέγξτε τη σύνδεση στο διαδίκτυο και το τείχος προστασίας.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Συνδεθείτε ξανά και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Νέα έκδοση της εφαρμογής είναι διαθέσιμη.&lt;br&gt;Ενημερώστε την εφαρμογή για να συνεχίσετε να τη χρησιμοποιείτε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Αποτυχία μεταφόρτωσης αρχείου καταγραφής (σφάλμα %1).&lt;br&gt;Δοκιμάστε ξανά αργότερα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Ο φάκελος συγχρονισμού δεν είναι πλέον προσβάσιμος (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί μόλις ο φάκελος γίνει προσβάσιμος.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Η μονάδα που περιέχει τον φάκελο συγχρονισμού δεν είναι συνδεδεμένη (σφάλμα %1).&lt;br&gt;Επανασυνδέστε την για να συνεχίσει ο συγχρονισμός.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Δεν υπάρχει αρκετή διαθέσιμη μνήμη.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Ο αριθμός των παρακολουθήσεων inotify δεν είναι επαρκής (σφάλμα %1).&lt;br&gt;Μπορείτε να αυξήσετε τον αριθμό επεξεργαζόμενοι το '/etc/sysctl.conf'.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Πρέπει να επιτρέψετε:&lt;br&gt;- kDrive στις Ρυθμίσεις συστήματος &gt;&gt; Γενικά &gt;&gt; Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις &gt;&gt; Επεκτάσεις ασφαλείας τερματικού&lt;br&gt;- kDrive LiteSync Extension στις Ρυθμίσεις συστήματος &gt;&gt; Απόρρητο &amp;amp; Ασφάλεια &gt;&gt; Πλήρης πρόσβαση δίσκου.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Η διεργασία LiteSyncExt δεν εκτελείται. Ο συγχρονισμός θα επαναληφθεί μόλις εκκινηθεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync είναι εγκατεστημένη και η υπηρεσία Αναζήτησης Windows είναι ενεργή.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync έχει τα σωστά δικαιώματα και εκτελείται.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Ένα αρχείο ή φάκελος εντός του φακέλου συγχρονισμού φαίνεται κατεστραμμένος.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Το kDrive βρίσκεται σε λειτουργία συντήρησης.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Ανανεώστε το kDrive. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Επικοινωνήστε με διαχειριστή για ανανέωση. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Το kDrive επανεκκινείται.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην &lt;a style="%1" href="%2"&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην ιστοσελίδα για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Δεν έχετε δικαίωμα πρόσβασης σε αυτό το kDrive.&lt;br&gt;Ο συγχρονισμός έχει ανασταλεί. Επικοινωνήστε με διαχειριστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Οι συνδέσεις δικτύου διακόπηκαν από τον πυρήνα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Δυστυχώς η παλαιά διαμόρφωση δεν ήταν δυνατό να μεταφερθεί.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει κενή διαμόρφωση.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Δυστυχώς η παλαιά διαμόρφωση διακομιστή μεσολάβησης δεν ήταν δυνατό να μεταφερθεί· οι διακομιστές SOCKS5 δεν υποστηρίζονται.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει τις ρυθμίσεις συστήματος.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Ο φάκελος συγχρονισμού αντικαταστάθηκε ή μετακινήθηκε με τρόπο που εμποδίζει τον συγχρονισμό (σφάλμα %1).&lt;br&gt;Αυτό μπορεί να συμβεί μετά από αντιγραφή, μετακίνηση ή επαναφορά.&lt;br&gt;Δημιουργήστε νέο συγχρονισμό με νέο φάκελο.&lt;br&gt;Σημείωση: αν υπάρχουν μη συγχρονισμένες αλλαγές, αντιγράψτε τες χειροκίνητα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός επανεκκινήθηκε. Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Παρουσιάστηκε σφάλμα πρόσβασης στη βάση δεδομένων συγχρονισμού (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Το διακριτικό είναι άκυρο ή έχει ανακληθεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Οι εμφωλευμένοι συγχρονισμοί απαγορεύονται (σφάλμα %1).&lt;br&gt;Διατηρήστε μόνο συγχρονισμούς με μη εμφωλευμένους φακέλους.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Ο φάκελος συγχρονισμού στο απομακρυσμένο kDrive δεν υπάρχει πλέον ή δεν είναι προσβάσιμος (σφάλμα %1).&lt;br&gt;Επαναφέρετέ τον ή δώστε ξανά δικαιώματα πρόσβασης ή διαγράψτε/δημιουργήστε ξανά τον συγχρονισμό.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Σφάλμα ανάλυσης ονόματος αρχείου (σφάλμα %1).&lt;br&gt;Ειδικοί χαρακτήρες όπως διπλά εισαγωγικά, ανάστροφες κάθετοι ή αλλαγές γραμμής μπορούν να προκαλέσουν αποτυχίες ανάλυσης.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Αυτό το στοιχείο μετακινήθηκε αλλού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Το τοπικό στοιχείο μετονομάστηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Το αρχείο τροποποιήθηκε ταυτόχρονα από άλλον χρήστη.&lt;br&gt;Οι τροποποιήσεις σας αποθηκεύτηκαν σε αντίγραφο.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Άλλος χρήστης μετακίνησε έναν γονικό φάκελο του προορισμού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Υπάρχον στοιχείο έχει πανομοιότυπο όνομα (ίδια πεζά/κεφαλαία).&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Το όνομα του στοιχείου περιέχει μη υποστηριζόμενο χαρακτήρα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Το όνομα του στοιχείου τελειώνει με κενό, κάτι που δεν επιτρέπεται στο λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Αυτό το όνομα στοιχείου είναι δεσμευμένο από το λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Το όνομα του στοιχείου είναι πολύ μακρύ.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Η διαδρομή του στοιχείου είναι πολύ μακριά.&lt;br&gt;Αγνοήθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Το όνομα του στοιχείου περιέχει πρόσφατο χαρακτήρα UNICODE που δεν υποστηρίζεται από το σύστημα αρχείων.&lt;br&gt;Εξαιρέθηκε από τον συγχρονισμό.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Το όνομα του στοιχείου περιέχει μόνο κενά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Είτε δεν έχετε άδεια να δημιουργήσετε ένα στοιχείο, είτε υπάρχει ήδη ένα άλλο στοιχείο με το ίδιο όνομα. Το στοιχείο αγνοήθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Δεν επιτρέπεται η επεξεργασία του στοιχείου.&lt;br&gt;Το αρχείο με τις αλλαγές σας μετονομάστηκε και εξαιρέθηκε από τον συγχρονισμό.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Δεν επιτρέπεται η μετονομασία του στοιχείου.&lt;br&gt;Θα αποκατασταθεί με το αρχικό του όνομα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Δεν επιτρέπεται η μετακίνηση στοιχείου στο "%1".&lt;br&gt;Θα αποκατασταθεί στον αρχικό γονικό φάκελο.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Δεν επιτρέπεται η διαγραφή του στοιχείου.&lt;br&gt;Θα αποκατασταθεί στην αρχική του θέση.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Αποτυχία μετακίνησης στοιχείου στον κάδο, τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Αποτυχία συγχρονισμού στοιχείου. Προσωρινά τέθηκε σε μαύρη λίστα.&lt;br&gt;Νέα προσπάθεια θα γίνει σε μία ώρα ή κατά την επόμενη εκκίνηση.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό βάσει προσαρμοσμένου προτύπου.&lt;br&gt;Μπορείτε να απενεργοποιήσετε αυτόν τον τύπο ειδοποίησης από τις Προτιμήσεις</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό επειδή είναι σκληρός σύνδεσμος.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Το αρχείο τροποποιήθηκε τοπικά ενώ διαγράφηκε στο απομακρυσμένο kDrive.&lt;br&gt;Το τοπικό αντίγραφο αποθηκεύτηκε στον φάκελο ανάκτησης.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Η λειτουργία που εκτελέστηκε στο στοιχείο απαγορεύεται.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Η λειτουργία στο στοιχείο απέτυχε.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Το αρχείο είναι πολύ μεγάλο για μεταφόρτωση. Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Έχετε υπερβεί το όριο χώρου. Αυξήστε το όριο για να επανενεργοποιήσετε τη μεταφόρτωση αρχείων.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Αδύνατη η λήψη του αρχείου.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Αυτό το στοιχείο είναι κλειδωμένο από άλλον χρήστη ηλεκτρονικά.&lt;br&gt;Θα επαναπροσπαθήσουμε τη μεταφόρτωση των αλλαγών αργότερα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Σφάλμα συγχρονισμού.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Δεν είναι δυνατή η πρόσβαση στο στοιχείο.&lt;br&gt;Ελέγξτε τα δικαιώματα ανάγνωσης και εγγραφής.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Η λήψη ακυρώθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Δεν είναι δυνατή η δημιουργία του αρχείου «%1», καθώς δεν υποστηρίζεται από το σύστημα αρχείων σας.&lt;br&gt;Έχει εξαιρεθεί από τον συγχρονισμό.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Σφάλμα συστήματος.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Το στοιχείο υπάρχει ήδη στην άλλη πλευρά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Μεταφορά ολοκληρώθηκε!&lt;br&gt;Χρησιμοποιήστε τον αναγνωριστικό &lt;b&gt;%1&lt;/b&gt; σε αναφορές σφαλμάτων.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Αποτυχία μεταφοράς!
-Χρησιμοποιήστε τον ακόλουθο σύνδεσμο για να στείλετε τα αρχεία καταγραφής: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Δεν έχει διαμορφωθεί kDrive!</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>Το kDrive χρειάζεται πρόσβαση εγγραφής στον προσωρινό κατάλογο.&lt;br&gt;Κάντε επανεκκίνηση της εφαρμογής kDrive για να επιλυθεί το πρόβλημα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Φαίνεται ότι η σύνδεση δικτύου διαθέτει πολύ μικρό χρονικό όριο για τη σωστή λειτουργία της εφαρμογής (σφάλμα %1).&lt;br&gt;Ελέγξτε τη διαμόρφωση δικτύου.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Αδύνατη η σύνδεση με τον διακομιστή kDrive (σφάλμα %1).&lt;br&gt;Προσπάθεια επανασύνδεσης. Ελέγξτε τη σύνδεση στο διαδίκτυο και το τείχος προστασίας.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Συνδεθείτε ξανά και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Νέα έκδοση της εφαρμογής είναι διαθέσιμη.&lt;br&gt;Ενημερώστε την εφαρμογή για να συνεχίσετε να τη χρησιμοποιείτε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Αποτυχία μεταφόρτωσης αρχείου καταγραφής (σφάλμα %1).&lt;br&gt;Δοκιμάστε ξανά αργότερα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Ο φάκελος συγχρονισμού δεν είναι πλέον προσβάσιμος (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί μόλις ο φάκελος γίνει προσβάσιμος.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Η μονάδα που περιέχει τον φάκελο συγχρονισμού δεν είναι συνδεδεμένη (σφάλμα %1).&lt;br&gt;Επανασυνδέστε την για να συνεχίσει ο συγχρονισμός.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Δεν υπάρχει αρκετή διαθέσιμη μνήμη.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Ο αριθμός των παρακολουθήσεων inotify δεν είναι επαρκής (σφάλμα %1).&lt;br&gt;Μπορείτε να αυξήσετε τον αριθμό επεξεργαζόμενοι το &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Πρέπει να επιτρέψετε:&lt;br&gt;- kDrive στις Ρυθμίσεις συστήματος &gt;&gt; Γενικά &gt;&gt; Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις &gt;&gt; Επεκτάσεις ασφαλείας τερματικού&lt;br&gt;- kDrive LiteSync Extension στις Ρυθμίσεις συστήματος &gt;&gt; Απόρρητο &amp;amp; Ασφάλεια &gt;&gt; Πλήρης πρόσβαση δίσκου.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Η διεργασία LiteSyncExt δεν εκτελείται. Ο συγχρονισμός θα επαναληφθεί μόλις εκκινηθεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync είναι εγκατεστημένη και η υπηρεσία Αναζήτησης Windows είναι ενεργή.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync έχει τα σωστά δικαιώματα και εκτελείται.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Ένα αρχείο ή φάκελος εντός του φακέλου συγχρονισμού φαίνεται κατεστραμμένος.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Το kDrive βρίσκεται σε λειτουργία συντήρησης.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Ανανεώστε το kDrive. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Επικοινωνήστε με διαχειριστή για ανανέωση. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Το kDrive επανεκκινείται.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην ιστοσελίδα για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Δεν έχετε δικαίωμα πρόσβασης σε αυτό το kDrive.&lt;br&gt;Ο συγχρονισμός έχει ανασταλεί. Επικοινωνήστε με διαχειριστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Οι συνδέσεις δικτύου διακόπηκαν από τον πυρήνα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Δυστυχώς η παλαιά διαμόρφωση δεν ήταν δυνατό να μεταφερθεί.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει κενή διαμόρφωση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Δυστυχώς η παλαιά διαμόρφωση διακομιστή μεσολάβησης δεν ήταν δυνατό να μεταφερθεί· οι διακομιστές SOCKS5 δεν υποστηρίζονται.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει τις ρυθμίσεις συστήματος.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Ο φάκελος συγχρονισμού αντικαταστάθηκε ή μετακινήθηκε με τρόπο που εμποδίζει τον συγχρονισμό (σφάλμα %1).&lt;br&gt;Αυτό μπορεί να συμβεί μετά από αντιγραφή, μετακίνηση ή επαναφορά.&lt;br&gt;Δημιουργήστε νέο συγχρονισμό με νέο φάκελο.&lt;br&gt;Σημείωση: αν υπάρχουν μη συγχρονισμένες αλλαγές, αντιγράψτε τες χειροκίνητα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός επανεκκινήθηκε. Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Παρουσιάστηκε σφάλμα πρόσβασης στη βάση δεδομένων συγχρονισμού (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Το διακριτικό είναι άκυρο ή έχει ανακληθεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Οι εμφωλευμένοι συγχρονισμοί απαγορεύονται (σφάλμα %1).&lt;br&gt;Διατηρήστε μόνο συγχρονισμούς με μη εμφωλευμένους φακέλους.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Ο φάκελος συγχρονισμού στο απομακρυσμένο kDrive δεν υπάρχει πλέον ή δεν είναι προσβάσιμος (σφάλμα %1).&lt;br&gt;Επαναφέρετέ τον ή δώστε ξανά δικαιώματα πρόσβασης ή διαγράψτε/δημιουργήστε ξανά τον συγχρονισμό.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Σφάλμα ανάλυσης ονόματος αρχείου (σφάλμα %1).&lt;br&gt;Ειδικοί χαρακτήρες όπως διπλά εισαγωγικά, ανάστροφες κάθετοι ή αλλαγές γραμμής μπορούν να προκαλέσουν αποτυχίες ανάλυσης.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Αυτό το στοιχείο μετακινήθηκε αλλού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Το τοπικό στοιχείο μετονομάστηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Το αρχείο τροποποιήθηκε ταυτόχρονα από άλλον χρήστη.&lt;br&gt;Οι τροποποιήσεις σας αποθηκεύτηκαν σε αντίγραφο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Άλλος χρήστης μετακίνησε έναν γονικό φάκελο του προορισμού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Υπάρχον στοιχείο έχει πανομοιότυπο όνομα (ίδια πεζά/κεφαλαία).&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Το όνομα του στοιχείου περιέχει μη υποστηριζόμενο χαρακτήρα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Το όνομα του στοιχείου τελειώνει με κενό, κάτι που δεν επιτρέπεται στο λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Αυτό το όνομα στοιχείου είναι δεσμευμένο από το λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Το όνομα του στοιχείου είναι πολύ μακρύ.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Η διαδρομή του στοιχείου είναι πολύ μακριά.&lt;br&gt;Αγνοήθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Το όνομα του στοιχείου περιέχει πρόσφατο χαρακτήρα UNICODE που δεν υποστηρίζεται από το σύστημα αρχείων.&lt;br&gt;Εξαιρέθηκε από τον συγχρονισμό.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Το όνομα του στοιχείου περιέχει μόνο κενά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Είτε δεν έχετε άδεια να δημιουργήσετε ένα στοιχείο, είτε υπάρχει ήδη ένα άλλο στοιχείο με το ίδιο όνομα. Το στοιχείο αγνοήθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Δεν επιτρέπεται η επεξεργασία του στοιχείου.&lt;br&gt;Το αρχείο με τις αλλαγές σας μετονομάστηκε και εξαιρέθηκε από τον συγχρονισμό.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Δεν επιτρέπεται η μετονομασία του στοιχείου.&lt;br&gt;Θα αποκατασταθεί με το αρχικό του όνομα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Δεν επιτρέπεται η μετακίνηση στοιχείου στο &quot;%1&quot;.&lt;br&gt;Θα αποκατασταθεί στον αρχικό γονικό φάκελο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Δεν επιτρέπεται η διαγραφή του στοιχείου.&lt;br&gt;Θα αποκατασταθεί στην αρχική του θέση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Αποτυχία μετακίνησης στοιχείου στον κάδο, τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Αποτυχία συγχρονισμού στοιχείου. Προσωρινά τέθηκε σε μαύρη λίστα.&lt;br&gt;Νέα προσπάθεια θα γίνει σε μία ώρα ή κατά την επόμενη εκκίνηση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό βάσει προσαρμοσμένου προτύπου.&lt;br&gt;Μπορείτε να απενεργοποιήσετε αυτόν τον τύπο ειδοποίησης από τις Προτιμήσεις</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό επειδή είναι σκληρός σύνδεσμος.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Το αρχείο τροποποιήθηκε τοπικά ενώ διαγράφηκε στο απομακρυσμένο kDrive.&lt;br&gt;Το τοπικό αντίγραφο αποθηκεύτηκε στον φάκελο ανάκτησης.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Η λειτουργία που εκτελέστηκε στο στοιχείο απαγορεύεται.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Η λειτουργία στο στοιχείο απέτυχε.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Το αρχείο είναι πολύ μεγάλο για μεταφόρτωση. Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Έχετε υπερβεί το όριο χώρου. Αυξήστε το όριο για να επανενεργοποιήσετε τη μεταφόρτωση αρχείων.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Αδύνατη η λήψη του αρχείου.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Αυτό το στοιχείο είναι κλειδωμένο από άλλον χρήστη ηλεκτρονικά.&lt;br&gt;Θα επαναπροσπαθήσουμε τη μεταφόρτωση των αλλαγών αργότερα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Σφάλμα συγχρονισμού.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Δεν είναι δυνατή η πρόσβαση στο στοιχείο.&lt;br&gt;Ελέγξτε τα δικαιώματα ανάγνωσης και εγγραφής.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Η λήψη ακυρώθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Δεν είναι δυνατή η δημιουργία του αρχείου «%1», καθώς δεν υποστηρίζεται από το σύστημα αρχείων σας.&lt;br&gt;Έχει εξαιρεθεί από τον συγχρονισμό.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Σφάλμα συστήματος.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Το στοιχείο υπάρχει ήδη στην άλλη πλευρά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Μεταφορά ολοκληρώθηκε!&lt;br&gt;Χρησιμοποιήστε τον αναγνωριστικό &lt;b&gt;%1&lt;/b&gt; σε αναφορές σφαλμάτων.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Αποτυχία μεταφοράς!
+Χρησιμοποιήστε τον ακόλουθο σύνδεσμο για να στείλετε τα αρχεία καταγραφής: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Δεν έχει διαμορφωθεί kDrive!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Αυτός ο συγχρονισμός διαγράφεται.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Αυτός ο συγχρονισμός διαγράφεται.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Επιστροφή στη λίστα μονάδων</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Προτιμήσεις</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Επιστροφή στη λίστα μονάδων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Προτιμήσεις</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Μη έγκυρος σύνδεσμος %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Κάποια διεργασία απέτυχε να εκτελεστεί.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Γενικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Ενεργοποίηση σκούρου θέματος</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Ενεργοποίηση μονόχρωμων εικονιδίων</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Εκκίνηση kDrive κατά την έναρξη</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Γλώσσα</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Μεταφορά διαγραμμένων αρχείων στον κάδο</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Ορισμένα αρχεία ή φάκελοι ενδέχεται να μην μεταφερθούν στον κάδο.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Μπορείτε πάντα να ανακτήσετε συγχρονισμένα αρχεία από τον κάδο της εφαρμογής ιστού kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Προεπιλογή</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Αγγλικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Γαλλικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Γερμανικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Ισπανικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Ιταλικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Σουηδικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Πορτογαλικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Πολωνικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Νορβηγικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Φινλανδικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Δανικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Ελληνικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Ολλανδικά</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Σύνθετα</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Πληροφορίες εντοπισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Αρχεία προς εξαίρεση</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Διακομιστής μεσολάβησης</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Μη έγκυρος σύνδεσμος %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Κάποια διεργασία απέτυχε να εκτελεστεί.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Γενικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Ενεργοποίηση σκούρου θέματος</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Ενεργοποίηση μονόχρωμων εικονιδίων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Εκκίνηση kDrive κατά την έναρξη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Γλώσσα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Μεταφορά διαγραμμένων αρχείων στον κάδο</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Ορισμένα αρχεία ή φάκελοι ενδέχεται να μην μεταφερθούν στον κάδο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Μπορείτε πάντα να ανακτήσετε συγχρονισμένα αρχεία από τον κάδο της εφαρμογής ιστού kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Προεπιλογή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Αγγλικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Γαλλικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Γερμανικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Ισπανικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Ιταλικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Σουηδικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Πορτογαλικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Πολωνικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Νορβηγικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Φινλανδικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Δανικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Ελληνικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Ολλανδικά</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Σύνθετα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Πληροφορίες εντοπισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Αρχεία προς εξαίρεση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Διακομιστής μεσολάβησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 σε χρήση</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 σε χρήση</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S) Διακομιστής μεσολάβησης</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Διακομιστής μεσολάβησης</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Χωρίς διακομιστή μεσολάβησης</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Χρήση παραμέτρων συστήματος</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Ρύθμιση διακομιστή μεσολάβησης χειροκίνητα</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Θύρα</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Διεύθυνση διακομιστή μεσολάβησης</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Απαιτείται ταυτοποίηση</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Χρήστης</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Κωδικός</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Αδύνατη η αποθήκευση, δεν έχουν συμπληρωθεί όλα τα υποχρεωτικά πεδία!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Ο διακομιστής μεσολάβησης δεν βρέθηκε. Αποθήκευση ούτως ή άλλως;</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S) Διακομιστής μεσολάβησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Διακομιστής μεσολάβησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Χωρίς διακομιστή μεσολάβησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Χρήση παραμέτρων συστήματος</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Ρύθμιση διακομιστή μεσολάβησης χειροκίνητα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Θύρα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Διεύθυνση διακομιστή μεσολάβησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Απαιτείται ταυτοποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Χρήστης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Κωδικός</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Αδύνατη η αποθήκευση, δεν έχουν συμπληρωθεί όλα τα υποχρεωτικά πεδία!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Ο διακομιστής μεσολάβησης δεν βρέθηκε. Αποθήκευση ούτως ή άλλως;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Διαχείριση πόρων</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Μέγιστη επιτρεπόμενη χρήση CPU</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Διαχείριση πόρων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Μέγιστη επιτρεπόμενη χρήση CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Επιλέξτε φάκελο στο kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Τα περιεχόμενα του επιλεγμένου φακέλου θα συγχρονιστούν στον φάκελο &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>ΣΥΝΕΧΕΙΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Διαθέσιμος χώρος στον υπολογιστή για τον τρέχοντα φάκελο: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Αυτός ο φάκελος συγχρονίζεται ήδη.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ΑΚΥΡΩΣΗ</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Επιλέξτε φάκελο στο kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Τα περιεχόμενα του επιλεγμένου φακέλου θα συγχρονιστούν στον φάκελο &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>ΣΥΝΕΧΕΙΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Διαθέσιμος χώρος στον υπολογιστή για τον τρέχοντα φάκελο: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Αυτός ο φάκελος συγχρονίζεται ήδη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ΑΚΥΡΩΣΗ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; περιέχει υποφακέλους,&lt;br&gt; επιλέξτε αυτούς που θέλετε να συγχρονίσετε</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>ΣΥΝΕΧΕΙΑ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; περιέχει υποφακέλους,&lt;br&gt; επιλέξτε αυτούς που θέλετε να συγχρονίσετε</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>ΣΥΝΕΧΕΙΑ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Συνέχιση συγχρονισμού kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Συνέχιση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Συνέχιση συγχρονισμού όλων των kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Παύση συγχρονισμού kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Παύση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Παύση συγχρονισμού όλων των kDrive</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Συνέχιση συγχρονισμού kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Συνέχιση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Συνέχιση συγχρονισμού όλων των kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Παύση συγχρονισμού kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Παύση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Παύση συγχρονισμού όλων των kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Άνοιγμα</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Προσθήκη στα αγαπημένα</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Αντιγραφή συνδέσμου κοινοποίησης</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Εμφάνιση στο kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Εμφάνιση στον φάκελο</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Περισσότερες ενέργειες</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Άνοιγμα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Προσθήκη στα αγαπημένα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Αντιγραφή συνδέσμου κοινοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Εμφάνιση στο kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Εμφάνιση στον φάκελο</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Περισσότερες ενέργειες</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Άνοιγμα στον φάκελο</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Άνοιγμα ιστοσελίδας %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Παράμετροι μονάδας</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Οι ειδοποιήσεις είναι απενεργοποιημένες έως %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Απενεργοποίηση ειδοποιήσεων</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Προτιμήσεις εφαρμογής</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Χρειάζεστε βοήθεια</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Αποστολή σχολίων</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Έξοδος από το kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Δεν είναι δυνατή η πρόσβαση στον ιστότοπο %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Εμφάνιση σφαλμάτων και πληροφοριών</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Εμφάνιση πληροφοριών</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Περισσότερες ενέργειες</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Ποτέ</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Για 1 ώρα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Έως αύριο στις 8:00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Για 3 ημέρες</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Για 1 εβδομάδα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Πάντα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Για 1 ακόμη ώρα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Για 3 ακόμη ημέρες</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Για 1 ακόμη εβδομάδα</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Άνοιγμα στον φάκελο</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Άνοιγμα ιστοσελίδας %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Παράμετροι μονάδας</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Οι ειδοποιήσεις είναι απενεργοποιημένες έως %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Απενεργοποίηση ειδοποιήσεων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Προτιμήσεις εφαρμογής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Χρειάζεστε βοήθεια</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Αποστολή σχολίων</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Έξοδος από το kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Δεν είναι δυνατή η πρόσβαση στον ιστότοπο %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Εμφάνιση σφαλμάτων και πληροφοριών</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Εμφάνιση πληροφοριών</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Περισσότερες ενέργειες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Ποτέ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Για 1 ώρα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Έως αύριο στις 8:00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Για 3 ημέρες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Για 1 εβδομάδα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Πάντα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Για 1 ακόμη ώρα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Για 3 ακόμη ημέρες</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Για 1 ακόμη εβδομάδα</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Συγχρονισμένα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Αγαπημένα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Δραστηριότητα</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Ενημέρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Λήψη ενημέρωσης σε εξέλιξη</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Αναζήτηση ενημέρωσης...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Χειροκίνητη ενημέρωση</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Μη διαθέσιμο</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Δεν έχει υλοποιηθεί!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Μη έγκυρος σύνδεσμος %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Ενημέρωση εφαρμογής kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Αυτή η έκδοση της εφαρμογής kDrive δεν υποστηρίζεται πλέον. Ενημερώστε για πρόσβαση στις τελευταίες λειτουργίες.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Κάντε κλικ εδώ για χειροκίνητη λήψη&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Κατεβάστε την τελευταία έκδοση από τον ιστότοπο.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Δεν υπάρχει συγχρονισμένος φάκελος για αυτή τη μονάδα!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Δεν έχει διαμορφωθεί kDrive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Μπορείτε να συγχρονίσετε αρχεία &lt;a style="%1" href="%2"&gt;από τον υπολογιστή σας&lt;/a&gt; ή στο &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Συγχρονισμένα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Αγαπημένα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Δραστηριότητα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Λήψη ενημέρωσης σε εξέλιξη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Αναζήτηση ενημέρωσης...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Χειροκίνητη ενημέρωση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Μη διαθέσιμο</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Δεν έχει υλοποιηθεί!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Μη έγκυρος σύνδεσμος %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Ενημέρωση εφαρμογής kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Αυτή η έκδοση της εφαρμογής kDrive δεν υποστηρίζεται πλέον. Ενημερώστε για πρόσβαση στις τελευταίες λειτουργίες.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Κάντε κλικ εδώ για χειροκίνητη λήψη&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Κατεβάστε την τελευταία έκδοση από τον ιστότοπο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Δεν υπάρχει συγχρονισμένος φάκελος για αυτή τη μονάδα!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Δεν έχει διαμορφωθεί kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Μπορείτε να συγχρονίσετε αρχεία &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;από τον υπολογιστή σας&lt;/a&gt; ή στο &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Η νέα έκδοση &lt;b&gt;%1&lt;/b&gt; του πελάτη %2 είναι διαθέσιμη και έχει ληφθεί.&lt;/p&gt;&lt;p&gt;Η εγκατεστημένη έκδοση είναι %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Παράλειψη αυτής της έκδοσης</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Υπενθύμιση αργότερα</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Εγκατάσταση ενημέρωσης</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Η νέα έκδοση &lt;b&gt;%1&lt;/b&gt; του πελάτη %2 είναι διαθέσιμη και έχει ληφθεί.&lt;/p&gt;&lt;p&gt;Η εγκατεστημένη έκδοση είναι %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Παράλειψη αυτής της έκδοσης</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Υπενθύμιση αργότερα</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Εγκατάσταση ενημέρωσης</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Νέα ενημέρωση διαθέσιμη.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Η έκδοση %1 είναι διαθέσιμη για λήψη.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Νέα ενημέρωση διαθέσιμη.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Η έκδοση %1 είναι διαθέσιμη για λήψη.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Προσθήκη λογαριασμού</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Προσθήκη λογαριασμού</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Εμφάνιση σημειώσεων έκδοσης&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Έκδοση</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>ΕΝΗΜΕΡΩΣΗ</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>Το %1 είναι ενημερωμένο!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Έλεγχος ενημέρωσης στον διακομιστή...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Διαθέσιμη ενημέρωση: %1.&lt;br&gt;Κατεβάστε τη από &lt;a style="%2" href="%3"&gt;εδώ&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Διαθέσιμη ενημέρωση: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Λήψη %1. Παρακαλώ περιμένετε...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Δεν ήταν δυνατός ο έλεγχος για νέες ενημερώσεις.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Παρουσιάστηκε σφάλμα κατά την ενημέρωση.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Δεν ήταν δυνατή η λήψη ενημέρωσης.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Η ενημέρωση απενεργοποιήθηκε.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Πρόγραμμα beta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Συμμετοχή</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Τροποποίηση</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Έξοδος</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Εμφάνιση σημειώσεων έκδοσης&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Έκδοση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>ΕΝΗΜΕΡΩΣΗ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>Το %1 είναι ενημερωμένο!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Έλεγχος ενημέρωσης στον διακομιστή...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Διαθέσιμη ενημέρωση: %1.&lt;br&gt;Κατεβάστε τη από &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;εδώ&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Διαθέσιμη ενημέρωση: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Λήψη %1. Παρακαλώ περιμένετε...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Δεν ήταν δυνατός ο έλεγχος για νέες ενημερώσεις.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά την ενημέρωση.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Δεν ήταν δυνατή η λήψη ενημέρωσης.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Η ενημέρωση απενεργοποιήθηκε.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Πρόγραμμα beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Συμμετοχή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Τροποποίηση</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Έξοδος</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Το Lite sync (Beta) είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Το Lite sync (Beta) είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Το Lite sync είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Το Lite sync είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Αδύνατη η αποθήκευση παραμέτρων, δοκιμάστε ξανά αργότερα.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Αδύνατη η αποθήκευση παραμέτρων!</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Διαθεσιμότητα τοπικά</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Ελευθέρωση τοπικού χώρου</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Ακύρωση ελευθέρωσης τοπικού χώρου</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Ακύρωση τοπικής διαθεσιμότητας</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Η κοινοποίηση αυτού του αρχείου δεν επιτρέπεται</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Η κοινοποίηση αυτού του φακέλου δεν επιτρέπεται</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Αντιγραφή δημόσιου συνδέσμου κοινοποίησης</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Αντιγραφή ιδιωτικού συνδέσμου κοινοποίησης</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Άνοιγμα στον περιηγητή</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Ο γονικός φάκελος είναι φάκελος συγχρονισμού ή περιέχεται σε έναν</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Δεν βρέθηκε έγκυρη διαδρομή</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Δεν επιλέχθηκε έγκυρος φάκελος!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Η επιλεγμένη διαδρομή δεν υπάρχει!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Η επιλεγμένη διαδρομή δεν είναι φάκελος!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Δεν έχετε δικαίωμα εγγραφής στον επιλεγμένο φάκελο!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Ο τοπικός φάκελος %1 περιέχει φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Ο τοπικός φάκελος %1 περιέχεται σε φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Ο τοπικός φάκελος %1 συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Το Lite sync (Beta) είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Το Lite sync (Beta) είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Το Lite sync είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Το Lite sync είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Αδύνατη η αποθήκευση παραμέτρων, δοκιμάστε ξανά αργότερα.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Αδύνατη η αποθήκευση παραμέτρων!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Διαθεσιμότητα τοπικά</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Ελευθέρωση τοπικού χώρου</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Ακύρωση ελευθέρωσης τοπικού χώρου</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Ακύρωση τοπικής διαθεσιμότητας</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Η κοινοποίηση αυτού του αρχείου δεν επιτρέπεται</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Η κοινοποίηση αυτού του φακέλου δεν επιτρέπεται</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Αντιγραφή δημόσιου συνδέσμου κοινοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Αντιγραφή ιδιωτικού συνδέσμου κοινοποίησης</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Άνοιγμα στον περιηγητή</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Ο γονικός φάκελος είναι φάκελος συγχρονισμού ή περιέχεται σε έναν</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Δεν βρέθηκε έγκυρη διαδρομή</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Δεν επιλέχθηκε έγκυρος φάκελος!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Η επιλεγμένη διαδρομή δεν υπάρχει!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Η επιλεγμένη διαδρομή δεν είναι φάκελος!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Δεν έχετε δικαίωμα εγγραφής στον επιλεγμένο φάκελο!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Ο τοπικός φάκελος %1 περιέχει φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Ο τοπικός φάκελος %1 περιέχεται σε φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Ο τοπικός φάκελος %1 συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>Η εφαρμογή kDrive θα κλείσει λόγω κρίσιμου σφάλματος.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>Η εφαρμογή kDrive θα κλείσει λόγω κρίσιμου σφάλματος.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n χρόνος</numerusform>
-<numerusform>%n χρόνια</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n μήνας</numerusform>
-<numerusform>%n μήνες</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n ημέρα</numerusform>
-<numerusform>%n ημέρες</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n ώρα</numerusform>
-<numerusform>%n ώρες</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n λεπτό</numerusform>
-<numerusform>%n λεπτά</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n δευτερόλεπτο</numerusform>
-<numerusform>%n δευτερόλεπτα</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
+    <name>Utility</name>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n χρόνος</numerusform>
+            <numerusform>%n χρόνια</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n μήνας</numerusform>
+            <numerusform>%n μήνες</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n ημέρα</numerusform>
+            <numerusform>%n ημέρες</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n ώρα</numerusform>
+            <numerusform>%n ώρες</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n λεπτό</numerusform>
+            <numerusform>%n λεπτά</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n δευτερόλεπτο</numerusform>
+            <numerusform>%n δευτερόλεπτα</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Η γραμμή συστήματος δεν είναι διαθέσιμη</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 απαιτεί μια λειτουργική γραμμή συστήματος. Εάν χρησιμοποιείτε XFCE, ακολουθήστε &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;αυτές τις οδηγίες&lt;/a&gt;. Διαφορετικά, εγκαταστήστε μια εφαρμογή γραμμής συστήματος όπως 'trayer' και δοκιμάστε ξανά.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Η γραμμή συστήματος δεν είναι διαθέσιμη</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 απαιτεί μια λειτουργική γραμμή συστήματος. Εάν χρησιμοποιείτε XFCE, ακολουθήστε &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;αυτές τις οδηγίες&lt;/a&gt;. Διαφορετικά, εγκαταστήστε μια εφαρμογή γραμμής συστήματος όπως &apos;trayer&apos; και δοκιμάστε ξανά.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Δεν ήταν δυνατό το άνοιγμα του περιηγητή</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του περιηγητή για το URL %1. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος περιηγητής;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Δεν ήταν δυνατό το άνοιγμα του πελάτη email</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του πελάτη email. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος πελάτης email;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Δεν είστε πλέον συνδεδεμένοι. &lt;a style="%1" href="%2"&gt;Σύνδεση&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Δεν ήταν δυνατό το άνοιγμα του περιηγητή</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του περιηγητή για το URL %1. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος περιηγητής;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Δεν ήταν δυνατό το άνοιγμα του πελάτη email</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του πελάτη email. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος πελάτης email;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Δεν είστε πλέον συνδεδεμένοι. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Σύνδεση&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Δεν υπάρχει φάκελος για συγχρονισμό
+        <translation>Δεν υπάρχει φάκελος για συγχρονισμό
 Μπορείτε να προσθέσετε έναν από τις ρυθμίσεις kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Συγχρονισμός σε εξέλιξη (%1 από %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Συγχρονισμός σε εξέλιξη (%1 από %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Συγχρονισμός σε εξέλιξη (%1 από %2)
+        <translation>Συγχρονισμός σε εξέλιξη (%1 από %2)
 %3 απομένουν...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Συγχρονισμός σε εξέλιξη (Βήμα %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Εκκίνηση συγχρονισμού</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Συγχρονισμός σε εξέλιξη.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Είστε ενημερωμένοι, με μη επιλυμένες συγκρούσεις.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Είστε ενημερωμένοι!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν. &lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Παύση συγχρονισμού...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Ο συγχρονισμός ανεστάλη.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή χρησιμοποιείται ήδη από άλλον συγχρονισμό.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχει τον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχεται στον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον φάκελο.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον. Προτεινόμενος: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Έχετε εξαιρέσει περισσότερους από %1 φακέλους. Αυτό θα επηρεάσει τις επιδόσεις συγχρονισμού.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Δεν μπορείτε να εξαιρέσετε περισσότερους από %1 φακέλους. Αποεπιλέξτε φακέλους υψηλότερου επιπέδου.</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Συγχρονισμός σε εξέλιξη (Βήμα %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Εκκίνηση συγχρονισμού</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Συγχρονισμός σε εξέλιξη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Είστε ενημερωμένοι, με μη επιλυμένες συγκρούσεις.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Είστε ενημερωμένοι!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Παύση συγχρονισμού...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Ο συγχρονισμός ανεστάλη.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή χρησιμοποιείται ήδη από άλλον συγχρονισμό.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχει τον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχεται στον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον φάκελο.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον. Προτεινόμενος: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Έχετε εξαιρέσει περισσότερους από %1 φακέλους. Αυτό θα επηρεάσει τις επιδόσεις συγχρονισμού.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Δεν μπορείτε να εξαιρέσετε περισσότερους από %1 φακέλους. Αποεπιλέξτε φακέλους υψηλότερου επιπέδου.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_el.ts
+++ b/translations/client_el.ts
@@ -1,2580 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="el_GR">
+<TS language="el_GR" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Σχετικά</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">ΚΛΕΙΣΙΜΟ</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Έκδοση %1. Για περισσότερες πληροφορίες επισκεφθείτε &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Πνευματικά δικαιώματα 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Διανέμεται από τον %1 και αδειοδοτείται υπό &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;Το %2 και το λογότυπο %2 είναι κατοχυρωμένα εμπορικά σήματα του %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Κατασκευάστηκε από &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;πηγές Git&lt;/a&gt; στις %2, %3 χρησιμοποιώντας Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Σχετικά</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>ΚΛΕΙΣΙΜΟ</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Έκδοση %1. Για περισσότερες πληροφορίες επισκεφθείτε &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Πνευματικά δικαιώματα 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Διανέμεται από τον %1 και αδειοδοτείται υπό &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;Το %2 και το λογότυπο %2 είναι κατοχυρωμένα εμπορικά σήματα του %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Κατασκευάστηκε από &lt;a style="color: #489EF3" href="%1"&gt;πηγές Git&lt;/a&gt; στις %2, %3 χρησιμοποιώντας Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Ο συγχρονισμός θα ξεκινήσει και θα μπορείτε να προσθέσετε αρχεία στον φάκελο %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Το kDrive σας είναι έτοιμο!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ΑΝΟΙΓΜΑ ΦΑΚΕΛΟΥ</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">ΠΑΡΑΜΕΤΡΟΙ</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Συγχρονισμός άλλης μονάδας</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Ο συγχρονισμός θα ξεκινήσει και θα μπορείτε να προσθέσετε αρχεία στον φάκελο %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Το kDrive σας είναι έτοιμο!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ΑΝΟΙΓΜΑ ΦΑΚΕΛΟΥ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>ΠΑΡΑΜΕΤΡΟΙ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Συγχρονισμός άλλης μονάδας</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">ΕΠΟΜΕΝΟ</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Επιλέξτε το kDrive που θέλετε να συγχρονίσετε</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Αποκτήστε kDrive δωρεάν</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Αποθηκεύστε φωτογραφίες, έγγραφα και email στην Ελβετία από ανεξάρτητη εταιρεία που σέβεται την ιδιωτικότητα. Μάθετε περισσότερα</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Δοκιμάστε δωρεάν</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Ακύρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>ΕΠΟΜΕΝΟ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Επιλέξτε το kDrive που θέλετε να συγχρονίσετε</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Αποκτήστε kDrive δωρεάν</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Αποθηκεύστε φωτογραφίες, έγγραφα και email στην Ελβετία από ανεξάρτητη εταιρεία που σέβεται την ιδιωτικότητα. Μάθετε περισσότερα</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Δοκιμάστε δωρεάν</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Θέλετε να ενεργοποιήσετε το Lite Sync (Beta);</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Θέλετε να ενεργοποιήσετε το Lite Sync;</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Το Lite Sync συγχρονίζει όλα τα αρχεία χωρίς να καταναλώνει χώρο στον υπολογιστή. Μπορείτε να περιηγηθείτε στα αρχεία του kDrive και να τα κατεβάσετε τοπικά όποτε θέλετε. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Εξοικονομήστε χώρο στον υπολογιστή</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Αποφασίστε ποια αρχεία θα είναι διαθέσιμα ηλεκτρονικά ή τοπικά</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">ΑΡΓΟΤΕΡΑ</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">ΝΑΙ</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Θέλετε να ενεργοποιήσετε το Lite Sync (Beta);</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Θέλετε να ενεργοποιήσετε το Lite Sync;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Το Lite Sync συγχρονίζει όλα τα αρχεία χωρίς να καταναλώνει χώρο στον υπολογιστή. Μπορείτε να περιηγηθείτε στα αρχεία του kDrive και να τα κατεβάσετε τοπικά όποτε θέλετε. &lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Εξοικονομήστε χώρο στον υπολογιστή</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Αποφασίστε ποια αρχεία θα είναι διαθέσιμα ηλεκτρονικά ή τοπικά</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>ΑΡΓΟΤΕΡΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>ΝΑΙ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Τοποθεσία του kDrive %1 σας</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Επεξεργασία φακέλου</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Θα βρείτε όλα τα αρχεία σας σε αυτόν τον φάκελο μόλις ολοκληρωθεί η διαμόρφωση. Μπορείτε να προσθέσετε νέα αρχεία για συγχρονισμό με το kDrive.</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ΤΕΛΟΣ</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">ΣΥΝΕΧΕΙΑ</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Τα περιεχόμενα του φακέλου &lt;b&gt;%1&lt;/b&gt; θα συγχρονιστούν στο kDrive</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Τοποθεσία του kDrive %1 σας</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Επεξεργασία φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Θα βρείτε όλα τα αρχεία σας σε αυτόν τον φάκελο μόλις ολοκληρωθεί η διαμόρφωση. Μπορείτε να προσθέσετε νέα αρχεία για συγχρονισμό με το kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>ΤΕΛΟΣ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>ΣΥΝΕΧΕΙΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Τα περιεχόμενα του φακέλου &lt;b&gt;%1&lt;/b&gt; θα συγχρονιστούν στο kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt; 
 Επιλέξτε άλλον φάκελο. Αν συνεχίσετε, το Lite Sync θα απενεργοποιηθεί.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Επιλογή φακέλου</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Επιλογή φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Σύνδεση μέσω του περιηγητή</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Ο περιηγητής σας θα ανοίξει αυτόματα για να ολοκληρωθεί η σύνδεση. Μόλις συνδεθείτε, θα επιστρέψετε αυτόματα στο kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Άνοιγμα σελίδας σύνδεσης</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά τον έλεγχο ταυτότητας. Κλείστε το παράθυρο σύνδεσης και δοκιμάστε ξανά.&lt;br&gt;Εάν το σφάλμα επιμένει, επικοινωνήστε με την ομάδα υποστήριξής μας.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Αποτυχία σύνδεσης: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Αποτυχία ανοίγματος σελίδας σύνδεσης στον περιηγητή</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Σύνδεση μέσω του περιηγητή</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Ο περιηγητής σας θα ανοίξει αυτόματα για να ολοκληρωθεί η σύνδεση. Μόλις συνδεθείτε, θα επιστρέψετε αυτόματα στο kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Άνοιγμα σελίδας σύνδεσης</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Παρουσιάστηκε σφάλμα κατά τον έλεγχο ταυτότητας. Κλείστε το παράθυρο σύνδεσης και δοκιμάστε ξανά.&lt;br&gt;Εάν το σφάλμα επιμένει, επικοινωνήστε με την ομάδα υποστήριξής μας.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Αποτυχία σύνδεσης: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Αποτυχία ανοίγματος σελίδας σύνδεσης στον περιηγητή</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Επιλέξτε φακέλους kDrive για συγχρονισμό στον υπολογιστή</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">ΣΥΝΕΧΕΙΑ</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Διαθέσιμος χώρος στον υπολογιστή: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Αδύνατη η φόρτωση της λίστας υποφακέλων. Το kDrive μπορεί να βρίσκεται σε συντήρηση.&lt;br&gt;Συνδεθείτε στην &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Επιλέξτε φακέλους kDrive για συγχρονισμό στον υπολογιστή</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>ΣΥΝΕΧΕΙΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Διαθέσιμος χώρος στον υπολογιστή: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Αδύνατη η φόρτωση της λίστας υποφακέλων. Το kDrive μπορεί να βρίσκεται σε συντήρηση.&lt;br&gt;Συνδεθείτε στην &lt;a style="%1" href="%2"&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Αποτυχία δημιουργίας τοπικού φακέλου %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">Το kDrive %1 είναι ήδη συγχρονισμένο σε αυτόν τον υπολογιστή. Θέλετε να συνεχίσετε;</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Αποτυχία δημιουργίας τοπικού φακέλου %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>Το kDrive %1 είναι ήδη συγχρονισμένο σε αυτόν τον υπολογιστή. Θέλετε να συνεχίσετε;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">Ο πελάτης kDrive εκτελείται με εσφαλμένες παραμέτρους!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">Ο πελάτης kDrive εκτελείται ήδη!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Ο χρήστης %1 δεν είναι συνδεδεμένος. Παρακαλώ συνδεθείτε ξανά.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>Ο πελάτης kDrive εκτελείται με εσφαλμένες παραμέτρους!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>Ο πελάτης kDrive εκτελείται ήδη!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Ο χρήστης %1 δεν είναι συνδεδεμένος. Παρακαλώ συνδεθείτε ξανά.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Ο σύνδεσμος κοινοποίησης αντιγράφηκε στο πρόχειρο</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 και %n άλλο αρχείο αφαιρέθηκαν.</numerusform>
-            <numerusform>%1 και %n άλλα αρχεία αφαιρέθηκαν.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">Το %1 αφαιρέθηκε.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 και %n άλλο αρχείο προστέθηκαν.</numerusform>
-            <numerusform>%1 και %n άλλα αρχεία προστέθηκαν.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">Το %1 προστέθηκε.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 και %n άλλο αρχείο ενημερώθηκαν.</numerusform>
-            <numerusform>%1 και %n άλλα αρχεία ενημερώθηκαν.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">Το %1 ενημερώθηκε.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλο αρχείο μετακινήθηκε.</numerusform>
-            <numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλα αρχεία μετακινήθηκαν.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">Το %1 μετακινήθηκε στο %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Δραστηριότητα συγχρονισμού</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Ο σύνδεσμος κοινοποίησης αντιγράφηκε στο πρόχειρο</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 και %n άλλο αρχείο αφαιρέθηκαν.</numerusform>
+<numerusform>%1 και %n άλλα αρχεία αφαιρέθηκαν.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>Το %1 αφαιρέθηκε.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 και %n άλλο αρχείο προστέθηκαν.</numerusform>
+<numerusform>%1 και %n άλλα αρχεία προστέθηκαν.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>Το %1 προστέθηκε.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 και %n άλλο αρχείο ενημερώθηκαν.</numerusform>
+<numerusform>%1 και %n άλλα αρχεία ενημερώθηκαν.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>Το %1 ενημερώθηκε.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλο αρχείο μετακινήθηκε.</numerusform>
+<numerusform>Το %1 μετακινήθηκε στο %2 και %n άλλα αρχεία μετακινήθηκαν.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>Το %1 μετακινήθηκε στο %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Δραστηριότητα συγχρονισμού</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Αποχώρηση από το πρόγραμμα beta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Συμμετοχή στο πρόγραμμα beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής πριν κυκλοφορήσουν στο ευρύ κοινό και συμμετάσχετε στη βελτίωσή της αποστέλλοντας τα σχόλιά σας.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Επωφεληθείτε από τις ενημερώσεις beta της εφαρμογής</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Όχι</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Δημόσια έκδοση beta</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Εσωτερική έκδοση beta</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Δοκιμαστική έκδοση</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Κατανοώ</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Είστε βέβαιοι ότι θέλετε να αποχωρήσετε από το πρόγραμμα beta;</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Αποθήκευση</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Η τρέχουσα έκδοση της εφαρμογής μπορεί να είναι πολύ πρόσφατη. Η επιλογή σας θα ισχύσει με την επόμενη διαθέσιμη ενημέρωση.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Οι εκδόσεις beta ενδέχεται να διακοπούν απροσδόκητα ή να προκαλέσουν αστάθειες.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Αποχώρηση από το πρόγραμμα beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Συμμετοχή στο πρόγραμμα beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής πριν κυκλοφορήσουν στο ευρύ κοινό και συμμετάσχετε στη βελτίωσή της αποστέλλοντας τα σχόλιά σας.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Επωφεληθείτε από τις ενημερώσεις beta της εφαρμογής</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Όχι</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Δημόσια έκδοση beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Εσωτερική έκδοση beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Δοκιμαστική έκδοση</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Κατανοώ</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Είστε βέβαιοι ότι θέλετε να αποχωρήσετε από το πρόγραμμα beta;</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Αποθήκευση</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Ακύρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Η τρέχουσα έκδοση της εφαρμογής μπορεί να είναι πολύ πρόσφατη. Η επιλογή σας θα ισχύσει με την επόμενη διαθέσιμη ενημέρωση.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Οι εκδόσεις beta ενδέχεται να διακοπούν απροσδόκητα ή να προκαλέσουν αστάθειες.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Δεν είναι δυνατή η αρχικοποίηση του πελάτη kDrive</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Αποτυχία επίλυσης %1 σύγκρουση(ων) σε φάκελο συγχρονισμού: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Παρακαλώ συνδεθείτε</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Ο συγχρονισμός έχει τεθεί σε παύση</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Φάκελος %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Δεν έχουν διαμορφωθεί φάκελοι συγχρονισμού.</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Απροσδιόριστη κατάσταση.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Αναμονή έναρξης συγχρονισμού.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Ο συγχρονισμός εκτελείται.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Ο συγχρονισμός ήταν επιτυχής, με μη επιλυμένες συγκρούσεις.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Ο τελευταίος συγχρονισμός ήταν επιτυχής.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Ακύρωση από τον χρήστη.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Ο συγχρονισμός είναι σε παύση.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Ο συγχρονισμός είναι σε παύση)</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Θέλετε πραγματικά να καταργήσετε τους συγχρονισμούς του λογαριασμού &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">ΚΑΤΑΡΓΗΣΗ ΟΛΩΝ ΤΩΝ ΣΥΓΧΡΟΝΙΣΜΩΝ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 στοιχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Για να αποφευχθούν ακούσιες διαγραφές, ο συγχρονισμός έχει τεθεί σε παύση.&lt;br&gt;Θέλετε να μεταφέρετε αυτές τις διαγραφές στο kDrive σας;</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Αρκετά αρχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Τα διαγραμμένα αρχεία βρίσκονται στον &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;κάδο ανακύκλωσης&lt;/a&gt; του kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Να μην εμφανίζεται ξανά</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Σύνοψη</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Προτιμήσεις</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Έξοδος</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Αποτυχία εκκίνησης συγχρονισμών!</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Δεν είναι δυνατή η αρχικοποίηση του πελάτη kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Αποτυχία επίλυσης %1 σύγκρουση(ων) σε φάκελο συγχρονισμού: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Παρακαλώ συνδεθείτε</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Ο συγχρονισμός έχει τεθεί σε παύση</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Φάκελος %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Δεν έχουν διαμορφωθεί φάκελοι συγχρονισμού.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Απροσδιόριστη κατάσταση.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Αναμονή έναρξης συγχρονισμού.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Ο συγχρονισμός εκτελείται.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Ο συγχρονισμός ήταν επιτυχής, με μη επιλυμένες συγκρούσεις.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Ο τελευταίος συγχρονισμός ήταν επιτυχής.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Ακύρωση από τον χρήστη.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Ο συγχρονισμός είναι σε παύση.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Ο συγχρονισμός είναι σε παύση)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Θέλετε πραγματικά να καταργήσετε τους συγχρονισμούς του λογαριασμού &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>ΚΑΤΑΡΓΗΣΗ ΟΛΩΝ ΤΩΝ ΣΥΓΧΡΟΝΙΣΜΩΝ</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 στοιχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Για να αποφευχθούν ακούσιες διαγραφές, ο συγχρονισμός έχει τεθεί σε παύση.&lt;br&gt;Θέλετε να μεταφέρετε αυτές τις διαγραφές στο kDrive σας;</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Αρκετά αρχεία διαγράφηκαν από τον τοπικό φάκελο συγχρονισμού σας &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Τα διαγραμμένα αρχεία βρίσκονται στον &lt;a style="%1" href="%3"&gt;κάδο ανακύκλωσης&lt;/a&gt; του kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Να μην εμφανίζεται ξανά</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Σύνοψη</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Προτιμήσεις</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Έξοδος</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Αποτυχία εκκίνησης συγχρονισμών!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Σύνοψη συγχρονισμού τοπικού φακέλου</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Τα περιεχόμενα του φακέλου στον υπολογιστή θα συγχρονιστούν με τον φάκελο του επιλεγμένου kDrive και αντίστροφα.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">ΣΥΓΧΡΟΝΙΣΜΟΣ</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Σύνοψη συγχρονισμού τοπικού φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Τα περιεχόμενα του φακέλου στον υπολογιστή θα συγχρονιστούν με τον φάκελο του επιλεγμένου kDrive και αντίστροφα.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>ΣΥΓΧΡΟΝΙΣΜΟΣ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Πριν την ολοκλήρωση</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Ακολουθήστε τα παρακάτω βήματα για να διασφαλίσετε τη σωστή λειτουργία του Lite Sync στον υπολογιστή σας και να ολοκληρώσετε τη διαμόρφωση του kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ανοίξτε τις &lt;b&gt;Γενικές ρυθμίσεις&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ανοίξτε τις ρυθμίσεις &lt;b&gt;Απόρρητο &amp;amp; Ασφάλεια&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ανοίξτε τις ρυθμίσεις &lt;b&gt;Ασφάλεια &amp;amp; Απόρρητο&lt;/b&gt; του Mac ή  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Μεταβείτε στην ενότητα &lt;b&gt;&quot;Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις&quot;&lt;/b&gt; και στη συνέχεια στο &lt;b&gt;&quot;Επεκτάσεις ασφαλείας τερματικού&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Εξουσιοδοτήστε την εφαρμογή kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Μεταβείτε στην ενότητα &lt;b&gt;&quot;Ασφάλεια&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Εξουσιοδοτήστε την εφαρμογή kDrive στο πλαίσιο που υποδεικνύει ότι το kDrive έχει αποκλειστεί</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Ξεκλειδώστε το λουκέτο &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; και εξουσιοδοτήστε την εφαρμογή kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Μεταβείτε στην ενότητα &lt;b&gt;&quot;Απόρρητο &amp;amp; Ασφάλεια&quot;&lt;/b&gt; και κάντε κλικ στο &lt;b&gt;&quot;Πλήρης πρόσβαση δίσκου&quot;&lt;/b&gt; ή &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Στις ρυθμίσεις Ασφάλεια &amp;amp; Απόρρητο, ανοίξτε την καρτέλα &lt;b&gt;&quot;Απόρρητο&quot;&lt;/b&gt; ή &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Επιλέξτε το πλαίσιο &quot;kDrive LiteSync Extension&quot; και στη συνέχεια το πλαίσιο &quot;kDrive.app&quot; (αν δεν είναι ήδη επιλεγμένο)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Ενδέχεται να προταθεί επανεκκίνηση της εφαρμογής, σε αυτή την περίπτωση αποδεχτείτε την</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Επιλέξτε το πλαίσιο &quot;kDrive LiteSync Extension&quot; (και &quot;kDrive.app&quot; αν υπάρχει) στην &lt;b&gt;&quot;Πλήρη πρόσβαση δίσκου&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">ΒΗΜΑ 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Ολοκληρώθηκε)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">ΒΗΜΑ 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">ΒΗΜΑΤΑ ΕΚΤΕΛΕΣΤΗΚΑΝ</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ΤΕΛΟΣ</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Πριν την ολοκλήρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Ακολουθήστε τα παρακάτω βήματα για να διασφαλίσετε τη σωστή λειτουργία του Lite Sync στον υπολογιστή σας και να ολοκληρώσετε τη διαμόρφωση του kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ανοίξτε τις &lt;b&gt;Γενικές ρυθμίσεις&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Απόρρητο &amp;amp; Ασφάλεια&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ανοίξτε τις ρυθμίσεις &lt;b&gt;Ασφάλεια &amp;amp; Απόρρητο&lt;/b&gt; του Mac ή  &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις"&lt;/b&gt; και στη συνέχεια στο &lt;b&gt;"Επεκτάσεις ασφαλείας τερματικού"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Εξουσιοδοτήστε την εφαρμογή kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Ασφάλεια"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Εξουσιοδοτήστε την εφαρμογή kDrive στο πλαίσιο που υποδεικνύει ότι το kDrive έχει αποκλειστεί</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Ξεκλειδώστε το λουκέτο &lt;img src=":/client/resources/icons/actions/lock.png"&gt; και εξουσιοδοτήστε την εφαρμογή kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Μεταβείτε στην ενότητα &lt;b&gt;"Απόρρητο &amp;amp; Ασφάλεια"&lt;/b&gt; και κάντε κλικ στο &lt;b&gt;"Πλήρης πρόσβαση δίσκου"&lt;/b&gt; ή &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Στις ρυθμίσεις Ασφάλεια &amp;amp; Απόρρητο, ανοίξτε την καρτέλα &lt;b&gt;"Απόρρητο"&lt;/b&gt; ή &lt;a style="%1" href="%2"&gt;κάντε κλικ εδώ&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Επιλέξτε το πλαίσιο "kDrive LiteSync Extension" και στη συνέχεια το πλαίσιο "kDrive.app" (αν δεν είναι ήδη επιλεγμένο)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Ενδέχεται να προταθεί επανεκκίνηση της εφαρμογής, σε αυτή την περίπτωση αποδεχτείτε την</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Επιλέξτε το πλαίσιο "kDrive LiteSync Extension" (και "kDrive.app" αν υπάρχει) στην &lt;b&gt;"Πλήρη πρόσβαση δίσκου"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>ΒΗΜΑ 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Ολοκληρώθηκε)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>ΒΗΜΑ 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>ΒΗΜΑΤΑ ΕΚΤΕΛΕΣΤΗΚΑΝ</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>ΤΕΛΟΣ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">ΟΚ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">ΝΑΙ</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">ΟΧΙ</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>ΟΚ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>ΝΑΙ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>ΟΧΙ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Αποστολή πληροφοριών εντοπισμού σφαλμάτων</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Αποστολή πληροφοριών εντοπισμού σφαλμάτων</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Ακύρωση</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Εντοπισμός σφαλμάτων</translation>
-    </message>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Πληροφορίες</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Προειδοποίηση</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Σφάλμα</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Κρίσιμο</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Ρυθμίσεις εντοπισμού σφαλμάτων</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Αποθήκευση πληροφοριών εντοπισμού σε φάκελο στον υπολογιστή (Συνιστάται)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Αυτές οι πληροφορίες επιτρέπουν στην τεχνική υποστήριξη να προσδιορίσει την αιτία ενός συμβάντος.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Επίπεδο εντοπισμού</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Το επίπεδο ιχνηλάτησης σάς επιτρέπει να επιλέξετε την έκταση των καταγεγραμμένων πληροφοριών εντοπισμού</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Το εκτεταμένο πλήρες αρχείο καταγραφής συλλέγει λεπτομερές ιστορικό για εντοπισμό σφαλμάτων. Η ενεργοποίησή του μπορεί να επιβραδύνει την εφαρμογή kDrive.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Εκτεταμένο πλήρες αρχείο καταγραφής</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Διαγραφή αρχείων καταγραφής παλαιότερων από %1 ημέρες</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Κοινοποίηση του φακέλου εντοπισμού με την υποστήριξη Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Η τελευταία συνεδρία είναι η περίοδος από την τελευταία εκκίνηση του kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Φόρτωση</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ΑΠΟΘΗΚΕΥΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Αποτυχία κοινοποίησης</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Βεβαιωθείτε ότι είστε συνδεδεμένοι &lt;br&gt;2. Βεβαιωθείτε ότι έχετε διαμορφώσει τουλάχιστον ένα kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Η σύνδεση διακόπηκε)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Κοινοποίηση του φακέλου μέσω SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Συμπιέσαμε αυτόματα το αρχείο καταγραφής σας &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;εδώ&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Μεταφέρετε το αρχείο με &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Κοινοποιήστε τον σύνδεσμο στο &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Τελευταία μεταφόρτωση στις %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Η κοινοποίηση ακυρώθηκε</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Το εκτεταμένο πλήρες αρχείο ενεργοποιείται μέσω της μεταβλητής περιβάλλοντος KDRIVE_FORCE_EXTENDED_LOG. Ορίστε το σε 0 για απενεργοποίηση.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 στις %4:%5 και %6 δευτερόλεπτα</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Κοινοποίηση</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Κοινοποίηση | βήμα 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Κοινοποίηση | βήμα 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Ακύρωση...</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Ο φάκελος είναι μεγάλος (&gt; 100 MB) και η κοινοποίησή του ενδέχεται να διαρκέσει. Για μικρότερο χρόνο, συνιστάται η κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive.</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Εντοπισμός σφαλμάτων</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Πληροφορίες</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Προειδοποίηση</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Σφάλμα</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Κρίσιμο</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Ρυθμίσεις εντοπισμού σφαλμάτων</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Αποθήκευση πληροφοριών εντοπισμού σε φάκελο στον υπολογιστή (Συνιστάται)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Αυτές οι πληροφορίες επιτρέπουν στην τεχνική υποστήριξη να προσδιορίσει την αιτία ενός συμβάντος.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Επίπεδο εντοπισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Το επίπεδο ιχνηλάτησης σάς επιτρέπει να επιλέξετε την έκταση των καταγεγραμμένων πληροφοριών εντοπισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Το εκτεταμένο πλήρες αρχείο καταγραφής συλλέγει λεπτομερές ιστορικό για εντοπισμό σφαλμάτων. Η ενεργοποίησή του μπορεί να επιβραδύνει την εφαρμογή kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Εκτεταμένο πλήρες αρχείο καταγραφής</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Διαγραφή αρχείων καταγραφής παλαιότερων από %1 ημέρες</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Κοινοποίηση του φακέλου εντοπισμού με την υποστήριξη Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Η τελευταία συνεδρία είναι η περίοδος από την τελευταία εκκίνηση του kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Φόρτωση</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Ακύρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Αποτυχία κοινοποίησης</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Βεβαιωθείτε ότι είστε συνδεδεμένοι &lt;br&gt;2. Βεβαιωθείτε ότι έχετε διαμορφώσει τουλάχιστον ένα kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Η σύνδεση διακόπηκε)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Κοινοποίηση του φακέλου μέσω SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Συμπιέσαμε αυτόματα το αρχείο καταγραφής σας &lt;a style="%1" href="%2"&gt;εδώ&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Μεταφέρετε το αρχείο με &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Κοινοποιήστε τον σύνδεσμο στο &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Τελευταία μεταφόρτωση στις %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Η κοινοποίηση ακυρώθηκε</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Το εκτεταμένο πλήρες αρχείο ενεργοποιείται μέσω της μεταβλητής περιβάλλοντος KDRIVE_FORCE_EXTENDED_LOG. Ορίστε το σε 0 για απενεργοποίηση.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 στις %4:%5 και %6 δευτερόλεπτα</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Κοινοποίηση</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Κοινοποίηση | βήμα 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Κοινοποίηση | βήμα 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Ακύρωση...</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Ο φάκελος είναι μεγάλος (&gt; 100 MB) και η κοινοποίησή του ενδέχεται να διαρκέσει. Για μικρότερο χρόνο, συνιστάται η κοινοποίηση μόνο της τελευταίας συνεδρίας kDrive.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Σφάλματα και πληροφορίες συγχρονισμού.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Συγχρονισμός τοπικού φακέλου</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Θέλετε πραγματικά να ενεργοποιήσετε το Lite Sync;</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Αυτή η λειτουργία μπορεί να διαρκέσει από λίγα δευτερόλεπτα έως λίγα λεπτά ανάλογα με το μέγεθος του φακέλου.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">ΕΠΙΒΕΒΑΙΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Θέλετε πραγματικά να απενεργοποιήσετε το Lite Sync;</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Δεν έχετε αρκετό χώρο για να συγχρονίσετε όλα τα αρχεία του kDrive (%1 απαιτούνται). Αν απενεργοποιήσετε το Lite Sync, πρέπει να επιλέξετε ποιους φακέλους θα συγχρονίσετε. Εν τω μεταξύ, ο συγχρονισμός θα τεθεί σε παύση.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Αν απενεργοποιήσετε το Lite Sync, όλα τα αρχεία θα ληφθούν στον υπολογιστή σας.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Αποτυχία συγχρονισμού νέου τοπικού φακέλου!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Το Lite Sync ενεργοποιήθηκε.</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Αποτυχία ενεργοποίησης Lite Sync.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Το Lite Sync απενεργοποιήθηκε.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Αποτυχία απενεργοποίησης Lite Sync.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Αυτή η μονάδα διαγράφεται.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του στοιχείου %1</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Θέλετε πραγματικά να σταματήσετε τον συγχρονισμό του φακέλου &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">ΚΑΤΑΡΓΗΣΗ ΣΥΝΔΕΣΗΣ ΣΥΓΧΡΟΝΙΣΜΟΥ ΦΑΚΕΛΟΥ</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Αποτυχία διακοπής συγχρονισμού φακέλου &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
-    </message>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Φάκελοι</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Ειδοποιήσεις</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Ενεργοποίηση ειδοποιήσεων για αυτό το kDrive</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Θα εμφανίζεται ειδοποίηση μόλις συγχρονιστεί ή τροποποιηθεί νέος φάκελος</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Συνδεδεμένος με</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Κατάργηση όλων των συγχρονισμών</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Αναζήτηση στο kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Αναζήτηση</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Σφάλματα και πληροφορίες συγχρονισμού.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Συγχρονισμός τοπικού φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Θέλετε πραγματικά να ενεργοποιήσετε το Lite Sync;</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Αυτή η λειτουργία μπορεί να διαρκέσει από λίγα δευτερόλεπτα έως λίγα λεπτά ανάλογα με το μέγεθος του φακέλου.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Θέλετε πραγματικά να απενεργοποιήσετε το Lite Sync;</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Δεν έχετε αρκετό χώρο για να συγχρονίσετε όλα τα αρχεία του kDrive (%1 απαιτούνται). Αν απενεργοποιήσετε το Lite Sync, πρέπει να επιλέξετε ποιους φακέλους θα συγχρονίσετε. Εν τω μεταξύ, ο συγχρονισμός θα τεθεί σε παύση.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Αν απενεργοποιήσετε το Lite Sync, όλα τα αρχεία θα ληφθούν στον υπολογιστή σας.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Αποτυχία δημιουργίας νέου συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Αποτυχία συγχρονισμού νέου τοπικού φακέλου!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Το Lite Sync ενεργοποιήθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Αποτυχία ενεργοποίησης Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Το Lite Sync απενεργοποιήθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Αποτυχία απενεργοποίησης Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Αυτή η μονάδα διαγράφεται.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του στοιχείου %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Θέλετε πραγματικά να σταματήσετε τον συγχρονισμό του φακέλου &lt;i&gt;%1&lt;/i&gt;;&lt;br&gt;&lt;b&gt;Σημείωση:&lt;/b&gt; Αυτό &lt;b&gt;δεν&lt;/b&gt; θα διαγράψει κανένα αρχείο.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>ΚΑΤΑΡΓΗΣΗ ΣΥΝΔΕΣΗΣ ΣΥΓΧΡΟΝΙΣΜΟΥ ΦΑΚΕΛΟΥ</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Αποτυχία διακοπής συγχρονισμού φακέλου &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Παρουσιάστηκε σφάλμα κατά τη φόρτωση της λίστας υποφακέλων.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Φάκελοι</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Ειδοποιήσεις</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Ενεργοποίηση ειδοποιήσεων για αυτό το kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Θα εμφανίζεται ειδοποίηση μόλις συγχρονιστεί ή τροποποιηθεί νέος φάκελος</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Συνδεδεμένος με</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Κατάργηση όλων των συγχρονισμών</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Αναζήτηση στο kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Αναζήτηση</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Προσθήκη kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Συγχρονισμός kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Προσθήκη kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Συγχρονισμός kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Εκκαθάριση ιστορικού</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Προς επίλυση</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">πρόβλημα(τα) εντοπίστηκαν</translation>
-    </message>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Επίλυση</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Στοιχείο(α) με σύγκρουση</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Στοιχείο(α) με μη υποστηριζόμενους χαρακτήρες</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Αυτόματη επίλυση</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">πρόβλημα(τα) επιλύθηκαν</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Εκκαθάριση ιστορικού</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Προς επίλυση</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>πρόβλημα(τα) εντοπίστηκαν</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Επίλυση</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Στοιχείο(α) με σύγκρουση</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Στοιχείο(α) με μη υποστηριζόμενους χαρακτήρες</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Αυτόματη επίλυση</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>πρόβλημα(τα) επιλύθηκαν</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Συγκρούσεις ή σφάλματα συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Σφάλματα</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Επιστροφή στις προτιμήσεις</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Συγκρούσεις ή σφάλματα συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Σφάλματα</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Επιστροφή στις προτιμήσεις</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν στα ακόλουθα kDrive:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 σφάλμα(τα))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 πληροφορία(ες))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 σφάλμα(τα) και %2 πληροφορία(ες))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Γενικά σφάλματα (%n προειδοποίηση ή σφάλμα)</numerusform>
-            <numerusform>Γενικά σφάλματα (%n προειδοποιήσεις ή σφάλματα)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν στα ακόλουθα kDrive:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 σφάλμα(τα))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 πληροφορία(ες))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 σφάλμα(τα) και %2 πληροφορία(ες))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Γενικά σφάλματα (%n προειδοποίηση ή σφάλμα)</numerusform>
+<numerusform>Γενικά σφάλματα (%n προειδοποιήσεις ή σφάλματα)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Εξαιρεθέντα αρχεία</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Προσθέστε αρχεία ή φακέλους που δεν θα συγχρονιστούν στον υπολογιστή.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Προσθήκη</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">ΟΝΟΜΑ</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">ΠΡΟΕΙΔΟΠΟΙΗΣΗ</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ΑΠΟΘΗΚΕΥΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Το πρότυπο εξαίρεσης υπάρχει ήδη!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Θέλετε πραγματικά να διαγράψετε;</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Αδύνατη η αποθήκευση αλλαγών!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Εξαιρεθέντα αρχεία</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Προσθέστε αρχεία ή φακέλους που δεν θα συγχρονιστούν στον υπολογιστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Προσθήκη</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>ΟΝΟΜΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>ΠΡΟΕΙΔΟΠΟΙΗΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Το πρότυπο εξαίρεσης υπάρχει ήδη!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Θέλετε πραγματικά να διαγράψετε;</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ΕΠΙΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>ΕΠΙΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Επίλυση σύγκρουσης(εων)</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Τι θέλετε να κάνετε με τα %1 στοιχεία με σύγκρουση;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Αποθήκευση των αλλαγών μου και αντικατάσταση των εκδόσεων άλλων χρηστών.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Αναίρεση των αλλαγών μου και διατήρηση των εκδόσεων άλλων χρηστών.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Οι αλλαγές σας ενδέχεται να διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Οι αλλαγές σας θα διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Εμφάνιση στοιχείων</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ΕΠΙΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Αυτά τα αρχεία έχουν τροποποιηθεί από πολλούς χρήστες σε πολλά μέρη (ηλεκτρονικά στο kDrive, σε υπολογιστή ή κινητό). Φάκελοι που περιέχουν αυτά τα αρχεία ενδέχεται επίσης να έχουν διαγραφεί.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Η τοπική έκδοση του στοιχείου σας &lt;b&gt;δεν είναι συγχρονισμένη&lt;/b&gt; με το kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Επίλυση σύγκρουσης(εων)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Τι θέλετε να κάνετε με τα %1 στοιχεία με σύγκρουση;&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Αποθήκευση των αλλαγών μου και αντικατάσταση των εκδόσεων άλλων χρηστών.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Αναίρεση των αλλαγών μου και διατήρηση των εκδόσεων άλλων χρηστών.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Οι αλλαγές σας ενδέχεται να διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Οι αλλαγές σας θα διαγραφούν οριστικά. Δεν μπορούν να αποκατασταθούν από την εφαρμογή ιστού kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Εμφάνιση στοιχείων</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>ΕΠΙΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Αυτά τα αρχεία έχουν τροποποιηθεί από πολλούς χρήστες σε πολλά μέρη (ηλεκτρονικά στο kDrive, σε υπολογιστή ή κινητό). Φάκελοι που περιέχουν αυτά τα αρχεία ενδέχεται επίσης να έχουν διαγραφεί.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Η τοπική έκδοση του στοιχείου σας &lt;b&gt;δεν είναι συγχρονισμένη&lt;/b&gt; με το kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Συγχρονίστηκε στο &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Ενεργοποίηση Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Ενεργοποίηση Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Απενεργοποίηση Lite Sync</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Παύση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Συνέχιση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Κατάργηση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Περισσότερες ενέργειες</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο αν περιέχουν εκτός σύνδεσης στοιχεία. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Οι μη επιλεγμένοι φάκελοι θα διαγραφούν &lt;b&gt;οριστικά&lt;/b&gt; από τον υπολογιστή. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Ακύρωση</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ΕΠΙΚΥΡΩΣΗ</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Συγχρονίστηκε στο &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Ενεργοποίηση Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Ενεργοποίηση Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Απενεργοποίηση Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Παύση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Συνέχιση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Κατάργηση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Περισσότερες ενέργειες</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο αν περιέχουν εκτός σύνδεσης στοιχεία. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Οι μη επιλεγμένοι φάκελοι θα μεταφερθούν στον κάδο. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Οι μη επιλεγμένοι φάκελοι θα διαγραφούν &lt;b&gt;οριστικά&lt;/b&gt; από τον υπολογιστή. Οι συγχρονισμένοι φάκελοι θα παραμείνουν διαθέσιμοι ηλεκτρονικά.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Ακύρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>ΕΠΙΚΥΡΩΣΗ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Αναγνωριστικό εφαρμογής</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Όνομα εφαρμογής</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ΕΠΙΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Αναγνωριστικό εφαρμογής</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Όνομα εφαρμογής</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>ΕΠΙΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Ορισμένες εφαρμογές (αντίγραφα ασφαλείας, antivirus...) έχουν πρόσβαση στα αρχεία σας, προκαλώντας τη λήψη τους όταν είναι &quot;ηλεκτρονικά&quot;. Προσθέστε τες παρακάτω για να αποφύγετε αυτή τη συμπεριφορά.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Προσθήκη</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ΑΝΑΓΝΩΡΙΣΤΙΚΟ ΕΦΑΡΜΟΓΗΣ</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">ΟΝΟΜΑ</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ΑΠΟΘΗΚΕΥΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Θέλετε πραγματικά να διαγράψετε;</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Αδύνατη η αποθήκευση αλλαγών!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Ορισμένες εφαρμογές (αντίγραφα ασφαλείας, antivirus...) έχουν πρόσβαση στα αρχεία σας, προκαλώντας τη λήψη τους όταν είναι "ηλεκτρονικά". Προσθέστε τες παρακάτω για να αποφύγετε αυτή τη συμπεριφορά.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Προσθήκη</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ΑΝΑΓΝΩΡΙΣΤΙΚΟ ΕΦΑΡΜΟΓΗΣ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>ΟΝΟΜΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Θέλετε πραγματικά να διαγράψετε;</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Αδύνατη η αποθήκευση αλλαγών!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Ποιον φάκελο στον υπολογιστή θέλετε να&lt;br&gt;συγχρονίσετε;</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Τα περιεχόμενα αυτού του φακέλου θα συγχρονιστούν στο kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Επιλογή φακέλου</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Επεξεργασία φακέλου</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">ΣΥΝΕΧΕΙΑ</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Ποιον φάκελο στον υπολογιστή θέλετε να&lt;br&gt;συγχρονίσετε;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Τα περιεχόμενα αυτού του φακέλου θα συγχρονιστούν στο kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Επιλογή φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Επεξεργασία φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>ΣΥΝΕΧΕΙΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Αυτός ο φάκελος δεν είναι συμβατός με το Lite Sync.&lt;br&gt;
 Επιλέξτε άλλον φάκελο. Αν συνεχίσετε, το Lite Sync θα απενεργοποιηθεί.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Επιλογή φακέλου</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Επιλογή φακέλου</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Σφάλμα</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Το αρχείο &apos;%1&apos;&lt;br/&gt;δεν μπορεί να ανοίξει για εγγραφή.&lt;br/&gt;&lt;br/&gt;Η καταγραφή &lt;b&gt;δεν&lt;/b&gt; μπορεί να αποθηκευτεί!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Σφάλμα</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Το αρχείο '%1'&lt;br/&gt;δεν μπορεί να ανοίξει για εγγραφή.&lt;br/&gt;&lt;br/&gt;Η καταγραφή &lt;b&gt;δεν&lt;/b&gt; μπορεί να αποθηκευτεί!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Προτιμήσεις</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Βοήθεια</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Προτιμήσεις</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Βοήθεια</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>Το kDrive χρειάζεται πρόσβαση εγγραφής στον προσωρινό κατάλογο.&lt;br&gt;Κάντε επανεκκίνηση της εφαρμογής kDrive για να επιλυθεί το πρόβλημα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Φαίνεται ότι η σύνδεση δικτύου διαθέτει πολύ μικρό χρονικό όριο για τη σωστή λειτουργία της εφαρμογής (σφάλμα %1).&lt;br&gt;Ελέγξτε τη διαμόρφωση δικτύου.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Αδύνατη η σύνδεση με τον διακομιστή kDrive (σφάλμα %1).&lt;br&gt;Προσπάθεια επανασύνδεσης. Ελέγξτε τη σύνδεση στο διαδίκτυο και το τείχος προστασίας.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Συνδεθείτε ξανά και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Νέα έκδοση της εφαρμογής είναι διαθέσιμη.&lt;br&gt;Ενημερώστε την εφαρμογή για να συνεχίσετε να τη χρησιμοποιείτε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Αποτυχία μεταφόρτωσης αρχείου καταγραφής (σφάλμα %1).&lt;br&gt;Δοκιμάστε ξανά αργότερα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Ο φάκελος συγχρονισμού δεν είναι πλέον προσβάσιμος (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί μόλις ο φάκελος γίνει προσβάσιμος.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Η μονάδα που περιέχει τον φάκελο συγχρονισμού δεν είναι συνδεδεμένη (σφάλμα %1).&lt;br&gt;Επανασυνδέστε την για να συνεχίσει ο συγχρονισμός.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Δεν υπάρχει αρκετή διαθέσιμη μνήμη.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Ο αριθμός των παρακολουθήσεων inotify δεν είναι επαρκής (σφάλμα %1).&lt;br&gt;Μπορείτε να αυξήσετε τον αριθμό επεξεργαζόμενοι το &apos;/etc/sysctl.conf&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Πρέπει να επιτρέψετε:&lt;br&gt;- kDrive στις Ρυθμίσεις συστήματος &gt;&gt; Γενικά &gt;&gt; Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις &gt;&gt; Επεκτάσεις ασφαλείας τερματικού&lt;br&gt;- kDrive LiteSync Extension στις Ρυθμίσεις συστήματος &gt;&gt; Απόρρητο &amp;amp; Ασφάλεια &gt;&gt; Πλήρης πρόσβαση δίσκου.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Η διεργασία LiteSyncExt δεν εκτελείται. Ο συγχρονισμός θα επαναληφθεί μόλις εκκινηθεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync είναι εγκατεστημένη και η υπηρεσία Αναζήτησης Windows είναι ενεργή.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync έχει τα σωστά δικαιώματα και εκτελείται.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Ένα αρχείο ή φάκελος εντός του φακέλου συγχρονισμού φαίνεται κατεστραμμένος.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Το kDrive βρίσκεται σε λειτουργία συντήρησης.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Ανανεώστε το kDrive. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Επικοινωνήστε με διαχειριστή για ανανέωση. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Το kDrive επανεκκινείται.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην ιστοσελίδα για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Δεν έχετε δικαίωμα πρόσβασης σε αυτό το kDrive.&lt;br&gt;Ο συγχρονισμός έχει ανασταλεί. Επικοινωνήστε με διαχειριστή.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Οι συνδέσεις δικτύου διακόπηκαν από τον πυρήνα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Δυστυχώς η παλαιά διαμόρφωση δεν ήταν δυνατό να μεταφερθεί.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει κενή διαμόρφωση.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Δυστυχώς η παλαιά διαμόρφωση διακομιστή μεσολάβησης δεν ήταν δυνατό να μεταφερθεί· οι διακομιστές SOCKS5 δεν υποστηρίζονται.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει τις ρυθμίσεις συστήματος.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Ο φάκελος συγχρονισμού αντικαταστάθηκε ή μετακινήθηκε με τρόπο που εμποδίζει τον συγχρονισμό (σφάλμα %1).&lt;br&gt;Αυτό μπορεί να συμβεί μετά από αντιγραφή, μετακίνηση ή επαναφορά.&lt;br&gt;Δημιουργήστε νέο συγχρονισμό με νέο φάκελο.&lt;br&gt;Σημείωση: αν υπάρχουν μη συγχρονισμένες αλλαγές, αντιγράψτε τες χειροκίνητα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός επανεκκινήθηκε. Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Παρουσιάστηκε σφάλμα πρόσβασης στη βάση δεδομένων συγχρονισμού (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Το διακριτικό είναι άκυρο ή έχει ανακληθεί.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Οι εμφωλευμένοι συγχρονισμοί απαγορεύονται (σφάλμα %1).&lt;br&gt;Διατηρήστε μόνο συγχρονισμούς με μη εμφωλευμένους φακέλους.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Ο φάκελος συγχρονισμού στο απομακρυσμένο kDrive δεν υπάρχει πλέον ή δεν είναι προσβάσιμος (σφάλμα %1).&lt;br&gt;Επαναφέρετέ τον ή δώστε ξανά δικαιώματα πρόσβασης ή διαγράψτε/δημιουργήστε ξανά τον συγχρονισμό.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Σφάλμα ανάλυσης ονόματος αρχείου (σφάλμα %1).&lt;br&gt;Ειδικοί χαρακτήρες όπως διπλά εισαγωγικά, ανάστροφες κάθετοι ή αλλαγές γραμμής μπορούν να προκαλέσουν αποτυχίες ανάλυσης.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Αυτό το στοιχείο μετακινήθηκε αλλού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Το τοπικό στοιχείο μετονομάστηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Το αρχείο τροποποιήθηκε ταυτόχρονα από άλλον χρήστη.&lt;br&gt;Οι τροποποιήσεις σας αποθηκεύτηκαν σε αντίγραφο.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Άλλος χρήστης μετακίνησε έναν γονικό φάκελο του προορισμού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Υπάρχον στοιχείο έχει πανομοιότυπο όνομα (ίδια πεζά/κεφαλαία).&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Το όνομα του στοιχείου περιέχει μη υποστηριζόμενο χαρακτήρα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Το όνομα του στοιχείου τελειώνει με κενό, κάτι που δεν επιτρέπεται στο λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Αυτό το όνομα στοιχείου είναι δεσμευμένο από το λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Το όνομα του στοιχείου είναι πολύ μακρύ.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Η διαδρομή του στοιχείου είναι πολύ μακριά.&lt;br&gt;Αγνοήθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Το όνομα του στοιχείου περιέχει πρόσφατο χαρακτήρα UNICODE που δεν υποστηρίζεται από το σύστημα αρχείων.&lt;br&gt;Εξαιρέθηκε από τον συγχρονισμό.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Το όνομα του στοιχείου περιέχει μόνο κενά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Είτε δεν έχετε άδεια να δημιουργήσετε ένα στοιχείο, είτε υπάρχει ήδη ένα άλλο στοιχείο με το ίδιο όνομα. Το στοιχείο αγνοήθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Δεν επιτρέπεται η επεξεργασία του στοιχείου.&lt;br&gt;Το αρχείο με τις αλλαγές σας μετονομάστηκε και εξαιρέθηκε από τον συγχρονισμό.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Δεν επιτρέπεται η μετονομασία του στοιχείου.&lt;br&gt;Θα αποκατασταθεί με το αρχικό του όνομα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Δεν επιτρέπεται η μετακίνηση στοιχείου στο &quot;%1&quot;.&lt;br&gt;Θα αποκατασταθεί στον αρχικό γονικό φάκελο.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Δεν επιτρέπεται η διαγραφή του στοιχείου.&lt;br&gt;Θα αποκατασταθεί στην αρχική του θέση.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Αποτυχία μετακίνησης στοιχείου στον κάδο, τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Αποτυχία συγχρονισμού στοιχείου. Προσωρινά τέθηκε σε μαύρη λίστα.&lt;br&gt;Νέα προσπάθεια θα γίνει σε μία ώρα ή κατά την επόμενη εκκίνηση.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό βάσει προσαρμοσμένου προτύπου.&lt;br&gt;Μπορείτε να απενεργοποιήσετε αυτόν τον τύπο ειδοποίησης από τις Προτιμήσεις</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό επειδή είναι σκληρός σύνδεσμος.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Το αρχείο τροποποιήθηκε τοπικά ενώ διαγράφηκε στο απομακρυσμένο kDrive.&lt;br&gt;Το τοπικό αντίγραφο αποθηκεύτηκε στον φάκελο ανάκτησης.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Η λειτουργία που εκτελέστηκε στο στοιχείο απαγορεύεται.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Η λειτουργία στο στοιχείο απέτυχε.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Το αρχείο είναι πολύ μεγάλο για μεταφόρτωση. Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Έχετε υπερβεί το όριο χώρου. Αυξήστε το όριο για να επανενεργοποιήσετε τη μεταφόρτωση αρχείων.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Αδύνατη η λήψη του αρχείου.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Αυτό το στοιχείο είναι κλειδωμένο από άλλον χρήστη ηλεκτρονικά.&lt;br&gt;Θα επαναπροσπαθήσουμε τη μεταφόρτωση των αλλαγών αργότερα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Σφάλμα συγχρονισμού.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Δεν είναι δυνατή η πρόσβαση στο στοιχείο.&lt;br&gt;Ελέγξτε τα δικαιώματα ανάγνωσης και εγγραφής.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Η λήψη ακυρώθηκε.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Αδύνατη η δημιουργία του αρχείου %1 γιατί δεν υποστηρίζεται από το σύστημα αρχείων σας.&lt;br&gt;Έχει εξαιρεθεί από τον συγχρονισμό.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Σφάλμα συστήματος.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Το στοιχείο υπάρχει ήδη στην άλλη πλευρά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Μεταφορά ολοκληρώθηκε!&lt;br&gt;Χρησιμοποιήστε τον αναγνωριστικό &lt;b&gt;%1&lt;/b&gt; σε αναφορές σφαλμάτων.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Αποτυχία μεταφοράς!
-Χρησιμοποιήστε τον ακόλουθο σύνδεσμο για να στείλετε τα αρχεία καταγραφής: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Δεν έχει διαμορφωθεί kDrive!</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>Το kDrive χρειάζεται πρόσβαση εγγραφής στον προσωρινό κατάλογο.&lt;br&gt;Κάντε επανεκκίνηση της εφαρμογής kDrive για να επιλυθεί το πρόβλημα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Φαίνεται ότι η σύνδεση δικτύου διαθέτει πολύ μικρό χρονικό όριο για τη σωστή λειτουργία της εφαρμογής (σφάλμα %1).&lt;br&gt;Ελέγξτε τη διαμόρφωση δικτύου.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Αδύνατη η σύνδεση με τον διακομιστή kDrive (σφάλμα %1).&lt;br&gt;Προσπάθεια επανασύνδεσης. Ελέγξτε τη σύνδεση στο διαδίκτυο και το τείχος προστασίας.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Συνδεθείτε ξανά και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Νέα έκδοση της εφαρμογής είναι διαθέσιμη.&lt;br&gt;Ενημερώστε την εφαρμογή για να συνεχίσετε να τη χρησιμοποιείτε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Αποτυχία μεταφόρτωσης αρχείου καταγραφής (σφάλμα %1).&lt;br&gt;Δοκιμάστε ξανά αργότερα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Ο φάκελος συγχρονισμού δεν είναι πλέον προσβάσιμος (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί μόλις ο φάκελος γίνει προσβάσιμος.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Η μονάδα που περιέχει τον φάκελο συγχρονισμού δεν είναι συνδεδεμένη (σφάλμα %1).&lt;br&gt;Επανασυνδέστε την για να συνεχίσει ο συγχρονισμός.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Δεν υπάρχει αρκετή διαθέσιμη μνήμη.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Ο αριθμός των παρακολουθήσεων inotify δεν είναι επαρκής (σφάλμα %1).&lt;br&gt;Μπορείτε να αυξήσετε τον αριθμό επεξεργαζόμενοι το '/etc/sysctl.conf'.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Πρέπει να επιτρέψετε:&lt;br&gt;- kDrive στις Ρυθμίσεις συστήματος &gt;&gt; Γενικά &gt;&gt; Στοιχεία σύνδεσης &amp;amp; Επεκτάσεις &gt;&gt; Επεκτάσεις ασφαλείας τερματικού&lt;br&gt;- kDrive LiteSync Extension στις Ρυθμίσεις συστήματος &gt;&gt; Απόρρητο &amp;amp; Ασφάλεια &gt;&gt; Πλήρης πρόσβαση δίσκου.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Αδύνατη η εκκίνηση συγχρονισμού (σφάλμα %1).&lt;br&gt;Η διεργασία LiteSyncExt δεν εκτελείται. Ο συγχρονισμός θα επαναληφθεί μόλις εκκινηθεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync είναι εγκατεστημένη και η υπηρεσία Αναζήτησης Windows είναι ενεργή.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Βεβαιωθείτε ότι η επέκταση Lite Sync έχει τα σωστά δικαιώματα και εκτελείται.&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Αδύνατη η εκκίνηση του προσθέτου Lite Sync (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό, κάντε επανεκκίνηση και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Ένα αρχείο ή φάκελος εντός του φακέλου συγχρονισμού φαίνεται κατεστραμμένος.&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Το kDrive βρίσκεται σε λειτουργία συντήρησης.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Ανανεώστε το kDrive. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Το kDrive είναι αποκλεισμένο.&lt;br&gt;Επικοινωνήστε με διαχειριστή για ανανέωση. Εάν δεν γίνει καμία ενέργεια, τα δεδομένα θα διαγραφούν οριστικά.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Το kDrive επανεκκινείται.&lt;br&gt;Ο συγχρονισμός θα ξεκινήσει ξανά το συντομότερο. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην &lt;a style="%1" href="%2"&gt;ιστοσελίδα&lt;/a&gt; για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>Το kDrive είναι σε αδράνεια.&lt;br&gt;Συνδεθείτε στην ιστοσελίδα για να ελέγξετε την κατάσταση ή επικοινωνήστε με τον διαχειριστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Δεν έχετε δικαίωμα πρόσβασης σε αυτό το kDrive.&lt;br&gt;Ο συγχρονισμός έχει ανασταλεί. Επικοινωνήστε με διαχειριστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός θα επαναληφθεί το συντομότερο δυνατό. Επικοινωνήστε με την υποστήριξη εάν το σφάλμα επιμείνει.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Οι συνδέσεις δικτύου διακόπηκαν από τον πυρήνα (σφάλμα %1).&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Δυστυχώς η παλαιά διαμόρφωση δεν ήταν δυνατό να μεταφερθεί.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει κενή διαμόρφωση.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Δυστυχώς η παλαιά διαμόρφωση διακομιστή μεσολάβησης δεν ήταν δυνατό να μεταφερθεί· οι διακομιστές SOCKS5 δεν υποστηρίζονται.&lt;br&gt;Η εφαρμογή θα χρησιμοποιήσει τις ρυθμίσεις συστήματος.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Ο φάκελος συγχρονισμού αντικαταστάθηκε ή μετακινήθηκε με τρόπο που εμποδίζει τον συγχρονισμό (σφάλμα %1).&lt;br&gt;Αυτό μπορεί να συμβεί μετά από αντιγραφή, μετακίνηση ή επαναφορά.&lt;br&gt;Δημιουργήστε νέο συγχρονισμό με νέο φάκελο.&lt;br&gt;Σημείωση: αν υπάρχουν μη συγχρονισμένες αλλαγές, αντιγράψτε τες χειροκίνητα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Παρουσιάστηκε τεχνικό σφάλμα (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός επανεκκινήθηκε. Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Παρουσιάστηκε σφάλμα πρόσβασης στη βάση δεδομένων συγχρονισμού (σφάλμα %1).&lt;br&gt;Ο συγχρονισμός έχει διακοπεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Παρουσιάστηκε πρόβλημα σύνδεσης (σφάλμα %1).&lt;br&gt;Το διακριτικό είναι άκυρο ή έχει ανακληθεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Οι εμφωλευμένοι συγχρονισμοί απαγορεύονται (σφάλμα %1).&lt;br&gt;Διατηρήστε μόνο συγχρονισμούς με μη εμφωλευμένους φακέλους.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Ο φάκελος συγχρονισμού στο απομακρυσμένο kDrive δεν υπάρχει πλέον ή δεν είναι προσβάσιμος (σφάλμα %1).&lt;br&gt;Επαναφέρετέ τον ή δώστε ξανά δικαιώματα πρόσβασης ή διαγράψτε/δημιουργήστε ξανά τον συγχρονισμό.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Σφάλμα ανάλυσης ονόματος αρχείου (σφάλμα %1).&lt;br&gt;Ειδικοί χαρακτήρες όπως διπλά εισαγωγικά, ανάστροφες κάθετοι ή αλλαγές γραμμής μπορούν να προκαλέσουν αποτυχίες ανάλυσης.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Αυτό το στοιχείο μετακινήθηκε αλλού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Στοιχείο με το ίδιο όνομα υπάρχει ήδη σε αυτή τη θέση.&lt;br&gt;Το τοπικό στοιχείο μετονομάστηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Το αρχείο τροποποιήθηκε ταυτόχρονα από άλλον χρήστη.&lt;br&gt;Οι τροποποιήσεις σας αποθηκεύτηκαν σε αντίγραφο.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Άλλος χρήστης μετακίνησε έναν γονικό φάκελο του προορισμού.&lt;br&gt;Η τοπική λειτουργία ακυρώθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Υπάρχον στοιχείο έχει πανομοιότυπο όνομα (ίδια πεζά/κεφαλαία).&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Το όνομα του στοιχείου περιέχει μη υποστηριζόμενο χαρακτήρα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Το όνομα του στοιχείου τελειώνει με κενό, κάτι που δεν επιτρέπεται στο λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Αυτό το όνομα στοιχείου είναι δεσμευμένο από το λειτουργικό σύστημα.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Το όνομα του στοιχείου είναι πολύ μακρύ.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Η διαδρομή του στοιχείου είναι πολύ μακριά.&lt;br&gt;Αγνοήθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Το όνομα του στοιχείου περιέχει πρόσφατο χαρακτήρα UNICODE που δεν υποστηρίζεται από το σύστημα αρχείων.&lt;br&gt;Εξαιρέθηκε από τον συγχρονισμό.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Το όνομα του στοιχείου περιέχει μόνο κενά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Είτε δεν έχετε άδεια να δημιουργήσετε ένα στοιχείο, είτε υπάρχει ήδη ένα άλλο στοιχείο με το ίδιο όνομα. Το στοιχείο αγνοήθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Δεν επιτρέπεται η επεξεργασία του στοιχείου.&lt;br&gt;Το αρχείο με τις αλλαγές σας μετονομάστηκε και εξαιρέθηκε από τον συγχρονισμό.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Δεν επιτρέπεται η μετονομασία του στοιχείου.&lt;br&gt;Θα αποκατασταθεί με το αρχικό του όνομα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Δεν επιτρέπεται η μετακίνηση στοιχείου στο "%1".&lt;br&gt;Θα αποκατασταθεί στον αρχικό γονικό φάκελο.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Δεν επιτρέπεται η διαγραφή του στοιχείου.&lt;br&gt;Θα αποκατασταθεί στην αρχική του θέση.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Αποτυχία μετακίνησης στοιχείου στον κάδο, τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Αποτυχία συγχρονισμού στοιχείου. Προσωρινά τέθηκε σε μαύρη λίστα.&lt;br&gt;Νέα προσπάθεια θα γίνει σε μία ώρα ή κατά την επόμενη εκκίνηση.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό βάσει προσαρμοσμένου προτύπου.&lt;br&gt;Μπορείτε να απενεργοποιήσετε αυτόν τον τύπο ειδοποίησης από τις Προτιμήσεις</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Αυτό το στοιχείο εξαιρέθηκε από τον συγχρονισμό επειδή είναι σκληρός σύνδεσμος.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Το αρχείο τροποποιήθηκε τοπικά ενώ διαγράφηκε στο απομακρυσμένο kDrive.&lt;br&gt;Το τοπικό αντίγραφο αποθηκεύτηκε στον φάκελο ανάκτησης.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Η λειτουργία που εκτελέστηκε στο στοιχείο απαγορεύεται.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Η λειτουργία στο στοιχείο απέτυχε.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Το αρχείο είναι πολύ μεγάλο για μεταφόρτωση. Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Έχετε υπερβεί το όριο χώρου. Αυξήστε το όριο για να επανενεργοποιήσετε τη μεταφόρτωση αρχείων.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Αδύνατη η λήψη του αρχείου.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Αυτό το στοιχείο είναι κλειδωμένο από άλλον χρήστη ηλεκτρονικά.&lt;br&gt;Θα επαναπροσπαθήσουμε τη μεταφόρτωση των αλλαγών αργότερα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Σφάλμα συγχρονισμού.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Δεν είναι δυνατή η πρόσβαση στο στοιχείο.&lt;br&gt;Ελέγξτε τα δικαιώματα ανάγνωσης και εγγραφής.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Δεν υπάρχει αρκετός ελεύθερος χώρος στον υπολογιστή.&lt;br&gt;Η λήψη ακυρώθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Δεν είναι δυνατή η δημιουργία του αρχείου «%1», καθώς δεν υποστηρίζεται από το σύστημα αρχείων σας.&lt;br&gt;Έχει εξαιρεθεί από τον συγχρονισμό.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Σφάλμα συστήματος.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Το στοιχείο υπάρχει ήδη στην άλλη πλευρά.&lt;br&gt;Προσωρινά τέθηκε σε μαύρη λίστα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Παρουσιάστηκε τεχνικό σφάλμα.&lt;br&gt;Εκκαθαρίστε το ιστορικό και αν το σφάλμα επιμείνει, επικοινωνήστε με την υποστήριξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα της διαδρομής φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Μεταφορά ολοκληρώθηκε!&lt;br&gt;Χρησιμοποιήστε τον αναγνωριστικό &lt;b&gt;%1&lt;/b&gt; σε αναφορές σφαλμάτων.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Αποτυχία μεταφοράς!
+Χρησιμοποιήστε τον ακόλουθο σύνδεσμο για να στείλετε τα αρχεία καταγραφής: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Δεν έχει διαμορφωθεί kDrive!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Αυτός ο συγχρονισμός διαγράφεται.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Αυτός ο συγχρονισμός διαγράφεται.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Επιστροφή στη λίστα μονάδων</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Προτιμήσεις</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Επιστροφή στη λίστα μονάδων</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Προτιμήσεις</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Μη έγκυρος σύνδεσμος %1.</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Κάποια διεργασία απέτυχε να εκτελεστεί.</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Γενικά</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Ενεργοποίηση σκούρου θέματος</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Ενεργοποίηση μονόχρωμων εικονιδίων</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Εκκίνηση kDrive κατά την έναρξη</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Γλώσσα</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Μεταφορά διαγραμμένων αρχείων στον κάδο</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Ορισμένα αρχεία ή φάκελοι ενδέχεται να μην μεταφερθούν στον κάδο.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Μπορείτε πάντα να ανακτήσετε συγχρονισμένα αρχεία από τον κάδο της εφαρμογής ιστού kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Προεπιλογή</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Αγγλικά</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Γαλλικά</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Γερμανικά</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Ισπανικά</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Ιταλικά</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Σουηδικά</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Πορτογαλικά</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Πολωνικά</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Νορβηγικά</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Φινλανδικά</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Δανικά</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Ελληνικά</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Ολλανδικά</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Σύνθετα</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Πληροφορίες εντοπισμού</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Αρχεία προς εξαίρεση</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Διακομιστής μεσολάβησης</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Μη έγκυρος σύνδεσμος %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Κάποια διεργασία απέτυχε να εκτελεστεί.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Γενικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Ενεργοποίηση σκούρου θέματος</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Ενεργοποίηση μονόχρωμων εικονιδίων</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Εκκίνηση kDrive κατά την έναρξη</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Γλώσσα</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Μεταφορά διαγραμμένων αρχείων στον κάδο</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Ορισμένα αρχεία ή φάκελοι ενδέχεται να μην μεταφερθούν στον κάδο.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Μπορείτε πάντα να ανακτήσετε συγχρονισμένα αρχεία από τον κάδο της εφαρμογής ιστού kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Προεπιλογή</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Αγγλικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Γαλλικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Γερμανικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Ισπανικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Ιταλικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Σουηδικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Πορτογαλικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Πολωνικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Νορβηγικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Φινλανδικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Δανικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Ελληνικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Ολλανδικά</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Σύνθετα</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Πληροφορίες εντοπισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Άνοιγμα φακέλου εντοπισμού&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Αρχεία προς εξαίρεση</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Διακομιστής μεσολάβησης</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 σε χρήση</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 σε χρήση</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S) Διακομιστής μεσολάβησης</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Διακομιστής μεσολάβησης</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Χωρίς διακομιστή μεσολάβησης</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Χρήση παραμέτρων συστήματος</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Ρύθμιση διακομιστή μεσολάβησης χειροκίνητα</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Θύρα</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Διεύθυνση διακομιστή μεσολάβησης</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Απαιτείται ταυτοποίηση</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Χρήστης</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Κωδικός</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ΑΠΟΘΗΚΕΥΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Αδύνατη η αποθήκευση, δεν έχουν συμπληρωθεί όλα τα υποχρεωτικά πεδία!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Ο διακομιστής μεσολάβησης δεν βρέθηκε. Αποθήκευση ούτως ή άλλως;</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S) Διακομιστής μεσολάβησης</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Διακομιστής μεσολάβησης</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Χωρίς διακομιστή μεσολάβησης</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Χρήση παραμέτρων συστήματος</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Ρύθμιση διακομιστή μεσολάβησης χειροκίνητα</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Θύρα</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Διεύθυνση διακομιστή μεσολάβησης</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Απαιτείται ταυτοποίηση</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Χρήστης</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Κωδικός</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Αδύνατη η αποθήκευση, δεν έχουν συμπληρωθεί όλα τα υποχρεωτικά πεδία!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Ο διακομιστής μεσολάβησης δεν βρέθηκε. Αποθήκευση ούτως ή άλλως;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Διαχείριση πόρων</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Μέγιστη επιτρεπόμενη χρήση CPU</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ΑΠΟΘΗΚΕΥΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Διαχείριση πόρων</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Μέγιστη επιτρεπόμενη χρήση CPU</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>ΑΠΟΘΗΚΕΥΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Θέλετε να αποθηκεύσετε τις αλλαγές;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Επιλέξτε φάκελο στο kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Τα περιεχόμενα του επιλεγμένου φακέλου θα συγχρονιστούν στον φάκελο &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">ΣΥΝΕΧΕΙΑ</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Διαθέσιμος χώρος στον υπολογιστή για τον τρέχοντα φάκελο: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Αυτός ο φάκελος συγχρονίζεται ήδη.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">ΕΠΙΒΕΒΑΙΩΣΗ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ΑΚΥΡΩΣΗ</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Επιλέξτε φάκελο στο kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Τα περιεχόμενα του επιλεγμένου φακέλου θα συγχρονιστούν στον φάκελο &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>ΣΥΝΕΧΕΙΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Διαθέσιμος χώρος στον υπολογιστή για τον τρέχοντα φάκελο: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Αυτός ο φάκελος συγχρονίζεται ήδη.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>ΕΠΙΒΕΒΑΙΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ΑΚΥΡΩΣΗ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; περιέχει υποφακέλους,&lt;br&gt; επιλέξτε αυτούς που θέλετε να συγχρονίσετε</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">ΣΥΝΕΧΕΙΑ</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; περιέχει υποφακέλους,&lt;br&gt; επιλέξτε αυτούς που θέλετε να συγχρονίσετε</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>ΣΥΝΕΧΕΙΑ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Δεν υπάρχουν υποφάκελοι αυτή τη στιγμή στον διακομιστή.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Συνέχιση συγχρονισμού kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Συνέχιση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Συνέχιση συγχρονισμού όλων των kDrive</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Παύση συγχρονισμού kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Παύση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Παύση συγχρονισμού όλων των kDrive</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Συνέχιση συγχρονισμού kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Συνέχιση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Συνέχιση συγχρονισμού όλων των kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Παύση συγχρονισμού kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Παύση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Παύση συγχρονισμού όλων των kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Άνοιγμα</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Προσθήκη στα αγαπημένα</translation>
-    </message>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Αντιγραφή συνδέσμου κοινοποίησης</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Εμφάνιση στο kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Εμφάνιση στον φάκελο</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Περισσότερες ενέργειες</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Άνοιγμα</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Προσθήκη στα αγαπημένα</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Αντιγραφή συνδέσμου κοινοποίησης</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Εμφάνιση στο kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Εμφάνιση στον φάκελο</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Περισσότερες ενέργειες</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Άνοιγμα στον φάκελο</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Άνοιγμα ιστοσελίδας %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Παράμετροι μονάδας</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Οι ειδοποιήσεις είναι απενεργοποιημένες έως %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Απενεργοποίηση ειδοποιήσεων</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Προτιμήσεις εφαρμογής</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Χρειάζεστε βοήθεια</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Αποστολή σχολίων</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Έξοδος από το kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Δεν είναι δυνατή η πρόσβαση στον ιστότοπο %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Εμφάνιση σφαλμάτων και πληροφοριών</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Εμφάνιση πληροφοριών</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Περισσότερες ενέργειες</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Ποτέ</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Για 1 ώρα</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Έως αύριο στις 8:00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Για 3 ημέρες</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Για 1 εβδομάδα</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Πάντα</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Για 1 ακόμη ώρα</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Για 3 ακόμη ημέρες</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Για 1 ακόμη εβδομάδα</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Άνοιγμα στον φάκελο</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Άνοιγμα ιστοσελίδας %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Παράμετροι μονάδας</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Οι ειδοποιήσεις είναι απενεργοποιημένες έως %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Απενεργοποίηση ειδοποιήσεων</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Προτιμήσεις εφαρμογής</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Χρειάζεστε βοήθεια</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Αποστολή σχολίων</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Έξοδος από το kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Δεν είναι δυνατή η πρόσβαση στον ιστότοπο %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Εμφάνιση σφαλμάτων και πληροφοριών</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Εμφάνιση πληροφοριών</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Περισσότερες ενέργειες</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Ποτέ</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Για 1 ώρα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Έως αύριο στις 8:00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Για 3 ημέρες</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Για 1 εβδομάδα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Πάντα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Για 1 ακόμη ώρα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Για 3 ακόμη ημέρες</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Για 1 ακόμη εβδομάδα</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Συγχρονισμένα</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Αγαπημένα</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Δραστηριότητα</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Ενημέρωση</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Λήψη ενημέρωσης σε εξέλιξη</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Αναζήτηση ενημέρωσης...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Χειροκίνητη ενημέρωση</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Μη διαθέσιμο</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Δεν έχει υλοποιηθεί!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Μη έγκυρος σύνδεσμος %1.</translation>
-    </message>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Ενημέρωση εφαρμογής kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Αυτή η έκδοση της εφαρμογής kDrive δεν υποστηρίζεται πλέον. Ενημερώστε για πρόσβαση στις τελευταίες λειτουργίες.</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Κάντε κλικ εδώ για χειροκίνητη λήψη&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Κατεβάστε την τελευταία έκδοση από τον ιστότοπο.</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Δεν υπάρχει συγχρονισμένος φάκελος για αυτή τη μονάδα!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Δεν έχει διαμορφωθεί kDrive!</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Μπορείτε να συγχρονίσετε αρχεία &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;από τον υπολογιστή σας&lt;/a&gt; ή στο &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Συγχρονισμένα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Αγαπημένα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Δραστηριότητα</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του URL φακέλου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Ενημέρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Λήψη ενημέρωσης σε εξέλιξη</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Αναζήτηση ενημέρωσης...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Χειροκίνητη ενημέρωση</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Μη διαθέσιμο</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Δεν έχει υλοποιηθεί!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Δεν είναι δυνατό το άνοιγμα του συνδέσμου %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Μη έγκυρος σύνδεσμος %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Ενημέρωση εφαρμογής kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Αυτή η έκδοση της εφαρμογής kDrive δεν υποστηρίζεται πλέον. Ενημερώστε για πρόσβαση στις τελευταίες λειτουργίες.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Κάντε κλικ εδώ για χειροκίνητη λήψη&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Κατεβάστε την τελευταία έκδοση από τον ιστότοπο.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Δεν υπάρχει συγχρονισμένος φάκελος για αυτή τη μονάδα!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Δεν έχει διαμορφωθεί kDrive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Μπορείτε να συγχρονίσετε αρχεία &lt;a style="%1" href="%2"&gt;από τον υπολογιστή σας&lt;/a&gt; ή στο &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Η νέα έκδοση &lt;b&gt;%1&lt;/b&gt; του πελάτη %2 είναι διαθέσιμη και έχει ληφθεί.&lt;/p&gt;&lt;p&gt;Η εγκατεστημένη έκδοση είναι %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Παράλειψη αυτής της έκδοσης</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Υπενθύμιση αργότερα</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Εγκατάσταση ενημέρωσης</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Η νέα έκδοση &lt;b&gt;%1&lt;/b&gt; του πελάτη %2 είναι διαθέσιμη και έχει ληφθεί.&lt;/p&gt;&lt;p&gt;Η εγκατεστημένη έκδοση είναι %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Παράλειψη αυτής της έκδοσης</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Υπενθύμιση αργότερα</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Εγκατάσταση ενημέρωσης</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Νέα ενημέρωση διαθέσιμη.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Η έκδοση %1 είναι διαθέσιμη για λήψη.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Νέα ενημέρωση διαθέσιμη.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Η έκδοση %1 είναι διαθέσιμη για λήψη.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Προσθήκη λογαριασμού</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Προσθήκη λογαριασμού</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Εμφάνιση σημειώσεων έκδοσης&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Έκδοση</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">ΕΝΗΜΕΡΩΣΗ</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">Το %1 είναι ενημερωμένο!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Έλεγχος ενημέρωσης στον διακομιστή...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Διαθέσιμη ενημέρωση: %1.&lt;br&gt;Κατεβάστε τη από &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;εδώ&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Διαθέσιμη ενημέρωση: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Λήψη %1. Παρακαλώ περιμένετε...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Δεν ήταν δυνατός ο έλεγχος για νέες ενημερώσεις.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά την ενημέρωση.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Δεν ήταν δυνατή η λήψη ενημέρωσης.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Η ενημέρωση απενεργοποιήθηκε.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Πρόγραμμα beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Συμμετοχή</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Τροποποίηση</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Έξοδος</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Εμφάνιση σημειώσεων έκδοσης&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Έκδοση</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>ΕΝΗΜΕΡΩΣΗ</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>Το %1 είναι ενημερωμένο!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Έλεγχος ενημέρωσης στον διακομιστή...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Διαθέσιμη ενημέρωση: %1.&lt;br&gt;Κατεβάστε τη από &lt;a style="%2" href="%3"&gt;εδώ&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Διαθέσιμη ενημέρωση: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Λήψη %1. Παρακαλώ περιμένετε...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Δεν ήταν δυνατός ο έλεγχος για νέες ενημερώσεις.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Παρουσιάστηκε σφάλμα κατά την ενημέρωση.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Δεν ήταν δυνατή η λήψη ενημέρωσης.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Η ενημέρωση απενεργοποιήθηκε.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Πρόγραμμα beta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Αποκτήστε πρώιμη πρόσβαση σε νέες εκδόσεις της εφαρμογής</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Συμμετοχή</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Τροποποίηση</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Έξοδος</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Το Lite sync (Beta) είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Το Lite sync (Beta) είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Το Lite sync είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Το Lite sync είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Αδύνατη η αποθήκευση παραμέτρων, δοκιμάστε ξανά αργότερα.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Αδύνατη η αποθήκευση παραμέτρων!</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Διαθεσιμότητα τοπικά</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Ελευθέρωση τοπικού χώρου</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Ακύρωση ελευθέρωσης τοπικού χώρου</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Ακύρωση τοπικής διαθεσιμότητας</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Η κοινοποίηση αυτού του αρχείου δεν επιτρέπεται</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Η κοινοποίηση αυτού του φακέλου δεν επιτρέπεται</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Αντιγραφή δημόσιου συνδέσμου κοινοποίησης</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Αντιγραφή ιδιωτικού συνδέσμου κοινοποίησης</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Άνοιγμα στον περιηγητή</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Ο γονικός φάκελος είναι φάκελος συγχρονισμού ή περιέχεται σε έναν</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Δεν βρέθηκε έγκυρη διαδρομή</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Δεν επιλέχθηκε έγκυρος φάκελος!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Η επιλεγμένη διαδρομή δεν υπάρχει!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Η επιλεγμένη διαδρομή δεν είναι φάκελος!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Δεν έχετε δικαίωμα εγγραφής στον επιλεγμένο φάκελο!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Ο τοπικός φάκελος %1 περιέχει φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Ο τοπικός φάκελος %1 περιέχεται σε φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Ο τοπικός φάκελος %1 συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Το Lite sync (Beta) είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Το Lite sync (Beta) είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Το Lite sync είναι ενεργό. Τα αρχεία από το kDrive παραμένουν στο Cloud και δεν χρησιμοποιούν χώρο αποθήκευσης.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Το Lite sync είναι ανενεργό. Τα αρχεία kDrive χρησιμοποιούν χώρο αποθήκευσης στον υπολογιστή.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Αδύνατη η αποθήκευση παραμέτρων, δοκιμάστε ξανά αργότερα.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Αδύνατη η αποθήκευση παραμέτρων!</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Διαθεσιμότητα τοπικά</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Ελευθέρωση τοπικού χώρου</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Ακύρωση ελευθέρωσης τοπικού χώρου</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Ακύρωση τοπικής διαθεσιμότητας</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Η κοινοποίηση αυτού του αρχείου δεν επιτρέπεται</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Η κοινοποίηση αυτού του φακέλου δεν επιτρέπεται</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Αντιγραφή δημόσιου συνδέσμου κοινοποίησης</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Αντιγραφή ιδιωτικού συνδέσμου κοινοποίησης</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Άνοιγμα στον περιηγητή</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Ο γονικός φάκελος είναι φάκελος συγχρονισμού ή περιέχεται σε έναν</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Δεν βρέθηκε έγκυρη διαδρομή</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Δεν επιλέχθηκε έγκυρος φάκελος!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Η επιλεγμένη διαδρομή δεν υπάρχει!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Η επιλεγμένη διαδρομή δεν είναι φάκελος!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Δεν έχετε δικαίωμα εγγραφής στον επιλεγμένο φάκελο!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Ο τοπικός φάκελος %1 περιέχει φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Ο τοπικός φάκελος %1 περιέχεται σε φάκελο που συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Ο τοπικός φάκελος %1 συγχρονίζεται ήδη. Επιλέξτε άλλον!</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">Η εφαρμογή kDrive θα κλείσει λόγω κρίσιμου σφάλματος.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>Η εφαρμογή kDrive θα κλείσει λόγω κρίσιμου σφάλματος.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n χρόνος</numerusform>
-            <numerusform>%n χρόνια</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n μήνας</numerusform>
-            <numerusform>%n μήνες</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n ημέρα</numerusform>
-            <numerusform>%n ημέρες</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n ώρα</numerusform>
-            <numerusform>%n ώρες</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n λεπτό</numerusform>
-            <numerusform>%n λεπτά</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n δευτερόλεπτο</numerusform>
-            <numerusform>%n δευτερόλεπτα</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
+<name>Utility</name>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n χρόνος</numerusform>
+<numerusform>%n χρόνια</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n μήνας</numerusform>
+<numerusform>%n μήνες</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n ημέρα</numerusform>
+<numerusform>%n ημέρες</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n ώρα</numerusform>
+<numerusform>%n ώρες</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n λεπτό</numerusform>
+<numerusform>%n λεπτά</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n δευτερόλεπτο</numerusform>
+<numerusform>%n δευτερόλεπτα</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Η γραμμή συστήματος δεν είναι διαθέσιμη</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 απαιτεί μια λειτουργική γραμμή συστήματος. Εάν χρησιμοποιείτε XFCE, ακολουθήστε &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;αυτές τις οδηγίες&lt;/a&gt;. Διαφορετικά, εγκαταστήστε μια εφαρμογή γραμμής συστήματος όπως &apos;trayer&apos; και δοκιμάστε ξανά.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Η γραμμή συστήματος δεν είναι διαθέσιμη</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 απαιτεί μια λειτουργική γραμμή συστήματος. Εάν χρησιμοποιείτε XFCE, ακολουθήστε &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;αυτές τις οδηγίες&lt;/a&gt;. Διαφορετικά, εγκαταστήστε μια εφαρμογή γραμμής συστήματος όπως 'trayer' και δοκιμάστε ξανά.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Δεν ήταν δυνατό το άνοιγμα του περιηγητή</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά την εκκίνηση του περιηγητή για το URL %1. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος περιηγητής;</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Δεν ήταν δυνατό το άνοιγμα του πελάτη email</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Παρουσιάστηκε σφάλμα κατά την εκκίνηση του πελάτη email. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος πελάτης email;</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Δεν είστε πλέον συνδεδεμένοι. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Σύνδεση&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Δεν ήταν δυνατό το άνοιγμα του περιηγητή</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του περιηγητή για το URL %1. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος περιηγητής;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Δεν ήταν δυνατό το άνοιγμα του πελάτη email</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Παρουσιάστηκε σφάλμα κατά την εκκίνηση του πελάτη email. Ίσως δεν έχει ρυθμιστεί προεπιλεγμένος πελάτης email;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Δεν είστε πλέον συνδεδεμένοι. &lt;a style="%1" href="%2"&gt;Σύνδεση&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Δεν υπάρχει φάκελος για συγχρονισμό
+<translation>Δεν υπάρχει φάκελος για συγχρονισμό
 Μπορείτε να προσθέσετε έναν από τις ρυθμίσεις kDrive.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Συγχρονισμός σε εξέλιξη (%1 από %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Συγχρονισμός σε εξέλιξη (%1 από %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Συγχρονισμός σε εξέλιξη (%1 από %2)
+<translation>Συγχρονισμός σε εξέλιξη (%1 από %2)
 %3 απομένουν...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Συγχρονισμός σε εξέλιξη (Βήμα %1/%2).</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Εκκίνηση συγχρονισμού</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Συγχρονισμός σε εξέλιξη.</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Είστε ενημερωμένοι, με μη επιλυμένες συγκρούσεις.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Είστε ενημερωμένοι!</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Παύση συγχρονισμού...</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Ο συγχρονισμός ανεστάλη.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή χρησιμοποιείται ήδη από άλλον συγχρονισμό.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχει τον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχεται στον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον φάκελο.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον. Προτεινόμενος: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Έχετε εξαιρέσει περισσότερους από %1 φακέλους. Αυτό θα επηρεάσει τις επιδόσεις συγχρονισμού.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Δεν μπορείτε να εξαιρέσετε περισσότερους από %1 φακέλους. Αποεπιλέξτε φακέλους υψηλότερου επιπέδου.</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Συγχρονισμός σε εξέλιξη (Βήμα %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Εκκίνηση συγχρονισμού</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Συγχρονισμός σε εξέλιξη.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Είστε ενημερωμένοι, με μη επιλυμένες συγκρούσεις.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Είστε ενημερωμένοι!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Ορισμένα αρχεία δεν ήταν δυνατό να συγχρονιστούν. &lt;a style="%1" href="%2"&gt;Μάθετε περισσότερα&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Παύση συγχρονισμού...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Ο συγχρονισμός ανεστάλη.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή χρησιμοποιείται ήδη από άλλον συγχρονισμό.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχει τον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί επειδή περιέχεται στον συγχρονισμένο φάκελο &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον φάκελο.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Ο φάκελος &lt;b&gt;%1&lt;/b&gt; δεν μπορεί να επιλεγεί ως φάκελος συγχρονισμού. Επιλέξτε άλλον. Προτεινόμενος: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Έχετε εξαιρέσει περισσότερους από %1 φακέλους. Αυτό θα επηρεάσει τις επιδόσεις συγχρονισμού.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Δεν μπορείτε να εξαιρέσετε περισσότερους από %1 φακέλους. Αποεπιλέξτε φακέλους υψηλότερου επιπέδου.</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -1,3095 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="es_ES" version="2.1">
+<TS version="2.1" language="es_ES">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Acerca de</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>CERRAR</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versión %1. Para más información, visita &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribuido por %1 y licenciado bajo &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 y el logotipo de %2 son marcas comerciales registradas de %1. &lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>No se puede abrir la carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Creado a partir de &lt;a style="color: #489EF3" href="%1"&gt;fuentes Git&lt;/a&gt; del %2, %3 con Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Acerca de</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>CERRAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versión %1. Para más información, visita &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuido por %1 y licenciado bajo &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 y el logotipo de %2 son marcas comerciales registradas de %1. &lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>No se puede abrir la carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Creado a partir de &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;fuentes Git&lt;/a&gt; del %2, %3 con Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>No es posible abrir la ruta de la carpeta %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>No es posible abrir la ruta de la carpeta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Se iniciará la sincronización y podrás añadir archivos a tu carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>¡Tu kDrive está listo!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ABRIR CARPETA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>PARÁMETROS</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Sincronizar otro drive</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Se iniciará la sincronización y podrás añadir archivos a tu carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>¡Tu kDrive está listo!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ABRIR CARPETA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>PARÁMETROS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Sincronizar otro drive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>SIGUIENTE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Selecciona el kDrive que deseas sincronizar</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Obtén kDrive gratis</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Almacena tus fotos, documentos y correos electrónicos en Suiza con una empresa independiente que respeta la privacidad. Más información</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Prueba gratuita</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SIGUIENTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Selecciona el kDrive que deseas sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Obtén kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Almacena tus fotos, documentos y correos electrónicos en Suiza con una empresa independiente que respeta la privacidad. Más información</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Prueba gratuita</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Ahorra espacio en el ordenador</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Elige qué archivos deben estar disponibles en línea o localmente</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>MÁS TARDE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>SÍ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync sincroniza todos los archivos sin usar espacio del ordenador. Puedes navegar por los archivos en kDrive y descargarlos localmente donde quieras. &lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>¿Deseas activar Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>¿Deseas activar Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Ahorra espacio en el ordenador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Elige qué archivos deben estar disponibles en línea o localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>MÁS TARDE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>SÍ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync sincroniza todos los archivos sin usar espacio del ordenador. Puedes navegar por los archivos en kDrive y descargarlos localmente donde quieras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>¿Deseas activar Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>¿Deseas activar Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Ubicación de tu kDrive %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Editar carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>FIN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Seleccionar carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>El contenido de la carpeta &lt;b&gt;%1&lt;/b&gt; se sincronizará en tu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Encontrarás todos tus archivos en esta carpeta cuando se complete la configuración. Puedes arrastrar nuevos archivos para sincronizarlos en tu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Ubicación de tu kDrive %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Editar carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>FIN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Seleccionar carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>El contenido de la carpeta &lt;b&gt;%1&lt;/b&gt; se sincronizará en tu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Encontrarás todos tus archivos en esta carpeta cuando se complete la configuración. Puedes arrastrar nuevos archivos para sincronizarlos en tu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
 Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Inicie sesión desde su navegador</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Tu navegador debería abrirse automáticamente para completar la conexión. Una vez conectado, volverás automáticamente a kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Abrir la página de inicio de sesión</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Inicio de sesión fallido: %1 – %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>No se pudo abrir la página de inicio de sesión en su navegador web</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Inicie sesión desde su navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Tu navegador debería abrirse automáticamente para completar la conexión. Una vez conectado, volverás automáticamente a kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Abrir la página de inicio de sesión</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Inicio de sesión fallido: %1 – %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>No se pudo abrir la página de inicio de sesión en su navegador web</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Seleccionar carpetas kDrive para sincronizar en tu escritorio</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Espacio disponible en tu ordenador: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>No se pudo cargar la lista de subcarpetas. Es posible que su kDrive esté en mantenimiento.&lt;br&gt;Inicie sesión en la &lt;a style="%1" href="%2"&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Seleccionar carpetas kDrive para sincronizar en tu escritorio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Espacio disponible en tu ordenador: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>No se pudo cargar la lista de subcarpetas. Es posible que su kDrive esté en mantenimiento.&lt;br&gt;Inicie sesión en la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>No se pudo crear una carpeta local %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>No se pudo crear la nueva sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>El kDrive %1 ya está sincronizado en este equipo.¿Continuar de todos modos?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>No se pudo crear una carpeta local %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>No se pudo crear la nueva sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>El kDrive %1 ya está sincronizado en este equipo.¿Continuar de todos modos?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>El cliente kDrive se ejecuta con parámetros erróneos.</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>¡El cliente de kDrive ya se está ejecutando!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>El usuario %1 no está conectado. Inicia sesión de nuevo.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>El cliente kDrive se ejecuta con parámetros erróneos.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>¡El cliente de kDrive ya se está ejecutando!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>El usuario %1 no está conectado. Inicia sesión de nuevo.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Enlace compartido copiado en el portapapeles</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
-<numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 ha sido eliminado.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
-<numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 ha sido añadido.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
-<numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 ha sido actualizado.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
-<numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 ha sido movido a %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Actividad de sincronización</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Enlace compartido copiado en el portapapeles</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
+            <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 ha sido eliminado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
+            <numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 ha sido añadido.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
+            <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 ha sido actualizado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
+            <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 ha sido movido a %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Actividad de sincronización</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>No hay subcarpetas actualmente en el servidor.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>No hay subcarpetas actualmente en el servidor.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Abandonar el programa beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Únase al programa beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación antes de que se publiquen para el público en general, y participe en la mejora de la aplicación enviándonos sus comentarios.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Benefíciese de las actualizaciones beta de las aplicaciones</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>No</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Versión beta pública</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Versión beta interna</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Versión de prueba</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Comprendo</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>¿Estás seguro de que quieres abandonar el programa beta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Guardar</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Es posible que su versión actual de la aplicación sea demasiado reciente, su elección será efectiva a partir de la próxima actualización disponible.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Las versiones beta pueden salir inesperadamente o causar inestabilidades.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Abandonar el programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Únase al programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación antes de que se publiquen para el público en general, y participe en la mejora de la aplicación enviándonos sus comentarios.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Benefíciese de las actualizaciones beta de las aplicaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Versión beta pública</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Versión beta interna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Versión de prueba</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Comprendo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>¿Estás seguro de que quieres abandonar el programa beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Es posible que su versión actual de la aplicación sea demasiado reciente, su elección será efectiva a partir de la próxima actualización disponible.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Las versiones beta pueden salir inesperadamente o causar inestabilidades.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Inicia sesión</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Carpeta %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>No hay carpetas de sincronización configuradas.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Síntesis</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Preferencias</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Salir</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Estado no definido.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Esperando para comenzar la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Ejecutando sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>La sincronización se ha realizado, pero hay conflictos sin resolver.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>La última sincronización se ha realizado correctamente.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Interrupción por el usuario.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>La sincronización está en pausa.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (sincronización en pausa)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>ELIMINAR TODAS LAS SINC.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 elementos han sido eliminados de su carpeta de sincronización local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Para evitar eliminaciones no deseadas, la sincronización ha sido pausada.&lt;br&gt;¿Desea propagar estas eliminaciones a su kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Varios archivos han sido eliminados de su carpeta de sincronización local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Los archivos eliminados se pueden encontrar en la &lt;a style="%1" href="%3"&gt;papelera&lt;/a&gt; de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>No volver a mostrar</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>¡Error al iniciar las sincronizaciones!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>No es posible abrir la ruta de la carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>No se puede inicializar el cliente de kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>No se pudieron solucionar los conflictos en %1 elementos en la carpeta de sincronización: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>La sincronización está en pausa</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Inicia sesión</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Carpeta %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>No hay carpetas de sincronización configuradas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Síntesis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Preferencias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Salir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Estado no definido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Esperando para comenzar la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Ejecutando sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>La sincronización se ha realizado, pero hay conflictos sin resolver.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>La última sincronización se ha realizado correctamente.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Interrupción por el usuario.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>La sincronización está en pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (sincronización en pausa)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>ELIMINAR TODAS LAS SINC.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 elementos han sido eliminados de su carpeta de sincronización local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Para evitar eliminaciones no deseadas, la sincronización ha sido pausada.&lt;br&gt;¿Desea propagar estas eliminaciones a su kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Varios archivos han sido eliminados de su carpeta de sincronización local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Los archivos eliminados se pueden encontrar en la &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papelera&lt;/a&gt; de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>No volver a mostrar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>¡Error al iniciar las sincronizaciones!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>No es posible abrir la ruta de la carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>No se puede inicializar el cliente de kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>No se pudieron solucionar los conflictos en %1 elementos en la carpeta de sincronización: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>La sincronización está en pausa</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Resumen de la sincronización de tu carpeta local</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Los contenidos de la carpeta en tu ordenador se sincronizarán a la carpeta del kDrive seleccionado y viceversa.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SINCRONIZAR</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Resumen de la sincronización de tu carpeta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Los contenidos de la carpeta en tu ordenador se sincronizarán a la carpeta del kDrive seleccionado y viceversa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SINCRONIZAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Antes de terminar</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Realiza los siguientes pasos para garantizar que Lite Sync funciona correctamente en tu ordenador y para completar la configuración del kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abra la &lt;b&gt;Configuración general&lt;/b&gt; de su Mac o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abre la &lt;b&gt;Configuración de Privacidad y Seguridad&lt;/b&gt; de tu Mac o &lt;a style="%1" href="%2"&gt;haz clic aquí&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abre la &lt;b&gt;Configuración de seguridad y privacidad&lt;/b&gt; de tu Mac o &lt;a style="%1" href="%2"&gt;haz clic aquí&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Vaya a la sección &lt;b&gt;"Elementos de inicio de sesión y extensiones"&lt;/b&gt; y, a continuación, a &lt;b&gt;"Extensiones de seguridad para puntos finales"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Autorizar la aplicación kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Ir a la sección &lt;b&gt;"Seguridad"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Autoriza la aplicación kDrive en la casilla que indica que kDrive está bloqueado</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Desbloquea el candado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; y autoriza la aplicación kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Vaya a la sección &lt;b&gt;"Privacidad y seguridad"&lt;/b&gt; y haga clic en &lt;b&gt;"Acceso total al disco"&lt;/b&gt; o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>En los ajustes de Seguridad y Privacidad, abre la pestaña &lt;b&gt;"Privacidad"&lt;/b&gt; o &lt;a style="%1" href="%2"&gt;pincha aquí&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Marca la casilla "Extensión LiteSync kDrive" y luego la casilla "kDrive.app" (si no está ya marcada)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Puede que se sugiera reiniciar la aplicación. En tal caso, acepta</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Marca la casilla Extensión LiteSync kDrive (y "kDrive.app" si existe) en &lt;b&gt;"Acceso disco completo"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>PASO 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Hecho)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>PASO 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>PASOS REALIZADOS</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>FIN</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Antes de terminar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Realiza los siguientes pasos para garantizar que Lite Sync funciona correctamente en tu ordenador y para completar la configuración del kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra la &lt;b&gt;Configuración general&lt;/b&gt; de su Mac o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abre la &lt;b&gt;Configuración de Privacidad y Seguridad&lt;/b&gt; de tu Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;haz clic aquí&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abre la &lt;b&gt;Configuración de seguridad y privacidad&lt;/b&gt; de tu Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;haz clic aquí&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Vaya a la sección &lt;b&gt;&quot;Elementos de inicio de sesión y extensiones&quot;&lt;/b&gt; y, a continuación, a &lt;b&gt;&quot;Extensiones de seguridad para puntos finales&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autorizar la aplicación kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Ir a la sección &lt;b&gt;&quot;Seguridad&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autoriza la aplicación kDrive en la casilla que indica que kDrive está bloqueado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Desbloquea el candado &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; y autoriza la aplicación kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Vaya a la sección &lt;b&gt;&quot;Privacidad y seguridad&quot;&lt;/b&gt; y haga clic en &lt;b&gt;&quot;Acceso total al disco&quot;&lt;/b&gt; o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>En los ajustes de Seguridad y Privacidad, abre la pestaña &lt;b&gt;&quot;Privacidad&quot;&lt;/b&gt; o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;pincha aquí&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Marca la casilla &quot;Extensión LiteSync kDrive&quot; y luego la casilla &quot;kDrive.app&quot; (si no está ya marcada)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Puede que se sugiera reiniciar la aplicación. En tal caso, acepta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Marca la casilla Extensión LiteSync kDrive (y &quot;kDrive.app&quot; si existe) en &lt;b&gt;&quot;Acceso disco completo&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>PASO 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Hecho)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>PASO 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>PASOS REALIZADOS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>FIN</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>Aceptar</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>SÍ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NO</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>Aceptar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>SÍ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NO</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Enviando información de depuración</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Enviando información de depuración</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Información</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Depurar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Advertencia</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Error</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Fatal</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Configuración de depuración</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Guardar información de depuración en una carpeta de mi computadora (recomendado)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Esta información permite al soporte de TI determinar el origen de un incidente.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Nivel de depuración</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>El nivel de seguimiento le permite elegir el alcance de la información de depuración registrada</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>El registro completo extendido recopila un historial detallado que se puede utilizar para la depuración. Habilitarlo puede ralentizar la aplicación kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Registro completo extendido</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Eliminar registros de más de %1 días</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Comparte la carpeta de depuración con el soporte de Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>La última sesión es el período desde el último inicio de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Comparte solo la última sesión de kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Cargando</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>No se pudo compartir</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Verifique que haya iniciado sesión &lt;br&gt;2. Comprueba que tienes configurado al menos un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Conexión interrumpida)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Compartir la carpeta con SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Comprimimos automáticamente su registro &lt;a style="%1" href="%2"&gt;aquí&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Transfiera el archivo con &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Comparte el enlace con &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Última carga el %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Compartir ha sido cancelado</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>El registro completo extendido se activa mediante la variable de entorno KDRIVE_FORCE_EXTENDED_LOG. Configúrelo en 0 para deshabilitarlo.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>La carpeta completa es grande (&gt; 100 MB) y puede tardar algún tiempo en compartirse. Para reducir el tiempo de compartición, le recomendamos que comparta sólo la última sesión de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%2/%1/%3 a las %4:%5 y %6s</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>¿Deseas guardar tus cambios?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>No se puede abrir la carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Compartir</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Compartir | paso 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Compartir | paso 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Cancelado...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Información</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Depurar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Advertencia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Configuración de depuración</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Guardar información de depuración en una carpeta de mi computadora (recomendado)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Esta información permite al soporte de TI determinar el origen de un incidente.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Nivel de depuración</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>El nivel de seguimiento le permite elegir el alcance de la información de depuración registrada</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>El registro completo extendido recopila un historial detallado que se puede utilizar para la depuración. Habilitarlo puede ralentizar la aplicación kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Registro completo extendido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Eliminar registros de más de %1 días</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Comparte la carpeta de depuración con el soporte de Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>La última sesión es el período desde el último inicio de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Comparte solo la última sesión de kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Cargando</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>No se pudo compartir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Verifique que haya iniciado sesión &lt;br&gt;2. Comprueba que tienes configurado al menos un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Conexión interrumpida)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Compartir la carpeta con SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Comprimimos automáticamente su registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aquí&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Transfiera el archivo con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Comparte el enlace con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Última carga el %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Compartir ha sido cancelado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>El registro completo extendido se activa mediante la variable de entorno KDRIVE_FORCE_EXTENDED_LOG. Configúrelo en 0 para deshabilitarlo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>La carpeta completa es grande (&gt; 100 MB) y puede tardar algún tiempo en compartirse. Para reducir el tiempo de compartición, le recomendamos que comparta sólo la última sesión de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%2/%1/%3 a las %4:%5 y %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>¿Deseas guardar tus cambios?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>No se puede abrir la carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Compartir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Compartir | paso 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Compartir | paso 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Cancelado...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Carpetas</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Notificaciones</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Se mostrará una notificación en cuanto se haya sincronizado o modificado una nueva carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Conectado con</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>¿Estás seguro de que deseas dejar de sincronizar la carpeta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Esta operación puede durar de unos segundos a unos minutos en función del tamaño de la carpeta.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>¡Error al sincronizar las nuevas carpetas locales!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Error en la activación de Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Ha fallado la desactivación de Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>ELIMINAR CONEXIÓN DE SINCRONIZACIÓN DE CARPETAS</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Habilitar las notificaciones para este kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>CONFIRMAR</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Errores de sincronización e información.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Sincronizar una carpeta local</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>¿Estás seguro de que deseas activar Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>¿Estás seguro de que deseas desactivar Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>No tienes suficiente espacio para sincronizar todos los archivos en el kDrive (falta %1). Si se desactiva Lite Sync, habrá que elegir qué carpetas se sincronizan en el ordenador. Mientras tanto, se detendrá la sincronización de tu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Si desactivas Lite Sync, todos los archivos se descargarán en tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>No se pudo crear la nueva sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync activado.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync desactivado.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Esta unidad se está eliminando.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Imposible abrir el elemento %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>No se pudo detener la sincronización de la carpeta &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Eliminar todas las sincronizaciones</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Busca en tu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Buscar en</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Carpetas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Notificaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Se mostrará una notificación en cuanto se haya sincronizado o modificado una nueva carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Conectado con</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>¿Estás seguro de que deseas dejar de sincronizar la carpeta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Esta operación puede durar de unos segundos a unos minutos en función del tamaño de la carpeta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>¡Error al sincronizar las nuevas carpetas locales!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Error en la activación de Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Ha fallado la desactivación de Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>ELIMINAR CONEXIÓN DE SINCRONIZACIÓN DE CARPETAS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Habilitar las notificaciones para este kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Errores de sincronización e información.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Sincronizar una carpeta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>¿Estás seguro de que deseas activar Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>¿Estás seguro de que deseas desactivar Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>No tienes suficiente espacio para sincronizar todos los archivos en el kDrive (falta %1). Si se desactiva Lite Sync, habrá que elegir qué carpetas se sincronizan en el ordenador. Mientras tanto, se detendrá la sincronización de tu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Si desactivas Lite Sync, todos los archivos se descargarán en tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>No se pudo crear la nueva sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync activado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync desactivado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Esta unidad se está eliminando.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Imposible abrir el elemento %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>No se pudo detener la sincronización de la carpeta &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Eliminar todas las sincronizaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Busca en tu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Buscar en</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Sincronizar un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Añadir a kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Sincronizar un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Añadir a kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Resolver</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Elementos en conflicto</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Elementos con caracteres no admitidos</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Borrar el historial</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Para Resolver</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Resuelto automáticamente</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problema(s) resuelto(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>problema(s) detectado(s)</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Resolver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elementos en conflicto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Elementos con caracteres no admitidos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Borrar el historial</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Para Resolver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Resuelto automáticamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problema(s) resuelto(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>problema(s) detectado(s)</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Conflictos o errores de sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Errores</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Volver a preferencias</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Conflictos o errores de sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Errores</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Volver a preferencias</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Algunos archivos no se han podido sincronizar en el/los siguiente(s) kDrive(s):</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 error(es))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 información(es))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 error(es) y %2 información(es))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
-<numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Algunos archivos no se han podido sincronizar en el/los siguiente(s) kDrive(s):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 error(es))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 información(es))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 error(es) y %2 información(es))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
+            <numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Archivos excluidos</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Añadir archivos o carpetas que no se sincronizarán en tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Añadir</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NOMBRE</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>ADVERTENCIA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>¿Deseas guardar tus cambios?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>¡La plantilla de exclusión ya existe!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>¿Estás seguro de que deseas eliminarlo?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>¡No se pueden guardar los cambios!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Archivos excluidos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Añadir archivos o carpetas que no se sincronizarán en tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NOMBRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>ADVERTENCIA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>¿Deseas guardar tus cambios?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>¡La plantilla de exclusión ya existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>¿Estás seguro de que deseas eliminarlo?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>¡No se pueden guardar los cambios!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Resolver conflictos</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;¿Qué desea hacer con los %1 elementos en conflicto?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Guardar mis cambios y reemplazar las versiones de otros usuarios.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Deshacer mis cambios y conservar las versiones de otros usuarios.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Es posible que los cambios se eliminen de forma permanente. No se pueden restaurar desde la aplicación web de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Los cambios se eliminarán de forma permanente. No se podrán restaurar desde la aplicación web de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Mostrar artículo(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Varios usuarios han realizado modificaciones en estos archivos en distintos lugares (en línea, en kDrive, en un ordenador o en un dispositivo móvil). Es posible que también se hayan eliminado las carpetas que contienen estos archivos.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>La versión local de su elemento &lt;b&gt;no está sincronizada&lt;/b&gt; con kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Más información&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Resolver conflictos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;¿Qué desea hacer con los %1 elementos en conflicto?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Guardar mis cambios y reemplazar las versiones de otros usuarios.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Deshacer mis cambios y conservar las versiones de otros usuarios.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Es posible que los cambios se eliminen de forma permanente. No se pueden restaurar desde la aplicación web de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Los cambios se eliminarán de forma permanente. No se podrán restaurar desde la aplicación web de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Mostrar artículo(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Varios usuarios han realizado modificaciones en estos archivos en distintos lugares (en línea, en kDrive, en un ordenador o en un dispositivo móvil). Es posible que también se hayan eliminado las carpetas que contienen estos archivos.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>La versión local de su elemento &lt;b&gt;no está sincronizada&lt;/b&gt; con kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Más acciones</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Sincronizado en &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Activar Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Activar Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Las carpetas no seleccionadas se moverán a la papelera siempre que contengan elementos sin conexión. Las carpetas sincronizadas con kDrive seguirán estando disponibles en línea.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Las carpetas no seleccionadas serán movidas a la papelera. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Las carpetas no seleccionadas se eliminarán &lt;b&gt;permanentemente&lt;/b&gt; del ordenador. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Pausar la sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Desactivar Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Reanudar la sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Eliminar la sincronización</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Más acciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Sincronizado en &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Activar Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Activar Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Las carpetas no seleccionadas se moverán a la papelera siempre que contengan elementos sin conexión. Las carpetas sincronizadas con kDrive seguirán estando disponibles en línea.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Las carpetas no seleccionadas serán movidas a la papelera. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Las carpetas no seleccionadas se eliminarán &lt;b&gt;permanentemente&lt;/b&gt; del ordenador. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar la sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Desactivar Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Reanudar la sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Eliminar la sincronización</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>No se puede abrir la ruta de la carpeta %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>No se puede abrir la ruta de la carpeta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>ID de aplicación</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Nombre de la aplicación</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>ID de aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nombre de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Algunas apps (copia de seguridad, anti-virus, ...) acceden a tus archivos, por lo que se descargan cuando están "online". Añádelas a la siguiente lista para evitarlo.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Añadir</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ID DE APLICACIÓN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NOMBRE</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>¿Deseas guardar tus cambios?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>¿Estás seguro de que deseas eliminarlo?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>¡No se pueden guardar los cambios!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Algunas apps (copia de seguridad, anti-virus, ...) acceden a tus archivos, por lo que se descargan cuando están &quot;online&quot;. Añádelas a la siguiente lista para evitarlo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Añadir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID DE APLICACIÓN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NOMBRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>¿Deseas guardar tus cambios?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>¿Estás seguro de que deseas eliminarlo?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>¡No se pueden guardar los cambios!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>¿Qué carpeta del ordenador deseas&lt;br&gt;sincronizar?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>El contenido de esta carpeta se sincronizará en el kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Seleccionar una carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Editar carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>¿Qué carpeta del ordenador deseas&lt;br&gt;sincronizar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>El contenido de esta carpeta se sincronizará en el kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Seleccionar una carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Editar carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
 Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Seleccionar carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Seleccionar carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Error</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;El archivo '%1'&lt;br/&gt;no se puede abrir para escritura.&lt;br/&gt;&lt;br/&gt;¡El archivo de registro &lt;b&gt;no&lt;/b&gt; se puede guardar!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Error</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;El archivo &apos;%1&apos;&lt;br/&gt;no se puede abrir para escritura.&lt;br/&gt;&lt;br/&gt;¡El archivo de registro &lt;b&gt;no&lt;/b&gt; se puede guardar!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Preferencias</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Ayuda</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferencias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ayuda</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>No es posible abrir la ruta de la carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>¡Transmisión realizada!&lt;br&gt;Consulta el identificador &lt;b&gt;%1&lt;/b&gt; en informes de fallos.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>¡La transmisión falló!
-Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>¡No hay ningún kDrive configurado!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Se ha producido un error técnico (error %1).&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Parece que su conexión de red está configurada con un tiempo de espera demasiado bajo para que la aplicación funcione correctamente (error %1).&lt;br&gt;Compruebe su configuración de red.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>No se puede conectar al servidor kDrive (error %1).&lt;br&gt;Intentando reconexión. Por favor verifique su conexión a Internet y su firewall.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Inicie sesión nuevamente y, si el error persiste, comuníquese con nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Hay una nueva versión de la aplicación disponible.&lt;br&gt;Actualice la aplicación para seguir usándola.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Error al cargar el registro (error %1).&lt;br&gt;Inténtelo de nuevo más tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Ya no se puede acceder a la carpeta de sincronización (error %1).&lt;br&gt;La sincronización se reanudará tan pronto como se pueda acceder a la carpeta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>La carpeta de sincronización se ha sustituido o movido de forma que impide la sincronización (error %1).&lt;br&gt;Esto puede ocurrir después de copiar, mover o restaurar la carpeta.&lt;br&gt;Para solucionarlo, cree una nueva sincronización con una carpeta nueva.&lt;br&gt;Nota: si tiene cambios sin sincronizar en la carpeta antigua, tendrá que copiarlos manualmente en la nueva.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>No queda suficiente memoria en su máquina.&lt;br&gt;La sincronización se ha detenido.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive necesita tener acceso de escritura al directorio temporal de tu ordenador. &lt;br&gt;Reinicia la aplicación kDrive para resolver este problema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Se ha producido un error técnico. La sincronización se reanudará lo antes posible. Si el error persiste, contacte con nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>El número de vigilancias de inotify es insuficiente (error %1).&lt;br&gt;Puede aumentar este número editando '/etc/sysctl.conf'.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>No se puede iniciar la sincronización (error %1).&lt;br&gt;Debe permitir:&lt;br&gt;- kDrive en Configuración del sistema &gt;&gt; General &gt;&gt; Elementos de inicio de sesión y extensiones &gt;&gt; Extensiones de seguridad de endpoints&lt;br&gt;- Extensión kDrive LiteSync en Configuración del sistema &gt;&gt; Privacidad y seguridad &gt;&gt; Acceso completo al disco.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync esté instalada y que el servicio de búsqueda de Windows esté habilitado.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync tenga los permisos correctos y se esté ejecutando.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive está en modo de mantenimiento.&lt;br&gt;La sincronización comenzará de nuevo lo antes posible. Ponte en contacto con nuestro equipo de asistencia si el error persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>El kDrive está bloqueado.&lt;br&gt;Renueva kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>El kDrive está bloqueado.&lt;br&gt;Ponte en contacto con un administrador para renovar el kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>El kDrive se está iniciando.&lt;br&gt;La sincronización se reanudará lo antes posible. Por favor, contacte con nuestro equipo de soporte si el error persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la &lt;a style="%1" href="%2"&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la versión web para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>No estás autorizado a acceder a este kDrive.&lt;br&gt;La sincronización se ha pausado. Por favor contacte a un administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Se ha producido un error técnico (error %1).&lt;br&gt;La sincronización se reanudará lo antes posible. Comuníquese con nuestro equipo de soporte si el error persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>El kernel ha interrumpido las conexiones de red (error %1).&lt;br&gt;Vacia el historial y, si el error persiste, ponte en contacto con nuestro equipo de soporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Desafortunadamente no se ha podido migrar tu configuración anterior.&lt;br&gt;La aplicación usará una configuración en blanco.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Desafortunadamente no se ha podido migrar tu antigua configuración de proxy. Los proxies SOCKS5 no son compatibles en este momento.&lt;br&gt;La aplicación usará la configuración del proxy del sistema en su lugar.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Se ha producido un error técnico (error %1).&lt;br&gt;Se ha reiniciado la sincronización. Vacía el historial y si el error persiste, contacta con nuestro equipo de asistencia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Se ha producido un error al acceder a la base de datos de sincronización (error %1).&lt;br&gt;La sincronización se ha detenido.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Token no válido o revocado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Las sincronizaciones anidadas están prohibidas (error %1).&lt;br&gt;Solo debes conservar las sincronizaciones cuyas carpetas no estén anidadas.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>La carpeta de sincronización en el kDrive remoto ya no existe o ya no es accesible (error %1).&lt;br&gt;Debe restaurarla o devolverle los derechos de acceso o eliminar/recrear la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Error de análisis del nombre de archivo (error %1).&lt;br&gt;Los caracteres especiales como comillas dobles, barras invertidas o retornos de línea pueden provocar errores de análisis.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>No tiene permiso para crear un elemento o ya existe otro elemento con el mismo nombre. El elemento ha sido ignorado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>No tiene permitido mover el elemento a "%1".&lt;br&gt;Se restaurará en su carpeta principal original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>No queda espacio suficiente en su ordenador.&lt;br&gt;Se ha cancelado la descarga.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>No es posible crear el archivo «%1» porque no es compatible con tu sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Este elemento se ha movido a otro lugar.&lt;br&gt;La operación local ha sido cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;Se ha cambiado el nombre del elemento local.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;La operación local ha sido cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>No queda espacio suficiente en el ordenador.&lt;br&gt;Se ha detenido la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>El archivo fue modificado al mismo tiempo por otro usuario.&lt;br&gt;Tus modificaciones se han guardado en una copia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Otro usuario ha movido una carpeta principal del destino.&lt;br&gt;La operación local ha sido cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>El nombre del elemento contiene solo espacios.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>No tienes permiso para editar elementos.&lt;br&gt;Se ha cambiado el nombre del archivo que contiene tus modificaciones y se le ha excluido de la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>No tienes permiso para cambiar el nombre del elemento.&lt;br&gt;Se restaurará con su nombre original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>No tienes permiso para eliminar el elemento.&lt;br&gt;Se restaurará a su ubicación original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>No se ha podido mover este elemento a la papelera, se ha incluido en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>El archivo se ha modificado localmente mientras se eliminó en el kDrive remoto.&lt;br&gt;Se ha guardado una copia local en la carpeta de rescate (rescue folder).</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>La operación realizada en el artículo está prohibida.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>La operación realizada en este artículo ha fallado.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>El archivo es demasiado grande para ser cargado. Ha sido temporalmente bloqueado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Imposible descargar el archivo.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Has excedido tu cuota. Aumente su cuota de espacio para volver a habilitar la carga de archivos.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>La unidad que contiene su carpeta de sincronización ya no está conectada (error %1).&lt;br&gt;Vuelva a conectarla para reanudar la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>No se puede iniciar la sincronización (error %1). El proceso LiteSyncExt no se está ejecutando. La sincronización se reanudará en cuanto se inicie.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Un elemento existente tiene un nombre idéntico con las mismas opciones de mayúsculas y minúsculas (mismas letras mayúsculas y minúsculas).&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>El nombre del artículo contiene un carácter no compatible.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>El nombre del elemento termina con un espacio, lo cual está prohibido en su sistema operativo.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Este nombre de artículo está reservado por su sistema operativo.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>El nombre del artículo es demasiado largo.&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>La ruta del elemento es demasiado larga.&lt;br&gt;Se ha ignorado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>El nombre del elemento contiene un carácter UNICODE reciente que aún no es compatible con su sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>No se pudo sincronizar este elemento. Se ha incluido temporalmente en la lista negra.&lt;br&gt;Se realizará otro intento de sincronización en una hora o en el próximo inicio de la aplicación.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Este artículo ha sido excluido del sincronizado por una plantilla personalizada. Puede desactivar este tipo de notificación desde las preferencias</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Este elemento se ha excluido de la sincronización porque es un enlace duro.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Este artículo está actualmente bloqueado por otro usuario en línea.&lt;br&gt;Volveremos a intentar subir tus cambios más tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Error de sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>No se puede acceder al elemento.&lt;br&gt;Por favor, corrija los permisos de lectura y escritura.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Error del sistema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>El elemento ya existe en el otro lado.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Se ha producido un error técnico.&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>No es posible abrir la ruta de la carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>¡Transmisión realizada!&lt;br&gt;Consulta el identificador &lt;b&gt;%1&lt;/b&gt; en informes de fallos.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>¡La transmisión falló!
+Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>¡No hay ningún kDrive configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Parece que su conexión de red está configurada con un tiempo de espera demasiado bajo para que la aplicación funcione correctamente (error %1).&lt;br&gt;Compruebe su configuración de red.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>No se puede conectar al servidor kDrive (error %1).&lt;br&gt;Intentando reconexión. Por favor verifique su conexión a Internet y su firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Inicie sesión nuevamente y, si el error persiste, comuníquese con nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Hay una nueva versión de la aplicación disponible.&lt;br&gt;Actualice la aplicación para seguir usándola.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Error al cargar el registro (error %1).&lt;br&gt;Inténtelo de nuevo más tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Ya no se puede acceder a la carpeta de sincronización (error %1).&lt;br&gt;La sincronización se reanudará tan pronto como se pueda acceder a la carpeta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>La carpeta de sincronización se ha sustituido o movido de forma que impide la sincronización (error %1).&lt;br&gt;Esto puede ocurrir después de copiar, mover o restaurar la carpeta.&lt;br&gt;Para solucionarlo, cree una nueva sincronización con una carpeta nueva.&lt;br&gt;Nota: si tiene cambios sin sincronizar en la carpeta antigua, tendrá que copiarlos manualmente en la nueva.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>No queda suficiente memoria en su máquina.&lt;br&gt;La sincronización se ha detenido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive necesita tener acceso de escritura al directorio temporal de tu ordenador. &lt;br&gt;Reinicia la aplicación kDrive para resolver este problema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Se ha producido un error técnico. La sincronización se reanudará lo antes posible. Si el error persiste, contacte con nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>El número de vigilancias de inotify es insuficiente (error %1).&lt;br&gt;Puede aumentar este número editando &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>No se puede iniciar la sincronización (error %1).&lt;br&gt;Debe permitir:&lt;br&gt;- kDrive en Configuración del sistema &gt;&gt; General &gt;&gt; Elementos de inicio de sesión y extensiones &gt;&gt; Extensiones de seguridad de endpoints&lt;br&gt;- Extensión kDrive LiteSync en Configuración del sistema &gt;&gt; Privacidad y seguridad &gt;&gt; Acceso completo al disco.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync esté instalada y que el servicio de búsqueda de Windows esté habilitado.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync tenga los permisos correctos y se esté ejecutando.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive está en modo de mantenimiento.&lt;br&gt;La sincronización comenzará de nuevo lo antes posible. Ponte en contacto con nuestro equipo de asistencia si el error persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>El kDrive está bloqueado.&lt;br&gt;Renueva kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>El kDrive está bloqueado.&lt;br&gt;Ponte en contacto con un administrador para renovar el kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>El kDrive se está iniciando.&lt;br&gt;La sincronización se reanudará lo antes posible. Por favor, contacte con nuestro equipo de soporte si el error persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la versión web para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>No estás autorizado a acceder a este kDrive.&lt;br&gt;La sincronización se ha pausado. Por favor contacte a un administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;La sincronización se reanudará lo antes posible. Comuníquese con nuestro equipo de soporte si el error persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>El kernel ha interrumpido las conexiones de red (error %1).&lt;br&gt;Vacia el historial y, si el error persiste, ponte en contacto con nuestro equipo de soporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Desafortunadamente no se ha podido migrar tu configuración anterior.&lt;br&gt;La aplicación usará una configuración en blanco.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Desafortunadamente no se ha podido migrar tu antigua configuración de proxy. Los proxies SOCKS5 no son compatibles en este momento.&lt;br&gt;La aplicación usará la configuración del proxy del sistema en su lugar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;Se ha reiniciado la sincronización. Vacía el historial y si el error persiste, contacta con nuestro equipo de asistencia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Se ha producido un error al acceder a la base de datos de sincronización (error %1).&lt;br&gt;La sincronización se ha detenido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Token no válido o revocado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Las sincronizaciones anidadas están prohibidas (error %1).&lt;br&gt;Solo debes conservar las sincronizaciones cuyas carpetas no estén anidadas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>La carpeta de sincronización en el kDrive remoto ya no existe o ya no es accesible (error %1).&lt;br&gt;Debe restaurarla o devolverle los derechos de acceso o eliminar/recrear la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Error de análisis del nombre de archivo (error %1).&lt;br&gt;Los caracteres especiales como comillas dobles, barras invertidas o retornos de línea pueden provocar errores de análisis.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>No tiene permiso para crear un elemento o ya existe otro elemento con el mismo nombre. El elemento ha sido ignorado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>No tiene permitido mover el elemento a &quot;%1&quot;.&lt;br&gt;Se restaurará en su carpeta principal original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>No queda espacio suficiente en su ordenador.&lt;br&gt;Se ha cancelado la descarga.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>No es posible crear el archivo «%1» porque no es compatible con tu sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Este elemento se ha movido a otro lugar.&lt;br&gt;La operación local ha sido cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;Se ha cambiado el nombre del elemento local.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;La operación local ha sido cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>No queda espacio suficiente en el ordenador.&lt;br&gt;Se ha detenido la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>El archivo fue modificado al mismo tiempo por otro usuario.&lt;br&gt;Tus modificaciones se han guardado en una copia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Otro usuario ha movido una carpeta principal del destino.&lt;br&gt;La operación local ha sido cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>El nombre del elemento contiene solo espacios.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>No tienes permiso para editar elementos.&lt;br&gt;Se ha cambiado el nombre del archivo que contiene tus modificaciones y se le ha excluido de la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>No tienes permiso para cambiar el nombre del elemento.&lt;br&gt;Se restaurará con su nombre original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>No tienes permiso para eliminar el elemento.&lt;br&gt;Se restaurará a su ubicación original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>No se ha podido mover este elemento a la papelera, se ha incluido en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>El archivo se ha modificado localmente mientras se eliminó en el kDrive remoto.&lt;br&gt;Se ha guardado una copia local en la carpeta de rescate (rescue folder).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>La operación realizada en el artículo está prohibida.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>La operación realizada en este artículo ha fallado.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>El archivo es demasiado grande para ser cargado. Ha sido temporalmente bloqueado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Imposible descargar el archivo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Has excedido tu cuota. Aumente su cuota de espacio para volver a habilitar la carga de archivos.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>La unidad que contiene su carpeta de sincronización ya no está conectada (error %1).&lt;br&gt;Vuelva a conectarla para reanudar la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>No se puede iniciar la sincronización (error %1). El proceso LiteSyncExt no se está ejecutando. La sincronización se reanudará en cuanto se inicie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Un elemento existente tiene un nombre idéntico con las mismas opciones de mayúsculas y minúsculas (mismas letras mayúsculas y minúsculas).&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>El nombre del artículo contiene un carácter no compatible.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>El nombre del elemento termina con un espacio, lo cual está prohibido en su sistema operativo.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Este nombre de artículo está reservado por su sistema operativo.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>El nombre del artículo es demasiado largo.&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>La ruta del elemento es demasiado larga.&lt;br&gt;Se ha ignorado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>El nombre del elemento contiene un carácter UNICODE reciente que aún no es compatible con su sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>No se pudo sincronizar este elemento. Se ha incluido temporalmente en la lista negra.&lt;br&gt;Se realizará otro intento de sincronización en una hora o en el próximo inicio de la aplicación.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Este artículo ha sido excluido del sincronizado por una plantilla personalizada. Puede desactivar este tipo de notificación desde las preferencias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Este elemento se ha excluido de la sincronización porque es un enlace duro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Este artículo está actualmente bloqueado por otro usuario en línea.&lt;br&gt;Volveremos a intentar subir tus cambios más tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Error de sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>No se puede acceder al elemento.&lt;br&gt;Por favor, corrija los permisos de lectura y escritura.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Error del sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>El elemento ya existe en el otro lado.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Se ha producido un error técnico.&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Esta sincronización se está eliminando.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Esta sincronización se está eliminando.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Volver a la lista de drives</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Preferencias</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Volver a la lista de drives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferencias</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>General</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Activar tema oscuro</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Activar iconos monocromos</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Ejecutar kDrive al arrancar</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Neerlandés</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avanzado</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Información de depuración</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Archivos a excluir</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Sueco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugués</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polaco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Noruego</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finlandés</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Danés</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Griego</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>No se puede abrir la carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Enlace %1 no válido.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Idioma</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Algún proceso no se ha ejecutado.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Mueva los archivos eliminados a la papelera de mi computadora</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Es posible que algunos archivos o carpetas no se muevan a la papelera de la computadora.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Siempre puedes recuperar archivos ya sincronizados desde la papelera de la aplicación web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Inglés</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Francés</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Alemán</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Español</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italiano</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Predeterminado</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>General</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Activar tema oscuro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Activar iconos monocromos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Ejecutar kDrive al arrancar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Neerlandés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avanzado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Información de depuración</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Archivos a excluir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Sueco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugués</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polaco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Noruego</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finlandés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Danés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Griego</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>No se puede abrir la carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Enlace %1 no válido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Algún proceso no se ha ejecutado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Mueva los archivos eliminados a la papelera de mi computadora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Es posible que algunos archivos o carpetas no se muevan a la papelera de la computadora.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Siempre puedes recuperar archivos ya sincronizados desde la papelera de la aplicación web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Inglés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Francés</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Alemán</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Español</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italiano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Predeterminado</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 en uso</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 en uso</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>Proxy HTTP(S)</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ningún servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Usar parámetros del sistema</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Indicar un proxy manualmente</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Puerto</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Dirección del servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Es necesaria una autenticación</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Usuario</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Contraseña</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>¿Deseas guardar tus cambios?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>¡No es posible guardar, no se han completado todos los campos obligatorios!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>No se encuentra el proxy, ¿guardar de todos modos?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ningún servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Usar parámetros del sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Indicar un proxy manualmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Puerto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Dirección del servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Es necesaria una autenticación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Usuario</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Contraseña</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>¿Deseas guardar tus cambios?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>¡No es posible guardar, no se han completado todos los campos obligatorios!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>No se encuentra el proxy, ¿guardar de todos modos?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Gerente de Recursos</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Uso máximo de CPU permitido</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>¿Deseas guardar tus cambios?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Gerente de Recursos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Uso máximo de CPU permitido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>¿Deseas guardar tus cambios?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Selecciona una carpeta en tu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>El contenido de esta carpeta se sincronizará en la carpeta &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Espacio disponible en tu ordenador para la carpeta actual: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Esta carpeta ya se está sincronizando.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>CONFIRMAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Selecciona una carpeta en tu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>El contenido de esta carpeta se sincronizará en la carpeta &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Espacio disponible en tu ordenador para la carpeta actual: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Esta carpeta ya se está sincronizando.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; contiene subcarpetas,&lt;br&gt; selecciona las que deseas sincronizar</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>No hay subcarpetas actualmente en el servidor.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; contiene subcarpetas,&lt;br&gt; selecciona las que deseas sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>No hay subcarpetas actualmente en el servidor.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Reanudar la sincronización de kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Reanudar la sincronización de todos los kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Pausar sincronización de kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Pausar la sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Pausar la sincronización de todos los kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Reanudar la sincronización</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Reanudar la sincronización de kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Reanudar la sincronización de todos los kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Pausar sincronización de kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar la sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Pausar la sincronización de todos los kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Reanudar la sincronización</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Copiar enlace compartido</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Mostrar en kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Mostrar en carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Más acciones</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Abrir</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Añadir a favoritos</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiar enlace compartido</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Mostrar en kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Mostrar en carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Más acciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Añadir a favoritos</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Nunca</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Durante 1 hora</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Hasta mañana a las 8:00AM</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Durante 3 días</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Durante 1 semana</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Siempre</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Por 1 hora más</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Por 3 días más</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Por 1 semana más</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>No es posible abrir la url de carpeta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Abrir en carpeta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Abrir la versión web de %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Parámetros de drive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Notificaciones deshabilitadas hasta %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Deshabilitar Notificaciones</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Preferencias de aplicación</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Se necesita ayuda</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Enviar comentarios</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Salir de kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>No es posible acceder al sitio web %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Mostrar errores e informaciones</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Mostrar información</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Más acciones</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Durante 1 hora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Hasta mañana a las 8:00AM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Durante 3 días</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Durante 1 semana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Siempre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Por 1 hora más</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Por 3 días más</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Por 1 semana más</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>No es posible abrir la url de carpeta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Abrir en carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Abrir la versión web de %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parámetros de drive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Notificaciones deshabilitadas hasta %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Deshabilitar Notificaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Preferencias de aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Se necesita ayuda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Enviar comentarios</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Salir de kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>No es posible acceder al sitio web %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Mostrar errores e informaciones</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Mostrar información</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Más acciones</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Actualizar la aplicación kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Esta versión de la aplicación kDrive ya no es compatible. Para acceder a las últimas funciones y mejoras, actualice.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Actualizar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Descargue la última versión del sitio web.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Descarga de actualización en curso</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Buscando actualización...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Actualización manual</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Indisponible</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Puedes sincronizar archivos &lt;a style="%1" href="%2"&gt;desde tu ordenador&lt;/a&gt; o en &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Sincronizado</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoritos</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Actividad</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>¡No implementado!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/es/aplicaciones/descargar-kdrive"&gt;Haga clic aquí para descargar manualmente&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>¡No hay ninguna carpeta sincronizada para este Drive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>¡No hay ningún kDrive configurado!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>No se puede abrir el enlace %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Enlace %1 no válido.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>No es posible abrir la url de carpeta %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Actualizar la aplicación kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Esta versión de la aplicación kDrive ya no es compatible. Para acceder a las últimas funciones y mejoras, actualice.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Actualizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Descargue la última versión del sitio web.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Descarga de actualización en curso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Buscando actualización...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Actualización manual</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Indisponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Puedes sincronizar archivos &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;desde tu ordenador&lt;/a&gt; o en &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Sincronizado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Actividad</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>¡No implementado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/es/aplicaciones/descargar-kdrive&quot;&gt;Haga clic aquí para descargar manualmente&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>¡No hay ninguna carpeta sincronizada para este Drive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>¡No hay ningún kDrive configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>No se puede abrir el enlace %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Enlace %1 no válido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>No es posible abrir la url de carpeta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;La nueva versión &lt;b&gt;%1&lt;/b&gt; del Cliente %2 está disponible y ha sido descargada.&lt;/p&gt;&lt;p&gt;La versión instalada es %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Omitir esta versión</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Recordármelo</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Instalar actualización</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;La nueva versión &lt;b&gt;%1&lt;/b&gt; del Cliente %2 está disponible y ha sido descargada.&lt;/p&gt;&lt;p&gt;La versión instalada es %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Omitir esta versión</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Recordármelo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Instalar actualización</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Nueva actualización disponible.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>La versión %1 está disponible para su descarga.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Nueva actualización disponible.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>La versión %1 está disponible para su descarga.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Añadir una cuenta</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Añadir una cuenta</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Mostrar nota de lanzamiento&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Versión</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>ACTUALIZAR</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>¡%1 está actualizado!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Comprobando actualización en servidor...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Hay una actualización disponible: %1. Descárgala &lt;a style="%2" href="%3"&gt;aquí&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Hay disponible una actualización: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Descargando %1. Espera...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>No se puede comprobar si hay actualizaciones.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Se ha producido un error durante la actualización.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>No se ha podido descargar la actualización.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Actualización desactivada.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Programa Beta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Contacto</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Modifique</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Salir</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar nota de lanzamiento&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Versión</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>ACTUALIZAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>¡%1 está actualizado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Comprobando actualización en servidor...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Hay una actualización disponible: %1. Descárgala &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aquí&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Hay disponible una actualización: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Descargando %1. Espera...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>No se puede comprobar si hay actualizaciones.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Se ha producido un error durante la actualización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>No se ha podido descargar la actualización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Actualización desactivada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Programa Beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Contacto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Modifique</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Salir</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>No se pueden guardar los parámetros, vuelva a intentarlo más tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>¡No se pueden guardar los parámetros!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>La carpeta principal es una carpeta de sincronización o está contenida en una</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>No se puede encontrar una ruta válida</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>¡No se ha seleccionado una carpeta válida!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>¡La ruta seleccionada no existe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>¡La ruta seleccionada no es una carpeta!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>La carpeta local %1 ya está sincronizada. ¡Seleccione otra!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync (Beta) está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync (Beta) está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite Sync está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite Sync está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Poner a disposición localmente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Liberar espacio local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Cancelar liberar espacio local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Cancelar disponible localmente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>No está permitido volver a compartir este archivo</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>No está permitido volver a compartir esta carpeta</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Copiar enlace para compartir públicamente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Copiar enlace para compartir privado</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Abrir en navegador</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>No se pueden guardar los parámetros, vuelva a intentarlo más tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>¡No se pueden guardar los parámetros!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>La carpeta principal es una carpeta de sincronización o está contenida en una</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>No se puede encontrar una ruta válida</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>¡No se ha seleccionado una carpeta válida!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>¡La ruta seleccionada no existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>¡La ruta seleccionada no es una carpeta!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>La carpeta local %1 ya está sincronizada. ¡Seleccione otra!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync (Beta) está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync (Beta) está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite Sync está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite Sync está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Poner a disposición localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Liberar espacio local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Cancelar liberar espacio local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Cancelar disponible localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>No está permitido volver a compartir este archivo</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>No está permitido volver a compartir esta carpeta</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Copiar enlace para compartir públicamente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Copiar enlace para compartir privado</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Abrir en navegador</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>La aplicación kDrive se cerrará debido a un error fatal.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>La aplicación kDrive se cerrará debido a un error fatal.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n año(s)</numerusform>
-<numerusform>%n año(s)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n mes(es)</numerusform>
-<numerusform>%n mes(es)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n día(s)</numerusform>
-<numerusform>%n día(s)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n hora(s)</numerusform>
-<numerusform>%n hora(s)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuto(s)</numerusform>
-<numerusform>%n minuto(s)</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n segundo(s)</numerusform>
-<numerusform>%n segundo(s)</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n año(s)</numerusform>
+            <numerusform>%n año(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n mes(es)</numerusform>
+            <numerusform>%n mes(es)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n día(s)</numerusform>
+            <numerusform>%n día(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n hora(s)</numerusform>
+            <numerusform>%n hora(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuto(s)</numerusform>
+            <numerusform>%n minuto(s)</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n segundo(s)</numerusform>
+            <numerusform>%n segundo(s)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Bandeja del sistema no disponible</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Bandeja del sistema no disponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>No se puede abrir el navegador</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Ocurrió un error al lanzar el navegador para ir a la URL %1. ¿Podría ser que no haya ningún navegador configurado como predeterminado?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>No se pudo abrir el cliente de correo</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Ocurrió un error al lanzar el cliente de correo electrónico para crear un nuevo mensaje. ¿Podría ser que no haya ningún cliente de correo electrónico configurado como predeterminado?¿Tal vez no hay ningún cliente de correo predeterminado configurado?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Ya no estás conectado. &lt;a style="%1" href="%2"&gt;Iniciar sesión&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>No se puede abrir el navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Ocurrió un error al lanzar el navegador para ir a la URL %1. ¿Podría ser que no haya ningún navegador configurado como predeterminado?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>No se pudo abrir el cliente de correo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Ocurrió un error al lanzar el cliente de correo electrónico para crear un nuevo mensaje. ¿Podría ser que no haya ningún cliente de correo electrónico configurado como predeterminado?¿Tal vez no hay ningún cliente de correo predeterminado configurado?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Ya no estás conectado. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Iniciar sesión&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>No hay carpeta para sincronizar
+        <translation>No hay carpeta para sincronizar
 Puedes agregar uno desde la configuración de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Sincronización en curso (%1 de %2)
+        <translation>Sincronización en curso (%1 de %2)
 quedan %3...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Sincronización en curso (Paso %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Sincronización en curso.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Algunos archivos no se han podido sincronizar. &lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Pausando sincronización...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>No se puede seleccionar la carpeta &lt;b&gt;%1&lt;/b&gt; porque otra sincronización está usando la misma carpeta.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque contiene la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>er &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque está contenido en la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar como carpeta de sincronización. Por favor, seleccione otra carpeta.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Iniciando sincronización</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Sincronización en pausa.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Sincronización en curso (%1 de %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Estás actualizado, conflictos sin resolver.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>¡Estás actualizado!</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Sincronización en curso (Paso %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Sincronización en curso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Algunos archivos no se han podido sincronizar. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Pausando sincronización...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>No se puede seleccionar la carpeta &lt;b&gt;%1&lt;/b&gt; porque otra sincronización está usando la misma carpeta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque contiene la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>er &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque está contenido en la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar como carpeta de sincronización. Por favor, seleccione otra carpeta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Iniciando sincronización</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Sincronización en pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Sincronización en curso (%1 de %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Estás actualizado, conflictos sin resolver.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>¡Estás actualizado!</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_es.ts
+++ b/translations/client_es.ts
@@ -1,2580 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="es_ES">
+<TS language="es_ES" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Acerca de</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">CERRAR</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versión %1. Para más información, visita &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribuido por %1 y licenciado bajo &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 y el logotipo de %2 son marcas comerciales registradas de %1. &lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">No se puede abrir la carpeta %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Creado a partir de &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;fuentes Git&lt;/a&gt; del %2, %3 con Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Acerca de</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>CERRAR</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versión %1. Para más información, visita &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribuido por %1 y licenciado bajo &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 y el logotipo de %2 son marcas comerciales registradas de %1. &lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>No se puede abrir la carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Creado a partir de &lt;a style="color: #489EF3" href="%1"&gt;fuentes Git&lt;/a&gt; del %2, %3 con Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">No es posible abrir la ruta de la carpeta %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>No es posible abrir la ruta de la carpeta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Se iniciará la sincronización y podrás añadir archivos a tu carpeta %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">¡Tu kDrive está listo!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ABRIR CARPETA</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">PARÁMETROS</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Sincronizar otro drive</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Se iniciará la sincronización y podrás añadir archivos a tu carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>¡Tu kDrive está listo!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ABRIR CARPETA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>PARÁMETROS</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Sincronizar otro drive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">SIGUIENTE</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Selecciona el kDrive que deseas sincronizar</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Obtén kDrive gratis</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Almacena tus fotos, documentos y correos electrónicos en Suiza con una empresa independiente que respeta la privacidad. Más información</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Prueba gratuita</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>SIGUIENTE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Selecciona el kDrive que deseas sincronizar</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Obtén kDrive gratis</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Almacena tus fotos, documentos y correos electrónicos en Suiza con una empresa independiente que respeta la privacidad. Más información</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Prueba gratuita</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Ahorra espacio en el ordenador</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Elige qué archivos deben estar disponibles en línea o localmente</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">MÁS TARDE</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SÍ</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync sincroniza todos los archivos sin usar espacio del ordenador. Puedes navegar por los archivos en kDrive y descargarlos localmente donde quieras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">¿Deseas activar Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">¿Deseas activar Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Ahorra espacio en el ordenador</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Elige qué archivos deben estar disponibles en línea o localmente</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>MÁS TARDE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>SÍ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync sincroniza todos los archivos sin usar espacio del ordenador. Puedes navegar por los archivos en kDrive y descargarlos localmente donde quieras. &lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>¿Deseas activar Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>¿Deseas activar Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Ubicación de tu kDrive %1</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Editar carpeta</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FIN</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Seleccionar carpeta</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">El contenido de la carpeta &lt;b&gt;%1&lt;/b&gt; se sincronizará en tu kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Encontrarás todos tus archivos en esta carpeta cuando se complete la configuración. Puedes arrastrar nuevos archivos para sincronizarlos en tu kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Ubicación de tu kDrive %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Editar carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>FIN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Seleccionar carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>El contenido de la carpeta &lt;b&gt;%1&lt;/b&gt; se sincronizará en tu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Encontrarás todos tus archivos en esta carpeta cuando se complete la configuración. Puedes arrastrar nuevos archivos para sincronizarlos en tu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
 Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Inicie sesión desde su navegador</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Tu navegador debería abrirse automáticamente para completar la conexión. Una vez conectado, volverás automáticamente a kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Abrir la página de inicio de sesión</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Inicio de sesión fallido: %1 – %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">No se pudo abrir la página de inicio de sesión en su navegador web</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Inicie sesión desde su navegador</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Tu navegador debería abrirse automáticamente para completar la conexión. Una vez conectado, volverás automáticamente a kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Abrir la página de inicio de sesión</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Se produjo un error durante la autenticación. Cierre la ventana de inicio de sesión e inténtelo de nuevo.&lt;br&gt;Si el error persiste, contacte con nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Inicio de sesión fallido: %1 – %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>No se pudo abrir la página de inicio de sesión en su navegador web</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Seleccionar carpetas kDrive para sincronizar en tu escritorio</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Espacio disponible en tu ordenador: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Se produjo un error al cargar la lista de subcarpetas.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">No se pudo cargar la lista de subcarpetas. Es posible que su kDrive esté en mantenimiento.&lt;br&gt;Inicie sesión en la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Seleccionar carpetas kDrive para sincronizar en tu escritorio</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Espacio disponible en tu ordenador: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>No se pudo cargar la lista de subcarpetas. Es posible que su kDrive esté en mantenimiento.&lt;br&gt;Inicie sesión en la &lt;a style="%1" href="%2"&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">No se pudo crear una carpeta local %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">No se pudo crear la nueva sincronización</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">El kDrive %1 ya está sincronizado en este equipo.¿Continuar de todos modos?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>No se pudo crear una carpeta local %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>No se pudo crear la nueva sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>El kDrive %1 ya está sincronizado en este equipo.¿Continuar de todos modos?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">El cliente kDrive se ejecuta con parámetros erróneos.</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">¡El cliente de kDrive ya se está ejecutando!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">El usuario %1 no está conectado. Inicia sesión de nuevo.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>El cliente kDrive se ejecuta con parámetros erróneos.</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>¡El cliente de kDrive ya se está ejecutando!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>El usuario %1 no está conectado. Inicia sesión de nuevo.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Enlace compartido copiado en el portapapeles</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
-            <numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 ha sido eliminado.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
-            <numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 ha sido añadido.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
-            <numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 ha sido actualizado.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
-            <numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 ha sido movido a %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Actividad de sincronización</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Enlace compartido copiado en el portapapeles</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
+<numerusform>%1 y otros %n archivo(s) han sido borrados.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 ha sido eliminado.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
+<numerusform>%1 y otros %n archivo(s) han sido añadidos.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 ha sido añadido.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
+<numerusform>%1 y otros %n archivo(s) han sido actualizados.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 ha sido actualizado.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
+<numerusform>%1 ha sido movido a %2 y otros %n archivo(s) han sido movidos.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 ha sido movido a %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Actividad de sincronización</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">No hay subcarpetas actualmente en el servidor.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>No hay subcarpetas actualmente en el servidor.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Abandonar el programa beta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Únase al programa beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Obtenga acceso anticipado a las nuevas versiones de la aplicación antes de que se publiquen para el público en general, y participe en la mejora de la aplicación enviándonos sus comentarios.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Benefíciese de las actualizaciones beta de las aplicaciones</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">No</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Versión beta pública</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Versión beta interna</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Versión de prueba</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Comprendo</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">¿Estás seguro de que quieres abandonar el programa beta?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Guardar</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Es posible que su versión actual de la aplicación sea demasiado reciente, su elección será efectiva a partir de la próxima actualización disponible.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Las versiones beta pueden salir inesperadamente o causar inestabilidades.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Abandonar el programa beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Únase al programa beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación antes de que se publiquen para el público en general, y participe en la mejora de la aplicación enviándonos sus comentarios.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Benefíciese de las actualizaciones beta de las aplicaciones</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Versión beta pública</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Versión beta interna</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Versión de prueba</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Comprendo</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>¿Estás seguro de que quieres abandonar el programa beta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Es posible que su versión actual de la aplicación sea demasiado reciente, su elección será efectiva a partir de la próxima actualización disponible.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Las versiones beta pueden salir inesperadamente o causar inestabilidades.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Inicia sesión</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Carpeta %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">No hay carpetas de sincronización configuradas.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Síntesis</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferencias</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Salir</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Estado no definido.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Esperando para comenzar la sincronización.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Ejecutando sincronización.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">La sincronización se ha realizado, pero hay conflictos sin resolver.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">La última sincronización se ha realizado correctamente.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Interrupción por el usuario.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">La sincronización está en pausa.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (sincronización en pausa)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">ELIMINAR TODAS LAS SINC.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 elementos han sido eliminados de su carpeta de sincronización local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Para evitar eliminaciones no deseadas, la sincronización ha sido pausada.&lt;br&gt;¿Desea propagar estas eliminaciones a su kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Varios archivos han sido eliminados de su carpeta de sincronización local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Los archivos eliminados se pueden encontrar en la &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papelera&lt;/a&gt; de kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">No volver a mostrar</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">¡Error al iniciar las sincronizaciones!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">No es posible abrir la ruta de la carpeta %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">No se puede inicializar el cliente de kDrive</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">No se pudieron solucionar los conflictos en %1 elementos en la carpeta de sincronización: %2</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">La sincronización está en pausa</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Inicia sesión</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Carpeta %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>No hay carpetas de sincronización configuradas.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Síntesis</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Preferencias</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Salir</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Estado no definido.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Esperando para comenzar la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Ejecutando sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>La sincronización se ha realizado, pero hay conflictos sin resolver.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>La última sincronización se ha realizado correctamente.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Interrupción por el usuario.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>La sincronización está en pausa.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (sincronización en pausa)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>¿Realmente desea eliminar las sincronizaciones de la cuenta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>ELIMINAR TODAS LAS SINC.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 elementos han sido eliminados de su carpeta de sincronización local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Para evitar eliminaciones no deseadas, la sincronización ha sido pausada.&lt;br&gt;¿Desea propagar estas eliminaciones a su kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Varios archivos han sido eliminados de su carpeta de sincronización local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Los archivos eliminados se pueden encontrar en la &lt;a style="%1" href="%3"&gt;papelera&lt;/a&gt; de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>No volver a mostrar</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>¡Error al iniciar las sincronizaciones!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>No es posible abrir la ruta de la carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>No se puede inicializar el cliente de kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>No se pudieron solucionar los conflictos en %1 elementos en la carpeta de sincronización: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>La sincronización está en pausa</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Resumen de la sincronización de tu carpeta local</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Los contenidos de la carpeta en tu ordenador se sincronizarán a la carpeta del kDrive seleccionado y viceversa.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SINCRONIZAR</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Resumen de la sincronización de tu carpeta local</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Los contenidos de la carpeta en tu ordenador se sincronizarán a la carpeta del kDrive seleccionado y viceversa.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SINCRONIZAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Antes de terminar</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Realiza los siguientes pasos para garantizar que Lite Sync funciona correctamente en tu ordenador y para completar la configuración del kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abra la &lt;b&gt;Configuración general&lt;/b&gt; de su Mac o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abre la &lt;b&gt;Configuración de Privacidad y Seguridad&lt;/b&gt; de tu Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;haz clic aquí&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abre la &lt;b&gt;Configuración de seguridad y privacidad&lt;/b&gt; de tu Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;haz clic aquí&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Vaya a la sección &lt;b&gt;&quot;Elementos de inicio de sesión y extensiones&quot;&lt;/b&gt; y, a continuación, a &lt;b&gt;&quot;Extensiones de seguridad para puntos finales&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Autorizar la aplicación kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Ir a la sección &lt;b&gt;&quot;Seguridad&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Autoriza la aplicación kDrive en la casilla que indica que kDrive está bloqueado</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Desbloquea el candado &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; y autoriza la aplicación kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Vaya a la sección &lt;b&gt;&quot;Privacidad y seguridad&quot;&lt;/b&gt; y haga clic en &lt;b&gt;&quot;Acceso total al disco&quot;&lt;/b&gt; o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">En los ajustes de Seguridad y Privacidad, abre la pestaña &lt;b&gt;&quot;Privacidad&quot;&lt;/b&gt; o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;pincha aquí&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Marca la casilla &quot;Extensión LiteSync kDrive&quot; y luego la casilla &quot;kDrive.app&quot; (si no está ya marcada)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Puede que se sugiera reiniciar la aplicación. En tal caso, acepta</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Marca la casilla Extensión LiteSync kDrive (y &quot;kDrive.app&quot; si existe) en &lt;b&gt;&quot;Acceso disco completo&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">PASO 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Hecho)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">PASO 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">PASOS REALIZADOS</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FIN</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Antes de terminar</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Realiza los siguientes pasos para garantizar que Lite Sync funciona correctamente en tu ordenador y para completar la configuración del kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abra la &lt;b&gt;Configuración general&lt;/b&gt; de su Mac o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abre la &lt;b&gt;Configuración de Privacidad y Seguridad&lt;/b&gt; de tu Mac o &lt;a style="%1" href="%2"&gt;haz clic aquí&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abre la &lt;b&gt;Configuración de seguridad y privacidad&lt;/b&gt; de tu Mac o &lt;a style="%1" href="%2"&gt;haz clic aquí&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Vaya a la sección &lt;b&gt;"Elementos de inicio de sesión y extensiones"&lt;/b&gt; y, a continuación, a &lt;b&gt;"Extensiones de seguridad para puntos finales"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Autorizar la aplicación kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Ir a la sección &lt;b&gt;"Seguridad"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Autoriza la aplicación kDrive en la casilla que indica que kDrive está bloqueado</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Desbloquea el candado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; y autoriza la aplicación kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Vaya a la sección &lt;b&gt;"Privacidad y seguridad"&lt;/b&gt; y haga clic en &lt;b&gt;"Acceso total al disco"&lt;/b&gt; o &lt;a style=%1 href=%2&gt;haga clic aquí&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>En los ajustes de Seguridad y Privacidad, abre la pestaña &lt;b&gt;"Privacidad"&lt;/b&gt; o &lt;a style="%1" href="%2"&gt;pincha aquí&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Marca la casilla "Extensión LiteSync kDrive" y luego la casilla "kDrive.app" (si no está ya marcada)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Puede que se sugiera reiniciar la aplicación. En tal caso, acepta</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Marca la casilla Extensión LiteSync kDrive (y "kDrive.app" si existe) en &lt;b&gt;"Acceso disco completo"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>PASO 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Hecho)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>PASO 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>PASOS REALIZADOS</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>FIN</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">Aceptar</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SÍ</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NO</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>Aceptar</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>SÍ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NO</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Enviando información de depuración</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Enviando información de depuración</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Información</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Depurar</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Advertencia</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Error</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Fatal</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Configuración de depuración</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Guardar información de depuración en una carpeta de mi computadora (recomendado)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Esta información permite al soporte de TI determinar el origen de un incidente.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Nivel de depuración</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">El nivel de seguimiento le permite elegir el alcance de la información de depuración registrada</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">El registro completo extendido recopila un historial detallado que se puede utilizar para la depuración. Habilitarlo puede ralentizar la aplicación kDrive.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Registro completo extendido</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Eliminar registros de más de %1 días</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Comparte la carpeta de depuración con el soporte de Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">La última sesión es el período desde el último inicio de kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Comparte solo la última sesión de kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Cargando</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">No se pudo compartir</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Verifique que haya iniciado sesión &lt;br&gt;2. Comprueba que tienes configurado al menos un kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Conexión interrumpida)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Compartir la carpeta con SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Comprimimos automáticamente su registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aquí&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Transfiera el archivo con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Comparte el enlace con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Última carga el %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Compartir ha sido cancelado</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">El registro completo extendido se activa mediante la variable de entorno KDRIVE_FORCE_EXTENDED_LOG. Configúrelo en 0 para deshabilitarlo.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">La carpeta completa es grande (&gt; 100 MB) y puede tardar algún tiempo en compartirse. Para reducir el tiempo de compartición, le recomendamos que comparta sólo la última sesión de kDrive.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%2/%1/%3 a las %4:%5 y %6s</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">¿Deseas guardar tus cambios?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">No se puede abrir la carpeta %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Compartir</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Compartir | paso 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Compartir | paso 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Cancelado...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Información</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Depurar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Advertencia</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Fatal</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Configuración de depuración</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Guardar información de depuración en una carpeta de mi computadora (recomendado)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Esta información permite al soporte de TI determinar el origen de un incidente.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Nivel de depuración</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>El nivel de seguimiento le permite elegir el alcance de la información de depuración registrada</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>El registro completo extendido recopila un historial detallado que se puede utilizar para la depuración. Habilitarlo puede ralentizar la aplicación kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Registro completo extendido</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Eliminar registros de más de %1 días</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Comparte la carpeta de depuración con el soporte de Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>La última sesión es el período desde el último inicio de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Comparte solo la última sesión de kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Cargando</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>No se pudo compartir</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Verifique que haya iniciado sesión &lt;br&gt;2. Comprueba que tienes configurado al menos un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Conexión interrumpida)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Compartir la carpeta con SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Comprimimos automáticamente su registro &lt;a style="%1" href="%2"&gt;aquí&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Transfiera el archivo con &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Comparte el enlace con &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Última carga el %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Compartir ha sido cancelado</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>El registro completo extendido se activa mediante la variable de entorno KDRIVE_FORCE_EXTENDED_LOG. Configúrelo en 0 para deshabilitarlo.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>La carpeta completa es grande (&gt; 100 MB) y puede tardar algún tiempo en compartirse. Para reducir el tiempo de compartición, le recomendamos que comparta sólo la última sesión de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%2/%1/%3 a las %4:%5 y %6s</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>¿Deseas guardar tus cambios?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>No se puede abrir la carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Compartir</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Compartir | paso 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Compartir | paso 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Cancelado...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Carpetas</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Notificaciones</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Se mostrará una notificación en cuanto se haya sincronizado o modificado una nueva carpeta</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Conectado con</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">¿Estás seguro de que deseas dejar de sincronizar la carpeta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Esta operación puede durar de unos segundos a unos minutos en función del tamaño de la carpeta.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">¡Error al sincronizar las nuevas carpetas locales!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Error en la activación de Lite Sync.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Ha fallado la desactivación de Lite Sync.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">ELIMINAR CONEXIÓN DE SINCRONIZACIÓN DE CARPETAS</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Se produjo un error al cargar la lista de subcarpetas.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Habilitar las notificaciones para este kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMAR</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Errores de sincronización e información.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Sincronizar una carpeta local</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">¿Estás seguro de que deseas activar Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">¿Estás seguro de que deseas desactivar Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">No tienes suficiente espacio para sincronizar todos los archivos en el kDrive (falta %1). Si se desactiva Lite Sync, habrá que elegir qué carpetas se sincronizan en el ordenador. Mientras tanto, se detendrá la sincronización de tu kDrive.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Si desactivas Lite Sync, todos los archivos se descargarán en tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">No se pudo crear la nueva sincronización</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync activado.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync desactivado.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Esta unidad se está eliminando.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Imposible abrir el elemento %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">No se pudo detener la sincronización de la carpeta &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Eliminar todas las sincronizaciones</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Busca en tu kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Buscar en</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Carpetas</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Notificaciones</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Se mostrará una notificación en cuanto se haya sincronizado o modificado una nueva carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Conectado con</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>¿Estás seguro de que deseas dejar de sincronizar la carpeta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Esto &lt;b&gt;no&lt;/b&gt; eliminará ningún archivo.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Esta operación puede durar de unos segundos a unos minutos en función del tamaño de la carpeta.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>¡Error al sincronizar las nuevas carpetas locales!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Error en la activación de Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Ha fallado la desactivación de Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>ELIMINAR CONEXIÓN DE SINCRONIZACIÓN DE CARPETAS</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Se produjo un error al cargar la lista de subcarpetas.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Habilitar las notificaciones para este kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>CONFIRMAR</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Errores de sincronización e información.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Sincronizar una carpeta local</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>¿Estás seguro de que deseas activar Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>¿Estás seguro de que deseas desactivar Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>No tienes suficiente espacio para sincronizar todos los archivos en el kDrive (falta %1). Si se desactiva Lite Sync, habrá que elegir qué carpetas se sincronizan en el ordenador. Mientras tanto, se detendrá la sincronización de tu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Si desactivas Lite Sync, todos los archivos se descargarán en tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>No se pudo crear la nueva sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync activado.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync desactivado.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Esta unidad se está eliminando.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Imposible abrir el elemento %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>No se pudo detener la sincronización de la carpeta &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Eliminar todas las sincronizaciones</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Busca en tu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Buscar en</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Sincronizar un kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Añadir a kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Sincronizar un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Añadir a kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Resolver</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Elementos en conflicto</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Elementos con caracteres no admitidos</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Borrar el historial</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Para Resolver</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Resuelto automáticamente</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problema(s) resuelto(s)</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">problema(s) detectado(s)</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Resolver</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Elementos en conflicto</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Elementos con caracteres no admitidos</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Borrar el historial</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Para Resolver</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Resuelto automáticamente</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problema(s) resuelto(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>problema(s) detectado(s)</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Conflictos o errores de sincronización</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Errores</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Volver a preferencias</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Conflictos o errores de sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Errores</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Volver a preferencias</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Algunos archivos no se han podido sincronizar en el/los siguiente(s) kDrive(s):</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 error(es))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 información(es))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 error(es) y %2 información(es))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
-            <numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Algunos archivos no se han podido sincronizar en el/los siguiente(s) kDrive(s):</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 error(es))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 información(es))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 error(es) y %2 información(es))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
+<numerusform>Errores genéricos (%n advertencia(s) o error(es))</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Archivos excluidos</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Añadir archivos o carpetas que no se sincronizarán en tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Añadir</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOMBRE</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">ADVERTENCIA</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">¿Deseas guardar tus cambios?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">¡La plantilla de exclusión ya existe!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">¿Estás seguro de que deseas eliminarlo?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">¡No se pueden guardar los cambios!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Archivos excluidos</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Añadir archivos o carpetas que no se sincronizarán en tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Añadir</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NOMBRE</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>ADVERTENCIA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>¿Deseas guardar tus cambios?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>¡La plantilla de exclusión ya existe!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>¿Estás seguro de que deseas eliminarlo?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>¡No se pueden guardar los cambios!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Resolver conflictos</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;¿Qué desea hacer con los %1 elementos en conflicto?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Guardar mis cambios y reemplazar las versiones de otros usuarios.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Deshacer mis cambios y conservar las versiones de otros usuarios.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Es posible que los cambios se eliminen de forma permanente. No se pueden restaurar desde la aplicación web de kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Los cambios se eliminarán de forma permanente. No se podrán restaurar desde la aplicación web de kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Mostrar artículo(s)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Varios usuarios han realizado modificaciones en estos archivos en distintos lugares (en línea, en kDrive, en un ordenador o en un dispositivo móvil). Es posible que también se hayan eliminado las carpetas que contienen estos archivos.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">La versión local de su elemento &lt;b&gt;no está sincronizada&lt;/b&gt; con kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Resolver conflictos</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;¿Qué desea hacer con los %1 elementos en conflicto?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Guardar mis cambios y reemplazar las versiones de otros usuarios.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Deshacer mis cambios y conservar las versiones de otros usuarios.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Es posible que los cambios se eliminen de forma permanente. No se pueden restaurar desde la aplicación web de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Los cambios se eliminarán de forma permanente. No se podrán restaurar desde la aplicación web de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Mostrar artículo(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Varios usuarios han realizado modificaciones en estos archivos en distintos lugares (en línea, en kDrive, en un ordenador o en un dispositivo móvil). Es posible que también se hayan eliminado las carpetas que contienen estos archivos.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>La versión local de su elemento &lt;b&gt;no está sincronizada&lt;/b&gt; con kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Más información&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Más acciones</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Sincronizado en &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Activar Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Activar Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Las carpetas no seleccionadas se moverán a la papelera siempre que contengan elementos sin conexión. Las carpetas sincronizadas con kDrive seguirán estando disponibles en línea.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Las carpetas no seleccionadas serán movidas a la papelera. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Las carpetas no seleccionadas se eliminarán &lt;b&gt;permanentemente&lt;/b&gt; del ordenador. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausar la sincronización</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Desactivar Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Reanudar la sincronización</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Eliminar la sincronización</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Más acciones</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Sincronizado en &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Activar Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Activar Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Las carpetas no seleccionadas se moverán a la papelera siempre que contengan elementos sin conexión. Las carpetas sincronizadas con kDrive seguirán estando disponibles en línea.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Las carpetas no seleccionadas serán movidas a la papelera. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Las carpetas no seleccionadas se eliminarán &lt;b&gt;permanentemente&lt;/b&gt; del ordenador. Las carpetas sincronizadas con kDrive permanecerán disponibles en línea.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Pausar la sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Desactivar Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Reanudar la sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Eliminar la sincronización</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">No se puede abrir la ruta de la carpeta %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>No se puede abrir la ruta de la carpeta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">ID de aplicación</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Nombre de la aplicación</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>ID de aplicación</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Nombre de la aplicación</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Algunas apps (copia de seguridad, anti-virus, ...) acceden a tus archivos, por lo que se descargan cuando están &quot;online&quot;. Añádelas a la siguiente lista para evitarlo.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Añadir</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ID DE APLICACIÓN</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOMBRE</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">¿Deseas guardar tus cambios?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">¿Estás seguro de que deseas eliminarlo?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">¡No se pueden guardar los cambios!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Algunas apps (copia de seguridad, anti-virus, ...) acceden a tus archivos, por lo que se descargan cuando están "online". Añádelas a la siguiente lista para evitarlo.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Añadir</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ID DE APLICACIÓN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NOMBRE</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>¿Deseas guardar tus cambios?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>¿Estás seguro de que deseas eliminarlo?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>¡No se pueden guardar los cambios!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">¿Qué carpeta del ordenador deseas&lt;br&gt;sincronizar?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">El contenido de esta carpeta se sincronizará en el kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Seleccionar una carpeta</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Editar carpeta</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>¿Qué carpeta del ordenador deseas&lt;br&gt;sincronizar?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>El contenido de esta carpeta se sincronizará en el kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Seleccionar una carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Editar carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Esta carpeta no es compatible con Lite Sync.&lt;br&gt;
 Seleccione otra carpeta. Si continúa, Lite Sync se deshabilitará.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Seleccionar carpeta</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Seleccionar carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Error</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;El archivo &apos;%1&apos;&lt;br/&gt;no se puede abrir para escritura.&lt;br/&gt;&lt;br/&gt;¡El archivo de registro &lt;b&gt;no&lt;/b&gt; se puede guardar!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Error</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;El archivo '%1'&lt;br/&gt;no se puede abrir para escritura.&lt;br/&gt;&lt;br/&gt;¡El archivo de registro &lt;b&gt;no&lt;/b&gt; se puede guardar!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferencias</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Ayuda</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Preferencias</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Ayuda</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>No es posible abrir la ruta de la carpeta %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>¡Transmisión realizada!&lt;br&gt;Consulta el identificador &lt;b&gt;%1&lt;/b&gt; en informes de fallos.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>¡La transmisión falló!
-Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>¡No hay ningún kDrive configurado!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Parece que su conexión de red está configurada con un tiempo de espera demasiado bajo para que la aplicación funcione correctamente (error %1).&lt;br&gt;Compruebe su configuración de red.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>No se puede conectar al servidor kDrive (error %1).&lt;br&gt;Intentando reconexión. Por favor verifique su conexión a Internet y su firewall.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Inicie sesión nuevamente y, si el error persiste, comuníquese con nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Hay una nueva versión de la aplicación disponible.&lt;br&gt;Actualice la aplicación para seguir usándola.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Error al cargar el registro (error %1).&lt;br&gt;Inténtelo de nuevo más tarde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Ya no se puede acceder a la carpeta de sincronización (error %1).&lt;br&gt;La sincronización se reanudará tan pronto como se pueda acceder a la carpeta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>La carpeta de sincronización se ha sustituido o movido de forma que impide la sincronización (error %1).&lt;br&gt;Esto puede ocurrir después de copiar, mover o restaurar la carpeta.&lt;br&gt;Para solucionarlo, cree una nueva sincronización con una carpeta nueva.&lt;br&gt;Nota: si tiene cambios sin sincronizar en la carpeta antigua, tendrá que copiarlos manualmente en la nueva.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>No queda suficiente memoria en su máquina.&lt;br&gt;La sincronización se ha detenido.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive necesita tener acceso de escritura al directorio temporal de tu ordenador. &lt;br&gt;Reinicia la aplicación kDrive para resolver este problema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Se ha producido un error técnico. La sincronización se reanudará lo antes posible. Si el error persiste, contacte con nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>El número de vigilancias de inotify es insuficiente (error %1).&lt;br&gt;Puede aumentar este número editando &apos;/etc/sysctl.conf&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>No se puede iniciar la sincronización (error %1).&lt;br&gt;Debe permitir:&lt;br&gt;- kDrive en Configuración del sistema &gt;&gt; General &gt;&gt; Elementos de inicio de sesión y extensiones &gt;&gt; Extensiones de seguridad de endpoints&lt;br&gt;- Extensión kDrive LiteSync en Configuración del sistema &gt;&gt; Privacidad y seguridad &gt;&gt; Acceso completo al disco.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync esté instalada y que el servicio de búsqueda de Windows esté habilitado.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync tenga los permisos correctos y se esté ejecutando.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive está en modo de mantenimiento.&lt;br&gt;La sincronización comenzará de nuevo lo antes posible. Ponte en contacto con nuestro equipo de asistencia si el error persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>El kDrive está bloqueado.&lt;br&gt;Renueva kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>El kDrive está bloqueado.&lt;br&gt;Ponte en contacto con un administrador para renovar el kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>El kDrive se está iniciando.&lt;br&gt;La sincronización se reanudará lo antes posible. Por favor, contacte con nuestro equipo de soporte si el error persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la versión web para comprobar el estado de su kDrive o contacte con su administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>No estás autorizado a acceder a este kDrive.&lt;br&gt;La sincronización se ha pausado. Por favor contacte a un administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;La sincronización se reanudará lo antes posible. Comuníquese con nuestro equipo de soporte si el error persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>El kernel ha interrumpido las conexiones de red (error %1).&lt;br&gt;Vacia el historial y, si el error persiste, ponte en contacto con nuestro equipo de soporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Desafortunadamente no se ha podido migrar tu configuración anterior.&lt;br&gt;La aplicación usará una configuración en blanco.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Desafortunadamente no se ha podido migrar tu antigua configuración de proxy. Los proxies SOCKS5 no son compatibles en este momento.&lt;br&gt;La aplicación usará la configuración del proxy del sistema en su lugar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Se ha producido un error técnico (error %1).&lt;br&gt;Se ha reiniciado la sincronización. Vacía el historial y si el error persiste, contacta con nuestro equipo de asistencia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Se ha producido un error al acceder a la base de datos de sincronización (error %1).&lt;br&gt;La sincronización se ha detenido.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Token no válido o revocado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Las sincronizaciones anidadas están prohibidas (error %1).&lt;br&gt;Solo debes conservar las sincronizaciones cuyas carpetas no estén anidadas.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>La carpeta de sincronización en el kDrive remoto ya no existe o ya no es accesible (error %1).&lt;br&gt;Debe restaurarla o devolverle los derechos de acceso o eliminar/recrear la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Error de análisis del nombre de archivo (error %1).&lt;br&gt;Los caracteres especiales como comillas dobles, barras invertidas o retornos de línea pueden provocar errores de análisis.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>No tiene permiso para crear un elemento o ya existe otro elemento con el mismo nombre. El elemento ha sido ignorado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>No tiene permitido mover el elemento a &quot;%1&quot;.&lt;br&gt;Se restaurará en su carpeta principal original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>No queda espacio suficiente en su ordenador.&lt;br&gt;Se ha cancelado la descarga.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Este elemento se ha movido a otro lugar.&lt;br&gt;La operación local ha sido cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;Se ha cambiado el nombre del elemento local.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;La operación local ha sido cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>No queda espacio suficiente en el ordenador.&lt;br&gt;Se ha detenido la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>El archivo fue modificado al mismo tiempo por otro usuario.&lt;br&gt;Tus modificaciones se han guardado en una copia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Otro usuario ha movido una carpeta principal del destino.&lt;br&gt;La operación local ha sido cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>El nombre del elemento contiene solo espacios.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>No tienes permiso para editar elementos.&lt;br&gt;Se ha cambiado el nombre del archivo que contiene tus modificaciones y se le ha excluido de la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>No tienes permiso para cambiar el nombre del elemento.&lt;br&gt;Se restaurará con su nombre original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>No tienes permiso para eliminar el elemento.&lt;br&gt;Se restaurará a su ubicación original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>No se ha podido mover este elemento a la papelera, se ha incluido en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>El archivo se ha modificado localmente mientras se eliminó en el kDrive remoto.&lt;br&gt;Se ha guardado una copia local en la carpeta de rescate (rescue folder).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>La operación realizada en el artículo está prohibida.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>La operación realizada en este artículo ha fallado.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>El archivo es demasiado grande para ser cargado. Ha sido temporalmente bloqueado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Imposible descargar el archivo.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Has excedido tu cuota. Aumente su cuota de espacio para volver a habilitar la carga de archivos.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>La unidad que contiene su carpeta de sincronización ya no está conectada (error %1).&lt;br&gt;Vuelva a conectarla para reanudar la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>No se puede iniciar la sincronización (error %1). El proceso LiteSyncExt no se está ejecutando. La sincronización se reanudará en cuanto se inicie.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Un elemento existente tiene un nombre idéntico con las mismas opciones de mayúsculas y minúsculas (mismas letras mayúsculas y minúsculas).&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>El nombre del artículo contiene un carácter no compatible.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>El nombre del elemento termina con un espacio, lo cual está prohibido en su sistema operativo.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Este nombre de artículo está reservado por su sistema operativo.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>El nombre del artículo es demasiado largo.&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>La ruta del elemento es demasiado larga.&lt;br&gt;Se ha ignorado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>El nombre del elemento contiene un carácter UNICODE reciente que aún no es compatible con su sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>No se pudo sincronizar este elemento. Se ha incluido temporalmente en la lista negra.&lt;br&gt;Se realizará otro intento de sincronización en una hora o en el próximo inicio de la aplicación.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Este artículo ha sido excluido del sincronizado por una plantilla personalizada. Puede desactivar este tipo de notificación desde las preferencias</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Este elemento se ha excluido de la sincronización porque es un enlace duro.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Este artículo está actualmente bloqueado por otro usuario en línea.&lt;br&gt;Volveremos a intentar subir tus cambios más tarde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Error de sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>No se puede acceder al elemento.&lt;br&gt;Por favor, corrija los permisos de lectura y escritura.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>No es posible crear el archivo %1 porque no es compatible con su sistema de archivos.&lt;br&gt;Ha sido excluido de la sincronización.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Error del sistema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>El elemento ya existe en el otro lado.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Se ha producido un error técnico.&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>No es posible abrir la ruta de la carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>¡Transmisión realizada!&lt;br&gt;Consulta el identificador &lt;b&gt;%1&lt;/b&gt; en informes de fallos.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>¡La transmisión falló!
+Por favor, utilice el siguiente enlace para enviar los registros al soporte: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>¡No hay ningún kDrive configurado!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Se ha producido un error técnico (error %1).&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Parece que su conexión de red está configurada con un tiempo de espera demasiado bajo para que la aplicación funcione correctamente (error %1).&lt;br&gt;Compruebe su configuración de red.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>No se puede conectar al servidor kDrive (error %1).&lt;br&gt;Intentando reconexión. Por favor verifique su conexión a Internet y su firewall.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Inicie sesión nuevamente y, si el error persiste, comuníquese con nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Hay una nueva versión de la aplicación disponible.&lt;br&gt;Actualice la aplicación para seguir usándola.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Error al cargar el registro (error %1).&lt;br&gt;Inténtelo de nuevo más tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Ya no se puede acceder a la carpeta de sincronización (error %1).&lt;br&gt;La sincronización se reanudará tan pronto como se pueda acceder a la carpeta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>La carpeta de sincronización se ha sustituido o movido de forma que impide la sincronización (error %1).&lt;br&gt;Esto puede ocurrir después de copiar, mover o restaurar la carpeta.&lt;br&gt;Para solucionarlo, cree una nueva sincronización con una carpeta nueva.&lt;br&gt;Nota: si tiene cambios sin sincronizar en la carpeta antigua, tendrá que copiarlos manualmente en la nueva.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>No queda suficiente memoria en su máquina.&lt;br&gt;La sincronización se ha detenido.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive necesita tener acceso de escritura al directorio temporal de tu ordenador. &lt;br&gt;Reinicia la aplicación kDrive para resolver este problema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Se ha producido un error técnico. La sincronización se reanudará lo antes posible. Si el error persiste, contacte con nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>El número de vigilancias de inotify es insuficiente (error %1).&lt;br&gt;Puede aumentar este número editando '/etc/sysctl.conf'.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>No se puede iniciar la sincronización (error %1).&lt;br&gt;Debe permitir:&lt;br&gt;- kDrive en Configuración del sistema &gt;&gt; General &gt;&gt; Elementos de inicio de sesión y extensiones &gt;&gt; Extensiones de seguridad de endpoints&lt;br&gt;- Extensión kDrive LiteSync en Configuración del sistema &gt;&gt; Privacidad y seguridad &gt;&gt; Acceso completo al disco.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync esté instalada y que el servicio de búsqueda de Windows esté habilitado.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Compruebe que la extensión Lite Sync tenga los permisos correctos y se esté ejecutando.&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>No se puede iniciar el complemento Lite Sync (error %1).&lt;br&gt;Vacia el historial, reinicia y, si el error persiste, contacta a nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Un archivo o carpeta dentro su carpeta de sincronización parece estar corrupto.&lt;br&gt;La sincronización se ha detenido.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive está en modo de mantenimiento.&lt;br&gt;La sincronización comenzará de nuevo lo antes posible. Ponte en contacto con nuestro equipo de asistencia si el error persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>El kDrive está bloqueado.&lt;br&gt;Renueva kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>El kDrive está bloqueado.&lt;br&gt;Ponte en contacto con un administrador para renovar el kDrive. Si no se toman medidas, los datos se eliminarán permanentemente y será imposible recuperarlos.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>El kDrive se está iniciando.&lt;br&gt;La sincronización se reanudará lo antes posible. Por favor, contacte con nuestro equipo de soporte si el error persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la &lt;a style="%1" href="%2"&gt;versión web&lt;/a&gt; para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>El kDrive está en reposo.&lt;br&gt;Inicie sesión en la versión web para comprobar el estado de su kDrive o contacte con su administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>No estás autorizado a acceder a este kDrive.&lt;br&gt;La sincronización se ha pausado. Por favor contacte a un administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Se ha producido un error técnico (error %1).&lt;br&gt;La sincronización se reanudará lo antes posible. Comuníquese con nuestro equipo de soporte si el error persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>El kernel ha interrumpido las conexiones de red (error %1).&lt;br&gt;Vacia el historial y, si el error persiste, ponte en contacto con nuestro equipo de soporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Desafortunadamente no se ha podido migrar tu configuración anterior.&lt;br&gt;La aplicación usará una configuración en blanco.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Desafortunadamente no se ha podido migrar tu antigua configuración de proxy. Los proxies SOCKS5 no son compatibles en este momento.&lt;br&gt;La aplicación usará la configuración del proxy del sistema en su lugar.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Se ha producido un error técnico (error %1).&lt;br&gt;Se ha reiniciado la sincronización. Vacía el historial y si el error persiste, contacta con nuestro equipo de asistencia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Se ha producido un error al acceder a la base de datos de sincronización (error %1).&lt;br&gt;La sincronización se ha detenido.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Se ha producido un problema de inicio de sesión (error %1).&lt;br&gt;Token no válido o revocado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Las sincronizaciones anidadas están prohibidas (error %1).&lt;br&gt;Solo debes conservar las sincronizaciones cuyas carpetas no estén anidadas.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>La carpeta de sincronización en el kDrive remoto ya no existe o ya no es accesible (error %1).&lt;br&gt;Debe restaurarla o devolverle los derechos de acceso o eliminar/recrear la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Error de análisis del nombre de archivo (error %1).&lt;br&gt;Los caracteres especiales como comillas dobles, barras invertidas o retornos de línea pueden provocar errores de análisis.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>No tiene permiso para crear un elemento o ya existe otro elemento con el mismo nombre. El elemento ha sido ignorado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>No tiene permitido mover el elemento a "%1".&lt;br&gt;Se restaurará en su carpeta principal original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>No queda espacio suficiente en su ordenador.&lt;br&gt;Se ha cancelado la descarga.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>No es posible crear el archivo «%1» porque no es compatible con tu sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Este elemento se ha movido a otro lugar.&lt;br&gt;La operación local ha sido cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;Se ha cambiado el nombre del elemento local.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Ya existe un elemento con el mismo nombre en esta ubicación.&lt;br&gt;La operación local ha sido cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>No queda espacio suficiente en el ordenador.&lt;br&gt;Se ha detenido la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>El archivo fue modificado al mismo tiempo por otro usuario.&lt;br&gt;Tus modificaciones se han guardado en una copia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Otro usuario ha movido una carpeta principal del destino.&lt;br&gt;La operación local ha sido cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>El nombre del elemento contiene solo espacios.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>No tienes permiso para editar elementos.&lt;br&gt;Se ha cambiado el nombre del archivo que contiene tus modificaciones y se le ha excluido de la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>No tienes permiso para cambiar el nombre del elemento.&lt;br&gt;Se restaurará con su nombre original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>No tienes permiso para eliminar el elemento.&lt;br&gt;Se restaurará a su ubicación original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>No se ha podido mover este elemento a la papelera, se ha incluido en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>El archivo se ha modificado localmente mientras se eliminó en el kDrive remoto.&lt;br&gt;Se ha guardado una copia local en la carpeta de rescate (rescue folder).</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>La operación realizada en el artículo está prohibida.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>La operación realizada en este artículo ha fallado.&lt;br&gt;El artículo ha sido incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>El archivo es demasiado grande para ser cargado. Ha sido temporalmente bloqueado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Imposible descargar el archivo.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Has excedido tu cuota. Aumente su cuota de espacio para volver a habilitar la carga de archivos.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>La unidad que contiene su carpeta de sincronización ya no está conectada (error %1).&lt;br&gt;Vuelva a conectarla para reanudar la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>No se puede iniciar la sincronización (error %1). El proceso LiteSyncExt no se está ejecutando. La sincronización se reanudará en cuanto se inicie.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Un elemento existente tiene un nombre idéntico con las mismas opciones de mayúsculas y minúsculas (mismas letras mayúsculas y minúsculas).&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>El nombre del artículo contiene un carácter no compatible.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>El nombre del elemento termina con un espacio, lo cual está prohibido en su sistema operativo.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Este nombre de artículo está reservado por su sistema operativo.&lt;br&gt;Se ha incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>El nombre del artículo es demasiado largo.&lt;br&gt;Ha sido incluido temporalmente en la lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>La ruta del elemento es demasiado larga.&lt;br&gt;Se ha ignorado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>El nombre del elemento contiene un carácter UNICODE reciente que aún no es compatible con su sistema de archivos.&lt;br&gt;Se ha excluido de la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>No se pudo sincronizar este elemento. Se ha incluido temporalmente en la lista negra.&lt;br&gt;Se realizará otro intento de sincronización en una hora o en el próximo inicio de la aplicación.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Este artículo ha sido excluido del sincronizado por una plantilla personalizada. Puede desactivar este tipo de notificación desde las preferencias</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Este elemento se ha excluido de la sincronización porque es un enlace duro.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Este artículo está actualmente bloqueado por otro usuario en línea.&lt;br&gt;Volveremos a intentar subir tus cambios más tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Error de sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>No se puede acceder al elemento.&lt;br&gt;Por favor, corrija los permisos de lectura y escritura.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Error del sistema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>El elemento ya existe en el otro lado.&lt;br&gt;Ha sido temporalmente puesto en lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Se ha producido un error técnico.&lt;br&gt;Vacíe el historial y, si el error persiste, póngase en contacto con nuestro equipo de soporte.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Esta sincronización se está eliminando.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Esta sincronización se está eliminando.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Volver a la lista de drives</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferencias</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Volver a la lista de drives</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Preferencias</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">General</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Activar tema oscuro</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Activar iconos monocromos</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Ejecutar kDrive al arrancar</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Neerlandés</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avanzado</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Información de depuración</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Archivos a excluir</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Servidor proxy</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Sueco</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugués</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polaco</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Noruego</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finlandés</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Danés</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Griego</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">No se puede abrir la carpeta %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Enlace %1 no válido.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Idioma</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Algún proceso no se ha ejecutado.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Mueva los archivos eliminados a la papelera de mi computadora</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Es posible que algunos archivos o carpetas no se muevan a la papelera de la computadora.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Siempre puedes recuperar archivos ya sincronizados desde la papelera de la aplicación web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Inglés</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Francés</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Alemán</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Español</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italiano</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Predeterminado</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>General</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Activar tema oscuro</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Activar iconos monocromos</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Ejecutar kDrive al arrancar</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Neerlandés</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avanzado</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Información de depuración</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Abrir carpeta de depuración&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Archivos a excluir</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Sueco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugués</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polaco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Noruego</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finlandés</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Danés</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Griego</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>No se puede abrir la carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Enlace %1 no válido.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Idioma</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Algún proceso no se ha ejecutado.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Mueva los archivos eliminados a la papelera de mi computadora</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Es posible que algunos archivos o carpetas no se muevan a la papelera de la computadora.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Siempre puedes recuperar archivos ya sincronizados desde la papelera de la aplicación web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Inglés</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Francés</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Alemán</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Español</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italiano</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Predeterminado</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 en uso</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 en uso</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">Proxy HTTP(S)</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Servidor proxy</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Ningún servidor proxy</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Usar parámetros del sistema</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Indicar un proxy manualmente</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Puerto</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Dirección del servidor proxy</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Es necesaria una autenticación</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Usuario</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Contraseña</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">¿Deseas guardar tus cambios?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">¡No es posible guardar, no se han completado todos los campos obligatorios!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">No se encuentra el proxy, ¿guardar de todos modos?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>Proxy HTTP(S)</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ningún servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Usar parámetros del sistema</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Indicar un proxy manualmente</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Puerto</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Dirección del servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Es necesaria una autenticación</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Usuario</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Contraseña</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>¿Deseas guardar tus cambios?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>¡No es posible guardar, no se han completado todos los campos obligatorios!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>No se encuentra el proxy, ¿guardar de todos modos?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Gerente de Recursos</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Uso máximo de CPU permitido</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">¿Deseas guardar tus cambios?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Gerente de Recursos</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Uso máximo de CPU permitido</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>¿Deseas guardar tus cambios?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Selecciona una carpeta en tu kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">El contenido de esta carpeta se sincronizará en la carpeta &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Espacio disponible en tu ordenador para la carpeta actual: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Esta carpeta ya se está sincronizando.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Selecciona una carpeta en tu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>El contenido de esta carpeta se sincronizará en la carpeta &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Espacio disponible en tu ordenador para la carpeta actual: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Esta carpeta ya se está sincronizando.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>CONFIRMAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">La carpeta &lt;b&gt;%1&lt;/b&gt; contiene subcarpetas,&lt;br&gt; selecciona las que deseas sincronizar</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">No hay subcarpetas actualmente en el servidor.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; contiene subcarpetas,&lt;br&gt; selecciona las que deseas sincronizar</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>No hay subcarpetas actualmente en el servidor.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Reanudar la sincronización de kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Reanudar la sincronización de todos los kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Pausar sincronización de kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausar la sincronización</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Pausar la sincronización de todos los kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Reanudar la sincronización</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Reanudar la sincronización de kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Reanudar la sincronización de todos los kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Pausar sincronización de kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Pausar la sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Pausar la sincronización de todos los kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Reanudar la sincronización</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Copiar enlace compartido</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Mostrar en kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Mostrar en carpeta</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Más acciones</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Abrir</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Añadir a favoritos</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Copiar enlace compartido</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Mostrar en kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Mostrar en carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Más acciones</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Abrir</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Añadir a favoritos</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Nunca</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Durante 1 hora</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Hasta mañana a las 8:00AM</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Durante 3 días</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Durante 1 semana</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Siempre</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Por 1 hora más</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Por 3 días más</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Por 1 semana más</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">No es posible abrir la url de carpeta %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Abrir en carpeta</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Abrir la versión web de %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Parámetros de drive</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Notificaciones deshabilitadas hasta %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Deshabilitar Notificaciones</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Preferencias de aplicación</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Se necesita ayuda</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Enviar comentarios</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Salir de kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">No es posible acceder al sitio web %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Mostrar errores e informaciones</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Mostrar información</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Más acciones</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Durante 1 hora</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Hasta mañana a las 8:00AM</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Durante 3 días</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Durante 1 semana</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Siempre</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Por 1 hora más</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Por 3 días más</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Por 1 semana más</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>No es posible abrir la url de carpeta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Abrir en carpeta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Abrir la versión web de %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Parámetros de drive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Notificaciones deshabilitadas hasta %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Deshabilitar Notificaciones</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Preferencias de aplicación</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Se necesita ayuda</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Enviar comentarios</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Salir de kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>No es posible acceder al sitio web %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Mostrar errores e informaciones</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Mostrar información</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Más acciones</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Actualizar la aplicación kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Esta versión de la aplicación kDrive ya no es compatible. Para acceder a las últimas funciones y mejoras, actualice.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Actualizar</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Descargue la última versión del sitio web.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Descarga de actualización en curso</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Buscando actualización...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Actualización manual</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Indisponible</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Puedes sincronizar archivos &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;desde tu ordenador&lt;/a&gt; o en &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Sincronizado</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoritos</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Actividad</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">¡No implementado!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/es/aplicaciones/descargar-kdrive&quot;&gt;Haga clic aquí para descargar manualmente&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">¡No hay ninguna carpeta sincronizada para este Drive!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">¡No hay ningún kDrive configurado!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">No se puede abrir el enlace %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Enlace %1 no válido.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">No es posible abrir la url de carpeta %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Actualizar la aplicación kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Esta versión de la aplicación kDrive ya no es compatible. Para acceder a las últimas funciones y mejoras, actualice.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Actualizar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Descargue la última versión del sitio web.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Descarga de actualización en curso</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Buscando actualización...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Actualización manual</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Indisponible</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Puedes sincronizar archivos &lt;a style="%1" href="%2"&gt;desde tu ordenador&lt;/a&gt; o en &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Sincronizado</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoritos</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Actividad</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>¡No implementado!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/es/aplicaciones/descargar-kdrive"&gt;Haga clic aquí para descargar manualmente&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>¡No hay ninguna carpeta sincronizada para este Drive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>¡No hay ningún kDrive configurado!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>No se puede abrir el enlace %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Enlace %1 no válido.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>No es posible abrir la url de carpeta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;La nueva versión &lt;b&gt;%1&lt;/b&gt; del Cliente %2 está disponible y ha sido descargada.&lt;/p&gt;&lt;p&gt;La versión instalada es %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Omitir esta versión</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Recordármelo</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Instalar actualización</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;La nueva versión &lt;b&gt;%1&lt;/b&gt; del Cliente %2 está disponible y ha sido descargada.&lt;/p&gt;&lt;p&gt;La versión instalada es %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Omitir esta versión</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Recordármelo</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Instalar actualización</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Nueva actualización disponible.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">La versión %1 está disponible para su descarga.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Nueva actualización disponible.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>La versión %1 está disponible para su descarga.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Añadir una cuenta</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Añadir una cuenta</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar nota de lanzamiento&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Versión</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">ACTUALIZAR</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">¡%1 está actualizado!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Comprobando actualización en servidor...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Hay una actualización disponible: %1. Descárgala &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aquí&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Hay disponible una actualización: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Descargando %1. Espera...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">No se puede comprobar si hay actualizaciones.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Se ha producido un error durante la actualización.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">No se ha podido descargar la actualización.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Actualización desactivada.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Programa Beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Obtenga acceso anticipado a las nuevas versiones de la aplicación</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Contacto</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Modifique</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Salir</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Mostrar nota de lanzamiento&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Versión</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>ACTUALIZAR</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>¡%1 está actualizado!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Comprobando actualización en servidor...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Hay una actualización disponible: %1. Descárgala &lt;a style="%2" href="%3"&gt;aquí&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Hay disponible una actualización: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Descargando %1. Espera...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>No se puede comprobar si hay actualizaciones.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Se ha producido un error durante la actualización.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>No se ha podido descargar la actualización.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Actualización desactivada.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Programa Beta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Contacto</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Modifique</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Salir</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">No se pueden guardar los parámetros, vuelva a intentarlo más tarde.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">¡No se pueden guardar los parámetros!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">La carpeta principal es una carpeta de sincronización o está contenida en una</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">No se puede encontrar una ruta válida</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">¡No se ha seleccionado una carpeta válida!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">¡La ruta seleccionada no existe!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">¡La ruta seleccionada no es una carpeta!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">La carpeta local %1 ya está sincronizada. ¡Seleccione otra!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync (Beta) está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync (Beta) está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite Sync está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite Sync está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Poner a disposición localmente</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Liberar espacio local</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Cancelar liberar espacio local</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Cancelar disponible localmente</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">No está permitido volver a compartir este archivo</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">No está permitido volver a compartir esta carpeta</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Copiar enlace para compartir públicamente</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Copiar enlace para compartir privado</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Abrir en navegador</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>No se pueden guardar los parámetros, vuelva a intentarlo más tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>¡No se pueden guardar los parámetros!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>La carpeta principal es una carpeta de sincronización o está contenida en una</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>No se puede encontrar una ruta válida</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>¡No se ha seleccionado una carpeta válida!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>¡La ruta seleccionada no existe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>¡La ruta seleccionada no es una carpeta!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>¡No tienes permiso para escribir en la carpeta seleccionada!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>La carpeta local %1 contiene una carpeta ya sincronizada.¡Elige otra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>La carpeta local %1 está contenida en una carpeta ya sincronizada.¡Elige otra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>La carpeta local %1 ya está sincronizada. ¡Seleccione otra!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync (Beta) está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync (Beta) está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite Sync está activado. Los archivos de kDrive permanecen en el Cloud y no utilizan el espacio de almacenamiento de tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite Sync está desactivado. Los archivos de kDrive utilizan el espacio de almacenamiento de tu ordenador.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Poner a disposición localmente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Liberar espacio local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Cancelar liberar espacio local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Cancelar disponible localmente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>No está permitido volver a compartir este archivo</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>No está permitido volver a compartir esta carpeta</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Copiar enlace para compartir públicamente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Copiar enlace para compartir privado</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Abrir en navegador</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">La aplicación kDrive se cerrará debido a un error fatal.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>La aplicación kDrive se cerrará debido a un error fatal.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n año(s)</numerusform>
-            <numerusform>%n año(s)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n mes(es)</numerusform>
-            <numerusform>%n mes(es)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n día(s)</numerusform>
-            <numerusform>%n día(s)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n hora(s)</numerusform>
-            <numerusform>%n hora(s)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minuto(s)</numerusform>
-            <numerusform>%n minuto(s)</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n segundo(s)</numerusform>
-            <numerusform>%n segundo(s)</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n año(s)</numerusform>
+<numerusform>%n año(s)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n mes(es)</numerusform>
+<numerusform>%n mes(es)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n día(s)</numerusform>
+<numerusform>%n día(s)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n hora(s)</numerusform>
+<numerusform>%n hora(s)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuto(s)</numerusform>
+<numerusform>%n minuto(s)</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n segundo(s)</numerusform>
+<numerusform>%n segundo(s)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Bandeja del sistema no disponible</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Bandeja del sistema no disponible</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 requiere una bandeja del sistema funcional. Si está utilizando XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instrucciones&lt;/a&gt;. De lo contrario, instale una aplicación de bandeja del sistema como «trayer» e inténtelo de nuevo.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">No se puede abrir el navegador</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Ocurrió un error al lanzar el navegador para ir a la URL %1. ¿Podría ser que no haya ningún navegador configurado como predeterminado?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">No se pudo abrir el cliente de correo</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Ocurrió un error al lanzar el cliente de correo electrónico para crear un nuevo mensaje. ¿Podría ser que no haya ningún cliente de correo electrónico configurado como predeterminado?¿Tal vez no hay ningún cliente de correo predeterminado configurado?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Ya no estás conectado. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Iniciar sesión&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>No se puede abrir el navegador</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Ocurrió un error al lanzar el navegador para ir a la URL %1. ¿Podría ser que no haya ningún navegador configurado como predeterminado?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>No se pudo abrir el cliente de correo</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Ocurrió un error al lanzar el cliente de correo electrónico para crear un nuevo mensaje. ¿Podría ser que no haya ningún cliente de correo electrónico configurado como predeterminado?¿Tal vez no hay ningún cliente de correo predeterminado configurado?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Ya no estás conectado. &lt;a style="%1" href="%2"&gt;Iniciar sesión&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">No hay carpeta para sincronizar
+<translation>No hay carpeta para sincronizar
 Puedes agregar uno desde la configuración de kDrive.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Sincronización en curso (%1 de %2)
+<translation>Sincronización en curso (%1 de %2)
 quedan %3...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Sincronización en curso (Paso %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Sincronización en curso.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Algunos archivos no se han podido sincronizar. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Más información&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Pausando sincronización...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">No se puede seleccionar la carpeta &lt;b&gt;%1&lt;/b&gt; porque otra sincronización está usando la misma carpeta.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque contiene la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">er &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque está contenido en la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar como carpeta de sincronización. Por favor, seleccione otra carpeta.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Iniciando sincronización</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Sincronización en pausa.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Sincronización en curso (%1 de %2)</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Estás actualizado, conflictos sin resolver.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">¡Estás actualizado!</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Sincronización en curso (Paso %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Sincronización en curso.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Algunos archivos no se han podido sincronizar. &lt;a style="%1" href="%2"&gt;Más información&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Pausando sincronización...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>No se puede seleccionar la carpeta &lt;b&gt;%1&lt;/b&gt; porque otra sincronización está usando la misma carpeta.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque contiene la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>er &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar porque está contenido en la carpeta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no se puede seleccionar como carpeta de sincronización. Por favor, seleccione otra carpeta.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>La carpeta &lt;b&gt;%1&lt;/b&gt; no puede seleccionarse como carpeta de sincronización. Por favor, seleccione otra carpeta. Carpeta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Ha excluido más de %1 carpetas, tenga en cuenta que esto afectará el rendimiento de la sincronización.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>No se pueden excluir más de %1 carpetas. Desmarque las carpetas de nivel superior.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Iniciando sincronización</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Sincronización en pausa.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Sincronización en curso (%1 de %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Estás actualizado, conflictos sin resolver.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>¡Estás actualizado!</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,3095 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="fi_FI" version="2.1">
+<TS version="2.1" language="fi_FI">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Tietoja</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>SULJE</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Tietoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>SULJE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versio %1. Lisätietoja: &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>%1 jakaa ja lisensoi &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>kDrive on valmis!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>AVAA KANSIO</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>ASETUKSET</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synkronoi toinen asema</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>kDrive on valmis!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>AVAA KANSIO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>ASETUKSET</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkronoi toinen asema</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>SEURAAVA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Valitse synkronoitava kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Hanki kDrive ilmaiseksi</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Kokeile ilmaiseksi</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SEURAAVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Valitse synkronoitava kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Hanki kDrive ilmaiseksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Kokeile ilmaiseksi</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Haluatko aktivoida Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Säästä tietokoneen tallennustilaa</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>MYÖHEMMIN</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>KYLLÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Haluatko aktivoida Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Säästä tietokoneen tallennustilaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>MYÖHEMMIN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>KYLLÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>%1 kDrive -aseman sijainti</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Muokkaa kansiota</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>LOPETA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>%1 kDrive -aseman sijainti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Muokkaa kansiota</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>LOPETA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Kirjaudu sisään selaimella</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Avaa kirjautumissivu</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Todennuksessa tapahtui virhe. Sulje kirjautumisikkuna ja yritä uudelleen.&lt;br&gt;Jos virhe jatkuu, ota yhteyttä tukitiimiimme.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Kirjautuminen epäonnistui: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Kirjaudu sisään selaimella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Avaa kirjautumissivu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Todennuksessa tapahtui virhe. Sulje kirjautumisikkuna ja yritä uudelleen.&lt;br&gt;Jos virhe jatkuu, ota yhteyttä tukitiimiimme.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Kirjautuminen epäonnistui: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Tietokoneella vapaata tilaa: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Tietokoneella vapaata tilaa: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Paikallisen kansion %1 luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Uuden synkronoinnin luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Paikallisen kansion %1 luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>kDrive-asiakas on jo käynnissä!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-asiakas on jo käynnissä!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Jakolinkki kopioitu leikepöydälle</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
-<numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on poistettu.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
-<numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on lisätty.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
-<numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 on päivitetty.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
-<numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 on siirretty kohteeseen %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synkronointiaktiviteetti</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Jakolinkki kopioitu leikepöydälle</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on poistettu.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on lisätty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
+            <numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 on päivitetty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
+            <numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 on siirretty kohteeseen %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synkronointiaktiviteetti</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Poistu beta-ohjelmasta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Liity beta-ohjelmaan</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Hyödy sovelluksen beta-päivityksistä</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Ei</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Julkinen beta-versio</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Sisäinen beta-versio</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Testiversio</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Ymmärrän</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Tallenna</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Poistu beta-ohjelmasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Liity beta-ohjelmaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Hyödy sovelluksen beta-päivityksistä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Ei</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Julkinen beta-versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Sisäinen beta-versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Testiversio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Ymmärrän</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Tallenna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Kirjaudu sisään</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synkronointi on keskeytetty</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Kansio %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Synkronointikansioita ei ole määritetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Määrittelemätön tila.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Odotetaan synkronoinnin käynnistymistä.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synkronointi käynnissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Viimeisin synkronointi onnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Käyttäjä keskeytti.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synkronointi on keskeytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synkronointi keskeytetty)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>POISTA KAIKKI SYNKRONOINNIT</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 kohdetta on poistettu paikallisesta synkronointikansiostasi &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Tahattomien poistojen estämiseksi synkronointi on keskeytetty.&lt;br&gt;Haluatko siirtää nämä poistot kDriveen?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Useita tiedostoja on poistettu paikallisesta synkronointikansiostasi &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Poistetut tiedostot löytyvät kDriven &lt;a style="%1" href="%3"&gt;roskakorista&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Älä näytä uudelleen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Yhteenveto</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Lopeta</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Synkronointien käynnistäminen epäonnistui!</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Kirjaudu sisään</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkronointi on keskeytetty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Kansio %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Synkronointikansioita ei ole määritetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Määrittelemätön tila.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Odotetaan synkronoinnin käynnistymistä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synkronointi käynnissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Viimeisin synkronointi onnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Käyttäjä keskeytti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synkronointi on keskeytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkronointi keskeytetty)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>POISTA KAIKKI SYNKRONOINNIT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 kohdetta on poistettu paikallisesta synkronointikansiostasi &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Tahattomien poistojen estämiseksi synkronointi on keskeytetty.&lt;br&gt;Haluatko siirtää nämä poistot kDriveen?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Useita tiedostoja on poistettu paikallisesta synkronointikansiostasi &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Poistetut tiedostot löytyvät kDriven &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;roskakorista&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Älä näytä uudelleen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Yhteenveto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Lopeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Synkronointien käynnistäminen epäonnistui!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNKRONOI</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONOI</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Ennen viimeistelyä</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Valtuuta kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>VAIHE 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Valmis)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>VAIHE 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>VAIHEET SUORITETTU</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>LOPETA</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Ennen viimeistelyä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Siirry &lt;b&gt;&quot;Kirjautumisobjektit ja laajennukset&quot;&lt;/b&gt;-osioon ja sitten &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;-osioon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Valtuuta kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Siirry &lt;b&gt;&quot;Turvallisuus&quot;&lt;/b&gt;-osioon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Avaa lukko &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; ja valtuuta kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Siirry &lt;b&gt;&quot;Tietosuoja ja turvallisuus&quot;&lt;/b&gt;-osioon ja napsauta &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;&quot;Tietosuoja&quot;&lt;/b&gt;-välilehti tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Valitse &quot;kDrive LiteSync Extension&quot; -ruutu ja sitten &quot;kDrive.app&quot;-ruutu (jos ei vielä valittu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Valitse &quot;kDrive LiteSync Extension&quot; -ruutu (ja &quot;kDrive.app&quot;, jos se on olemassa) kohdassa &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>VAIHE 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Valmis)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>VAIHE 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>VAIHEET SUORITETTU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>LOPETA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>KYLLÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>EI</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>KYLLÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>EI</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Lähetetään virheenkorjaustietoja</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Lähetetään virheenkorjaustietoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Virheenkorjaus</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Tiedot</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Varoitus</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Virhe</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Kriittinen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Virheenkorjausasetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Virheenkorjaustaso</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Laajennettu täysloki</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Jaa vain viimeisin kDrive-istunto</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Ladataan</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Jakaminen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Yhteys katkaistu)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Viimeisin lähetys %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Jakaminen on peruutettu</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 klo %4:%5:%6</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Jaa</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Jaetaan | vaihe 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Jaetaan | vaihe 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Peruutetaan...</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Virheenkorjaus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Tiedot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Varoitus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Virhe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Kriittinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Virheenkorjausasetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Virheenkorjaustaso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Laajennettu täysloki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Jaa vain viimeisin kDrive-istunto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Ladataan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Jakaminen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Yhteys katkaistu)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Pakkasimme lokisi automaattisesti &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Siirrä arkisto &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Jaa linkki osoitteeseen &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Viimeisin lähetys %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Jakaminen on peruutettu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 klo %4:%5:%6</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Jaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Jaetaan | vaihe 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Jaetaan | vaihe 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Peruutetaan...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synkronointivirheet ja tiedot.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synkronoi paikallinen kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Uuden synkronoinnin luominen epäonnistui</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync aktivoitu.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Lite Sync -aktivointi epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync poistettu käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Lite Sync -deaktivointi epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Tämä asema poistetaan.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Kohteen %1 avaaminen ei onnistu</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Kansiot</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Ilmoitukset</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Yhdistetty:</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Poista kaikki synkronoinnit</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Hae kDrivesta</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Haku</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkronointivirheet ja tiedot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkronoi paikallinen kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Uuden synkronoinnin luominen epäonnistui</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync aktivoitu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Lite Sync -aktivointi epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync poistettu käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Lite Sync -deaktivointi epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Tämä asema poistetaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Kohteen %1 avaaminen ei onnistu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Kansiot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Ilmoitukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Yhdistetty:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Poista kaikki synkronoinnit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Hae kDrivesta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Haku</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Lisää kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synkronoi kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Lisää kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkronoi kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Tyhjennä historia</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Ratkaistavana</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>havaittu ongelma(t)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Ratkaise</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Ristiriitainen kohde (kohteet)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Automaattisesti ratkaistu</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>ratkaistut ongelma(t)</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Tyhjennä historia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Ratkaistavana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>havaittu ongelma(t)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Ratkaise</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Ristiriitainen kohde (kohteet)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Automaattisesti ratkaistu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>ratkaistut ongelma(t)</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synkronointiristiriidat tai -virheet</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Virheet</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Takaisin asetuksiin</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkronointiristiriidat tai -virheet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Virheet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Takaisin asetuksiin</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 virhe(ttä))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 tiedote(tta))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
-<numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 virhe(ttä))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 tiedote(tta))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
+            <numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Poissuljetut tiedostot</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NIMI</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>VAROITUS</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Poissulkumalli on jo olemassa!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Haluatko todella poistaa?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Muutoksia ei voi tallentaa!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Poissuljetut tiedostot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NIMI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>VAROITUS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Poissulkumalli on jo olemassa!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Haluatko todella poistaa?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Muutoksia ei voi tallentaa!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Ratkaise ristiriita(t)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Näytä kohde(et)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Ratkaise ristiriita(t)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Näytä kohde(et)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Ota Lite Sync käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Ota Lite Sync (Beta) käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Poista Lite Sync käytöstä</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Keskeytä synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Jatka synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Poista synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Peruuta</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkronoitu kohteeseen &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Ota Lite Sync käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Ota Lite Sync (Beta) käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Poista Lite Sync käytöstä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Keskeytä synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Jatka synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Poista synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Peruuta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Sovelluksen tunnus</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Sovelluksen nimi</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Sovelluksen tunnus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Sovelluksen nimi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>SOVELLUKSEN TUNNUS</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NIMI</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Haluatko todella poistaa?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Muutoksia ei voi tallentaa!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat &quot;verkossa&quot;. Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>SOVELLUKSEN TUNNUS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NIMI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Haluatko todella poistaa?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Muutoksia ei voi tallentaa!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Muokkaa kansiota</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Muokkaa kansiota</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Valitse kansio</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Valitse kansio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Virhe</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Virhe</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Tiedostoa &apos;%1&apos;&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Ohje</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ohje</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Sinulla ei joko ole oikeutta luoda kohdetta tai toinen kohde samalla nimellä on jo olemassa. Kohde ohitettiin.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Tiedostoa ei voi ladata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Synkronointivirhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Tiedostoa ”%1” ei voitu luoda, koska se ei ole tuettu käyttämäsi tiedostojärjestelmässä.&lt;br&gt;Se on jätetty pois synkronoinnista.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Järjestelmävirhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kansion polkua %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Siirto epäonnistui!
-Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>kDrivea ei ole määritetty!</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla &apos;/etc/sysctl.conf&apos;-tiedostoa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Sinulla ei joko ole oikeutta luoda kohdetta tai toinen kohde samalla nimellä on jo olemassa. Kohde ohitettiin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen &quot;%1&quot;.&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Tiedostoa ei voi ladata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Synkronointivirhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Tiedostoa ”%1” ei voitu luoda, koska se ei ole tuettu käyttämäsi tiedostojärjestelmässä.&lt;br&gt;Se on jätetty pois synkronoinnista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Järjestelmävirhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kansion polkua %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Siirto epäonnistui!
+Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrivea ei ole määritetty!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Tätä synkronointia poistetaan.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Tätä synkronointia poistetaan.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Takaisin asemaluetteloon</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Asetukset</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Takaisin asemaluetteloon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Asetukset</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Kansiota %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Virheellinen linkki %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Yleiset</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Ota tumma teema käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Käynnistä kDrive automaattisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Kieli</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Oletus</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Englanti</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Ranska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Saksa</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Espanja</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italia</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Ruotsi</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugali</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Puola</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norja</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Suomi</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Tanska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Kreikka</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Hollanti</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Lisäasetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Virheenkorjaustiedot</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Suljettavat tiedostot</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kansiota %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Virheellinen linkki %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Yleiset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Ota tumma teema käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Käynnistä kDrive automaattisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Kieli</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Oletus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Englanti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Ranska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Saksa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Espanja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Ruotsi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugali</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Puola</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Suomi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Tanska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Kreikka</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Hollanti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Lisäasetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Virheenkorjaustiedot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Suljettavat tiedostot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 käytössä</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 käytössä</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S)-välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Välityspalvelin</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ei välityspalvelinta</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Käytä järjestelmäasetuksia</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Määritä välityspalvelin manuaalisesti</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Portti</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Välityspalvelimen osoite</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Todennus vaaditaan</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Käyttäjä</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Salasana</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Välityspalvelin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ei välityspalvelinta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Käytä järjestelmäasetuksia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Määritä välityspalvelin manuaalisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Portti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Välityspalvelimen osoite</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Todennus vaaditaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Käyttäjä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Salasana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Resurssien hallinta</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Suurin sallittu suorittimen käyttö</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>TALLENNA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Haluatko tallentaa muutokset?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Resurssien hallinta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Suurin sallittu suorittimen käyttö</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>TALLENNA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Haluatko tallentaa muutokset?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Valitse kansio kDrivesta</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Tämä kansio on jo synkronoinnissa.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>VAHVISTA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>PERUUTA</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Valitse kansio kDrivesta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Tämä kansio on jo synkronoinnissa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>VAHVISTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>PERUUTA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>JATKA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>JATKA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Jatka kDrive "%1" synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Jatka synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Keskeytä kDrive "%1" synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Keskeytä synkronointi</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Jatka kDrive &quot;%1&quot; synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Jatka synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Keskeytä kDrive &quot;%1&quot; synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Keskeytä synkronointi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Avaa</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Lisää suosikkeihin</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Kopioi jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Näytä kansiossa</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Avaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Lisää suosikkeihin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopioi jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Näytä kansiossa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Avaa kansiossa</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Avaa %1 verkkoversio</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Aseman asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Poista ilmoitukset käytöstä</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Sovelluksen asetukset</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Tarvitsetko apua</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Lähetä palautetta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Lopeta kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Verkkosivustolle %1 ei pääse.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Näytä virheet ja tiedotteet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Näytä tiedotteet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Lisää toimintoja</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Ei koskaan</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>1 tunnin ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Huomiseen klo 8:00 asti</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>3 päivän ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>1 viikon ajaksi</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Aina</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>1 tunti lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>3 päivää lisää</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>1 viikko lisää</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Avaa kansiossa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Avaa %1 verkkoversio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Aseman asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Poista ilmoitukset käytöstä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Sovelluksen asetukset</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Tarvitsetko apua</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Lähetä palautetta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Lopeta kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Verkkosivustolle %1 ei pääse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Näytä virheet ja tiedotteet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Näytä tiedotteet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Lisää toimintoja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Ei koskaan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>1 tunnin ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Huomiseen klo 8:00 asti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>3 päivän ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>1 viikon ajaksi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Aina</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>1 tunti lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>3 päivää lisää</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>1 viikko lisää</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synkronoitu</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Suosikit</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Toiminta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Päivitä</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Päivitystä ladataan</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Etsitään päivitystä...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Manuaalinen päivitys</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Ei saatavilla</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Ei toteutettu!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Linkkiä %1 ei voi avata.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Virheellinen linkki %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Päivitä kDrive-sovellus</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Lataa uusin versio verkkosivustolta.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>kDrivea ei ole määritetty!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synkronoitu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Suosikit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Toiminta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Päivitä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Päivitystä ladataan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Etsitään päivitystä...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Manuaalinen päivitys</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Ei saatavilla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Ei toteutettu!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Linkkiä %1 ei voi avata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Virheellinen linkki %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Päivitä kDrive-sovellus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Lataa uusin versio verkkosivustolta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrivea ei ole määritetty!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Voit synkronoida tiedostoja &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Ohita tämä versio</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Muistuta myöhemmin</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Asenna päivitys</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Ohita tämä versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Muistuta myöhemmin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Asenna päivitys</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Uusi päivitys saatavilla.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Versio %1 on ladattavissa.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Uusi päivitys saatavilla.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Versio %1 on ladattavissa.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Lisää tili</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Lisää tili</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Versio</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>PÄIVITÄ</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 on ajan tasalla!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Tarkistetaan päivitystä palvelimelta...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Päivitys on saatavilla: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Ladataan %1. Odota...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Päivitysten tarkistus epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Päivityksen aikana tapahtui virhe.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Päivityksen lataaminen epäonnistui.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Päivitys poistettu käytöstä.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Beta-ohjelma</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Liity</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Muokkaa</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Lopeta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Versio</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>PÄIVITÄ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 on ajan tasalla!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Tarkistetaan päivitystä palvelimelta...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;täältä&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Päivitys on saatavilla: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Ladataan %1. Odota...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Päivitysten tarkistus epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Päivityksen aikana tapahtui virhe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Päivityksen lataaminen epäonnistui.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Päivitys poistettu käytöstä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Beta-ohjelma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Liity</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Muokkaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Lopeta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Parametreja ei voi tallentaa!</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Tee saataville paikallisesti</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Vapauta paikallista tilaa</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Peruuta paikallisen tilan vapautus</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Peruuta paikallinen saatavillaolo</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Kopioi julkinen jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Kopioi yksityinen jakolinkki</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Avaa selaimessa</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Kelvollista polkua ei löydy</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Kelvollista kansiota ei ole valittu!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Valittu polku ei ole olemassa!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Valittu polku ei ole kansio!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Parametreja ei voi tallentaa!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Tee saataville paikallisesti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Vapauta paikallista tilaa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Peruuta paikallisen tilan vapautus</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Peruuta paikallinen saatavillaolo</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Kopioi julkinen jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Kopioi yksityinen jakolinkki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Avaa selaimessa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Kelvollista polkua ei löydy</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Kelvollista kansiota ei ole valittu!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Valittu polku ei ole olemassa!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Valittu polku ei ole kansio!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n vuosi</numerusform>
-<numerusform>%n vuotta</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n kuukausi</numerusform>
-<numerusform>%n kuukautta</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n päivä</numerusform>
-<numerusform>%n päivää</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n tunti</numerusform>
-<numerusform>%n tuntia</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuutti</numerusform>
-<numerusform>%n minuuttia</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekunti</numerusform>
-<numerusform>%n sekuntia</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
+    <name>Utility</name>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n vuosi</numerusform>
+            <numerusform>%n vuotta</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n kuukausi</numerusform>
+            <numerusform>%n kuukautta</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n päivä</numerusform>
+            <numerusform>%n päivää</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n tunti</numerusform>
+            <numerusform>%n tuntia</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuutti</numerusform>
+            <numerusform>%n minuuttia</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekunti</numerusform>
+            <numerusform>%n sekuntia</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Järjestelmäpalkki ei ole käytettävissä</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 vaatii toimivan järjestelmäpalkin. Jos käytät XFCE:tä, noudata &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;näitä ohjeita&lt;/a&gt;. Muussa tapauksessa asenna järjestelmäpalkkisovellus, kuten 'trayer', ja yritä uudelleen.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Järjestelmäpalkki ei ole käytettävissä</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 vaatii toimivan järjestelmäpalkin. Jos käytät XFCE:tä, noudata &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;näitä ohjeita&lt;/a&gt;. Muussa tapauksessa asenna järjestelmäpalkkisovellus, kuten &apos;trayer&apos;, ja yritä uudelleen.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Selainta ei voi avata</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Sähköpostiohjelmaa ei voi avata</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Selainta ei voi avata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Sähköpostiohjelmaa ei voi avata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Et ole enää kirjautunut. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Kirjaudu sisään&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Ei synkronoitavaa kansiota
+        <translation>Ei synkronoitavaa kansiota
 Voit lisätä sellaisen kDriven asetuksista.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synkronointi käynnissä (%1/%2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronointi käynnissä (%1/%2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synkronointi käynnissä (%1/%2)
+        <translation>Synkronointi käynnissä (%1/%2)
 %3 jäljellä...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synkronointi alkaa</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synkronointi käynnissä.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Olet ajan tasalla!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synkronointi keskeytymässä...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synkronointi keskeytetty.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronointi alkaa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronointi käynnissä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Olet ajan tasalla!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronointi keskeytymässä...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkronointi keskeytetty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_fi.ts
+++ b/translations/client_fi.ts
@@ -1,2580 +1,3095 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fi_FI">
+<TS language="fi_FI" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Tietoja</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">SULJE</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versio %1. Lisätietoja: &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">%1 jakaa ja lisensoi &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kansiota %1 ei voi avata.</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Tietoja</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>SULJE</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versio %1. Lisätietoja: &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>%1 jakaa ja lisensoi &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;-lisenssin alla.&lt;br&gt;&lt;br&gt;%2 ja %2-logo ovat %1:n rekisteröityjä tavaramerkkejä.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Rakennettu &lt;a style="color: #489EF3" href="%1"&gt;Git-lähteistä&lt;/a&gt; %2, %3 käyttäen Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kansion polkua %1 ei voi avata.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">kDrive on valmis!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">AVAA KANSIO</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">ASETUKSET</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Synkronoi toinen asema</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Synkronointi käynnistyy ja voit lisätä tiedostoja %1-kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>kDrive on valmis!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>AVAA KANSIO</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>ASETUKSET</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synkronoi toinen asema</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Peruuta</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">SEURAAVA</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Valitse synkronoitava kDrive</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Hanki kDrive ilmaiseksi</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Kokeile ilmaiseksi</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>SEURAAVA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Valitse synkronoitava kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Hanki kDrive ilmaiseksi</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Tallenna kuvasi, asiakirjasi ja sähköpostisi Sveitsiin riippumattomassa yrityksessä, joka kunnioittaa yksityisyyttä. Lue lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Kokeile ilmaiseksi</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Haluatko aktivoida Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Haluatko aktivoida Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Säästä tietokoneen tallennustilaa</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">MYÖHEMMIN</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">KYLLÄ</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Haluatko aktivoida Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Haluatko aktivoida Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synkronoi kaikki tiedostosi käyttämättä tietokoneen tallennustilaa. Voit selata kDrive-tiedostojasi ja ladata ne paikallisesti milloin tahansa. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Säästä tietokoneen tallennustilaa</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Päätä, mitkä tiedostot ovat saatavilla verkossa tai paikallisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>MYÖHEMMIN</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>KYLLÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">%1 kDrive -aseman sijainti</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Muokkaa kansiota</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">LOPETA</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">JATKA</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>%1 kDrive -aseman sijainti</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Muokkaa kansiota</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Löydät kaikki tiedostosi tästä kansiosta konfiguroinnin jälkeen. Voit lisätä uusia tiedostoja kansioon synkronoidaksesi ne kDriveen.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>LOPETA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>&lt;b&gt;%1&lt;/b&gt;-kansion sisältö synkronoidaan kDriveen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt; 
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Valitse kansio</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Kirjaudu sisään selaimella</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Avaa kirjautumissivu</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Todennuksessa tapahtui virhe. Sulje kirjautumisikkuna ja yritä uudelleen.&lt;br&gt;Jos virhe jatkuu, ota yhteyttä tukitiimiimme.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Kirjautuminen epäonnistui: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Kirjaudu sisään selaimella</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Selaimesi avautuu automaattisesti yhteyden muodostamiseksi. Kun olet kirjautunut, palaat automaattisesti kDriveen.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Avaa kirjautumissivu</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Todennuksessa tapahtui virhe. Sulje kirjautumisikkuna ja yritä uudelleen.&lt;br&gt;Jos virhe jatkuu, ota yhteyttä tukitiimiimme.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Kirjautuminen epäonnistui: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Kirjautumissivun avaaminen selaimessa epäonnistui</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">JATKA</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Tietokoneella vapaata tilaa: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Alikansioiden listan lataaminen epäonnistui.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Valitse synkronoitavat kDrive-kansiot tietokoneellesi</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Tietokoneella vapaata tilaa: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Alikansioiden listaa ei voi ladata. kDrive saattaa olla huoltotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Paikallisen kansion %1 luominen epäonnistui</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Uuden synkronoinnin luominen epäonnistui</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Paikallisen kansion %1 luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Uuden synkronoinnin luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>kDrive %1 on jo synkronoitu tällä tietokoneella. Jatketaanko?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">kDrive-asiakas on jo käynnissä!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-asiakas käynnistettiin virheellisillä parametreillä!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>kDrive-asiakas on jo käynnissä!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Käyttäjä %1 ei ole kirjautunut. Kirjaudu uudelleen.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Jakolinkki kopioitu leikepöydälle</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
-            <numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 on poistettu.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
-            <numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 on lisätty.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
-            <numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 on päivitetty.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
-            <numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 on siirretty kohteeseen %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synkronointiaktiviteetti</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Jakolinkki kopioitu leikepöydälle</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on poistettu.</numerusform>
+<numerusform>%1 ja %n muuta tiedostoa on poistettu.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on poistettu.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on lisätty.</numerusform>
+<numerusform>%1 ja %n muuta tiedostoa on lisätty.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on lisätty.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 ja %n muu tiedosto on päivitetty.</numerusform>
+<numerusform>%1 ja %n muuta tiedostoa on päivitetty.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 on päivitetty.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 on siirretty kohteeseen %2 ja %n muu tiedosto on siirretty.</numerusform>
+<numerusform>%1 on siirretty kohteeseen %2 ja %n muuta tiedostoa on siirretty.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 on siirretty kohteeseen %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synkronointiaktiviteetti</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Poistu beta-ohjelmasta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Liity beta-ohjelmaan</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Hyödy sovelluksen beta-päivityksistä</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Ei</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Julkinen beta-versio</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Sisäinen beta-versio</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Testiversio</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Ymmärrän</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Tallenna</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Peruuta</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Poistu beta-ohjelmasta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Liity beta-ohjelmaan</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Saa varhainen pääsy sovelluksen uusiin versioihin ennen niiden julkaisua ja osallistu sovelluksen kehittämiseen lähettämällä kommenttisi.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Hyödy sovelluksen beta-päivityksistä</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Ei</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Julkinen beta-versio</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Sisäinen beta-versio</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Testiversio</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Ymmärrän</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Oletko varma, että haluat poistua beta-ohjelmasta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Tallenna</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Sovelluksesi nykyinen versio saattaa olla liian uusi; valintasi astuu voimaan seuraavan päivityksen yhteydessä.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Beta-versiot saattavat kaatua odottamatta tai aiheuttaa epävakautta.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">kDrive-asiakkaan alustaminen epäonnistui</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Kirjaudu sisään</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synkronointi on keskeytetty</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Kansio %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Synkronointikansioita ei ole määritetty.</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Määrittelemätön tila.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Odotetaan synkronoinnin käynnistymistä.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synkronointi käynnissä.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Viimeisin synkronointi onnistui.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Käyttäjä keskeytti.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synkronointi on keskeytetty.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synkronointi keskeytetty)</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kansion polkua %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">POISTA KAIKKI SYNKRONOINNIT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 kohdetta on poistettu paikallisesta synkronointikansiostasi &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Tahattomien poistojen estämiseksi synkronointi on keskeytetty.&lt;br&gt;Haluatko siirtää nämä poistot kDriveen?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Useita tiedostoja on poistettu paikallisesta synkronointikansiostasi &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Poistetut tiedostot löytyvät kDriven &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;roskakorista&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Älä näytä uudelleen</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Yhteenveto</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Asetukset</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Lopeta</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Synkronointien käynnistäminen epäonnistui!</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>kDrive-asiakkaan alustaminen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Ristiriitojen korjaaminen kohteessa %1 synkronointikansiossa epäonnistui: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Kirjaudu sisään</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synkronointi on keskeytetty</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Kansio %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Synkronointikansioita ei ole määritetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Määrittelemätön tila.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Odotetaan synkronoinnin käynnistymistä.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synkronointi käynnissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synkronointi onnistui, ratkaisemattomia ristiriitoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Viimeisin synkronointi onnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Käyttäjä keskeytti.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synkronointi on keskeytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synkronointi keskeytetty)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Haluatko todella poistaa tilin &lt;i&gt;%1&lt;/i&gt; synkronoinnit?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>POISTA KAIKKI SYNKRONOINNIT</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 kohdetta on poistettu paikallisesta synkronointikansiostasi &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Tahattomien poistojen estämiseksi synkronointi on keskeytetty.&lt;br&gt;Haluatko siirtää nämä poistot kDriveen?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Useita tiedostoja on poistettu paikallisesta synkronointikansiostasi &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Poistetut tiedostot löytyvät kDriven &lt;a style="%1" href="%3"&gt;roskakorista&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Älä näytä uudelleen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Yhteenveto</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Lopeta</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Synkronointien käynnistäminen epäonnistui!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Yhteenveto paikallisen kansion synkronoinnista</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNKRONOI</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Yhteenveto paikallisen kansion synkronoinnista</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Tietokoneesi kansion sisältö synkronoidaan valitun kDriven kansioon ja päinvastoin.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNKRONOI</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Ennen viimeistelyä</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Siirry &lt;b&gt;&quot;Kirjautumisobjektit ja laajennukset&quot;&lt;/b&gt;-osioon ja sitten &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;-osioon</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Valtuuta kDrive-sovellus</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Siirry &lt;b&gt;&quot;Turvallisuus&quot;&lt;/b&gt;-osioon</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Avaa lukko &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; ja valtuuta kDrive-sovellus</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Siirry &lt;b&gt;&quot;Tietosuoja ja turvallisuus&quot;&lt;/b&gt;-osioon ja napsauta &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;&quot;Tietosuoja&quot;&lt;/b&gt;-välilehti tai &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;napsauta tästä&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Valitse &quot;kDrive LiteSync Extension&quot; -ruutu ja sitten &quot;kDrive.app&quot;-ruutu (jos ei vielä valittu)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Valitse &quot;kDrive LiteSync Extension&quot; -ruutu (ja &quot;kDrive.app&quot;, jos se on olemassa) kohdassa &lt;b&gt;&quot;Täysi levynkäyttöoikeus&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">VAIHE 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Valmis)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">VAIHE 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">VAIHEET SUORITETTU</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">LOPETA</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Ennen viimeistelyä</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Suorita seuraavat vaiheet varmistaaksesi, että Lite Sync toimii oikein tietokoneellasi ja viimeistelläksesi kDriven konfiguroinnin.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Yleiset asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Tietosuoja- ja turva-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Avaa Macin &lt;b&gt;Turvallisuus- ja tietosuoja-asetukset&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Siirry &lt;b&gt;"Kirjautumisobjektit ja laajennukset"&lt;/b&gt;-osioon ja sitten &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;-osioon</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Valtuuta kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Siirry &lt;b&gt;"Turvallisuus"&lt;/b&gt;-osioon</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Valtuuta kDrive-sovellus ruudussa, jossa ilmoitetaan kDriven olevan estetty</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Avaa lukko &lt;img src=":/client/resources/icons/actions/lock.png"&gt; ja valtuuta kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Siirry &lt;b&gt;"Tietosuoja ja turvallisuus"&lt;/b&gt;-osioon ja napsauta &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt; tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Turvallisuus- ja tietosuoja-asetuksissa avaa &lt;b&gt;"Tietosuoja"&lt;/b&gt;-välilehti tai &lt;a style="%1" href="%2"&gt;napsauta tästä&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Valitse "kDrive LiteSync Extension" -ruutu ja sitten "kDrive.app"-ruutu (jos ei vielä valittu)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Sovelluksen uudelleenkäynnistystä saatetaan ehdottaa; hyväksy se siinä tapauksessa</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Valitse "kDrive LiteSync Extension" -ruutu (ja "kDrive.app", jos se on olemassa) kohdassa &lt;b&gt;"Täysi levynkäyttöoikeus"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>VAIHE 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Valmis)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>VAIHE 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>VAIHEET SUORITETTU</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>LOPETA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">KYLLÄ</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">EI</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>KYLLÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>EI</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Lähetetään virheenkorjaustietoja</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Peruuta</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Lähetetään virheenkorjaustietoja</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Virheenkorjaus</translation>
-    </message>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Tiedot</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Varoitus</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Virhe</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Kriittinen</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Virheenkorjausasetukset</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Virheenkorjaustaso</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Laajennettu täysloki</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Jaa virheenkorjauskansio Infomaniakille.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Jaa vain viimeisin kDrive-istunto</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Ladataan</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Peruuta</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">TALLENNA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Jakaminen epäonnistui</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Yhteys katkaistu)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Jaa kansio SwissTransferillä &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Pakkasimme lokisi automaattisesti &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Siirrä arkisto &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Jaa linkki osoitteeseen &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Viimeisin lähetys %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Jakaminen on peruutettu</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 klo %4:%5:%6</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Haluatko tallentaa muutokset?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kansiota %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Jaa</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Jaetaan | vaihe 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Jaetaan | vaihe 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Peruutetaan...</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Virheenkorjaus</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Tiedot</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Varoitus</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Virhe</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Kriittinen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Virheenkorjausasetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Tallenna virheenkorjaustiedot kansioon tietokoneellani (Suositeltu)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Nämä tiedot auttavat IT-tukea selvittämään tapauksen alkuperän.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Virheenkorjaustaso</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Jäljitystaso antaa sinun valita tallennettavien virheenkorjaustietojen laajuuden</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Laajennettu täysloki kerää yksityiskohtaisen historian virheenkorjausta varten. Sen käyttöönotto voi hidastaa kDrive-sovellusta.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Laajennettu täysloki</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Poista lokeja, jotka ovat vanhempia kuin %1 päivää</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Jaa virheenkorjauskansio Infomaniakille.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Viimeinen istunto on ajanjakso viimeisimmästä kDriven käynnistyksestä.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Jaa vain viimeisin kDrive-istunto</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Ladataan</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Jakaminen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Tarkista, että olet kirjautunut sisään &lt;br&gt;2. Tarkista, että olet määrittänyt vähintään yhden kDriven</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Yhteys katkaistu)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Jaa kansio SwissTransferillä &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Pakkasimme lokisi automaattisesti &lt;a style="%1" href="%2"&gt;tähän&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Siirrä arkisto &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;-palvelun avulla&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Jaa linkki osoitteeseen &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Viimeisin lähetys %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Jakaminen on peruutettu</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Laajennettu täysloki on aktivoitu KDRIVE_FORCE_EXTENDED_LOG-ympäristömuuttujalla. Aseta se arvoon 0 poistaaksesi sen käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 klo %4:%5:%6</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Jaa</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Jaetaan | vaihe 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Jaetaan | vaihe 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Peruutetaan...</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Koko kansio on suuri (&gt; 100 Mt) ja jakaminen voi kestää jonkin aikaa. Jakamisajan lyhentämiseksi suosittelemme jakamaan vain viimeisimmän kDrive-istunnon.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synkronointivirheet ja tiedot.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Synkronoi paikallinen kansio</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Haluatko todella ottaa Lite Sync käyttöön?</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Haluatko todella poistaa Lite Sync käytöstä?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Uuden synkronoinnin luominen epäonnistui</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Uuden paikallisen kansion synkronointi epäonnistui!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync aktivoitu.</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Lite Sync -aktivointi epäonnistui.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync poistettu käytöstä.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Lite Sync -deaktivointi epäonnistui.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Tämä asema poistetaan.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Kohteen %1 avaaminen ei onnistu</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">POISTA KANSION SYNKRONOINTIYHTEYS</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Alikansioiden listan lataaminen epäonnistui.</translation>
-    </message>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Kansiot</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Ilmoitukset</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Ota tämän kDriven ilmoitukset käyttöön</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Yhdistetty:</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Poista kaikki synkronoinnit</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Hae kDrivesta</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Haku</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synkronointivirheet ja tiedot.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synkronoi paikallinen kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Haluatko todella ottaa Lite Sync käyttöön?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Tämä toiminto voi kestää muutamasta sekunnista muutamaan minuuttiin kansion koosta riippuen.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Haluatko todella poistaa Lite Sync käytöstä?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Sinulla ei ole tarpeeksi tilaa kaikkien kDrive-tiedostojen synkronointiin (%1 puuttuu). Jos poistat Lite Sync käytöstä, sinun on valittava synkronoitavat kansiot tietokoneellasi. Sillä välin kDriven synkronointi keskeytetään.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Jos poistat Lite Sync käytöstä, kaikki tiedostot ladataan tietokoneellesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Uuden synkronoinnin luominen epäonnistui</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Uuden paikallisen kansion synkronointi epäonnistui!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync aktivoitu.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Lite Sync -aktivointi epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync poistettu käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Lite Sync -deaktivointi epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Tämä asema poistetaan.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Kohteen %1 avaaminen ei onnistu</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Haluatko todella lopettaa kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin?&lt;br&gt;&lt;b&gt;Huom:&lt;/b&gt; Tämä &lt;b&gt;ei&lt;/b&gt; poista tiedostoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>POISTA KANSION SYNKRONOINTIYHTEYS</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Kansion &lt;i&gt;%1&lt;/i&gt; synkronoinnin pysäyttäminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Alikansioiden listan lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Kansiot</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Ilmoitukset</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Ota tämän kDriven ilmoitukset käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Ilmoitus näytetään heti, kun uusi kansio on synkronoitu tai muokattu</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Yhdistetty:</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Poista kaikki synkronoinnit</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Hae kDrivesta</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Haku</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Lisää kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Synkronoi kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Lisää kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synkronoi kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Tyhjennä historia</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Ratkaistavana</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">havaittu ongelma(t)</translation>
-    </message>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Ratkaise</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Ristiriitainen kohde (kohteet)</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Kohde(et), joissa on ei-tuettuja merkkejä</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Automaattisesti ratkaistu</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">ratkaistut ongelma(t)</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Tyhjennä historia</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Ratkaistavana</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>havaittu ongelma(t)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Ratkaise</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Ristiriitainen kohde (kohteet)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Kohde(et), joissa on ei-tuettuja merkkejä</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Automaattisesti ratkaistu</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>ratkaistut ongelma(t)</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synkronointiristiriidat tai -virheet</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Virheet</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Takaisin asetuksiin</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synkronointiristiriidat tai -virheet</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Virheet</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Takaisin asetuksiin</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 virhe(ttä))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 tiedote(tta))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
-            <numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Joitakin tiedostoja ei voitu synkronoida seuraavilla kDrive-asemilla:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 virhe(ttä))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 tiedote(tta))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 virhe(ttä) ja %2 tiedote(tta))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Yleiset virheet (%n varoitus tai virhe)</numerusform>
+<numerusform>Yleiset virheet (%n varoitusta tai virhettä)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Poissuljetut tiedostot</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Lisää</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NIMI</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">VAROITUS</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">TALLENNA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Haluatko tallentaa muutokset?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Poissulkumalli on jo olemassa!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Haluatko todella poistaa?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Muutoksia ei voi tallentaa!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Poissuljetut tiedostot</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Lisää tiedostoja tai kansioita, joita ei synkronoida tietokoneellesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NIMI</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>VAROITUS</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Poissulkumalli on jo olemassa!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Haluatko todella poistaa?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Muutoksia ei voi tallentaa!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Ratkaise ristiriita(t)</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Näytä kohde(et)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Ratkaise ristiriita(t)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Mitä haluat tehdä %1 ristiriitaiselle kohteelle?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Tallenna muutokseni ja korvaa muiden käyttäjien versiot.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Kumoa muutokseni ja säilytä muiden käyttäjien versiot.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Muutoksesi voidaan poistaa pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Muutoksesi poistetaan pysyvästi. Niitä ei voi palauttaa kDrive-verkkosovelluksesta.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Näytä kohde(et)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Useat käyttäjät ovat muokanneet näitä tiedostoja useissa paikoissa (kDrivessa verkossa, tietokoneella tai mobiililaitteella). Myös nämä tiedostot sisältävät kansiot on saatettu poistaa.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Kohteesi paikallinen versio &lt;b&gt;ei ole synkronoitu&lt;/b&gt; kDriven kanssa. &lt;a style="color: #489EF3" href="%1"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synkronoitu kohteeseen &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Ota Lite Sync käyttöön</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Ota Lite Sync (Beta) käyttöön</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Poista Lite Sync käytöstä</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Keskeytä synkronointi</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Jatka synkronointia</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Poista synkronointi</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Lisää toimintoja</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Peruuta</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synkronoitu kohteeseen &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Ota Lite Sync käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Ota Lite Sync (Beta) käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Poista Lite Sync käytöstä</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Keskeytä synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Jatka synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Poista synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot siirretään roskakoriin, jos ne sisältävät offline-kohteita. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot siirretään roskakoriin. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Valitsemattomat kansiot poistetaan &lt;b&gt;pysyvästi&lt;/b&gt; tietokoneelta. kDriveen synkronoidut kansiot pysyvät saatavilla verkossa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Peruuta</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kansion polkua %1 ei voi avata.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Sovelluksen tunnus</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Sovelluksen nimi</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Sovelluksen tunnus</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Sovelluksen nimi</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat &quot;verkossa&quot;. Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Lisää</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">SOVELLUKSEN TUNNUS</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NIMI</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">TALLENNA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Haluatko tallentaa muutokset?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Haluatko todella poistaa?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Muutoksia ei voi tallentaa!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Jotkut sovellukset (varmuuskopiointi, virustorjunta...) käyttävät tiedostojasi, mikä johtaa niiden lataamiseen, kun ne ovat "verkossa". Lisää ne alla olevaan luetteloon tämän käyttäytymisen välttämiseksi.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>SOVELLUKSEN TUNNUS</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NIMI</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Haluatko todella poistaa?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Muutoksia ei voi tallentaa!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Tämän kansion sisältö synkronoidaan kDriveen</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Valitse kansio</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Muokkaa kansiota</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">JATKA</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Minkä tietokoneen kansion haluat&lt;br&gt;synkronoida?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Tämän kansion sisältö synkronoidaan kDriveen</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Muokkaa kansiota</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Tämä kansio ei ole yhteensopiva Lite Sync -toiminnon kanssa.&lt;br&gt;
 Valitse toinen kansio. Jos jatkat, Lite Sync poistetaan käytöstä.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Valitse kansio</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Valitse kansio</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Virhe</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Tiedostoa &apos;%1&apos;&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Virhe</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Tiedostoa '%1'&lt;br/&gt;ei voi avata kirjoittamista varten.&lt;br/&gt;&lt;br/&gt;Lokia &lt;b&gt;ei&lt;/b&gt; voi tallentaa!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Asetukset</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Ohje</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Ohje</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla &apos;/etc/sysctl.conf&apos;-tiedostoa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Sinulla ei joko ole oikeutta luoda kohdetta tai toinen kohde samalla nimellä on jo olemassa. Kohde ohitettiin.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen &quot;%1&quot;.&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Tiedostoa ei voi ladata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Synkronointivirhe.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Tiedostoa %1 ei voi luoda, koska tiedostojärjestelmä ei tue sitä.&lt;br&gt;Se on jätetty synkronoinnin ulkopuolelle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Järjestelmävirhe.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Kansion polkua %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Siirto epäonnistui!
-Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrivea ei ole määritetty!</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrivella on oltava kirjoitusoikeus tietokoneesi väliaikaiseen hakemistoon.&lt;br&gt;Käynnistä kDrive-sovellus uudelleen ratkaistaksesi tämän ongelman.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Verkkoyhteyden aikakatkaisuarvo näyttää olevan liian pieni sovelluksen oikeaa toimintaa varten (virhe %1).&lt;br&gt;Tarkista verkkoasetuksesi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>kDrive-palvelimeen ei saada yhteyttä (virhe %1).&lt;br&gt;Yritetään yhdistää uudelleen. Tarkista Internet-yhteys ja palomuuri.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Kirjaudu uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Sovelluksesta on saatavilla uusi versio.&lt;br&gt;Päivitä sovellus jatkaaksesi sen käyttöä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Lokin lähetys epäonnistui (virhe %1).&lt;br&gt;Yritä myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Synkronointikansio ei ole enää käytettävissä (virhe %1).&lt;br&gt;Synkronointi jatkuu heti, kun kansio on taas käytettävissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Synkronointikansion sisältävä asema ei ole enää yhteydessä (virhe %1).&lt;br&gt;Yhdistä se uudelleen jatkaaksesi synkronointia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi muistia.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Inotify-tarkkailijamäärä on riittämätön (virhe %1).&lt;br&gt;Voit kasvattaa tätä lukua muokkaamalla '/etc/sysctl.conf'-tiedostoa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;Sinun on sallittava:&lt;br&gt;- kDrive kohdassa Järjestelmäasetukset &gt;&gt; Yleiset &gt;&gt; Kirjautumisobjektit ja laajennukset &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension kohdassa Järjestelmäasetukset &gt;&gt; Tietosuoja ja turvallisuus &gt;&gt; Täysi levynkäyttöoikeus.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Synkronointia ei voi käynnistää (virhe %1).&lt;br&gt;LiteSyncExt-prosessi ei ole käynnissä. Synkronointi jatkuu heti, kun se käynnistyy.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennus on asennettu ja Windowsin hakupalvelu on käytössä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tarkista, että Lite Sync -laajennuksella on oikeat käyttöoikeudet ja se on käynnissä.&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Lite Sync -laajennusta ei voi käynnistää (virhe %1).&lt;br&gt;Tyhjennä historia, käynnistä uudelleen ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Synkronointikansiossa oleva tiedosto tai kansio näyttää vioittuneelta.&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive on huoltotilassa.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive on estetty.&lt;br&gt;Uudista kDrive. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive on estetty.&lt;br&gt;Ota yhteyttä järjestelmänvalvojaan kDriven uudistamiseksi. Jos toimenpiteitä ei tehdä, tiedot poistetaan pysyvästi eikä niitä voi palauttaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive herää.&lt;br&gt;Synkronointi alkaa uudelleen mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu &lt;a style="%1" href="%2"&gt;verkkoversioon&lt;/a&gt; tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive on lepotilassa.&lt;br&gt;Kirjaudu verkkoversioon tarkistaaksesi kDriven tilan tai ota yhteyttä järjestelmänvalvojaasi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Sinulla ei ole oikeutta käyttää tätä kDrivea.&lt;br&gt;Synkronointi on keskeytetty. Ota yhteyttä järjestelmänvalvojaan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi jatkuu mahdollisimman pian. Ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Käyttöjärjestelmän ydin katkaisi verkkoyhteydet (virhe %1).&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Vanhaa konfiguraatiota ei valitettavasti voitu siirtää.&lt;br&gt;Sovellus käyttää tyhjää konfiguraatiota.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Vanhaa välityspalvelinasetusten konfiguraatiota ei valitettavasti voitu siirtää, SOCKS5-välityspalvelimia ei tueta tällä hetkellä.&lt;br&gt;Sovellus käyttää järjestelmän välityspalvelinasetuksia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Synkronointikansio on korvattu tai siirretty tavalla, joka estää synkronoinnin (virhe %1).&lt;br&gt;Tämä voi tapahtua kansion kopioinnin, siirtämisen tai palauttamisen jälkeen.&lt;br&gt;Korjataksesi tämän, luo uusi synkronointi uuteen kansioon.&lt;br&gt;Huom: jos vanhassa kansiossa on synkronoimattomia muutoksia, ne täytyy kopioida manuaalisesti uuteen kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut (virhe %1).&lt;br&gt;Synkronointi on käynnistetty uudelleen. Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Synkronointitietokannan käyttämisessä tapahtui virhe (virhe %1).&lt;br&gt;Synkronointi on pysäytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Kirjautumisvirhe (virhe %1).&lt;br&gt;Tunnus on virheellinen tai peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Sisäkkäiset synkronoinnit ovat kiellettyjä (virhe %1).&lt;br&gt;Säilytä vain synkronoinnit, joiden kansiot eivät ole sisäkkäisiä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>kDriven etäpalvelimella oleva synkronointikansio ei ole enää olemassa tai käytettävissä (virhe %1).&lt;br&gt;Sinun on palautettava se tai annettava sille takaisin käyttöoikeudet tai poistettava/luotava synkronointi uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Tiedostonimen jäsennysvirhe (virhe %1).&lt;br&gt;Erikoismerkit kuten lainausmerkit, kenoviivat tai rivinvaihdot voivat aiheuttaa jäsennysvirheitä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Tämä elementti on siirretty muualle.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Samanlaisella nimellä oleva elementti on jo olemassa tässä sijainnissa.&lt;br&gt;Paikallinen elementti on nimetty uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Toinen käyttäjä muokkasi tiedostoa samanaikaisesti.&lt;br&gt;Muutoksesi on tallennettu kopioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Toinen käyttäjä on siirtänyt kohteen ylätason kansion.&lt;br&gt;Paikallinen toiminto on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Olemassa olevalla kohteella on sama nimi samoilla kirjainkoolla.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi sisältää ei-tuetun merkin.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi päättyy välilyöntiin, mikä on kiellettyä käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Tämä nimi on varattu käyttöjärjestelmässäsi.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi on liian pitkä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Kohteen polku on liian pitkä.&lt;br&gt;Se on ohitettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Kohteen nimi sisältää uuden Unicode-merkin, jota tiedostojärjestelmäsi ei vielä tue.&lt;br&gt;Se on suljettu pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohteen nimi sisältää vain välilyöntejä.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Sinulla ei joko ole oikeutta luoda kohdetta tai toinen kohde samalla nimellä on jo olemassa. Kohde ohitettiin.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Sinulla ei ole oikeutta muokata kohdetta.&lt;br&gt;Muutoksesi sisältävä tiedosto on nimetty uudelleen ja suljettu pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Sinulla ei ole oikeutta nimetä kohdetta uudelleen.&lt;br&gt;Se palautetaan alkuperäisellä nimellään.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Sinulla ei ole oikeutta siirtää kohdetta kohteeseen "%1".&lt;br&gt;Se palautetaan alkuperäiseen yläkansioonsa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Sinulla ei ole oikeutta poistaa kohdetta.&lt;br&gt;Se palautetaan alkuperäiseen sijaintiinsa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Kohteen siirtäminen roskakoriin epäonnistui, se on lisätty estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Kohteen synkronointi epäonnistui. Se on lisätty väliaikaisesti estolistalle.&lt;br&gt;Synkronointia yritetään uudelleen tunnin kuluttua tai seuraavalla sovelluksen käynnistyksellä.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Tämä kohde on suljettu synkronoinnista mukautetun mallin avulla.&lt;br&gt;Voit poistaa tämän tyyppiset ilmoitukset käytöstä Asetuksissa</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Tämä kohde on suljettu synkronoinnista, koska se on kova linkki.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Tiedostoa on muokattu paikallisesti, kun se on poistettu etä-kDrivesta.&lt;br&gt;Paikallinen kopio on tallennettu pelastuskansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Kohteelle suoritettu toiminto on kielletty.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Kohteelle suoritettu toiminto epäonnistui.&lt;br&gt;Kohde on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Tiedosto on liian suuri ladattavaksi. Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Olet ylittänyt kiintiösi. Kasvata tallennustilaasi ottaaksesi tiedostojen lataamisen uudelleen käyttöön.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Tiedostoa ei voi ladata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Toinen käyttäjä on tällä hetkellä lukinnut tämän kohteen verkossa.&lt;br&gt;Yritämme ladata muutoksesi myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Synkronointivirhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Kohdetta ei voi käyttää.&lt;br&gt;Korjaa luku- ja kirjoitusoikeudet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Tietokoneellasi ei ole tarpeeksi tilaa.&lt;br&gt;Lataus on peruutettu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Tiedostoa ”%1” ei voitu luoda, koska se ei ole tuettu käyttämäsi tiedostojärjestelmässä.&lt;br&gt;Se on jätetty pois synkronoinnista.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Järjestelmävirhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Kohde on jo olemassa toisella puolella.&lt;br&gt;Se on lisätty väliaikaisesti estolistalle.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Tekninen virhe on tapahtunut.&lt;br&gt;Tyhjennä historia ja ota yhteyttä tukitiimiimme, jos virhe toistuu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kansion polkua %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Siirto valmis!&lt;br&gt;Viittaa tunnukseen &lt;b&gt;%1&lt;/b&gt; virheraporteissa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Siirto epäonnistui!
+Käytä seuraavaa linkkiä lähettääksesi lokit tuelle: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>kDrivea ei ole määritetty!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Tätä synkronointia poistetaan.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Tätä synkronointia poistetaan.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Takaisin asemaluetteloon</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Asetukset</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Takaisin asemaluetteloon</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Asetukset</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kansiota %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Virheellinen linkki %1.</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Joidenkin prosessien käynnistyminen epäonnistui.</translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Yleiset</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Ota tumma teema käyttöön</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Ota yksivärisiä kuvakkeita käyttöön</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Käynnistä kDrive automaattisesti</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Kieli</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Oletus</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Englanti</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Ranska</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Saksa</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Espanja</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italia</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Ruotsi</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugali</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Puola</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norja</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Suomi</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Tanska</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Kreikka</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Hollanti</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Lisäasetukset</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Virheenkorjaustiedot</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Suljettavat tiedostot</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Välityspalvelin</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Kansiota %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Virheellinen linkki %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Joidenkin prosessien käynnistyminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Yleiset</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Ota tumma teema käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Ota yksivärisiä kuvakkeita käyttöön</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Käynnistä kDrive automaattisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Kieli</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Joitakin tiedostoja tai kansioita ei ehkä voi siirtää tietokoneen roskakoriin.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Voit aina palauttaa jo synkronoidut tiedostot kDriven verkkosovelluksen roskakorista.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Oletus</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Englanti</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Ranska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Saksa</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Espanja</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italia</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Ruotsi</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugali</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Puola</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norja</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Suomi</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Tanska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Kreikka</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Hollanti</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Lisäasetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Virheenkorjaustiedot</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Avaa virheenkorjauskansio&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Suljettavat tiedostot</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 käytössä</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 käytössä</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S)-välityspalvelin</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Välityspalvelin</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Ei välityspalvelinta</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Käytä järjestelmäasetuksia</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Määritä välityspalvelin manuaalisesti</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Portti</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Välityspalvelimen osoite</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Todennus vaaditaan</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Käyttäjä</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Salasana</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">TALLENNA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Haluatko tallentaa muutokset?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S)-välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Välityspalvelin</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ei välityspalvelinta</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Käytä järjestelmäasetuksia</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Määritä välityspalvelin manuaalisesti</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Portti</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Välityspalvelimen osoite</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Todennus vaaditaan</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Käyttäjä</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Salasana</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Tallennus epäonnistui, kaikki pakolliset kentät eivät ole täytetty!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Välityspalvelinta ei löydy, tallennetaanko silti?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Resurssien hallinta</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Suurin sallittu suorittimen käyttö</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">TALLENNA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Haluatko tallentaa muutokset?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Resurssien hallinta</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Suurin sallittu suorittimen käyttö</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>TALLENNA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Haluatko tallentaa muutokset?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Valitse kansio kDrivesta</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">JATKA</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Nykyisen kansion tilaa tietokoneella: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Tämä kansio on jo synkronoinnissa.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">VAHVISTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">PERUUTA</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Valitse kansio kDrivesta</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Valitun kansion sisältö synkronoidaan &lt;b&gt;%1&lt;/b&gt;-kansioon.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Nykyisen kansion tilaa tietokoneella: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Tämä kansio on jo synkronoinnissa.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>VAHVISTA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>PERUUTA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">JATKA</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Palvelimella ei ole alikansioita tällä hetkellä.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>&lt;b&gt;%1&lt;/b&gt;-kansio sisältää alikansioita,&lt;br&gt; valitse synkronoitavat kansiot</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>JATKA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Palvelimella ei ole alikansioita tällä hetkellä.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Jatka kDrive &quot;%1&quot; synkronointia</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Jatka synkronointia</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Jatka kaikkien kDrive-asemien synkronointia</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Keskeytä kDrive &quot;%1&quot; synkronointi</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Keskeytä synkronointi</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Keskeytä kaikkien kDrive-asemien synkronointi</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Jatka kDrive "%1" synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Jatka synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Jatka kaikkien kDrive-asemien synkronointia</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Keskeytä kDrive "%1" synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Keskeytä synkronointi</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Keskeytä kaikkien kDrive-asemien synkronointi</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Avaa</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Lisää suosikkeihin</translation>
-    </message>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Kopioi jakolinkki</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Näytä kdrive.infomaniak.com-sivustolla</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Näytä kansiossa</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Lisää toimintoja</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Avaa</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Lisää suosikkeihin</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Kopioi jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Näytä kdrive.infomaniak.com-sivustolla</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Näytä kansiossa</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kansion URL-osoitetta %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Avaa kansiossa</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Avaa %1 verkkoversio</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Aseman asetukset</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Ilmoitukset poistettu käytöstä %1 asti</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Poista ilmoitukset käytöstä</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Sovelluksen asetukset</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Tarvitsetko apua</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Lähetä palautetta</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Lopeta kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Verkkosivustolle %1 ei pääse.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Näytä virheet ja tiedotteet</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Näytä tiedotteet</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Lisää toimintoja</translation>
-    </message>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Ei koskaan</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">1 tunnin ajaksi</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Huomiseen klo 8:00 asti</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">3 päivän ajaksi</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">1 viikon ajaksi</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Aina</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">1 tunti lisää</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">3 päivää lisää</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">1 viikko lisää</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Avaa kansiossa</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Avaa %1 verkkoversio</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Aseman asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Ilmoitukset poistettu käytöstä %1 asti</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Poista ilmoitukset käytöstä</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Sovelluksen asetukset</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Tarvitsetko apua</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Lähetä palautetta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Lopeta kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Verkkosivustolle %1 ei pääse.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Näytä virheet ja tiedotteet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Näytä tiedotteet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Lisää toimintoja</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Ei koskaan</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>1 tunnin ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Huomiseen klo 8:00 asti</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>3 päivän ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>1 viikon ajaksi</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Aina</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>1 tunti lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>3 päivää lisää</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>1 viikko lisää</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synkronoitu</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Suosikit</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Toiminta</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kansion URL-osoitetta %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Päivitä</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Päivitystä ladataan</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Etsitään päivitystä...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Manuaalinen päivitys</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Ei saatavilla</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Ei toteutettu!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Linkkiä %1 ei voi avata.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Virheellinen linkki %1.</translation>
-    </message>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Päivitä kDrive-sovellus</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Lataa uusin versio verkkosivustolta.</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Tälle asemalle ei ole synkronoitua kansiota!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">kDrivea ei ole määritetty!</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Voit synkronoida tiedostoja &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synkronoitu</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Suosikit</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Toiminta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Kansion URL-osoitetta %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Päivitä</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Päivitystä ladataan</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Etsitään päivitystä...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Manuaalinen päivitys</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Ei saatavilla</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Ei toteutettu!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Linkkiä %1 ei voi avata.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Virheellinen linkki %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Päivitä kDrive-sovellus</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Tätä kDrive-sovellusversiota ei enää tueta. Päivitä sovellus uusimpiin ominaisuuksiin pääsemiseksi.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Napsauta tästä ladataksesi manuaalisesti&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Lataa uusin versio verkkosivustolta.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Tälle asemalle ei ole synkronoitua kansiota!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>kDrivea ei ole määritetty!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Voit synkronoida tiedostoja &lt;a style="%1" href="%2"&gt;tietokoneeltasi&lt;/a&gt; tai &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;-sivustolla.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Ohita tämä versio</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Muistuta myöhemmin</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Asenna päivitys</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;%2-asiakkaan uusi versio &lt;b&gt;%1&lt;/b&gt; on saatavilla ja ladattu.&lt;/p&gt;&lt;p&gt;Asennettu versio on %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Ohita tämä versio</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Muistuta myöhemmin</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Asenna päivitys</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Uusi päivitys saatavilla.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Versio %1 on ladattavissa.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Uusi päivitys saatavilla.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Versio %1 on ladattavissa.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Lisää tili</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Lisää tili</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Versio</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">PÄIVITÄ</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 on ajan tasalla!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Tarkistetaan päivitystä palvelimelta...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;täältä&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Päivitys on saatavilla: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Ladataan %1. Odota...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Päivitysten tarkistus epäonnistui.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Päivityksen aikana tapahtui virhe.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Päivityksen lataaminen epäonnistui.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Päivitys poistettu käytöstä.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Beta-ohjelma</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Liity</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Muokkaa</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Lopeta</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Näytä julkaisutiedot&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Versio</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>PÄIVITÄ</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 on ajan tasalla!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Tarkistetaan päivitystä palvelimelta...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Päivitys on saatavilla: %1.&lt;br&gt;Lataa se &lt;a style="%2" href="%3"&gt;täältä&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Päivitys on saatavilla: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Ladataan %1. Odota...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Päivitysten tarkistus epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Päivityksen aikana tapahtui virhe.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Päivityksen lataaminen epäonnistui.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Päivitys poistettu käytöstä.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Beta-ohjelma</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Saa varhainen pääsy sovelluksen uusiin versioihin</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Liity</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Muokkaa</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Lopeta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Parametreja ei voi tallentaa!</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Tee saataville paikallisesti</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Vapauta paikallista tilaa</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Peruuta paikallisen tilan vapautus</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Peruuta paikallinen saatavillaolo</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Kopioi julkinen jakolinkki</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Kopioi yksityinen jakolinkki</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Avaa selaimessa</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Kelvollista polkua ei löydy</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Kelvollista kansiota ei ole valittu!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Valittu polku ei ole olemassa!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Valittu polku ei ole kansio!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync (Beta) on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync (Beta) ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync on käytössä. kDriven tiedostot pysyvät pilvessä eivätkä käytä tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync ei ole käytössä. kDriven tiedostot käyttävät tietokoneen tallennustilaa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Parametrien tallentaminen epäonnistui, yritä myöhemmin uudelleen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Parametreja ei voi tallentaa!</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Tee saataville paikallisesti</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Vapauta paikallista tilaa</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Peruuta paikallisen tilan vapautus</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Peruuta paikallinen saatavillaolo</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Tämän tiedoston jakaminen uudelleen ei ole sallittu</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Tämän kansion jakaminen uudelleen ei ole sallittu</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Kopioi julkinen jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Kopioi yksityinen jakolinkki</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Avaa selaimessa</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Ylätason kansio on synkronointikansio tai sisältyy yhteen</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Kelvollista polkua ei löydy</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Kelvollista kansiota ei ole valittu!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Valittu polku ei ole olemassa!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Valittu polku ei ole kansio!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Sinulla ei ole kirjoitusoikeutta valittuun kansioon!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 sisältää jo synkronoidun kansion. Valitse toinen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 on jo synkronoidun kansion sisällä. Valitse toinen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Paikallinen kansio %1 on jo synkronoitu. Valitse toinen!</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>kDrive-sovellus suljetaan kriittisen virheen vuoksi.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n vuosi</numerusform>
-            <numerusform>%n vuotta</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n kuukausi</numerusform>
-            <numerusform>%n kuukautta</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n päivä</numerusform>
-            <numerusform>%n päivää</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n tunti</numerusform>
-            <numerusform>%n tuntia</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minuutti</numerusform>
-            <numerusform>%n minuuttia</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n sekunti</numerusform>
-            <numerusform>%n sekuntia</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
+<name>Utility</name>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n vuosi</numerusform>
+<numerusform>%n vuotta</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n kuukausi</numerusform>
+<numerusform>%n kuukautta</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n päivä</numerusform>
+<numerusform>%n päivää</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n tunti</numerusform>
+<numerusform>%n tuntia</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuutti</numerusform>
+<numerusform>%n minuuttia</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekunti</numerusform>
+<numerusform>%n sekuntia</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Järjestelmäpalkki ei ole käytettävissä</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 vaatii toimivan järjestelmäpalkin. Jos käytät XFCE:tä, noudata &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;näitä ohjeita&lt;/a&gt;. Muussa tapauksessa asenna järjestelmäpalkkisovellus, kuten &apos;trayer&apos;, ja yritä uudelleen.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Järjestelmäpalkki ei ole käytettävissä</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 vaatii toimivan järjestelmäpalkin. Jos käytät XFCE:tä, noudata &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;näitä ohjeita&lt;/a&gt;. Muussa tapauksessa asenna järjestelmäpalkkisovellus, kuten 'trayer', ja yritä uudelleen.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Selainta ei voi avata</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Sähköpostiohjelmaa ei voi avata</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Et ole enää kirjautunut. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Kirjaudu sisään&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Selainta ei voi avata</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Selaimen käynnistäminen URL-osoitteeseen %1 siirtymiseksi epäonnistui. Onko oletusselain määritetty?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Sähköpostiohjelmaa ei voi avata</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Sähköpostiohjelman käynnistäminen uuden viestin luomiseksi epäonnistui. Onko oletussähköpostiohjelma määritetty?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Et ole enää kirjautunut. &lt;a style="%1" href="%2"&gt;Kirjaudu sisään&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Ei synkronoitavaa kansiota
+<translation>Ei synkronoitavaa kansiota
 Voit lisätä sellaisen kDriven asetuksista.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synkronointi käynnissä (%1/%2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synkronointi käynnissä (%1/%2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synkronointi käynnissä (%1/%2)
+<translation>Synkronointi käynnissä (%1/%2)
 %3 jäljellä...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synkronointi käynnissä (vaihe %1/%2).</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Synkronointi alkaa</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synkronointi käynnissä.</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Olet ajan tasalla!</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Joitakin tiedostoja ei voitu synkronoida. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Lue lisää&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synkronointi keskeytymässä...</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synkronointi keskeytetty.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synkronointi käynnissä (vaihe %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synkronointi alkaa</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synkronointi käynnissä.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Olet ajan tasalla, ratkaisemattomia ristiriitoja.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Olet ajan tasalla!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Joitakin tiedostoja ei voitu synkronoida. &lt;a style="%1" href="%2"&gt;Lue lisää&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synkronointi keskeytymässä...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synkronointi keskeytetty.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska toinen synkronointi käyttää samaa kansiota.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se sisältää synkronoidun kansion &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita, koska se on synkronoidun kansion &lt;b&gt;%2&lt;/b&gt; sisällä.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Kansiota &lt;b&gt;%1&lt;/b&gt; ei voi valita synkronointikansioksi. Valitse toinen kansio. Ehdotettu kansio: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Olet sulkenut pois enemmän kuin %1 kansiota, huomaa, että tämä vaikuttaa synkronoinnin suorituskykyyn.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Et voi sulkea pois enemmän kuin %1 kansiota. Poista ylätason kansioiden valinta.</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -1,3096 +1,3096 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="fr_FR" version="2.1">
+<TS version="2.1" language="fr_FR">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>À propos</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>FERMER</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Version %1. Pour plus d’informations, visiter &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribué par %1 et sous licence  &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 et le logo %2 sont des marques déposées de %1. &lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossible d'ouvrir le dossier %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Compilé à partir des &lt;a style="color: #489EF3" href="%1"&gt;sources Git&lt;/a&gt; le %2, %3 en utilisant Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>À propos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>FERMER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Version %1. Pour plus d’informations, visiter &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribué par %1 et sous licence  &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 et le logo %2 sont des marques déposées de %1. &lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossible d&apos;ouvrir le dossier %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Compilé à partir des &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;sources Git&lt;/a&gt; le %2, %3 en utilisant Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>La synchronisation va commencer et vous pourrez ajouter des fichiers à votre dossier %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Votre kDrive est prêt !</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>OUVRIR LE DOSSIER LOCAL</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>PARAMÈTRES</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synchroniser un autre kDrive</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>La synchronisation va commencer et vous pourrez ajouter des fichiers à votre dossier %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Votre kDrive est prêt !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>OUVRIR LE DOSSIER LOCAL</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>PARAMÈTRES</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synchroniser un autre kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Annuler</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>SUIVANT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Sélectionnez le kDrive que vous souhaitez synchroniser</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Obtenez kDrive gratuitement</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Stockez vos photos, documents et e-mails en Suisse auprès d'une société indépendante qui respecte la vie privée. Apprendre encore plus</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Testez gratuitement</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SUIVANT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Sélectionnez le kDrive que vous souhaitez synchroniser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Obtenez kDrive gratuitement</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Stockez vos photos, documents et e-mails en Suisse auprès d&apos;une société indépendante qui respecte la vie privée. Apprendre encore plus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Testez gratuitement</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Economiser l'espace de votre ordinateur</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Décider quels fichiers doivent être disponibles en ligne ou localement.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>PLUS TARD</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>OUI</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>La Lite Sync synchronise tous vos fichiers sans utiliser l'espace de votre ordinateur. Vous pouvez parcourir les fichiers de votre kDrive et les télécharger quand vous le souhaitez. &lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Voulez vous activer la Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Voulez vous activer la Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Economiser l&apos;espace de votre ordinateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Décider quels fichiers doivent être disponibles en ligne ou localement.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>PLUS TARD</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>OUI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>La Lite Sync synchronise tous vos fichiers sans utiliser l&apos;espace de votre ordinateur. Vous pouvez parcourir les fichiers de votre kDrive et les télécharger quand vous le souhaitez. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Voulez vous activer la Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Voulez vous activer la Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Emplacement de votre kDrive %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Modifier le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>TERMINER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Sélectionner le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Le contenu du dossier &lt;b&gt;%1&lt;/b&gt; sera synchronisé sur votre kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Vous retrouverez tous vos fichiers dans ce dossier une fois la configuration terminée. Vous pouvez y glisser de nouveaux fichiers pour les synchroniser avec votre kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Emplacement de votre kDrive %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Modifier le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>TERMINER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Sélectionner le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Le contenu du dossier &lt;b&gt;%1&lt;/b&gt; sera synchronisé sur votre kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Vous retrouverez tous vos fichiers dans ce dossier une fois la configuration terminée. Vous pouvez y glisser de nouveaux fichiers pour les synchroniser avec votre kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Ce dossier n'est pas compatible avec Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ce dossier n&apos;est pas compatible avec Lite Sync.&lt;br&gt;
 Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désactivé.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>CONTINUER</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Connectez-vous depuis votre navigateur</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Votre navigateur devrait s'ouvrir automatiquement pour établir la connexion. Une fois connecté, vous serez automatiquement redirigé vers kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Ouvrir la page de connexion</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Une erreur est survenue pendant l'authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l'erreur persiste, contactez notre équipe de support.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>La connexion a échoué : %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Impossible d'ouvrir la page de connexion dans votre navigateur Web</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Connectez-vous depuis votre navigateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Votre navigateur devrait s&apos;ouvrir automatiquement pour établir la connexion. Une fois connecté, vous serez automatiquement redirigé vers kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Ouvrir la page de connexion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Une erreur est survenue pendant l&apos;authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l&apos;erreur persiste, contactez notre équipe de support.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>La connexion a échoué&#xa0;: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Impossible d&apos;ouvrir la page de connexion dans votre navigateur Web</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Sélectionnez les dossiers kDrive à synchroniser sur votre ordinateur</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>CONTINUER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Espace disponible sur votre ordinateur : %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Une erreur s'est produite lors du chargement de la liste des sous-dossiers.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Impossible de charger la liste des sous-dossiers. Votre kDrive est peut-être en maintenance.&lt;br&gt;Veuillez vous connecter à la &lt;a style="%1" href="%2"&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Sélectionnez les dossiers kDrive à synchroniser sur votre ordinateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Espace disponible sur votre ordinateur : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Une erreur s&apos;est produite lors du chargement de la liste des sous-dossiers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Impossible de charger la liste des sous-dossiers. Votre kDrive est peut-être en maintenance.&lt;br&gt;Veuillez vous connecter à la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>La création du dossier local %1 a échoué</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Impossible de créer une nouvelle synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>Le kDrive %1 est déjà synchronisé sur cet ordinateur. Continuer quand même?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>La création du dossier local %1 a échoué</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Impossible de créer une nouvelle synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Le kDrive %1 est déjà synchronisé sur cet ordinateur. Continuer quand même?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>Le client kDrive est exécuté avec de mauvais paramètres!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>Le client kDrive est déjà en cours d'exécution !</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>L'utilisateur %1 n'est pas connecté. Veuillez vous reconnecter.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>Le client kDrive est exécuté avec de mauvais paramètres!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Le client kDrive est déjà en cours d&apos;exécution&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>L&apos;utilisateur %1 n&apos;est pas connecté. Veuillez vous reconnecter.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Lien de partage copié dans le presse-papiers</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 a été supprimé.</numerusform>
-<numerusform>%1 et %n autres fichiers ont été supprimés.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 a été supprimé.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
-<numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 a été ajouté.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 a été mis à jour.</numerusform>
-<numerusform>%1 et %n autres fichiers ont été mis à jour.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 a été mis à jour.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 a été déplacé vers %2.</numerusform>
-<numerusform>%1 a été déplacé vers %2 et  %n autres fichiers ont été déplacés.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 a été déplacé vers %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Activité de synchronisation</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Lien de partage copié dans le presse-papiers</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 a été supprimé.</numerusform>
+            <numerusform>%1 et %n autres fichiers ont été supprimés.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 a été supprimé.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
+            <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 a été ajouté.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 a été mis à jour.</numerusform>
+            <numerusform>%1 et %n autres fichiers ont été mis à jour.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 a été mis à jour.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 a été déplacé vers %2.</numerusform>
+            <numerusform>%1 a été déplacé vers %2 et  %n autres fichiers ont été déplacés.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 a été déplacé vers %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Activité de synchronisation</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Aucun sous-dossier sur le serveur.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Aucun sous-dossier sur le serveur.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Quitter le programme bêta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Rejoindre le programme bêta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Bénéficiez d'un accès anticipé aux nouvelles versions de l'application avant qu'elles ne soient diffusées au grand public et participez à l'amélioration de l'application en nous faisant part de vos commentaires.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Bénéficier des mises à jour de la version bêta des applications</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Non</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Version bêta publique</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Version bêta interne</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Version de test</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Je comprends</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Êtes-vous sûr de vouloir quitter le programme bêta ?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Enregistrer</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Annuler</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Votre version actuelle de l'application est peut-être trop récente, votre choix sera effectif lorsque la prochaine mise à jour sera disponible.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Les versions bêta peuvent quitter de manière inattendue ou provoquer des instabilités.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Quitter le programme bêta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Rejoindre le programme bêta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Bénéficiez d&apos;un accès anticipé aux nouvelles versions de l&apos;application avant qu&apos;elles ne soient diffusées au grand public et participez à l&apos;amélioration de l&apos;application en nous faisant part de vos commentaires.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Bénéficier des mises à jour de la version bêta des applications</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Non</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Version bêta publique</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Version bêta interne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Version de test</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Je comprends</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Êtes-vous sûr de vouloir quitter le programme bêta ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Enregistrer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Votre version actuelle de l&apos;application est peut-être trop récente, votre choix sera effectif lorsque la prochaine mise à jour sera disponible.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Les versions bêta peuvent quitter de manière inattendue ou provoquer des instabilités.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Échec de la résolution des conflits sur %1 élément(s) dans le dossier de synchronisation : %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Veuillez vous connecter</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Dossier %1 : %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Aucun dossier à synchroniser n'est configuré.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Synthèse</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translatorcomment>Préférences</translatorcomment>
-<translation>Préférences</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Quitter</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Statut indéfini.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>En attente de synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synchronisation en cours.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synchronisation réussie, conflits non résolus.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Synchronisation terminée avec succès.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Abandon par l'utilisateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>La synchronisation est en pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synchronisation en pause)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque :&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>SUPPRIMER TOUTES LES SYNC</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 éléments ont été supprimés de votre dossier de synchronisation local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Pour éviter les suppressions involontaires, la synchronisation a été mise en pause.&lt;br&gt;Voulez-vous propager ces suppressions vers votre kDrive ?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Plusieurs fichiers ont été supprimés de votre dossier de synchronisation local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Les fichiers supprimés se trouvent dans la &lt;a style="%1" href="%3"&gt;corbeille&lt;/a&gt; de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Ne plus afficher</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Échec du démarrage des synchronisations !</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Impossible d'initialiser le client kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>La synchronisation est en pause</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Échec de la résolution des conflits sur %1 élément(s) dans le dossier de synchronisation : %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Veuillez vous connecter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Dossier %1 : %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Aucun dossier à synchroniser n&apos;est configuré.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Synthèse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Préférences</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Quitter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Statut indéfini.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>En attente de synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synchronisation en cours.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synchronisation réussie, conflits non résolus.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Synchronisation terminée avec succès.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Abandon par l&apos;utilisateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>La synchronisation est en pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synchronisation en pause)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque&#xa0;:&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>SUPPRIMER TOUTES LES SYNC</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 éléments ont été supprimés de votre dossier de synchronisation local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Pour éviter les suppressions involontaires, la synchronisation a été mise en pause.&lt;br&gt;Voulez-vous propager ces suppressions vers votre kDrive&#xa0;?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Plusieurs fichiers ont été supprimés de votre dossier de synchronisation local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Les fichiers supprimés se trouvent dans la &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;corbeille&lt;/a&gt; de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Ne plus afficher</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Échec du démarrage des synchronisations&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Impossible d&apos;initialiser le client kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>La synchronisation est en pause</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Résumé de la synchronisation de votre dossier local</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Le contenu du dossier sur votre ordinateur sera synchronisé avec le dossier du kDrive sélectionné et inversement.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNCHRONISER</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Résumé de la synchronisation de votre dossier local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Le contenu du dossier sur votre ordinateur sera synchronisé avec le dossier du kDrive sélectionné et inversement.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNCHRONISER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Avant de terminer</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Suivez les étapes suivantes pour assurer le bon fonctionnement de la Lite Sync sur votre ordinateur et terminer la configuration du kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ouvrez les &lt;b&gt;Paramètres généraux&lt;/b&gt; de votre Mac ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ouvrez les &lt;b&gt;paramètres de confidentialité et de sécurité&lt;/b&gt; de votre Mac ou &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ouvrez les &lt;b&gt;Paramètres de sécurité et confidentialité&lt;/b&gt; de votre Mac ou  &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Allez dans la section &lt;b&gt;"Éléments de connexion et extensions"&lt;/b&gt;, puis dans &lt;b&gt;"Extensions de sécurité de point de terminaison"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Autoriser l'application kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Allez dans la section &lt;b&gt;"Sécurité"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Autoriser l'application kDrive dans la case indiquant que kDrive a été bloqué</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Déverrouillez le cadenas &lt;img src=":/client/resources/icons/actions/lock.png"&gt; et autorisez l’application kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Allez dans la section &lt;b&gt;"Confidentialité et sécurité"&lt;/b&gt; et cliquez sur &lt;b&gt;"Accès complet au disque"&lt;/b&gt; ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Toujours dans les paramètres de sécurité et de confidentialité, ouvrez l'onglet &lt;b&gt;"Confidentialité"&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Cochez la case "kDrive LiteSync Extension" puis la case "kDrive.app" (si pas déjà cochée)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Un redémarrage de l'application pourra vous être proposé, dans ce cas acceptez-le</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Cochez la case "kDrive LiteSync Extension" (et "kDrive.app si elle existe) dans &lt;b&gt;"Accès complet au disque"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>ÉTAPE 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Effectuée)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>ÉTAPE 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>ÉTAPES EFFECTUÉES</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>TERMINER</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Avant de terminer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Suivez les étapes suivantes pour assurer le bon fonctionnement de la Lite Sync sur votre ordinateur et terminer la configuration du kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ouvrez les &lt;b&gt;Paramètres généraux&lt;/b&gt; de votre Mac ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ouvrez les &lt;b&gt;paramètres de confidentialité et de sécurité&lt;/b&gt; de votre Mac ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ouvrez les &lt;b&gt;Paramètres de sécurité et confidentialité&lt;/b&gt; de votre Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Allez dans la section &lt;b&gt;&quot;Éléments de connexion et extensions&quot;&lt;/b&gt;, puis dans &lt;b&gt;&quot;Extensions de sécurité de point de terminaison&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autoriser l&apos;application kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Allez dans la section &lt;b&gt;&quot;Sécurité&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autoriser l&apos;application kDrive dans la case indiquant que kDrive a été bloqué</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Déverrouillez le cadenas &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; et autorisez l’application kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Allez dans la section &lt;b&gt;&quot;Confidentialité et sécurité&quot;&lt;/b&gt; et cliquez sur &lt;b&gt;&quot;Accès complet au disque&quot;&lt;/b&gt; ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Toujours dans les paramètres de sécurité et de confidentialité, ouvrez l&apos;onglet &lt;b&gt;&quot;Confidentialité&quot;&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Cochez la case &quot;kDrive LiteSync Extension&quot; puis la case &quot;kDrive.app&quot; (si pas déjà cochée)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Un redémarrage de l&apos;application pourra vous être proposé, dans ce cas acceptez-le</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Cochez la case &quot;kDrive LiteSync Extension&quot; (et &quot;kDrive.app si elle existe) dans &lt;b&gt;&quot;Accès complet au disque&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>ÉTAPE 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Effectuée)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>ÉTAPE 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>ÉTAPES EFFECTUÉES</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>TERMINER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>OUI</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NON</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>OUI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NON</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Envoi des informations de débogage</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Annuler</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Envoi des informations de débogage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Information</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Débogage</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Avertissement</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Erreur</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Fatal</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Paramètres de débogage</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Enregistrer les informations de débogage dans un dossier sur mon ordinateur (recommandé)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Ces informations permettent au support informatique de déterminer l’origine d’un incident.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Niveau de débogage</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Le niveau de trace vous permet de choisir l'étendue des informations de débogage enregistrées</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Le journal complet étendu collecte un historique détaillé qui peut être utilisé pour le débogage. L'activer peut ralentir l'application kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Journal complet étendu</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Supprimer les journaux datant de plus de %1 jours</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Partagez le dossier debug avec le support Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>La dernière session est la période depuis le dernier démarrage de kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Partager uniquement la dernière session kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Chargement</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Annuler</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>ENREGISTRER</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Échec du partage</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Vérifiez que vous êtes connecté &lt;br&gt;2. Vérifiez que vous avez configuré au moins un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Connexion interrompue)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Partager le dossier avec SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Nous avons automatiquement compressé votre journal &lt;a style="%1" href="%2"&gt;ici&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Transférez l'archive avec &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Partagez le lien avec &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Dernier envoi le %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Le partage a été annulé</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Le journal complet étendu est activé via la variable d'environnement KDRIVE_FORCE_EXTENDED_LOG. Définissez-la à 0 pour le désactiver.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Le dossier entier est volumineux (&gt; 100 Mo) et son partage peut prendre un certain temps. Pour réduire le temps de partage, nous vous recommandons de ne partager que la dernière session kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%2/%1/%3 à %4h%5 et %6s</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Voulez-vous enregistrer vos modifications ?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossible d'ouvrir le dossier %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Partager</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Partage | étape 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Partage | étape 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Annulation...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Débogage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Avertissement</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Paramètres de débogage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Enregistrer les informations de débogage dans un dossier sur mon ordinateur (recommandé)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Ces informations permettent au support informatique de déterminer l’origine d’un incident.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Niveau de débogage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Le niveau de trace vous permet de choisir l&apos;étendue des informations de débogage enregistrées</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Le journal complet étendu collecte un historique détaillé qui peut être utilisé pour le débogage. L&apos;activer peut ralentir l&apos;application kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Journal complet étendu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Supprimer les journaux datant de plus de %1 jours</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Partagez le dossier debug avec le support Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>La dernière session est la période depuis le dernier démarrage de kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Partager uniquement la dernière session kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Chargement</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Échec du partage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Vérifiez que vous êtes connecté &lt;br&gt;2. Vérifiez que vous avez configuré au moins un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Connexion interrompue)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Partager le dossier avec SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Nous avons automatiquement compressé votre journal &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ici&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Transférez l&apos;archive avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Partagez le lien avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Dernier envoi le %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Le partage a été annulé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Le journal complet étendu est activé via la variable d&apos;environnement KDRIVE_FORCE_EXTENDED_LOG. Définissez-la à 0 pour le désactiver.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Le dossier entier est volumineux (&gt; 100 Mo) et son partage peut prendre un certain temps. Pour réduire le temps de partage, nous vous recommandons de ne partager que la dernière session kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%2/%1/%3 à %4h%5 et %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Voulez-vous enregistrer vos modifications ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossible d&apos;ouvrir le dossier %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Partager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Partage | étape 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Partage | étape 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Annulation...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Dossiers</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Notifications</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Une notification sera affichée dès qu’un nouveau dossier aura été synchronisé ou modifié</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Connecté avec</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Voulez-vous vraiment arrêter de synchroniser le dossier &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note :&lt;/b&gt; &lt;/b&gt;Aucun&lt;/b&gt; fichier ne sera supprimé.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Cette opération peut prendre de quelques secondes à quelques minutes en fonction de la taille du dossier.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>La synchronisation du nouveau dossier local a échoué!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>L'activation de la Lite Sync a échoué.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>La désactivation de la Lite Sync a échoué.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>SUPPRIMER LA SYNC. DU DOSSIER</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Une erreur s'est produite lors du chargement de la liste des sous-dossiers.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Activer les notifications pour ce kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>CONFIRMER</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Erreurs et informations de synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synchroniser un dossier local</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Voulez-vous vraiment activer la Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Voulez vous vraiment désactiver la Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Vous n'avez pas assez de place pour synchroniser tous les fichiers sur votre kDrive (manque %1). Si vous désactivez la Lite Sync, vous devrez sélectionner les dossiers à synchroniser sur votre ordinateur. Dans un premier temps, la synchronisation de votre kDrive sera mise en pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Si vous désactivez la Lite Sync, tous les fichiers seront téléchargés sur votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Impossible de créer une nouvelle synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync activée.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync désactivée.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Ce lecteur est en cours de suppression.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Impossible d'ouvrir le poste %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Échec de l'arrêt de la synchronisation du dossier &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Supprimer toutes les synchronisations</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Recherche dans votre kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Recherche</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Dossiers</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Notifications</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Une notification sera affichée dès qu’un nouveau dossier aura été synchronisé ou modifié</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Connecté avec</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Voulez-vous vraiment arrêter de synchroniser le dossier &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note :&lt;/b&gt; &lt;/b&gt;Aucun&lt;/b&gt; fichier ne sera supprimé.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Cette opération peut prendre de quelques secondes à quelques minutes en fonction de la taille du dossier.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>La synchronisation du nouveau dossier local a échoué!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>L&apos;activation de la Lite Sync a échoué.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>La désactivation de la Lite Sync a échoué.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>SUPPRIMER LA SYNC. DU DOSSIER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Une erreur s&apos;est produite lors du chargement de la liste des sous-dossiers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Activer les notifications pour ce kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Erreurs et informations de synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synchroniser un dossier local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Voulez-vous vraiment activer la Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Voulez vous vraiment désactiver la Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Vous n&apos;avez pas assez de place pour synchroniser tous les fichiers sur votre kDrive (manque %1). Si vous désactivez la Lite Sync, vous devrez sélectionner les dossiers à synchroniser sur votre ordinateur. Dans un premier temps, la synchronisation de votre kDrive sera mise en pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Si vous désactivez la Lite Sync, tous les fichiers seront téléchargés sur votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Impossible de créer une nouvelle synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync activée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync désactivée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Ce lecteur est en cours de suppression.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Impossible d&apos;ouvrir le poste %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Échec de l&apos;arrêt de la synchronisation du dossier &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Supprimer toutes les synchronisations</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Recherche dans votre kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Recherche</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synchroniser un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Ajouter un kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synchroniser un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Ajouter un kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Résoudre</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Elément(s) en conflit</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Élément(s) contenant des caractères non pris en charge</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Vider l'historique</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>A résoudre</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Résolu automatiquement</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problème(s) résolu(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>problème(s) détecté(s)</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Résoudre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elément(s) en conflit</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Élément(s) contenant des caractères non pris en charge</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Vider l&apos;historique</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>A résoudre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Résolu automatiquement</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problème(s) résolu(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>problème(s) détecté(s)</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Conflits ou erreurs de synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Erreurs</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Retour aux préférences</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Conflits ou erreurs de synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Erreurs</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Retour aux préférences</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Certains fichiers n’ont pas pu être synchronisés sur le kDrive suivant :</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 erreur(s))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 information(s))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 erreur(s) et %2 information(s))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Erreurs génériques (%n avertissement ou erreur)</numerusform>
-<numerusform>Erreurs génériques (%n avertissements ou erreurs)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Certains fichiers n’ont pas pu être synchronisés sur le kDrive suivant :</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 erreur(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 information(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 erreur(s) et %2 information(s))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Erreurs génériques (%n avertissement ou erreur)</numerusform>
+            <numerusform>Erreurs génériques (%n avertissements ou erreurs)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Fichiers exclus</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Ajoutez des fichiers ou des dossiers qui ne seront pas synchronisés sur votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Ajouter</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NOM</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>AVERTISSEMENT</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>ENREGISTRER</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Voulez-vous enregistrer vos modifications ?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Le modèle d'exclusion existe déjà !</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Voulez-vous vraiment supprimer ?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Impossible d'enregistrer les modifications !</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Fichiers exclus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Ajoutez des fichiers ou des dossiers qui ne seront pas synchronisés sur votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Ajouter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NOM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>AVERTISSEMENT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Voulez-vous enregistrer vos modifications ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Le modèle d&apos;exclusion existe déjà&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Voulez-vous vraiment supprimer ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Impossible d&apos;enregistrer les modifications !</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>VALIDER</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VALIDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Résoudre le(s) conflit(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Que voulez-vous faire avec les %1 éléments en conflit ?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Enregistrer mes modifications et remplacer les versions des autres utilisateurs.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Annuler mes modifications et conserver les versions des autres utilisateurs.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Vos modifications peuvent être supprimées définitivement. Elles ne peuvent pas être restaurées à partir de l'application Web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Vos modifications seront définitivement supprimées. Elles ne pourront pas être restaurées à partir de l'application Web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Voir l'(les) élément(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>VALIDER</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Des modifications ont été apportées à ces fichiers par plusieurs utilisateurs à plusieurs endroits (en ligne sur kDrive, un ordinateur ou un mobile). Les dossiers contenant ces fichiers peuvent également avoir été supprimés.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>La version locale de votre élément &lt;b&gt;n'est pas synchronisée&lt;/b&gt; avec kDrive. &lt;a style="color: #489EF3" href="%1"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Résoudre le(s) conflit(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Que voulez-vous faire avec les %1 éléments en conflit&#xa0;?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Enregistrer mes modifications et remplacer les versions des autres utilisateurs.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Annuler mes modifications et conserver les versions des autres utilisateurs.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Vos modifications peuvent être supprimées définitivement. Elles ne peuvent pas être restaurées à partir de l&apos;application Web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Vos modifications seront définitivement supprimées. Elles ne pourront pas être restaurées à partir de l&apos;application Web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Voir l&apos;(les) élément(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VALIDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Des modifications ont été apportées à ces fichiers par plusieurs utilisateurs à plusieurs endroits (en ligne sur kDrive, un ordinateur ou un mobile). Les dossiers contenant ces fichiers peuvent également avoir été supprimés.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>La version locale de votre élément &lt;b&gt;n&apos;est pas synchronisée&lt;/b&gt; avec kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Autres actions</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synchronisé dans &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Activer la Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Activer la Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Les dossiers non sélectionnés seront déplacés vers la corbeille s'ils contiennent des éléments hors ligne. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Les dossiers non sélectionnés seront déplacés vers la corbeille. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Les dossiers non sélectionnés seront supprimés &lt;b&gt;définitivement&lt;/b&gt; de l'ordinateur. Les dossiers synchronisés sur kDrive resteront disponibles en ligne.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Annuler</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>VALIDER</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Mettre en pause la synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Désactiver Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Reprendre la synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Supprimer la synchronisation</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Autres actions</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synchronisé dans &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Activer la Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Activer la Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Les dossiers non sélectionnés seront déplacés vers la corbeille s&apos;ils contiennent des éléments hors ligne. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Les dossiers non sélectionnés seront déplacés vers la corbeille. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Les dossiers non sélectionnés seront supprimés &lt;b&gt;définitivement&lt;/b&gt; de l&apos;ordinateur. Les dossiers synchronisés sur kDrive resteront disponibles en ligne.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Annuler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VALIDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Mettre en pause la synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Désactiver Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Reprendre la synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Supprimer la synchronisation</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossible d'ouvrir le chemin du dossier %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossible d&apos;ouvrir le chemin du dossier %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Identifiant de l'application</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Nom de l'application</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>VALIDER</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Identifiant de l&apos;application</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nom de l&apos;application</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VALIDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Certaines applications (sauvegarde, anti-virus...) accèdent à vos fichiers, ce qui entraîne leur téléchargement lorsqu'ils sont "en ligne". Ajoutez-les dans la liste ci-dessous pour éviter ce comportement.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Ajouter</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ID DE L'APPLICATION</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NOM</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>ENREGISTRER</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Voulez-vous enregistrer vos modifications ?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Voulez-vous vraiment supprimer ?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Impossible d'enregistrer les modifications !</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Certaines applications (sauvegarde, anti-virus...) accèdent à vos fichiers, ce qui entraîne leur téléchargement lorsqu&apos;ils sont &quot;en ligne&quot;. Ajoutez-les dans la liste ci-dessous pour éviter ce comportement.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Ajouter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID DE L&apos;APPLICATION</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NOM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Voulez-vous enregistrer vos modifications ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Voulez-vous vraiment supprimer ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Impossible d&apos;enregistrer les modifications !</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Quel dossier de votre ordinateur voulez-vous&lt;br&gt;synchroniser ?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Le contenu de ce dossier sera synchronisé sur le kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Sélectionner un dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Modifier le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>CONTINUER</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Quel dossier de votre ordinateur voulez-vous&lt;br&gt;synchroniser ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Le contenu de ce dossier sera synchronisé sur le kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Sélectionner un dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Modifier le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Ce dossier n'est pas compatible avec Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ce dossier n&apos;est pas compatible avec Lite Sync.&lt;br&gt;
 Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désactivé.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Sélectionner le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Sélectionner le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Erreur</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Le fichier '%1'&lt;br/&gt;ne peut être ouvert en écriture.&lt;br/&gt;&lt;br/&gt;Le fichier de journalisation &lt;b&gt;ne peut pas&lt;/b&gt; être enregistré !&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Erreur</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Le fichier &apos;%1&apos;&lt;br/&gt;ne peut être ouvert en écriture.&lt;br/&gt;&lt;br/&gt;Le fichier de journalisation &lt;b&gt;ne peut pas&lt;/b&gt; être enregistré !&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Préférences</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Aide</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Préférences</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Aide</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Transmission effectuée !&lt;br&gt;Veuillez vous référer à l'identifiant &lt;b&gt;%1&lt;/b&gt; dans vos rapports de bugs.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Aucun kDrive configuré !</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Échec de la transmission !
-Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Il semble que votre connexion réseau soit configurée avec un délai d'expiration trop court pour que l'application fonctionne correctement (erreur %1).&lt;br&gt;Veuillez vérifier votre configuration réseau.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Impossible de se connecter au serveur kDrive (erreur %1).&lt;br&gt;Tentative de reconnexion. Veuillez vérifier votre connexion Internet et votre pare-feu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Veuillez vous reconnecter et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Une nouvelle version de l'application est disponible.&lt;br&gt;Veuillez mettre à jour l'application pour continuer à l'utiliser.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Le téléchargement du journal a échoué (erreur %1).&lt;br&gt;Veuillez réessayer plus tard.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Le dossier de synchronisation n'est plus accessible (erreur %1).&lt;br&gt;La synchronisation reprendra dès que le dossier sera accessible.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Le dossier de synchronisation a été remplacé ou déplacé d'une manière qui empêche la synchronisation (erreur %1).&lt;br&gt;Cela peut se produire après avoir copié, déplacé ou restauré le dossier.&lt;br&gt;Pour résoudre ce problème, veuillez créer une nouvelle synchronisation avec un nouveau dossier.&lt;br&gt;Note : si vous avez des modifications non synchronisées dans l'ancien dossier, vous devrez les copier manuellement dans le nouveau.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Il ne reste plus assez de mémoire sur votre machine.&lt;br&gt;La synchronisation a été arrêtée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive doit disposer d'un accès en écriture au répertoire temporaire de votre ordinateur.&lt;br&gt;Veuillez redémarrer l'application kDrive pour résoudre ce problème.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Une erreur technique s'est produite. La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Le nombre d'observateurs inotify est insuffisant (erreur %1).&lt;br&gt;Vous pouvez augmenter ce nombre en éditant '/etc/sysctl.conf'.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Vous devez autoriser:&lt;br&gt;- kDrive dans Paramètres système &gt;&gt; Général &gt;&gt; Éléments de connexion et extensions &gt;&gt; Extensions Endpoint Security&lt;br&gt;- Extension kDrive LiteSync dans Paramètres système &gt;&gt; Confidentialité et sécurité &gt;&gt; Accès complet au disque.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossible de démarrer le plug-in Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l'extension Lite Sync est installée et que le service Windows Search est activé.&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l'extension Lite Sync dispose des autorisations appropriées et est en cours d'exécution.&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Un fichier ou un dossier dans votre dossier de synchronisation semble être corrompu.&lt;br&gt;La synchronisation a été arrêtée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Le kDrive est en mode maintenance.&lt;br&gt;La synchronisation recommencera dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Le kDrive est bloqué.&lt;br&gt;Veuillez renouveler le kDrive. Si aucune action n'est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Le kDrive est bloqué.&lt;br&gt;Veuillez contacter un administrateur pour renouveler le kDrive. Si aucune action n'est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Le kDrive est en cours de réveil.&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe de support si l’erreur persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la &lt;a style="%1" href="%2"&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la version web pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Vous n'êtes pas autorisé à accéder à ce kDrive.&lt;br&gt;La synchronisation a été suspendue. Veuillez contacter un administrateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Les connexions réseau ont été interrompues par le noyau (erreur %1).&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Malheureusement, votre ancienne configuration n'a pas pu être migrée.&lt;br&gt;L'application utilisera une configuration vierge.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Malheureusement, votre ancienne configuration de proxy n'a pas pu être migrée, les proxys SOCKS5 ne sont pas pris en charge pour le moment.&lt;br&gt;L'application utilisera à la place les paramètres de proxy du système.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;La synchronisation a été redémarrée. Veuillez vider l'historique et si l'erreur persiste, veuillez contacter notre équipe d'assistance.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Une erreur d'accès à la base de données de synchronisation s'est produite (erreur %1).&lt;br&gt;La synchronisation a été arrêtée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Jeton invalide ou révoqué.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Les synchronisations imbriquées sont interdites (erreur %1).&lt;br&gt;Vous ne devez conserver que les synchronisations dont les dossiers ne sont pas imbriqués.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Le dossier de synchronisation sur le kDrive distant n'existe plus ou n'est plus accessible (erreur %1).&lt;br&gt;Vous devez le restaurer ou lui redonner des droits d'accès ou supprimer/recréer la synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Erreur d'analyse du nom de fichier (erreur %1).&lt;br&gt;Les caractères spéciaux tels que les guillemets doubles, les barres obliques inverses ou les retours de ligne peuvent provoquer des échecs d'analyse.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Vous n'êtes pas autorisé à créer cet élément, ou un autre élément portant le même nom existe déjà. L'élément a été ignoré.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Vous n'êtes pas autorisé à déplacer l'élément vers "%1".&lt;br&gt;Il sera restauré dans son dossier parent d'origine.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>L'espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;Le téléchargement a été annulé.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Impossible de créer le fichier « %1 » car il n'est pas pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Cet élément a été déplacé ailleurs.&lt;br&gt;L'opération locale a été annulée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L'élément local a été renommé.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L'opération locale a été annulée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>L'espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;La synchronisation a été interrompue.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Le fichier a été modifié au même moment par un autre utilisateur.&lt;br&gt;Vos modifications ont été enregistrées dans une copie.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Un autre utilisateur a déplacé un dossier parent de la destination.&lt;br&gt;L'opération locale a été annulée.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Le nom de l'élément ne contient que des espaces.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Vous n'êtes pas autorisé à modifier l'élément.&lt;br&gt;Le fichier contenant vos modifications a été renommé et exclu de la synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Vous n'êtes pas autorisé à renommer l'élément.&lt;br&gt;Il sera restauré avec son nom d'origine.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Vous n'êtes pas autorisé à supprimer l'élément.&lt;br&gt;Il sera restauré à son emplacement d'origine.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Échec du déplacement de cet élément vers la corbeille, il a été mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Le fichier a été modifié localement alors qu’il a été supprimé sur le kDrive distant.&lt;br&gt;Une copie locale a été enregistrée dans le dossier de récupération (rescue folder).</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>L'opération effectuée sur l'élément est interdite.&lt;br&gt;L'article a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>L'opération effectuée sur cet élément a échoué.&lt;br&gt;L'article a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Le fichier est trop volumineux pour être téléchargé. Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Impossible de télécharger le fichier.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Vous avez dépassé votre quota. Augmentez votre quota d'espace pour réactiver le téléchargement de fichiers.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Le disque contenant votre dossier de synchronisation n’est plus connecté (erreur %1).&lt;br&gt;Veuillez le reconnecter pour reprendre la synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Le processus LiteSyncExt n'est pas en cours d'exécution. La synchronisation reprendra dès son démarrage.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Un élément existant a un nom identique avec les mêmes options de casse (mêmes lettres majuscules et minuscules).&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Le nom de l'élément contient un caractère non pris en charge.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Le nom de l'élément se termine par un espace, ce qui est interdit sur votre système d'exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Ce nom d'élément est réservé par votre système d'exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Le nom de l'élément est trop long.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Le chemin de l'élément est trop long.&lt;br&gt;Il a été ignoré.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Le nom de l'élément contient un caractère UNICODE récent qui n'est pas encore pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Échec de la synchronisation de cet élément. Il a été temporairement mis sur liste noire.&lt;br&gt;Une autre tentative de synchronisation sera effectuée dans une heure ou au prochain démarrage de l'application.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Cet élément a été exclu de la synchronisation par un modèle personnalisé. Vous pouvez désactiver ce type de notification dans les préférences</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Cet article a été exclu de la synchronisation parce qu'il s'agit d'un lien dur.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Cet item est actuellement verrouillé par un autre utilisateur en ligne. Nous réessayerons de télécharger vos modifications plus tard.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Erreur de synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Impossible d'accéder à l'élément.&lt;br&gt;Veuillez corriger les autorisations de lecture et d'écriture.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Erreur système.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>L'élément existe déjà de l'autre côté.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Une erreur technique s'est produite.&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Transmission effectuée !&lt;br&gt;Veuillez vous référer à l&apos;identifiant &lt;b&gt;%1&lt;/b&gt; dans vos rapports de bugs.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Aucun kDrive configuré !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Échec de la transmission&#xa0;!
+Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Il semble que votre connexion réseau soit configurée avec un délai d&apos;expiration trop court pour que l&apos;application fonctionne correctement (erreur %1).&lt;br&gt;Veuillez vérifier votre configuration réseau.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Impossible de se connecter au serveur kDrive (erreur %1).&lt;br&gt;Tentative de reconnexion. Veuillez vérifier votre connexion Internet et votre pare-feu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Veuillez vous reconnecter et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Une nouvelle version de l&apos;application est disponible.&lt;br&gt;Veuillez mettre à jour l&apos;application pour continuer à l&apos;utiliser.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Le téléchargement du journal a échoué (erreur %1).&lt;br&gt;Veuillez réessayer plus tard.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Le dossier de synchronisation n&apos;est plus accessible (erreur %1).&lt;br&gt;La synchronisation reprendra dès que le dossier sera accessible.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Le dossier de synchronisation a été remplacé ou déplacé d&apos;une manière qui empêche la synchronisation (erreur %1).&lt;br&gt;Cela peut se produire après avoir copié, déplacé ou restauré le dossier.&lt;br&gt;Pour résoudre ce problème, veuillez créer une nouvelle synchronisation avec un nouveau dossier.&lt;br&gt;Note : si vous avez des modifications non synchronisées dans l&apos;ancien dossier, vous devrez les copier manuellement dans le nouveau.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Il ne reste plus assez de mémoire sur votre machine.&lt;br&gt;La synchronisation a été arrêtée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive doit disposer d&apos;un accès en écriture au répertoire temporaire de votre ordinateur.&lt;br&gt;Veuillez redémarrer l&apos;application kDrive pour résoudre ce problème.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Une erreur technique s&apos;est produite. La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Le nombre d&apos;observateurs inotify est insuffisant (erreur %1).&lt;br&gt;Vous pouvez augmenter ce nombre en éditant &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Vous devez autoriser:&lt;br&gt;- kDrive dans Paramètres système &gt;&gt; Général &gt;&gt; Éléments de connexion et extensions &gt;&gt; Extensions Endpoint Security&lt;br&gt;- Extension kDrive LiteSync dans Paramètres système &gt;&gt; Confidentialité et sécurité &gt;&gt; Accès complet au disque.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossible de démarrer le plug-in Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l&apos;extension Lite Sync est installée et que le service Windows Search est activé.&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l&apos;extension Lite Sync dispose des autorisations appropriées et est en cours d&apos;exécution.&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Un fichier ou un dossier dans votre dossier de synchronisation semble être corrompu.&lt;br&gt;La synchronisation a été arrêtée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Le kDrive est en mode maintenance.&lt;br&gt;La synchronisation recommencera dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Le kDrive est bloqué.&lt;br&gt;Veuillez renouveler le kDrive. Si aucune action n&apos;est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Le kDrive est bloqué.&lt;br&gt;Veuillez contacter un administrateur pour renouveler le kDrive. Si aucune action n&apos;est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Le kDrive est en cours de réveil.&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe de support si l’erreur persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la version web pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Vous n&apos;êtes pas autorisé à accéder à ce kDrive.&lt;br&gt;La synchronisation a été suspendue. Veuillez contacter un administrateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Les connexions réseau ont été interrompues par le noyau (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Malheureusement, votre ancienne configuration n&apos;a pas pu être migrée.&lt;br&gt;L&apos;application utilisera une configuration vierge.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Malheureusement, votre ancienne configuration de proxy n&apos;a pas pu être migrée, les proxys SOCKS5 ne sont pas pris en charge pour le moment.&lt;br&gt;L&apos;application utilisera à la place les paramètres de proxy du système.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation a été redémarrée. Veuillez vider l&apos;historique et si l&apos;erreur persiste, veuillez contacter notre équipe d&apos;assistance.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Une erreur d&apos;accès à la base de données de synchronisation s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation a été arrêtée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Jeton invalide ou révoqué.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Les synchronisations imbriquées sont interdites (erreur %1).&lt;br&gt;Vous ne devez conserver que les synchronisations dont les dossiers ne sont pas imbriqués.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Le dossier de synchronisation sur le kDrive distant n&apos;existe plus ou n&apos;est plus accessible (erreur %1).&lt;br&gt;Vous devez le restaurer ou lui redonner des droits d&apos;accès ou supprimer/recréer la synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Erreur d&apos;analyse du nom de fichier (erreur %1).&lt;br&gt;Les caractères spéciaux tels que les guillemets doubles, les barres obliques inverses ou les retours de ligne peuvent provoquer des échecs d&apos;analyse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Vous n&apos;êtes pas autorisé à créer cet élément, ou un autre élément portant le même nom existe déjà. L&apos;élément a été ignoré.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Vous n&apos;êtes pas autorisé à déplacer l&apos;élément vers &quot;%1&quot;.&lt;br&gt;Il sera restauré dans son dossier parent d&apos;origine.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>L&apos;espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;Le téléchargement a été annulé.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Impossible de créer le fichier « %1 » car il n&apos;est pas pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Cet élément a été déplacé ailleurs.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L&apos;élément local a été renommé.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>L&apos;espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;La synchronisation a été interrompue.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Le fichier a été modifié au même moment par un autre utilisateur.&lt;br&gt;Vos modifications ont été enregistrées dans une copie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Un autre utilisateur a déplacé un dossier parent de la destination.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Le nom de l&apos;élément ne contient que des espaces.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Vous n&apos;êtes pas autorisé à modifier l&apos;élément.&lt;br&gt;Le fichier contenant vos modifications a été renommé et exclu de la synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Vous n&apos;êtes pas autorisé à renommer l&apos;élément.&lt;br&gt;Il sera restauré avec son nom d&apos;origine.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Vous n&apos;êtes pas autorisé à supprimer l&apos;élément.&lt;br&gt;Il sera restauré à son emplacement d&apos;origine.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Échec du déplacement de cet élément vers la corbeille, il a été mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Le fichier a été modifié localement alors qu’il a été supprimé sur le kDrive distant.&lt;br&gt;Une copie locale a été enregistrée dans le dossier de récupération (rescue folder).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>L&apos;opération effectuée sur l&apos;élément est interdite.&lt;br&gt;L&apos;article a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>L&apos;opération effectuée sur cet élément a échoué.&lt;br&gt;L&apos;article a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Le fichier est trop volumineux pour être téléchargé. Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Impossible de télécharger le fichier.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Vous avez dépassé votre quota. Augmentez votre quota d&apos;espace pour réactiver le téléchargement de fichiers.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Le disque contenant votre dossier de synchronisation n’est plus connecté (erreur %1).&lt;br&gt;Veuillez le reconnecter pour reprendre la synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Le processus LiteSyncExt n&apos;est pas en cours d&apos;exécution. La synchronisation reprendra dès son démarrage.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Un élément existant a un nom identique avec les mêmes options de casse (mêmes lettres majuscules et minuscules).&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Le nom de l&apos;élément contient un caractère non pris en charge.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Le nom de l&apos;élément se termine par un espace, ce qui est interdit sur votre système d&apos;exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ce nom d&apos;élément est réservé par votre système d&apos;exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Le nom de l&apos;élément est trop long.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Le chemin de l&apos;élément est trop long.&lt;br&gt;Il a été ignoré.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Le nom de l&apos;élément contient un caractère UNICODE récent qui n&apos;est pas encore pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Échec de la synchronisation de cet élément. Il a été temporairement mis sur liste noire.&lt;br&gt;Une autre tentative de synchronisation sera effectuée dans une heure ou au prochain démarrage de l&apos;application.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Cet élément a été exclu de la synchronisation par un modèle personnalisé. Vous pouvez désactiver ce type de notification dans les préférences</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Cet article a été exclu de la synchronisation parce qu&apos;il s&apos;agit d&apos;un lien dur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Cet item est actuellement verrouillé par un autre utilisateur en ligne. Nous réessayerons de télécharger vos modifications plus tard.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Erreur de synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Impossible d&apos;accéder à l&apos;élément.&lt;br&gt;Veuillez corriger les autorisations de lecture et d&apos;écriture.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Erreur système.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>L&apos;élément existe déjà de l&apos;autre côté.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Une erreur technique s&apos;est produite.&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Cette synchronisation est en cours de suppression.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Cette synchronisation est en cours de suppression.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Retour à la liste des kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Préférences</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Retour à la liste des kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Préférences</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Paramètres</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Activer le thème foncé</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Activer les icônes monochromes</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Lancer kDrive au démarrage</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Néerlandais</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avancé</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Informations de débogage</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Fichiers à exclure</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Serveur proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Suédois</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugais</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polonais</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norvégien</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finnois</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Danois</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Grec</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossible d'ouvrir le dossier %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Lien %1 invalide.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Langue</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Certains processus n'ont pas pu s'exécuter.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Déplacer les fichiers supprimés vers la corbeille de mon ordinateur</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Certains fichiers ou dossiers peuvent ne pas être déplacés vers la corbeille de l'ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Vous pouvez toujours récupérer les fichiers déjà synchronisés depuis la corbeille de l'application Web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Anglais</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Français</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Allemand</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Espagnol</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italien</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Défaut</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Paramètres</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Activer le thème foncé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Activer les icônes monochromes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Lancer kDrive au démarrage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Néerlandais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avancé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Informations de débogage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Fichiers à exclure</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Serveur proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Suédois</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polonais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norvégien</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finnois</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Danois</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Grec</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossible d&apos;ouvrir le dossier %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Lien %1 invalide.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Langue</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Certains processus n&apos;ont pas pu s&apos;exécuter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Déplacer les fichiers supprimés vers la corbeille de mon ordinateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Certains fichiers ou dossiers peuvent ne pas être déplacés vers la corbeille de l&apos;ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Vous pouvez toujours récupérer les fichiers déjà synchronisés depuis la corbeille de l&apos;application Web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Anglais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Français</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Allemand</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Espagnol</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italien</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Défaut</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 utilisés</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 utilisés</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>Proxy HTTP(S)</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Serveur proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Aucun serveur proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Utiliser les paramètres système</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Indiquer un proxy manuellement</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Port</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Adresse du serveur proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Authentification requise</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Utilisateur</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Mot de passe</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>ENREGISTRER</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Voulez-vous enregistrer vos modifications ?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Enregistrement impossible ; tous les champs obligatoires n’ont pas été complétés !</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy non trouvé, enregistrer quand même ?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Serveur proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Aucun serveur proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Utiliser les paramètres système</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Indiquer un proxy manuellement</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adresse du serveur proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Authentification requise</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Utilisateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Mot de passe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Voulez-vous enregistrer vos modifications ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Enregistrement impossible ; tous les champs obligatoires n’ont pas été complétés !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy non trouvé, enregistrer quand même ?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Gestionnaire des ressources</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Utilisation maximale du processeur autorisée</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>ENREGISTRER</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Voulez-vous enregistrer vos modifications ?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Gestionnaire des ressources</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Utilisation maximale du processeur autorisée</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>ENREGISTRER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Voulez-vous enregistrer vos modifications ?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Sélectionnez un dossier dans votre kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Le contenu du dossier sélectionné sera synchronisé dans le dossier &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>CONTINUER</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Espace disponible sur votre ordinateur pour le dossier actuel : %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Ce dossier est déjà en cours de synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>CONFIRMER</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ANNULER</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Sélectionnez un dossier dans votre kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Le contenu du dossier sélectionné sera synchronisé dans le dossier &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Espace disponible sur votre ordinateur pour le dossier actuel : %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Ce dossier est déjà en cours de synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANNULER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; contient des sous-dossier,&lt;br&gt; sélectionnez ceux que vous voulez synchroniser</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>CONTINUER</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Aucun sous-dossier sur le serveur.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; contient des sous-dossier,&lt;br&gt; sélectionnez ceux que vous voulez synchroniser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Aucun sous-dossier sur le serveur.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Reprendre la synchronisation du kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Reprendre la synchronisation de tous les kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Suspendre la synchronisation du kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Mettre en pause la synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Suspendre la synchronisation de tous les kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Reprendre la synchronisation</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Reprendre la synchronisation du kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Reprendre la synchronisation de tous les kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Suspendre la synchronisation du kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Mettre en pause la synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Suspendre la synchronisation de tous les kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Reprendre la synchronisation</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Copier le lien de partage</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Afficher sur kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Afficher dans le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Autres actions</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Ouvrir</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Ajouter aux favoris</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copier le lien de partage</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Afficher sur kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Afficher dans le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Autres actions</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Ouvrir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Ajouter aux favoris</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Jamais</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Pendant 1 heure</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Jusqu’à demain 8h00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Pendant 3 jours</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Pendant 1 semaine</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Toujours</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Pour 1 heure de plus</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Pour 3 heures de plus</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Pour 1 semaine de plus</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Ouvrir dans le dossier</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Ouvrir la version Web de %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Paramètres du kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Notifications désactivées jusqu’à %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Désactiver les notifications</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Préférences de l’application</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Besoin d’aide</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Envoyer des commentaires</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Quitter kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Impossible d’accéder au site %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Afficher les erreurs et les informations</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Afficher les informations</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Autres actions</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Jamais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Pendant 1 heure</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Jusqu’à demain 8h00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Pendant 3 jours</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Pendant 1 semaine</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Toujours</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Pour 1 heure de plus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Pour 3 heures de plus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Pour 1 semaine de plus</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Ouvrir dans le dossier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Ouvrir la version Web de %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Paramètres du kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Notifications désactivées jusqu’à %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Désactiver les notifications</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Préférences de l’application</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Besoin d’aide</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Envoyer des commentaires</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Quitter kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Impossible d’accéder au site %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Afficher les erreurs et les informations</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Afficher les informations</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Autres actions</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Mettre à jour l'application kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Cette version de l'application kDrive n'est plus prise en charge. Pour accéder aux dernières fonctionnalités et améliorations, veuillez mettre à jour.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Mise à jour</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Veuillez télécharger la dernière version sur le site Web.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Téléchargement de la mise à jour en cours</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Recherche d'une mise à jour...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Mise à jour manuelle</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Indisponible</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Vous pouvez synchroniser les fichiers &lt;a style="%1" href="%2"&gt;depuis votre ordinateur&lt;/a&gt; ou sur &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synchronisé</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoris</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Activité</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Non implémenté !</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/fr/applications/telecharger-kdrive"&gt;Cliquez ici pour télécharger manuellement&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Aucun fichier synchronisé pour ce kDrive !</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Aucun kDrive configuré !</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Impossible d’ouvrir le lien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Lien %1 invalide.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Mettre à jour l&apos;application kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Cette version de l&apos;application kDrive n&apos;est plus prise en charge. Pour accéder aux dernières fonctionnalités et améliorations, veuillez mettre à jour.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Mise à jour</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Veuillez télécharger la dernière version sur le site Web.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Téléchargement de la mise à jour en cours</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Recherche d&apos;une mise à jour...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Mise à jour manuelle</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Indisponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Vous pouvez synchroniser les fichiers &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;depuis votre ordinateur&lt;/a&gt; ou sur &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synchronisé</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoris</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Activité</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Non implémenté&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/fr/applications/telecharger-kdrive&quot;&gt;Cliquez ici pour télécharger manuellement&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Aucun fichier synchronisé pour ce kDrive&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Aucun kDrive configuré !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossible d’ouvrir le lien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Lien %1 invalide.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;La nouvelle version &lt;b&gt;%1&lt;/b&gt; du client %2 est disponible et a été téléchargée.&lt;/p&gt;&lt;p&gt;La version installée est %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Ignorer cette version</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Pas maintenant</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installer</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;La nouvelle version &lt;b&gt;%1&lt;/b&gt; du client %2 est disponible et a été téléchargée.&lt;/p&gt;&lt;p&gt;La version installée est %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Ignorer cette version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Pas maintenant</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installer</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Nouvelle mise à jour disponible.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>La version %1 est disponible au téléchargement.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Nouvelle mise à jour disponible.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>La version %1 est disponible au téléchargement.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Ajouter un compte</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Ajouter un compte</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Afficher la note de version&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Version</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>METTRE A JOUR</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 est à jour !</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Vérification de la mise à jour sur le serveur...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Une mise à jour est disponible : %1.&lt;br&gt;Veuillez la télécharger depuis &lt;a style="%2" href="%3"&gt;ici&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Une mise à jour est disponible: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Téléchargement %1 en cours. Veuillez patienter…</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Impossible de vérifier la présence de nouvelles mises à jour.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Une erreur s'est produite lors de la mise à jour.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Impossible de télécharger la mise à jour.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Mise à jour désactivée.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Programme bêta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Bénéficier d'un accès anticipé aux nouvelles versions de l'application</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Rejoindre</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Modifier</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Quitter</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Afficher la note de version&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>METTRE A JOUR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 est à jour !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Vérification de la mise à jour sur le serveur...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Une mise à jour est disponible&#xa0;: %1.&lt;br&gt;Veuillez la télécharger depuis &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;ici&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Une mise à jour est disponible: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Téléchargement %1 en cours. Veuillez patienter…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Impossible de vérifier la présence de nouvelles mises à jour.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Une erreur s&apos;est produite lors de la mise à jour.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Impossible de télécharger la mise à jour.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Mise à jour désactivée.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Programme bêta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Bénéficier d&apos;un accès anticipé aux nouvelles versions de l&apos;application</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Rejoindre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Modifier</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Quitter</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Impossible d'enregistrer les paramètres, veuillez réessayer plus tard.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Impossible d'enregistrer les paramètres !</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Le dossier parent est un dossier de synchronisation ou contenu dans un</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Impossible de trouver un chemin valide</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Aucun dossier valable sélectionné!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Le chemin sélectionné n’existe pas!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Le chemin sélectionné n'est pas un dossier!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Vous n'avez pas la permission d'écrire dans le dossier sélectionné!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre !</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre !</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Le dossier local %1 est déjà synchronisé. Veuillez en choisir un autre !</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>La Lite sync (bêta) est activée. Les fichiers de kDrive restent dans le Cloud et n'utilisent pas l'espace de stockage de votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>La Lite sync(bêta) est désactivée. Les fichiers kDrive utilisent l'espace de stockage de votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>La Lite sync est activée. Les fichiers de kDrive restent dans le Cloud et n'utilisent pas l'espace de stockage de votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>La Lite sync est désactivée. Les fichiers kDrive utilisent l'espace de stockage de votre ordinateur.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Rendre disponible localement</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Libérer de l’espace local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Annuler libérer l'espace local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Annuler rendre disponible localement</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Le partage de ce fichier n'est pas autorisé</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Le partage de ce dossier n'est pas autorisé</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Copier le lien de partage public</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Copier le lien de partage privé</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Ouvrir dans le navigateur web</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Impossible d&apos;enregistrer les paramètres, veuillez réessayer plus tard.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Impossible d&apos;enregistrer les paramètres&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Le dossier parent est un dossier de synchronisation ou contenu dans un</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Impossible de trouver un chemin valide</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Aucun dossier valable sélectionné!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Le chemin sélectionné n’existe pas!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Le chemin sélectionné n&apos;est pas un dossier!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Vous n&apos;avez pas la permission d&apos;écrire dans le dossier sélectionné!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Le dossier local %1 est déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>La Lite sync (bêta) est activée. Les fichiers de kDrive restent dans le Cloud et n&apos;utilisent pas l&apos;espace de stockage de votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>La Lite sync(bêta) est désactivée. Les fichiers kDrive utilisent l&apos;espace de stockage de votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>La Lite sync est activée. Les fichiers de kDrive restent dans le Cloud et n&apos;utilisent pas l&apos;espace de stockage de votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>La Lite sync est désactivée. Les fichiers kDrive utilisent l&apos;espace de stockage de votre ordinateur.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Rendre disponible localement</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Libérer de l’espace local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Annuler libérer l&apos;espace local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Annuler rendre disponible localement</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Le partage de ce fichier n&apos;est pas autorisé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Le partage de ce dossier n&apos;est pas autorisé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Copier le lien de partage public</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Copier le lien de partage privé</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Ouvrir dans le navigateur web</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>L'application kDrive se fermera en raison d'une erreur fatale.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>L&apos;application kDrive se fermera en raison d&apos;une erreur fatale.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 Go</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 Mo</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 Ko</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 octets</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n an</numerusform>
-<numerusform>%n ans</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n mois</numerusform>
-<numerusform>%n mois</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n jour</numerusform>
-<numerusform>%n jours</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n heure</numerusform>
-<numerusform>%n heures</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minute</numerusform>
-<numerusform>%n minutes</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n seconde</numerusform>
-<numerusform>%n secondes</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 Go</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 Mo</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 Ko</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 octets</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n an</numerusform>
+            <numerusform>%n ans</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n mois</numerusform>
+            <numerusform>%n mois</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n jour</numerusform>
+            <numerusform>%n jours</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n heure</numerusform>
+            <numerusform>%n heures</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minute</numerusform>
+            <numerusform>%n minutes</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n seconde</numerusform>
+            <numerusform>%n secondes</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Zone de notification indisponible</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Zone de notification indisponible</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Impossible de démarrer le navigateur</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Une erreur est survenue au lancement du navigateur pour visiter l'adresse %1. Il est possible qu'aucun navigateur par défaut ne soit configuré?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Impossible d'ouvrir le client de messagerie</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Il y a eu une erreur lors du lancement du client de messagerie pour créer un nouveau message. Peut-être qu'aucun client de messagerie n'est configuré ?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Vous n'êtes plus connecté. &lt;a style="%1" href="%2"&gt;Connexion&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synchronisation en cours (Étape %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synchronisation en cours.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Certains fichiers n'ont pas pu être synchronisés. &lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Pause de la synchronisation...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Impossible de sélectionner le dossier &lt;b&gt;%1&lt;/b&gt; car une autre synchronisation utilise le même dossier.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il contient le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il est contenu dans le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Démarrage de la synchronisation</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synchronisation en pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synchronisation en cours (%1 sur %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Impossible de démarrer le navigateur</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Une erreur est survenue au lancement du navigateur pour visiter l&apos;adresse %1. Il est possible qu&apos;aucun navigateur par défaut ne soit configuré?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Impossible d&apos;ouvrir le client de messagerie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Il y a eu une erreur lors du lancement du client de messagerie pour créer un nouveau message. Peut-être qu&apos;aucun client de messagerie n&apos;est configuré ?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Vous n&apos;êtes plus connecté. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Connexion&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synchronisation en cours (Étape %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synchronisation en cours.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Certains fichiers n&apos;ont pas pu être synchronisés. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Pause de la synchronisation...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Impossible de sélectionner le dossier &lt;b&gt;%1&lt;/b&gt; car une autre synchronisation utilise le même dossier.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il contient le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il est contenu dans le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Démarrage de la synchronisation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synchronisation en pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synchronisation en cours (%1 sur %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synchronisation en cours (%1 sur %2)
+        <translation>Synchronisation en cours (%1 sur %2)
 %3 restantes...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Vous êtes à jour, conflits non résolus.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Vous êtes à jour !</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Vous êtes à jour, conflits non résolus.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Vous êtes à jour !</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Aucun dossier à synchroniser.
+        <translation>Aucun dossier à synchroniser.
 Ajoutez-en un depuis la configuration du kDrive.</translation>
-</message>
+    </message>
 </context>
 </TS>

--- a/translations/client_fr.ts
+++ b/translations/client_fr.ts
@@ -1,2581 +1,3096 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="fr_FR">
+<TS language="fr_FR" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">À propos</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">FERMER</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Version %1. Pour plus d’informations, visiter &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribué par %1 et sous licence  &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 et le logo %2 sont des marques déposées de %1. &lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le dossier %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Compilé à partir des &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;sources Git&lt;/a&gt; le %2, %3 en utilisant Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>À propos</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>FERMER</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Version %1. Pour plus d’informations, visiter &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribué par %1 et sous licence  &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 et le logo %2 sont des marques déposées de %1. &lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossible d'ouvrir le dossier %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Compilé à partir des &lt;a style="color: #489EF3" href="%1"&gt;sources Git&lt;/a&gt; le %2, %3 en utilisant Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le dossier de débogage %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">La synchronisation va commencer et vous pourrez ajouter des fichiers à votre dossier %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Votre kDrive est prêt !</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">OUVRIR LE DOSSIER LOCAL</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">PARAMÈTRES</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Synchroniser un autre kDrive</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>La synchronisation va commencer et vous pourrez ajouter des fichiers à votre dossier %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Votre kDrive est prêt !</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>OUVRIR LE DOSSIER LOCAL</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>PARAMÈTRES</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synchroniser un autre kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">SUIVANT</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Sélectionnez le kDrive que vous souhaitez synchroniser</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Obtenez kDrive gratuitement</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Stockez vos photos, documents et e-mails en Suisse auprès d&apos;une société indépendante qui respecte la vie privée. Apprendre encore plus</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Testez gratuitement</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>SUIVANT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Sélectionnez le kDrive que vous souhaitez synchroniser</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Obtenez kDrive gratuitement</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Stockez vos photos, documents et e-mails en Suisse auprès d'une société indépendante qui respecte la vie privée. Apprendre encore plus</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Testez gratuitement</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Economiser l&apos;espace de votre ordinateur</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Décider quels fichiers doivent être disponibles en ligne ou localement.</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">PLUS TARD</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">OUI</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">La Lite Sync synchronise tous vos fichiers sans utiliser l&apos;espace de votre ordinateur. Vous pouvez parcourir les fichiers de votre kDrive et les télécharger quand vous le souhaitez. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Voulez vous activer la Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Voulez vous activer la Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Economiser l'espace de votre ordinateur</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Décider quels fichiers doivent être disponibles en ligne ou localement.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>PLUS TARD</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>OUI</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>La Lite Sync synchronise tous vos fichiers sans utiliser l'espace de votre ordinateur. Vous pouvez parcourir les fichiers de votre kDrive et les télécharger quand vous le souhaitez. &lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Voulez vous activer la Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Voulez vous activer la Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Emplacement de votre kDrive %1</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Modifier le dossier</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">TERMINER</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Sélectionner le dossier</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Le contenu du dossier &lt;b&gt;%1&lt;/b&gt; sera synchronisé sur votre kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Vous retrouverez tous vos fichiers dans ce dossier une fois la configuration terminée. Vous pouvez y glisser de nouveaux fichiers pour les synchroniser avec votre kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Emplacement de votre kDrive %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Modifier le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>TERMINER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Sélectionner le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Le contenu du dossier &lt;b&gt;%1&lt;/b&gt; sera synchronisé sur votre kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Vous retrouverez tous vos fichiers dans ce dossier une fois la configuration terminée. Vous pouvez y glisser de nouveaux fichiers pour les synchroniser avec votre kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Ce dossier n&apos;est pas compatible avec Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Ce dossier n'est pas compatible avec Lite Sync.&lt;br&gt;
 Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désactivé.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUER</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>CONTINUER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Connectez-vous depuis votre navigateur</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Votre navigateur devrait s&apos;ouvrir automatiquement pour établir la connexion. Une fois connecté, vous serez automatiquement redirigé vers kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Ouvrir la page de connexion</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Une erreur est survenue pendant l&apos;authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l&apos;erreur persiste, contactez notre équipe de support.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">La connexion a échoué&#xa0;: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Impossible d&apos;ouvrir la page de connexion dans votre navigateur Web</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Connectez-vous depuis votre navigateur</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Votre navigateur devrait s'ouvrir automatiquement pour établir la connexion. Une fois connecté, vous serez automatiquement redirigé vers kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Ouvrir la page de connexion</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Une erreur est survenue pendant l'authentification. Veuillez fermer la fenêtre de connexion et réessayer.&lt;br&gt;Si l'erreur persiste, contactez notre équipe de support.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>La connexion a échoué : %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Impossible d'ouvrir la page de connexion dans votre navigateur Web</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Sélectionnez les dossiers kDrive à synchroniser sur votre ordinateur</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUER</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Espace disponible sur votre ordinateur : %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Une erreur s&apos;est produite lors du chargement de la liste des sous-dossiers.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Impossible de charger la liste des sous-dossiers. Votre kDrive est peut-être en maintenance.&lt;br&gt;Veuillez vous connecter à la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Sélectionnez les dossiers kDrive à synchroniser sur votre ordinateur</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>CONTINUER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Espace disponible sur votre ordinateur : %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Une erreur s'est produite lors du chargement de la liste des sous-dossiers.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Impossible de charger la liste des sous-dossiers. Votre kDrive est peut-être en maintenance.&lt;br&gt;Veuillez vous connecter à la &lt;a style="%1" href="%2"&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">La création du dossier local %1 a échoué</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Impossible de créer une nouvelle synchronisation</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">Le kDrive %1 est déjà synchronisé sur cet ordinateur. Continuer quand même?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>La création du dossier local %1 a échoué</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Impossible de créer une nouvelle synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>Le kDrive %1 est déjà synchronisé sur cet ordinateur. Continuer quand même?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">Le client kDrive est exécuté avec de mauvais paramètres!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">Le client kDrive est déjà en cours d&apos;exécution&#xa0;!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">L&apos;utilisateur %1 n&apos;est pas connecté. Veuillez vous reconnecter.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>Le client kDrive est exécuté avec de mauvais paramètres!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>Le client kDrive est déjà en cours d'exécution !</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>L'utilisateur %1 n'est pas connecté. Veuillez vous reconnecter.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Lien de partage copié dans le presse-papiers</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 a été supprimé.</numerusform>
-            <numerusform>%1 et %n autres fichiers ont été supprimés.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 a été supprimé.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
-            <numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 a été ajouté.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 a été mis à jour.</numerusform>
-            <numerusform>%1 et %n autres fichiers ont été mis à jour.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 a été mis à jour.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 a été déplacé vers %2.</numerusform>
-            <numerusform>%1 a été déplacé vers %2 et  %n autres fichiers ont été déplacés.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 a été déplacé vers %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Activité de synchronisation</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Lien de partage copié dans le presse-papiers</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 a été supprimé.</numerusform>
+<numerusform>%1 et %n autres fichiers ont été supprimés.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 a été supprimé.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
+<numerusform>%1 et %n autre(s) fichier(s) ont été ajouté(s).</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 a été ajouté.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 a été mis à jour.</numerusform>
+<numerusform>%1 et %n autres fichiers ont été mis à jour.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 a été mis à jour.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 a été déplacé vers %2.</numerusform>
+<numerusform>%1 a été déplacé vers %2 et  %n autres fichiers ont été déplacés.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 a été déplacé vers %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Activité de synchronisation</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Aucun sous-dossier sur le serveur.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Aucun sous-dossier sur le serveur.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Quitter le programme bêta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Rejoindre le programme bêta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Bénéficiez d&apos;un accès anticipé aux nouvelles versions de l&apos;application avant qu&apos;elles ne soient diffusées au grand public et participez à l&apos;amélioration de l&apos;application en nous faisant part de vos commentaires.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Bénéficier des mises à jour de la version bêta des applications</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Non</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Version bêta publique</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Version bêta interne</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Version de test</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Je comprends</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Êtes-vous sûr de vouloir quitter le programme bêta ?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Enregistrer</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Votre version actuelle de l&apos;application est peut-être trop récente, votre choix sera effectif lorsque la prochaine mise à jour sera disponible.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Les versions bêta peuvent quitter de manière inattendue ou provoquer des instabilités.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Quitter le programme bêta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Rejoindre le programme bêta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Bénéficiez d'un accès anticipé aux nouvelles versions de l'application avant qu'elles ne soient diffusées au grand public et participez à l'amélioration de l'application en nous faisant part de vos commentaires.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Bénéficier des mises à jour de la version bêta des applications</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Non</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Version bêta publique</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Version bêta interne</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Version de test</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Je comprends</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Êtes-vous sûr de vouloir quitter le programme bêta ?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Enregistrer</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Votre version actuelle de l'application est peut-être trop récente, votre choix sera effectif lorsque la prochaine mise à jour sera disponible.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Les versions bêta peuvent quitter de manière inattendue ou provoquer des instabilités.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Échec de la résolution des conflits sur %1 élément(s) dans le dossier de synchronisation : %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Veuillez vous connecter</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Dossier %1 : %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Aucun dossier à synchroniser n&apos;est configuré.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Synthèse</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation type="vanished">Préférences</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Quitter</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Statut indéfini.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">En attente de synchronisation.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synchronisation en cours.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synchronisation réussie, conflits non résolus.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Synchronisation terminée avec succès.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Abandon par l&apos;utilisateur.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">La synchronisation est en pause.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synchronisation en pause)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque&#xa0;:&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">SUPPRIMER TOUTES LES SYNC</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 éléments ont été supprimés de votre dossier de synchronisation local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Pour éviter les suppressions involontaires, la synchronisation a été mise en pause.&lt;br&gt;Voulez-vous propager ces suppressions vers votre kDrive&#xa0;?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Plusieurs fichiers ont été supprimés de votre dossier de synchronisation local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Les fichiers supprimés se trouvent dans la &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;corbeille&lt;/a&gt; de kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Ne plus afficher</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Échec du démarrage des synchronisations&#xa0;!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le dossier de débogage %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Impossible d&apos;initialiser le client kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">La synchronisation est en pause</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Échec de la résolution des conflits sur %1 élément(s) dans le dossier de synchronisation : %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Veuillez vous connecter</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Dossier %1 : %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Aucun dossier à synchroniser n'est configuré.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Synthèse</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translatorcomment>Préférences</translatorcomment>
+<translation>Préférences</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Quitter</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Statut indéfini.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>En attente de synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synchronisation en cours.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synchronisation réussie, conflits non résolus.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Synchronisation terminée avec succès.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Abandon par l'utilisateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>La synchronisation est en pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synchronisation en pause)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Voulez-vous vraiment supprimer les synchronisations du compte &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Remarque :&lt;/b&gt; Cela &lt;b&gt;ne&lt;/b&gt; supprimera aucun fichier.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>SUPPRIMER TOUTES LES SYNC</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 éléments ont été supprimés de votre dossier de synchronisation local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Pour éviter les suppressions involontaires, la synchronisation a été mise en pause.&lt;br&gt;Voulez-vous propager ces suppressions vers votre kDrive ?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Plusieurs fichiers ont été supprimés de votre dossier de synchronisation local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Les fichiers supprimés se trouvent dans la &lt;a style="%1" href="%3"&gt;corbeille&lt;/a&gt; de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Ne plus afficher</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Échec du démarrage des synchronisations !</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Impossible d'initialiser le client kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>La synchronisation est en pause</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Résumé de la synchronisation de votre dossier local</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Le contenu du dossier sur votre ordinateur sera synchronisé avec le dossier du kDrive sélectionné et inversement.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNCHRONISER</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Résumé de la synchronisation de votre dossier local</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Le contenu du dossier sur votre ordinateur sera synchronisé avec le dossier du kDrive sélectionné et inversement.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNCHRONISER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Avant de terminer</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Suivez les étapes suivantes pour assurer le bon fonctionnement de la Lite Sync sur votre ordinateur et terminer la configuration du kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ouvrez les &lt;b&gt;Paramètres généraux&lt;/b&gt; de votre Mac ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ouvrez les &lt;b&gt;paramètres de confidentialité et de sécurité&lt;/b&gt; de votre Mac ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ouvrez les &lt;b&gt;Paramètres de sécurité et confidentialité&lt;/b&gt; de votre Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Allez dans la section &lt;b&gt;&quot;Éléments de connexion et extensions&quot;&lt;/b&gt;, puis dans &lt;b&gt;&quot;Extensions de sécurité de point de terminaison&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Autoriser l&apos;application kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Allez dans la section &lt;b&gt;&quot;Sécurité&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Autoriser l&apos;application kDrive dans la case indiquant que kDrive a été bloqué</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Déverrouillez le cadenas &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; et autorisez l’application kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Allez dans la section &lt;b&gt;&quot;Confidentialité et sécurité&quot;&lt;/b&gt; et cliquez sur &lt;b&gt;&quot;Accès complet au disque&quot;&lt;/b&gt; ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Toujours dans les paramètres de sécurité et de confidentialité, ouvrez l&apos;onglet &lt;b&gt;&quot;Confidentialité&quot;&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;cliquez ici&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Cochez la case &quot;kDrive LiteSync Extension&quot; puis la case &quot;kDrive.app&quot; (si pas déjà cochée)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Un redémarrage de l&apos;application pourra vous être proposé, dans ce cas acceptez-le</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Cochez la case &quot;kDrive LiteSync Extension&quot; (et &quot;kDrive.app si elle existe) dans &lt;b&gt;&quot;Accès complet au disque&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">ÉTAPE 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Effectuée)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">ÉTAPE 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">ÉTAPES EFFECTUÉES</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">TERMINER</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Avant de terminer</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Suivez les étapes suivantes pour assurer le bon fonctionnement de la Lite Sync sur votre ordinateur et terminer la configuration du kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ouvrez les &lt;b&gt;Paramètres généraux&lt;/b&gt; de votre Mac ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ouvrez les &lt;b&gt;paramètres de confidentialité et de sécurité&lt;/b&gt; de votre Mac ou &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ouvrez les &lt;b&gt;Paramètres de sécurité et confidentialité&lt;/b&gt; de votre Mac ou  &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Allez dans la section &lt;b&gt;"Éléments de connexion et extensions"&lt;/b&gt;, puis dans &lt;b&gt;"Extensions de sécurité de point de terminaison"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Autoriser l'application kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Allez dans la section &lt;b&gt;"Sécurité"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Autoriser l'application kDrive dans la case indiquant que kDrive a été bloqué</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Déverrouillez le cadenas &lt;img src=":/client/resources/icons/actions/lock.png"&gt; et autorisez l’application kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Allez dans la section &lt;b&gt;"Confidentialité et sécurité"&lt;/b&gt; et cliquez sur &lt;b&gt;"Accès complet au disque"&lt;/b&gt; ou &lt;a style=%1 href=%2&gt;cliquez ici&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Toujours dans les paramètres de sécurité et de confidentialité, ouvrez l'onglet &lt;b&gt;"Confidentialité"&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;cliquez ici&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Cochez la case "kDrive LiteSync Extension" puis la case "kDrive.app" (si pas déjà cochée)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Un redémarrage de l'application pourra vous être proposé, dans ce cas acceptez-le</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Cochez la case "kDrive LiteSync Extension" (et "kDrive.app si elle existe) dans &lt;b&gt;"Accès complet au disque"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>ÉTAPE 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Effectuée)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>ÉTAPE 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>ÉTAPES EFFECTUÉES</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>TERMINER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">OUI</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NON</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>OUI</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NON</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Envoi des informations de débogage</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Envoi des informations de débogage</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Information</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Débogage</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Avertissement</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Erreur</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Fatal</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Paramètres de débogage</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Enregistrer les informations de débogage dans un dossier sur mon ordinateur (recommandé)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Ces informations permettent au support informatique de déterminer l’origine d’un incident.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Niveau de débogage</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Le niveau de trace vous permet de choisir l&apos;étendue des informations de débogage enregistrées</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Le journal complet étendu collecte un historique détaillé qui peut être utilisé pour le débogage. L&apos;activer peut ralentir l&apos;application kDrive.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Journal complet étendu</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Supprimer les journaux datant de plus de %1 jours</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Partagez le dossier debug avec le support Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">La dernière session est la période depuis le dernier démarrage de kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Partager uniquement la dernière session kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Chargement</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ENREGISTRER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Échec du partage</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Vérifiez que vous êtes connecté &lt;br&gt;2. Vérifiez que vous avez configuré au moins un kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Connexion interrompue)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Partager le dossier avec SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Nous avons automatiquement compressé votre journal &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;ici&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Transférez l&apos;archive avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Partagez le lien avec &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Dernier envoi le %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Le partage a été annulé</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Le journal complet étendu est activé via la variable d&apos;environnement KDRIVE_FORCE_EXTENDED_LOG. Définissez-la à 0 pour le désactiver.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Le dossier entier est volumineux (&gt; 100 Mo) et son partage peut prendre un certain temps. Pour réduire le temps de partage, nous vous recommandons de ne partager que la dernière session kDrive.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%2/%1/%3 à %4h%5 et %6s</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Voulez-vous enregistrer vos modifications ?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le dossier %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Partager</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Partage | étape 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Partage | étape 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Annulation...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Information</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Débogage</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Avertissement</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Erreur</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Fatal</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Paramètres de débogage</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Enregistrer les informations de débogage dans un dossier sur mon ordinateur (recommandé)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Ces informations permettent au support informatique de déterminer l’origine d’un incident.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Niveau de débogage</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Le niveau de trace vous permet de choisir l'étendue des informations de débogage enregistrées</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Le journal complet étendu collecte un historique détaillé qui peut être utilisé pour le débogage. L'activer peut ralentir l'application kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Journal complet étendu</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Supprimer les journaux datant de plus de %1 jours</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Partagez le dossier debug avec le support Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>La dernière session est la période depuis le dernier démarrage de kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Partager uniquement la dernière session kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Chargement</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>ENREGISTRER</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Échec du partage</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Vérifiez que vous êtes connecté &lt;br&gt;2. Vérifiez que vous avez configuré au moins un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Connexion interrompue)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Partager le dossier avec SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Nous avons automatiquement compressé votre journal &lt;a style="%1" href="%2"&gt;ici&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Transférez l'archive avec &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Partagez le lien avec &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Dernier envoi le %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Le partage a été annulé</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Le journal complet étendu est activé via la variable d'environnement KDRIVE_FORCE_EXTENDED_LOG. Définissez-la à 0 pour le désactiver.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Le dossier entier est volumineux (&gt; 100 Mo) et son partage peut prendre un certain temps. Pour réduire le temps de partage, nous vous recommandons de ne partager que la dernière session kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%2/%1/%3 à %4h%5 et %6s</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Voulez-vous enregistrer vos modifications ?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossible d'ouvrir le dossier %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Partager</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Partage | étape 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Partage | étape 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Annulation...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Dossiers</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Notifications</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Une notification sera affichée dès qu’un nouveau dossier aura été synchronisé ou modifié</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Connecté avec</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Voulez-vous vraiment arrêter de synchroniser le dossier &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note :&lt;/b&gt; &lt;/b&gt;Aucun&lt;/b&gt; fichier ne sera supprimé.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Cette opération peut prendre de quelques secondes à quelques minutes en fonction de la taille du dossier.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">La synchronisation du nouveau dossier local a échoué!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">L&apos;activation de la Lite Sync a échoué.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">La désactivation de la Lite Sync a échoué.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">SUPPRIMER LA SYNC. DU DOSSIER</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Une erreur s&apos;est produite lors du chargement de la liste des sous-dossiers.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Activer les notifications pour ce kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMER</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Erreurs et informations de synchronisation.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Synchroniser un dossier local</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Voulez-vous vraiment activer la Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Voulez vous vraiment désactiver la Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Vous n&apos;avez pas assez de place pour synchroniser tous les fichiers sur votre kDrive (manque %1). Si vous désactivez la Lite Sync, vous devrez sélectionner les dossiers à synchroniser sur votre ordinateur. Dans un premier temps, la synchronisation de votre kDrive sera mise en pause.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Si vous désactivez la Lite Sync, tous les fichiers seront téléchargés sur votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Impossible de créer une nouvelle synchronisation</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync activée.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync désactivée.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Ce lecteur est en cours de suppression.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le poste %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Échec de l&apos;arrêt de la synchronisation du dossier &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Supprimer toutes les synchronisations</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Recherche dans votre kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Recherche</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Dossiers</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Notifications</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Une notification sera affichée dès qu’un nouveau dossier aura été synchronisé ou modifié</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Connecté avec</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Voulez-vous vraiment arrêter de synchroniser le dossier &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note :&lt;/b&gt; &lt;/b&gt;Aucun&lt;/b&gt; fichier ne sera supprimé.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Cette opération peut prendre de quelques secondes à quelques minutes en fonction de la taille du dossier.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>La synchronisation du nouveau dossier local a échoué!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>L'activation de la Lite Sync a échoué.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>La désactivation de la Lite Sync a échoué.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>SUPPRIMER LA SYNC. DU DOSSIER</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Une erreur s'est produite lors du chargement de la liste des sous-dossiers.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Activer les notifications pour ce kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>CONFIRMER</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Erreurs et informations de synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synchroniser un dossier local</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Voulez-vous vraiment activer la Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Voulez vous vraiment désactiver la Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Vous n'avez pas assez de place pour synchroniser tous les fichiers sur votre kDrive (manque %1). Si vous désactivez la Lite Sync, vous devrez sélectionner les dossiers à synchroniser sur votre ordinateur. Dans un premier temps, la synchronisation de votre kDrive sera mise en pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Si vous désactivez la Lite Sync, tous les fichiers seront téléchargés sur votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Impossible de créer une nouvelle synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync activée.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync désactivée.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Ce lecteur est en cours de suppression.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Impossible d'ouvrir le poste %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Échec de l'arrêt de la synchronisation du dossier &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Supprimer toutes les synchronisations</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Recherche dans votre kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Recherche</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Synchroniser un kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Ajouter un kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synchroniser un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Ajouter un kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Résoudre</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Elément(s) en conflit</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Élément(s) contenant des caractères non pris en charge</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Vider l&apos;historique</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">A résoudre</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Résolu automatiquement</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problème(s) résolu(s)</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">problème(s) détecté(s)</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Résoudre</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Elément(s) en conflit</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Élément(s) contenant des caractères non pris en charge</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Vider l'historique</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>A résoudre</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Résolu automatiquement</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problème(s) résolu(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>problème(s) détecté(s)</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Conflits ou erreurs de synchronisation</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Erreurs</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Retour aux préférences</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Conflits ou erreurs de synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Erreurs</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Retour aux préférences</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Certains fichiers n’ont pas pu être synchronisés sur le kDrive suivant :</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 erreur(s))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 information(s))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 erreur(s) et %2 information(s))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Erreurs génériques (%n avertissement ou erreur)</numerusform>
-            <numerusform>Erreurs génériques (%n avertissements ou erreurs)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Certains fichiers n’ont pas pu être synchronisés sur le kDrive suivant :</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 erreur(s))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 information(s))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 erreur(s) et %2 information(s))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Erreurs génériques (%n avertissement ou erreur)</numerusform>
+<numerusform>Erreurs génériques (%n avertissements ou erreurs)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Fichiers exclus</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Ajoutez des fichiers ou des dossiers qui ne seront pas synchronisés sur votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Ajouter</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOM</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">AVERTISSEMENT</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ENREGISTRER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Voulez-vous enregistrer vos modifications ?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Le modèle d&apos;exclusion existe déjà&#xa0;!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Voulez-vous vraiment supprimer ?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Impossible d&apos;enregistrer les modifications !</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Fichiers exclus</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Ajoutez des fichiers ou des dossiers qui ne seront pas synchronisés sur votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Ajouter</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NOM</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>AVERTISSEMENT</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>ENREGISTRER</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Voulez-vous enregistrer vos modifications ?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Le modèle d'exclusion existe déjà !</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Voulez-vous vraiment supprimer ?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Impossible d'enregistrer les modifications !</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>VALIDER</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Résoudre le(s) conflit(s)</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Que voulez-vous faire avec les %1 éléments en conflit&#xa0;?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Enregistrer mes modifications et remplacer les versions des autres utilisateurs.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Annuler mes modifications et conserver les versions des autres utilisateurs.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Vos modifications peuvent être supprimées définitivement. Elles ne peuvent pas être restaurées à partir de l&apos;application Web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Vos modifications seront définitivement supprimées. Elles ne pourront pas être restaurées à partir de l&apos;application Web kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Voir l&apos;(les) élément(s)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Des modifications ont été apportées à ces fichiers par plusieurs utilisateurs à plusieurs endroits (en ligne sur kDrive, un ordinateur ou un mobile). Les dossiers contenant ces fichiers peuvent également avoir été supprimés.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">La version locale de votre élément &lt;b&gt;n&apos;est pas synchronisée&lt;/b&gt; avec kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Résoudre le(s) conflit(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Que voulez-vous faire avec les %1 éléments en conflit ?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Enregistrer mes modifications et remplacer les versions des autres utilisateurs.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Annuler mes modifications et conserver les versions des autres utilisateurs.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Vos modifications peuvent être supprimées définitivement. Elles ne peuvent pas être restaurées à partir de l'application Web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Vos modifications seront définitivement supprimées. Elles ne pourront pas être restaurées à partir de l'application Web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Voir l'(les) élément(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>VALIDER</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Des modifications ont été apportées à ces fichiers par plusieurs utilisateurs à plusieurs endroits (en ligne sur kDrive, un ordinateur ou un mobile). Les dossiers contenant ces fichiers peuvent également avoir été supprimés.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>La version locale de votre élément &lt;b&gt;n'est pas synchronisée&lt;/b&gt; avec kDrive. &lt;a style="color: #489EF3" href="%1"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Autres actions</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synchronisé dans &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Activer la Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Activer la Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Les dossiers non sélectionnés seront déplacés vers la corbeille s&apos;ils contiennent des éléments hors ligne. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Les dossiers non sélectionnés seront déplacés vers la corbeille. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Les dossiers non sélectionnés seront supprimés &lt;b&gt;définitivement&lt;/b&gt; de l&apos;ordinateur. Les dossiers synchronisés sur kDrive resteront disponibles en ligne.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annuler</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDER</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Mettre en pause la synchronisation</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Désactiver Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Reprendre la synchronisation</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Supprimer la synchronisation</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Autres actions</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synchronisé dans &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Activer la Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Activer la Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Les dossiers non sélectionnés seront déplacés vers la corbeille s'ils contiennent des éléments hors ligne. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Les dossiers non sélectionnés seront déplacés vers la corbeille. Les dossiers synchronisés avec kDrive resteront disponibles en ligne.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Les dossiers non sélectionnés seront supprimés &lt;b&gt;définitivement&lt;/b&gt; de l'ordinateur. Les dossiers synchronisés sur kDrive resteront disponibles en ligne.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Annuler</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>VALIDER</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Mettre en pause la synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Désactiver Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Reprendre la synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Supprimer la synchronisation</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le chemin du dossier %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossible d'ouvrir le chemin du dossier %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Identifiant de l&apos;application</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Nom de l&apos;application</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Identifiant de l'application</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Nom de l'application</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>VALIDER</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Certaines applications (sauvegarde, anti-virus...) accèdent à vos fichiers, ce qui entraîne leur téléchargement lorsqu&apos;ils sont &quot;en ligne&quot;. Ajoutez-les dans la liste ci-dessous pour éviter ce comportement.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Ajouter</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ID DE L&apos;APPLICATION</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOM</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ENREGISTRER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Voulez-vous enregistrer vos modifications ?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Voulez-vous vraiment supprimer ?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Impossible d&apos;enregistrer les modifications !</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Certaines applications (sauvegarde, anti-virus...) accèdent à vos fichiers, ce qui entraîne leur téléchargement lorsqu'ils sont "en ligne". Ajoutez-les dans la liste ci-dessous pour éviter ce comportement.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Ajouter</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ID DE L'APPLICATION</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NOM</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>ENREGISTRER</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Voulez-vous enregistrer vos modifications ?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Voulez-vous vraiment supprimer ?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Impossible d'enregistrer les modifications !</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Quel dossier de votre ordinateur voulez-vous&lt;br&gt;synchroniser ?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Le contenu de ce dossier sera synchronisé sur le kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Sélectionner un dossier</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Modifier le dossier</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUER</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Quel dossier de votre ordinateur voulez-vous&lt;br&gt;synchroniser ?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Le contenu de ce dossier sera synchronisé sur le kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Sélectionner un dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Modifier le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>CONTINUER</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Ce dossier n&apos;est pas compatible avec Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Ce dossier n'est pas compatible avec Lite Sync.&lt;br&gt;
 Veuillez sélectionner un autre dossier. Si vous continuez, Lite Sync sera désactivé.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Sélectionner le dossier</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Sélectionner le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Erreur</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Le fichier &apos;%1&apos;&lt;br/&gt;ne peut être ouvert en écriture.&lt;br/&gt;&lt;br/&gt;Le fichier de journalisation &lt;b&gt;ne peut pas&lt;/b&gt; être enregistré !&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Erreur</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Le fichier '%1'&lt;br/&gt;ne peut être ouvert en écriture.&lt;br/&gt;&lt;br/&gt;Le fichier de journalisation &lt;b&gt;ne peut pas&lt;/b&gt; être enregistré !&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Préférences</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Aide</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Préférences</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Aide</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Transmission effectuée !&lt;br&gt;Veuillez vous référer à l&apos;identifiant &lt;b&gt;%1&lt;/b&gt; dans vos rapports de bugs.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Aucun kDrive configuré !</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Échec de la transmission&#xa0;!
-Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Il semble que votre connexion réseau soit configurée avec un délai d&apos;expiration trop court pour que l&apos;application fonctionne correctement (erreur %1).&lt;br&gt;Veuillez vérifier votre configuration réseau.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Impossible de se connecter au serveur kDrive (erreur %1).&lt;br&gt;Tentative de reconnexion. Veuillez vérifier votre connexion Internet et votre pare-feu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Veuillez vous reconnecter et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Une nouvelle version de l&apos;application est disponible.&lt;br&gt;Veuillez mettre à jour l&apos;application pour continuer à l&apos;utiliser.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Le téléchargement du journal a échoué (erreur %1).&lt;br&gt;Veuillez réessayer plus tard.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Le dossier de synchronisation n&apos;est plus accessible (erreur %1).&lt;br&gt;La synchronisation reprendra dès que le dossier sera accessible.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Le dossier de synchronisation a été remplacé ou déplacé d&apos;une manière qui empêche la synchronisation (erreur %1).&lt;br&gt;Cela peut se produire après avoir copié, déplacé ou restauré le dossier.&lt;br&gt;Pour résoudre ce problème, veuillez créer une nouvelle synchronisation avec un nouveau dossier.&lt;br&gt;Note : si vous avez des modifications non synchronisées dans l&apos;ancien dossier, vous devrez les copier manuellement dans le nouveau.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Il ne reste plus assez de mémoire sur votre machine.&lt;br&gt;La synchronisation a été arrêtée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive doit disposer d&apos;un accès en écriture au répertoire temporaire de votre ordinateur.&lt;br&gt;Veuillez redémarrer l&apos;application kDrive pour résoudre ce problème.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Une erreur technique s&apos;est produite. La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Le nombre d&apos;observateurs inotify est insuffisant (erreur %1).&lt;br&gt;Vous pouvez augmenter ce nombre en éditant &apos;/etc/sysctl.conf&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Vous devez autoriser:&lt;br&gt;- kDrive dans Paramètres système &gt;&gt; Général &gt;&gt; Éléments de connexion et extensions &gt;&gt; Extensions Endpoint Security&lt;br&gt;- Extension kDrive LiteSync dans Paramètres système &gt;&gt; Confidentialité et sécurité &gt;&gt; Accès complet au disque.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossible de démarrer le plug-in Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l&apos;extension Lite Sync est installée et que le service Windows Search est activé.&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l&apos;extension Lite Sync dispose des autorisations appropriées et est en cours d&apos;exécution.&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique, redémarrer et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Un fichier ou un dossier dans votre dossier de synchronisation semble être corrompu.&lt;br&gt;La synchronisation a été arrêtée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Le kDrive est en mode maintenance.&lt;br&gt;La synchronisation recommencera dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Le kDrive est bloqué.&lt;br&gt;Veuillez renouveler le kDrive. Si aucune action n&apos;est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Le kDrive est bloqué.&lt;br&gt;Veuillez contacter un administrateur pour renouveler le kDrive. Si aucune action n&apos;est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Le kDrive est en cours de réveil.&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe de support si l’erreur persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la version web pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Vous n&apos;êtes pas autorisé à accéder à ce kDrive.&lt;br&gt;La synchronisation a été suspendue. Veuillez contacter un administrateur.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d&apos;assistance si l&apos;erreur persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Les connexions réseau ont été interrompues par le noyau (erreur %1).&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Malheureusement, votre ancienne configuration n&apos;a pas pu être migrée.&lt;br&gt;L&apos;application utilisera une configuration vierge.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Malheureusement, votre ancienne configuration de proxy n&apos;a pas pu être migrée, les proxys SOCKS5 ne sont pas pris en charge pour le moment.&lt;br&gt;L&apos;application utilisera à la place les paramètres de proxy du système.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Une erreur technique s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation a été redémarrée. Veuillez vider l&apos;historique et si l&apos;erreur persiste, veuillez contacter notre équipe d&apos;assistance.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Une erreur d&apos;accès à la base de données de synchronisation s&apos;est produite (erreur %1).&lt;br&gt;La synchronisation a été arrêtée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Jeton invalide ou révoqué.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Les synchronisations imbriquées sont interdites (erreur %1).&lt;br&gt;Vous ne devez conserver que les synchronisations dont les dossiers ne sont pas imbriqués.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Le dossier de synchronisation sur le kDrive distant n&apos;existe plus ou n&apos;est plus accessible (erreur %1).&lt;br&gt;Vous devez le restaurer ou lui redonner des droits d&apos;accès ou supprimer/recréer la synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Erreur d&apos;analyse du nom de fichier (erreur %1).&lt;br&gt;Les caractères spéciaux tels que les guillemets doubles, les barres obliques inverses ou les retours de ligne peuvent provoquer des échecs d&apos;analyse.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Vous n&apos;êtes pas autorisé à créer cet élément, ou un autre élément portant le même nom existe déjà. L&apos;élément a été ignoré.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Vous n&apos;êtes pas autorisé à déplacer l&apos;élément vers &quot;%1&quot;.&lt;br&gt;Il sera restauré dans son dossier parent d&apos;origine.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>L&apos;espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;Le téléchargement a été annulé.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Cet élément a été déplacé ailleurs.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L&apos;élément local a été renommé.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>L&apos;espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;La synchronisation a été interrompue.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Le fichier a été modifié au même moment par un autre utilisateur.&lt;br&gt;Vos modifications ont été enregistrées dans une copie.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Un autre utilisateur a déplacé un dossier parent de la destination.&lt;br&gt;L&apos;opération locale a été annulée.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Le nom de l&apos;élément ne contient que des espaces.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Vous n&apos;êtes pas autorisé à modifier l&apos;élément.&lt;br&gt;Le fichier contenant vos modifications a été renommé et exclu de la synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Vous n&apos;êtes pas autorisé à renommer l&apos;élément.&lt;br&gt;Il sera restauré avec son nom d&apos;origine.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Vous n&apos;êtes pas autorisé à supprimer l&apos;élément.&lt;br&gt;Il sera restauré à son emplacement d&apos;origine.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Échec du déplacement de cet élément vers la corbeille, il a été mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Le fichier a été modifié localement alors qu’il a été supprimé sur le kDrive distant.&lt;br&gt;Une copie locale a été enregistrée dans le dossier de récupération (rescue folder).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>L&apos;opération effectuée sur l&apos;élément est interdite.&lt;br&gt;L&apos;article a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>L&apos;opération effectuée sur cet élément a échoué.&lt;br&gt;L&apos;article a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Le fichier est trop volumineux pour être téléchargé. Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Impossible de télécharger le fichier.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Vous avez dépassé votre quota. Augmentez votre quota d&apos;espace pour réactiver le téléchargement de fichiers.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Le disque contenant votre dossier de synchronisation n’est plus connecté (erreur %1).&lt;br&gt;Veuillez le reconnecter pour reprendre la synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Le processus LiteSyncExt n&apos;est pas en cours d&apos;exécution. La synchronisation reprendra dès son démarrage.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Un élément existant a un nom identique avec les mêmes options de casse (mêmes lettres majuscules et minuscules).&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Le nom de l&apos;élément contient un caractère non pris en charge.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Le nom de l&apos;élément se termine par un espace, ce qui est interdit sur votre système d&apos;exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ce nom d&apos;élément est réservé par votre système d&apos;exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Le nom de l&apos;élément est trop long.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Le chemin de l&apos;élément est trop long.&lt;br&gt;Il a été ignoré.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Le nom de l&apos;élément contient un caractère UNICODE récent qui n&apos;est pas encore pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Échec de la synchronisation de cet élément. Il a été temporairement mis sur liste noire.&lt;br&gt;Une autre tentative de synchronisation sera effectuée dans une heure ou au prochain démarrage de l&apos;application.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Cet élément a été exclu de la synchronisation par un modèle personnalisé. Vous pouvez désactiver ce type de notification dans les préférences</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Cet article a été exclu de la synchronisation parce qu&apos;il s&apos;agit d&apos;un lien dur.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Cet item est actuellement verrouillé par un autre utilisateur en ligne. Nous réessayerons de télécharger vos modifications plus tard.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Erreur de synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Impossible d&apos;accéder à l&apos;élément.&lt;br&gt;Veuillez corriger les autorisations de lecture et d&apos;écriture.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Impossible de créer le fichier %1 car il n&apos;est pas pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Erreur système.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>L&apos;élément existe déjà de l&apos;autre côté.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Une erreur technique s&apos;est produite.&lt;br&gt;Veuillez vider l&apos;historique et si l&apos;erreur persiste, contactez notre équipe d&apos;assistance.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossible d’ouvrir le dossier de débogage %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Transmission effectuée !&lt;br&gt;Veuillez vous référer à l'identifiant &lt;b&gt;%1&lt;/b&gt; dans vos rapports de bugs.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Aucun kDrive configuré !</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Échec de la transmission !
+Veuillez utiliser le lien suivant pour envoyer les logs au support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Il semble que votre connexion réseau soit configurée avec un délai d'expiration trop court pour que l'application fonctionne correctement (erreur %1).&lt;br&gt;Veuillez vérifier votre configuration réseau.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Impossible de se connecter au serveur kDrive (erreur %1).&lt;br&gt;Tentative de reconnexion. Veuillez vérifier votre connexion Internet et votre pare-feu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Veuillez vous reconnecter et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Une nouvelle version de l'application est disponible.&lt;br&gt;Veuillez mettre à jour l'application pour continuer à l'utiliser.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Le téléchargement du journal a échoué (erreur %1).&lt;br&gt;Veuillez réessayer plus tard.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Le dossier de synchronisation n'est plus accessible (erreur %1).&lt;br&gt;La synchronisation reprendra dès que le dossier sera accessible.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Le dossier de synchronisation a été remplacé ou déplacé d'une manière qui empêche la synchronisation (erreur %1).&lt;br&gt;Cela peut se produire après avoir copié, déplacé ou restauré le dossier.&lt;br&gt;Pour résoudre ce problème, veuillez créer une nouvelle synchronisation avec un nouveau dossier.&lt;br&gt;Note : si vous avez des modifications non synchronisées dans l'ancien dossier, vous devrez les copier manuellement dans le nouveau.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Il ne reste plus assez de mémoire sur votre machine.&lt;br&gt;La synchronisation a été arrêtée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive doit disposer d'un accès en écriture au répertoire temporaire de votre ordinateur.&lt;br&gt;Veuillez redémarrer l'application kDrive pour résoudre ce problème.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Une erreur technique s'est produite. La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Le nombre d'observateurs inotify est insuffisant (erreur %1).&lt;br&gt;Vous pouvez augmenter ce nombre en éditant '/etc/sysctl.conf'.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Vous devez autoriser:&lt;br&gt;- kDrive dans Paramètres système &gt;&gt; Général &gt;&gt; Éléments de connexion et extensions &gt;&gt; Extensions Endpoint Security&lt;br&gt;- Extension kDrive LiteSync dans Paramètres système &gt;&gt; Confidentialité et sécurité &gt;&gt; Accès complet au disque.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossible de démarrer le plug-in Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l'extension Lite Sync est installée et que le service Windows Search est activé.&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Vérifiez que l'extension Lite Sync dispose des autorisations appropriées et est en cours d'exécution.&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossible de démarrer le plugin Lite Sync (erreur %1).&lt;br&gt;Veuillez vider l'historique, redémarrer et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Un fichier ou un dossier dans votre dossier de synchronisation semble être corrompu.&lt;br&gt;La synchronisation a été arrêtée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Le kDrive est en mode maintenance.&lt;br&gt;La synchronisation recommencera dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Le kDrive est bloqué.&lt;br&gt;Veuillez renouveler le kDrive. Si aucune action n'est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Le kDrive est bloqué.&lt;br&gt;Veuillez contacter un administrateur pour renouveler le kDrive. Si aucune action n'est entreprise, les données seront définitivement supprimées et il sera impossible de les récupérer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Le kDrive est en cours de réveil.&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe de support si l’erreur persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la &lt;a style="%1" href="%2"&gt;version web&lt;/a&gt; pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>Le kDrive est en veille.&lt;br&gt;Veuillez vous connecter à la version web pour vérifier l’état de votre kDrive, ou contactez votre administrateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Vous n'êtes pas autorisé à accéder à ce kDrive.&lt;br&gt;La synchronisation a été suspendue. Veuillez contacter un administrateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;La synchronisation reprendra dès que possible. Veuillez contacter notre équipe d'assistance si l'erreur persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Les connexions réseau ont été interrompues par le noyau (erreur %1).&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Malheureusement, votre ancienne configuration n'a pas pu être migrée.&lt;br&gt;L'application utilisera une configuration vierge.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Malheureusement, votre ancienne configuration de proxy n'a pas pu être migrée, les proxys SOCKS5 ne sont pas pris en charge pour le moment.&lt;br&gt;L'application utilisera à la place les paramètres de proxy du système.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Une erreur technique s'est produite (erreur %1).&lt;br&gt;La synchronisation a été redémarrée. Veuillez vider l'historique et si l'erreur persiste, veuillez contacter notre équipe d'assistance.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Une erreur d'accès à la base de données de synchronisation s'est produite (erreur %1).&lt;br&gt;La synchronisation a été arrêtée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Un problème de connexion est survenu (erreur %1).&lt;br&gt;Jeton invalide ou révoqué.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Les synchronisations imbriquées sont interdites (erreur %1).&lt;br&gt;Vous ne devez conserver que les synchronisations dont les dossiers ne sont pas imbriqués.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Le dossier de synchronisation sur le kDrive distant n'existe plus ou n'est plus accessible (erreur %1).&lt;br&gt;Vous devez le restaurer ou lui redonner des droits d'accès ou supprimer/recréer la synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Erreur d'analyse du nom de fichier (erreur %1).&lt;br&gt;Les caractères spéciaux tels que les guillemets doubles, les barres obliques inverses ou les retours de ligne peuvent provoquer des échecs d'analyse.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Vous n'êtes pas autorisé à créer cet élément, ou un autre élément portant le même nom existe déjà. L'élément a été ignoré.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Vous n'êtes pas autorisé à déplacer l'élément vers "%1".&lt;br&gt;Il sera restauré dans son dossier parent d'origine.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>L'espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;Le téléchargement a été annulé.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Impossible de créer le fichier « %1 » car il n'est pas pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Cet élément a été déplacé ailleurs.&lt;br&gt;L'opération locale a été annulée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L'élément local a été renommé.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Un élément portant le même nom existe déjà à cet emplacement.&lt;br&gt;L'opération locale a été annulée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>L'espace disponible sur votre ordinateur est insuffisant.&lt;br&gt;La synchronisation a été interrompue.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Le fichier a été modifié au même moment par un autre utilisateur.&lt;br&gt;Vos modifications ont été enregistrées dans une copie.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Un autre utilisateur a déplacé un dossier parent de la destination.&lt;br&gt;L'opération locale a été annulée.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Le nom de l'élément ne contient que des espaces.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Vous n'êtes pas autorisé à modifier l'élément.&lt;br&gt;Le fichier contenant vos modifications a été renommé et exclu de la synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Vous n'êtes pas autorisé à renommer l'élément.&lt;br&gt;Il sera restauré avec son nom d'origine.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Vous n'êtes pas autorisé à supprimer l'élément.&lt;br&gt;Il sera restauré à son emplacement d'origine.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Échec du déplacement de cet élément vers la corbeille, il a été mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Le fichier a été modifié localement alors qu’il a été supprimé sur le kDrive distant.&lt;br&gt;Une copie locale a été enregistrée dans le dossier de récupération (rescue folder).</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>L'opération effectuée sur l'élément est interdite.&lt;br&gt;L'article a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>L'opération effectuée sur cet élément a échoué.&lt;br&gt;L'article a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Le fichier est trop volumineux pour être téléchargé. Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Impossible de télécharger le fichier.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Vous avez dépassé votre quota. Augmentez votre quota d'espace pour réactiver le téléchargement de fichiers.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Le disque contenant votre dossier de synchronisation n’est plus connecté (erreur %1).&lt;br&gt;Veuillez le reconnecter pour reprendre la synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Impossible de démarrer la synchronisation (erreur %1).&lt;br&gt;Le processus LiteSyncExt n'est pas en cours d'exécution. La synchronisation reprendra dès son démarrage.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Un élément existant a un nom identique avec les mêmes options de casse (mêmes lettres majuscules et minuscules).&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Le nom de l'élément contient un caractère non pris en charge.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Le nom de l'élément se termine par un espace, ce qui est interdit sur votre système d'exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Ce nom d'élément est réservé par votre système d'exploitation.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Le nom de l'élément est trop long.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Le chemin de l'élément est trop long.&lt;br&gt;Il a été ignoré.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Le nom de l'élément contient un caractère UNICODE récent qui n'est pas encore pris en charge par votre système de fichiers.&lt;br&gt;Il a été exclu de la synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Échec de la synchronisation de cet élément. Il a été temporairement mis sur liste noire.&lt;br&gt;Une autre tentative de synchronisation sera effectuée dans une heure ou au prochain démarrage de l'application.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Cet élément a été exclu de la synchronisation par un modèle personnalisé. Vous pouvez désactiver ce type de notification dans les préférences</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Cet article a été exclu de la synchronisation parce qu'il s'agit d'un lien dur.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Cet item est actuellement verrouillé par un autre utilisateur en ligne. Nous réessayerons de télécharger vos modifications plus tard.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Erreur de synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Impossible d'accéder à l'élément.&lt;br&gt;Veuillez corriger les autorisations de lecture et d'écriture.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Erreur système.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>L'élément existe déjà de l'autre côté.&lt;br&gt;Il a été temporairement mis sur liste noire.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Une erreur technique s'est produite.&lt;br&gt;Veuillez vider l'historique et si l'erreur persiste, contactez notre équipe d'assistance.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Cette synchronisation est en cours de suppression.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Cette synchronisation est en cours de suppression.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Retour à la liste des kDrives</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Préférences</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Retour à la liste des kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Préférences</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Paramètres</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Activer le thème foncé</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Activer les icônes monochromes</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Lancer kDrive au démarrage</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Néerlandais</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avancé</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Informations de débogage</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Fichiers à exclure</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Serveur proxy</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Suédois</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugais</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polonais</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norvégien</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finnois</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Danois</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Grec</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le dossier %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Lien %1 invalide.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Langue</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Certains processus n&apos;ont pas pu s&apos;exécuter.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Déplacer les fichiers supprimés vers la corbeille de mon ordinateur</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Certains fichiers ou dossiers peuvent ne pas être déplacés vers la corbeille de l&apos;ordinateur.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Vous pouvez toujours récupérer les fichiers déjà synchronisés depuis la corbeille de l&apos;application Web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Anglais</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Français</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Allemand</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Espagnol</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italien</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Défaut</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Paramètres</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Activer le thème foncé</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Activer les icônes monochromes</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Lancer kDrive au démarrage</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Néerlandais</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avancé</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Informations de débogage</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Ouvrir le dossier de débogage&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Fichiers à exclure</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Serveur proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Suédois</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugais</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polonais</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norvégien</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finnois</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Danois</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Grec</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossible d'ouvrir le dossier %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Lien %1 invalide.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Langue</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Certains processus n'ont pas pu s'exécuter.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Déplacer les fichiers supprimés vers la corbeille de mon ordinateur</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Certains fichiers ou dossiers peuvent ne pas être déplacés vers la corbeille de l'ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Vous pouvez toujours récupérer les fichiers déjà synchronisés depuis la corbeille de l'application Web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Anglais</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Français</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Allemand</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Espagnol</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italien</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Défaut</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 utilisés</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 utilisés</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">Proxy HTTP(S)</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Serveur proxy</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Aucun serveur proxy</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Utiliser les paramètres système</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Indiquer un proxy manuellement</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Port</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Adresse du serveur proxy</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Authentification requise</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Utilisateur</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Mot de passe</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ENREGISTRER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Voulez-vous enregistrer vos modifications ?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Enregistrement impossible ; tous les champs obligatoires n’ont pas été complétés !</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy non trouvé, enregistrer quand même ?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>Proxy HTTP(S)</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Serveur proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Aucun serveur proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Utiliser les paramètres système</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Indiquer un proxy manuellement</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Port</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Adresse du serveur proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Authentification requise</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Utilisateur</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Mot de passe</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>ENREGISTRER</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Voulez-vous enregistrer vos modifications ?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Enregistrement impossible ; tous les champs obligatoires n’ont pas été complétés !</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy non trouvé, enregistrer quand même ?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Gestionnaire des ressources</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Utilisation maximale du processeur autorisée</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ENREGISTRER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Voulez-vous enregistrer vos modifications ?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Gestionnaire des ressources</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Utilisation maximale du processeur autorisée</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>ENREGISTRER</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Voulez-vous enregistrer vos modifications ?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Sélectionnez un dossier dans votre kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Le contenu du dossier sélectionné sera synchronisé dans le dossier &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUER</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Espace disponible sur votre ordinateur pour le dossier actuel : %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Ce dossier est déjà en cours de synchronisation.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULER</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Sélectionnez un dossier dans votre kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Le contenu du dossier sélectionné sera synchronisé dans le dossier &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>CONTINUER</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Espace disponible sur votre ordinateur pour le dossier actuel : %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Ce dossier est déjà en cours de synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>CONFIRMER</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ANNULER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Le dossier &lt;b&gt;%1&lt;/b&gt; contient des sous-dossier,&lt;br&gt; sélectionnez ceux que vous voulez synchroniser</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUER</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Aucun sous-dossier sur le serveur.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; contient des sous-dossier,&lt;br&gt; sélectionnez ceux que vous voulez synchroniser</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>CONTINUER</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Aucun sous-dossier sur le serveur.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Reprendre la synchronisation du kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Reprendre la synchronisation de tous les kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Suspendre la synchronisation du kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Mettre en pause la synchronisation</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Suspendre la synchronisation de tous les kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Reprendre la synchronisation</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Reprendre la synchronisation du kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Reprendre la synchronisation de tous les kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Suspendre la synchronisation du kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Mettre en pause la synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Suspendre la synchronisation de tous les kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Reprendre la synchronisation</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Copier le lien de partage</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Afficher sur kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Afficher dans le dossier</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Autres actions</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Ouvrir</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Ajouter aux favoris</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Copier le lien de partage</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Afficher sur kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Afficher dans le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Autres actions</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Ouvrir</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Ajouter aux favoris</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Jamais</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Pendant 1 heure</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Jusqu’à demain 8h00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Pendant 3 jours</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Pendant 1 semaine</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Toujours</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Pour 1 heure de plus</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Pour 3 heures de plus</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Pour 1 semaine de plus</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Impossible d’ouvrir l’URL du dossier %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Ouvrir dans le dossier</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Ouvrir la version Web de %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Paramètres du kDrive</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Notifications désactivées jusqu’à %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Désactiver les notifications</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Préférences de l’application</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Besoin d’aide</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Envoyer des commentaires</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Quitter kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Impossible d’accéder au site %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Afficher les erreurs et les informations</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Afficher les informations</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Autres actions</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Jamais</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Pendant 1 heure</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Jusqu’à demain 8h00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Pendant 3 jours</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Pendant 1 semaine</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Toujours</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Pour 1 heure de plus</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Pour 3 heures de plus</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Pour 1 semaine de plus</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Ouvrir dans le dossier</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Ouvrir la version Web de %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Paramètres du kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Notifications désactivées jusqu’à %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Désactiver les notifications</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Préférences de l’application</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Besoin d’aide</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Envoyer des commentaires</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Quitter kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Impossible d’accéder au site %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Afficher les erreurs et les informations</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Afficher les informations</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Autres actions</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Mettre à jour l&apos;application kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Cette version de l&apos;application kDrive n&apos;est plus prise en charge. Pour accéder aux dernières fonctionnalités et améliorations, veuillez mettre à jour.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Mise à jour</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Veuillez télécharger la dernière version sur le site Web.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Téléchargement de la mise à jour en cours</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Recherche d&apos;une mise à jour...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Mise à jour manuelle</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Indisponible</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Vous pouvez synchroniser les fichiers &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;depuis votre ordinateur&lt;/a&gt; ou sur &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synchronisé</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoris</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Activité</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Non implémenté&#xa0;!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/fr/applications/telecharger-kdrive&quot;&gt;Cliquez ici pour télécharger manuellement&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Aucun fichier synchronisé pour ce kDrive&#xa0;!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Aucun kDrive configuré !</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossible d’ouvrir le lien %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Lien %1 invalide.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Impossible d’ouvrir l’URL du dossier %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Mettre à jour l'application kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Cette version de l'application kDrive n'est plus prise en charge. Pour accéder aux dernières fonctionnalités et améliorations, veuillez mettre à jour.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Mise à jour</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Veuillez télécharger la dernière version sur le site Web.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Téléchargement de la mise à jour en cours</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Recherche d'une mise à jour...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Mise à jour manuelle</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Indisponible</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Vous pouvez synchroniser les fichiers &lt;a style="%1" href="%2"&gt;depuis votre ordinateur&lt;/a&gt; ou sur &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synchronisé</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoris</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Activité</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Non implémenté !</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/fr/applications/telecharger-kdrive"&gt;Cliquez ici pour télécharger manuellement&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Aucun fichier synchronisé pour ce kDrive !</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Aucun kDrive configuré !</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Impossible d’ouvrir le lien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Lien %1 invalide.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Impossible d’ouvrir l’URL du dossier %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;La nouvelle version &lt;b&gt;%1&lt;/b&gt; du client %2 est disponible et a été téléchargée.&lt;/p&gt;&lt;p&gt;La version installée est %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Ignorer cette version</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Pas maintenant</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installer</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;La nouvelle version &lt;b&gt;%1&lt;/b&gt; du client %2 est disponible et a été téléchargée.&lt;/p&gt;&lt;p&gt;La version installée est %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Ignorer cette version</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Pas maintenant</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installer</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Nouvelle mise à jour disponible.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">La version %1 est disponible au téléchargement.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Nouvelle mise à jour disponible.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>La version %1 est disponible au téléchargement.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Ajouter un compte</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Ajouter un compte</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Afficher la note de version&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Version</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">METTRE A JOUR</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 est à jour !</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Vérification de la mise à jour sur le serveur...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Une mise à jour est disponible&#xa0;: %1.&lt;br&gt;Veuillez la télécharger depuis &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;ici&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Une mise à jour est disponible: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Téléchargement %1 en cours. Veuillez patienter…</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Impossible de vérifier la présence de nouvelles mises à jour.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Une erreur s&apos;est produite lors de la mise à jour.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Impossible de télécharger la mise à jour.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Mise à jour désactivée.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Programme bêta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Bénéficier d&apos;un accès anticipé aux nouvelles versions de l&apos;application</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Rejoindre</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Modifier</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Quitter</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Afficher la note de version&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Version</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>METTRE A JOUR</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 est à jour !</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Vérification de la mise à jour sur le serveur...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Une mise à jour est disponible : %1.&lt;br&gt;Veuillez la télécharger depuis &lt;a style="%2" href="%3"&gt;ici&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Une mise à jour est disponible: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Téléchargement %1 en cours. Veuillez patienter…</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Impossible de vérifier la présence de nouvelles mises à jour.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Une erreur s'est produite lors de la mise à jour.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Impossible de télécharger la mise à jour.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Mise à jour désactivée.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Programme bêta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Bénéficier d'un accès anticipé aux nouvelles versions de l'application</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Rejoindre</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Modifier</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Quitter</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Impossible d&apos;enregistrer les paramètres, veuillez réessayer plus tard.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Impossible d&apos;enregistrer les paramètres&#xa0;!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Le dossier parent est un dossier de synchronisation ou contenu dans un</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Impossible de trouver un chemin valide</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Aucun dossier valable sélectionné!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Le chemin sélectionné n’existe pas!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Le chemin sélectionné n&apos;est pas un dossier!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Vous n&apos;avez pas la permission d&apos;écrire dans le dossier sélectionné!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Le dossier local %1 est déjà synchronisé. Veuillez en choisir un autre&#xa0;!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">La Lite sync (bêta) est activée. Les fichiers de kDrive restent dans le Cloud et n&apos;utilisent pas l&apos;espace de stockage de votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">La Lite sync(bêta) est désactivée. Les fichiers kDrive utilisent l&apos;espace de stockage de votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">La Lite sync est activée. Les fichiers de kDrive restent dans le Cloud et n&apos;utilisent pas l&apos;espace de stockage de votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">La Lite sync est désactivée. Les fichiers kDrive utilisent l&apos;espace de stockage de votre ordinateur.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Rendre disponible localement</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Libérer de l’espace local</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Annuler libérer l&apos;espace local</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Annuler rendre disponible localement</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Le partage de ce fichier n&apos;est pas autorisé</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Le partage de ce dossier n&apos;est pas autorisé</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Copier le lien de partage public</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Copier le lien de partage privé</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Ouvrir dans le navigateur web</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Impossible d'enregistrer les paramètres, veuillez réessayer plus tard.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Impossible d'enregistrer les paramètres !</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Le dossier parent est un dossier de synchronisation ou contenu dans un</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Impossible de trouver un chemin valide</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Aucun dossier valable sélectionné!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Le chemin sélectionné n’existe pas!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Le chemin sélectionné n'est pas un dossier!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Vous n'avez pas la permission d'écrire dans le dossier sélectionné!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Le dossier local %1 contient un dossier déjà synchronisé. Veuillez en choisir un autre !</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Le dossier local %1 est contenu dans un dossier déjà synchronisé. Veuillez en choisir un autre !</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Le dossier local %1 est déjà synchronisé. Veuillez en choisir un autre !</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>La Lite sync (bêta) est activée. Les fichiers de kDrive restent dans le Cloud et n'utilisent pas l'espace de stockage de votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>La Lite sync(bêta) est désactivée. Les fichiers kDrive utilisent l'espace de stockage de votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>La Lite sync est activée. Les fichiers de kDrive restent dans le Cloud et n'utilisent pas l'espace de stockage de votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>La Lite sync est désactivée. Les fichiers kDrive utilisent l'espace de stockage de votre ordinateur.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Rendre disponible localement</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Libérer de l’espace local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Annuler libérer l'espace local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Annuler rendre disponible localement</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Le partage de ce fichier n'est pas autorisé</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Le partage de ce dossier n'est pas autorisé</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Copier le lien de partage public</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Copier le lien de partage privé</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Ouvrir dans le navigateur web</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">L&apos;application kDrive se fermera en raison d&apos;une erreur fatale.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>L'application kDrive se fermera en raison d'une erreur fatale.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 Go</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 Mo</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 Ko</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 octets</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n an</numerusform>
-            <numerusform>%n ans</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n mois</numerusform>
-            <numerusform>%n mois</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n jour</numerusform>
-            <numerusform>%n jours</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n heure</numerusform>
-            <numerusform>%n heures</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minute</numerusform>
-            <numerusform>%n minutes</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n seconde</numerusform>
-            <numerusform>%n secondes</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 Go</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 Mo</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 Ko</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 octets</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n an</numerusform>
+<numerusform>%n ans</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n mois</numerusform>
+<numerusform>%n mois</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n jour</numerusform>
+<numerusform>%n jours</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n heure</numerusform>
+<numerusform>%n heures</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minute</numerusform>
+<numerusform>%n minutes</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n seconde</numerusform>
+<numerusform>%n secondes</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Zone de notification indisponible</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Zone de notification indisponible</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 nécessite une zone de notification (system tray) fonctionnelle. Si vous utilisez XFCE, veuillez suivre &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;ces instructions&lt;/a&gt;. Sinon, veuillez installer une application de zone de notification telle que « trayer » et réessayer.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Impossible de démarrer le navigateur</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Une erreur est survenue au lancement du navigateur pour visiter l&apos;adresse %1. Il est possible qu&apos;aucun navigateur par défaut ne soit configuré?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Impossible d&apos;ouvrir le client de messagerie</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Il y a eu une erreur lors du lancement du client de messagerie pour créer un nouveau message. Peut-être qu&apos;aucun client de messagerie n&apos;est configuré ?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Vous n&apos;êtes plus connecté. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Connexion&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synchronisation en cours (Étape %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synchronisation en cours.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Certains fichiers n&apos;ont pas pu être synchronisés. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;En savoir plus&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Pause de la synchronisation...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Impossible de sélectionner le dossier &lt;b&gt;%1&lt;/b&gt; car une autre synchronisation utilise le même dossier.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il contient le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il est contenu dans le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Démarrage de la synchronisation</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synchronisation en pause.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synchronisation en cours (%1 sur %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Impossible de démarrer le navigateur</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Une erreur est survenue au lancement du navigateur pour visiter l'adresse %1. Il est possible qu'aucun navigateur par défaut ne soit configuré?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Impossible d'ouvrir le client de messagerie</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Il y a eu une erreur lors du lancement du client de messagerie pour créer un nouveau message. Peut-être qu'aucun client de messagerie n'est configuré ?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Vous n'êtes plus connecté. &lt;a style="%1" href="%2"&gt;Connexion&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synchronisation en cours (Étape %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synchronisation en cours.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Certains fichiers n'ont pas pu être synchronisés. &lt;a style="%1" href="%2"&gt;En savoir plus&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Pause de la synchronisation...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Impossible de sélectionner le dossier &lt;b&gt;%1&lt;/b&gt; car une autre synchronisation utilise le même dossier.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il contient le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné car il est contenu dans le dossier synchronisé &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Le dossier &lt;b&gt;%1&lt;/b&gt; ne peut pas être sélectionné comme dossier de synchronisation. Veuillez sélectionner un autre dossier. Dossier suggéré : &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Vous avez exclu plus de %1 dossiers. Veuillez noter que cela affectera les performances de synchronisation.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Vous ne pouvez pas exclure plus de %1 dossiers. Veuillez décocher les dossiers de niveau supérieur.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Démarrage de la synchronisation</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synchronisation en pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synchronisation en cours (%1 sur %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synchronisation en cours (%1 sur %2)
+<translation>Synchronisation en cours (%1 sur %2)
 %3 restantes...</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Vous êtes à jour, conflits non résolus.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Vous êtes à jour !</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Vous êtes à jour, conflits non résolus.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Vous êtes à jour !</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Aucun dossier à synchroniser.
+<translation>Aucun dossier à synchroniser.
 Ajoutez-en un depuis la configuration du kDrive.</translation>
-    </message>
+</message>
 </context>
 </TS>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -1,3097 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="it_IT" version="2.1">
+<TS version="2.1" language="it_IT">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Informazioni su</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>CHIUDI</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versione %1. Per maggiori informazioni, visita &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribuito da %1 e concesso in licenza &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e il logo %2 sono marchi registrati di %1. &lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossibile aprire la cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Compilato da &lt;a style="color: #489EF3" href="%1"&gt;fonti Git&lt;/a&gt; il %2, alle %3 usando Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Informazioni su</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>CHIUDI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versione %1. Per maggiori informazioni, visita &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuito da %1 e concesso in licenza &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e il logo %2 sono marchi registrati di %1. &lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossibile aprire la cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Compilato da &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;fonti Git&lt;/a&gt; il %2, alle %3 usando Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossibile aprire il percorso della cartella %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossibile aprire il percorso della cartella %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>La sincronizzazione sarà avviata e potrai aggiungere i file alla tua cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Il tuo kDrive è pronto!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>APRI CARTELLA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>PARAMETRI</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Sincronizza un'altra unità</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>La sincronizzazione sarà avviata e potrai aggiungere i file alla tua cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Il tuo kDrive è pronto!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>APRI CARTELLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>PARAMETRI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Sincronizza un&apos;altra unità</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Annulla</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>AVANTI</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Seleziona il kDrive che vuoi sincronizzare</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Ottieni kDrive gratuitamente</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Archivia le tue foto, documenti ed e-mail in Svizzera presso un'azienda indipendente che rispetta la privacy. Maggiori informazioni</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Prova gratuita</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>AVANTI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Seleziona il kDrive che vuoi sincronizzare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Ottieni kDrive gratuitamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Archivia le tue foto, documenti ed e-mail in Svizzera presso un&apos;azienda indipendente che rispetta la privacy. Maggiori informazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Prova gratuita</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Risparmia spazio sul tuo computer</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Scegli quali file rendere disponibili online o localmente</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>PIÙ TARDI</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>SÌ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync sincronizza tutti i tuoi file senza occupare spazio sul tuo computer. Puoi sfogliare i file sul tuo kDrive e scaricarli localmente quando vuoi. &lt;a style="%1" href="%2"&gt;Maggiori informazioni&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Attivare Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Attivare Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Risparmia spazio sul tuo computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Scegli quali file rendere disponibili online o localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>PIÙ TARDI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>SÌ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync sincronizza tutti i tuoi file senza occupare spazio sul tuo computer. Puoi sfogliare i file sul tuo kDrive e scaricarli localmente quando vuoi. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Maggiori informazioni&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Attivare Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Attivare Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Posizione del tuo %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Modifica cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>FINE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Seleziona cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Il contenuto della cartella &lt;b&gt;%1&lt;/b&gt; verrà sincronizzato nel tuo kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Al termine della configurazione tutti i tuoi file saranno in questa cartella. Puoi trascinare nuovi file in questa cartella per sincronizzarli con il tuo kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Posizione del tuo %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Modifica cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>FINE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Seleziona cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Il contenuto della cartella &lt;b&gt;%1&lt;/b&gt; verrà sincronizzato nel tuo kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Al termine della configurazione tutti i tuoi file saranno in questa cartella. Puoi trascinare nuovi file in questa cartella per sincronizzarli con il tuo kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
-Seleziona un'altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>CONTINUA</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
+Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Accedi dal tuo browser</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Il browser dovrebbe aprirsi automaticamente per completare la connessione. Una volta connesso, tornerai automaticamente a kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Apri la pagina di accesso</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Si è verificato un errore durante l'autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Accesso non riuscito: %1 – %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Impossibile aprire la pagina di accesso nel browser web</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Accedi dal tuo browser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Il browser dovrebbe aprirsi automaticamente per completare la connessione. Una volta connesso, tornerai automaticamente a kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Apri la pagina di accesso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Si è verificato un errore durante l&apos;autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Accesso non riuscito: %1 – %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Impossibile aprire la pagina di accesso nel browser web</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Seleziona cartelle kDrive da sincronizzare sul tuo desktop</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>CONTINUA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Spazio disponibile nel computer: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Si è verificato un errore durante il caricamento dell'elenco delle sottocartelle.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Die Liste der Unterordner konnte nicht geladen werden. Ihr kDrive befindet sich möglicherweise in Wartung.&lt;br&gt;Melden Sie sich bei der &lt;a style="%1" href="%2"&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Seleziona cartelle kDrive da sincronizzare sul tuo desktop</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Spazio disponibile nel computer: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Si è verificato un errore durante il caricamento dell&apos;elenco delle sottocartelle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Die Liste der Unterordner konnte nicht geladen werden. Ihr kDrive befindet sich möglicherweise in Wartung.&lt;br&gt;Melden Sie sich bei der &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Creazione della la cartella locale %1 non riuscita</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Creazione della nuova sincronizzazione non riuscita</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>Il kDrive %1 è già sincronizzato su questo computer. Continuare lo stesso?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Creazione della la cartella locale %1 non riuscita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Creazione della nuova sincronizzazione non riuscita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Il kDrive %1 è già sincronizzato su questo computer. Continuare lo stesso?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>Il client kDrive viene eseguito con parametri errati</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>Il client kDrive è già in esecuzione!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>L'utente %1 non è connesso. Effettuare nuovamente il login.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>Il client kDrive viene eseguito con parametri errati</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Il client kDrive è già in esecuzione!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>L&apos;utente %1 non è connesso. Effettuare nuovamente il login.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Link di condivisione copiato negli appunti</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
-<numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 è stato rimosso.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
-<numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 è stato aggiunto.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
-<numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 è stato aggiornato.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
-<numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 è stato spostato in %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Sincronizza attività</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Link di condivisione copiato negli appunti</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
+            <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 è stato rimosso.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
+            <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 è stato aggiunto.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
+            <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 è stato aggiornato.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
+            <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 è stato spostato in %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Sincronizza attività</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Attualmente non ci sono sottocartelle sul server.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Attualmente non ci sono sottocartelle sul server.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Abbandonare il programma beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Partecipare al programma beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Ottenete l'accesso anticipato alle nuove versioni dell'applicazione prima che vengano rilasciate al pubblico e partecipate al miglioramento dell'applicazione inviandoci i vostri commenti.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Beneficiare degli aggiornamenti beta delle applicazioni</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>No</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Versione beta pubblica</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Versione beta interna</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Versione di prova</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Capisco</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Siete sicuri di voler abbandonare il programma beta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Salva</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Annulla</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>La tua attuale versione dell'applicazione potrebbe essere troppo recente, la tua scelta sarà effettiva dal prossimo aggiornamento disponibile.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Le versioni beta possono uscire inaspettatamente o causare instabilità.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Abbandonare il programma beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Partecipare al programma beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Ottenete l&apos;accesso anticipato alle nuove versioni dell&apos;applicazione prima che vengano rilasciate al pubblico e partecipate al miglioramento dell&apos;applicazione inviandoci i vostri commenti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Beneficiare degli aggiornamenti beta delle applicazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>No</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Versione beta pubblica</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Versione beta interna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Versione di prova</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Capisco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Siete sicuri di voler abbandonare il programma beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Salva</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>La tua attuale versione dell&apos;applicazione potrebbe essere troppo recente, la tua scelta sarà effettiva dal prossimo aggiornamento disponibile.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Le versioni beta possono uscire inaspettatamente o causare instabilità.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Accedi</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Cartella %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Sintesi</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translation>Preferenze</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Esci</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Stato non definito.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>In attesa di iniziare la sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Sincronizzazione in corso.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>La sincronizzazione è stata completata correttamente, sono presenti conflitti non risolti.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>L'ultima sincronizzazione è stata completata correttamente.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Interrotto dall'utente.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Sincronizzazione sospesa.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Sincronizzazione sospesa)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vuoi davvero rimuovere le sincronizzazioni dell'account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>RIMUOVERE TUTTE LE SINC</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 elementi sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Per evitare eliminazioni involontarie, la sincronizzazione è stata messa in pausa.&lt;br&gt;Vuoi propagare queste eliminazioni al tuo kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Diversi file sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. I file eliminati si trovano nel &lt;a style="%1" href="%3"&gt;cestino&lt;/a&gt; di kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Non mostrare più</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Impossibile avviare la sincronizzazione!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossibile aprire il percorso della cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Impossibile inizializzare il client kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Impossibile risolvere i conflitti su %1 elemento/i nella cartella di sincronizzazione: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Sincronizzazione sospesa</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Accedi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Cartella %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Sintesi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translation>Preferenze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Esci</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Stato non definito.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>In attesa di iniziare la sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Sincronizzazione in corso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>La sincronizzazione è stata completata correttamente, sono presenti conflitti non risolti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>L&apos;ultima sincronizzazione è stata completata correttamente.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Interrotto dall&apos;utente.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Sincronizzazione sospesa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Sincronizzazione sospesa)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vuoi davvero rimuovere le sincronizzazioni dell&apos;account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>RIMUOVERE TUTTE LE SINC</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 elementi sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Per evitare eliminazioni involontarie, la sincronizzazione è stata messa in pausa.&lt;br&gt;Vuoi propagare queste eliminazioni al tuo kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Diversi file sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. I file eliminati si trovano nel &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;cestino&lt;/a&gt; di kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Non mostrare più</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Impossibile avviare la sincronizzazione!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossibile aprire il percorso della cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Impossibile inizializzare il client kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Impossibile risolvere i conflitti su %1 elemento/i nella cartella di sincronizzazione: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Sincronizzazione sospesa</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Riepilogo della sincronizzazione della cartella locale</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>I contenuti delle cartelle nel computer saranno sincronizzati con la cartella del kDrive selezionato e viceversa.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SINCRONIZZA</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Riepilogo della sincronizzazione della cartella locale</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>I contenuti delle cartelle nel computer saranno sincronizzati con la cartella del kDrive selezionato e viceversa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SINCRONIZZA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Prima di terminare</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Esegui le fasi seguenti per assicurare che Lite Sync funzioni correttamente sul computer e per completare la configurazione del kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Aprite le &lt;b&gt;Impostazioni generali&lt;/b&gt; del vostro Mac o &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Apri le &lt;b&gt;impostazioni Privacy e sicurezza&lt;/b&gt; del tuo Mac o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Apri le &lt;b&gt;impostazioni di sicurezza e privacy&lt;/b&gt; del tuo Mac o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Andare alla sezione &lt;b&gt;"Elementi ed estensioni di accesso"&lt;/b&gt; e quindi a &lt;b&gt;"Estensioni di sicurezza per gli endpoint"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Autorizzare l'applicazione kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Vai alla sezione &lt;b&gt;"Sicurezza"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Autorizza l'applicazione kDrive nella casella indicando che kDrive è stato bloccato</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Sblocca il lucchetto&lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorizza l'applicazione kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Andate alla sezione &lt;b&gt;"Privacy e sicurezza"&lt;/b&gt; e fate clic su &lt;b&gt;"Accesso completo al disco"&lt;/b&gt; oppure &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Sempre nelle impostazioni di Sicurezza e Privacy, apri la scheda &lt;b&gt;"Privacy"&lt;/b&gt; o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Seleziona la casella "kDrive LiteSync Extension" quindi la casella "kDrive.app" (se non è già selezionata)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Potrebbe essere proposto un riavvio dell'app, in questo caso accettarlo</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Spunta la casella "kDrive LiteSync Extension" (e "kDrive.app" se esiste) in &lt;b&gt;"Accesso completo al disco"&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>FASE 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Fatto)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>FASE 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>FASI ESEGUITE</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>FINE</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Prima di terminare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Esegui le fasi seguenti per assicurare che Lite Sync funzioni correttamente sul computer e per completare la configurazione del kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Aprite le &lt;b&gt;Impostazioni generali&lt;/b&gt; del vostro Mac o &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Apri le &lt;b&gt;impostazioni Privacy e sicurezza&lt;/b&gt; del tuo Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Apri le &lt;b&gt;impostazioni di sicurezza e privacy&lt;/b&gt; del tuo Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Andare alla sezione &lt;b&gt;&quot;Elementi ed estensioni di accesso&quot;&lt;/b&gt; e quindi a &lt;b&gt;&quot;Estensioni di sicurezza per gli endpoint&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autorizzare l&apos;applicazione kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Vai alla sezione &lt;b&gt;&quot;Sicurezza&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autorizza l&apos;applicazione kDrive nella casella indicando che kDrive è stato bloccato</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Sblocca il lucchetto&lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; e autorizza l&apos;applicazione kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Andate alla sezione &lt;b&gt;&quot;Privacy e sicurezza&quot;&lt;/b&gt; e fate clic su &lt;b&gt;&quot;Accesso completo al disco&quot;&lt;/b&gt; oppure &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Sempre nelle impostazioni di Sicurezza e Privacy, apri la scheda &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Seleziona la casella &quot;kDrive LiteSync Extension&quot; quindi la casella &quot;kDrive.app&quot; (se non è già selezionata)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Potrebbe essere proposto un riavvio dell&apos;app, in questo caso accettarlo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Spunta la casella &quot;kDrive LiteSync Extension&quot; (e &quot;kDrive.app&quot; se esiste) in &lt;b&gt;&quot;Accesso completo al disco&quot;&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>FASE 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Fatto)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>FASE 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>FASI ESEGUITE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>FINE</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>SÌ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NO</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>SÌ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NO</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Invio di informazioni di debug in corso</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Annulla</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Invio di informazioni di debug in corso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Info</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Debug</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Avviso</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Errore</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Irreversibile</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Impostazioni di debug</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Salva le informazioni di debug in una cartella sul mio computer (consigliato)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Queste informazioni consentono al supporto IT di determinare l'origine di un incidente.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Apri cartella di debug&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Livello di debug</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Il livello di traccia consente di scegliere l'entità delle informazioni di debug registrate</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Il registro completo esteso raccoglie una cronologia dettagliata che può essere utilizzata per il debug. Abilitarla può rallentare l'applicazione kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Log completo esteso</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Elimina i registri più vecchi di %1 giorni</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Condividi la cartella debug con il supporto di Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>L'ultima sessione è il periodo trascorso dall'ultimo avvio di kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Condividi solo l'ultima sessione di kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Caricamento</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Annulla</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>SALVA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Impossibile condividere</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Verifica di aver effettuato l'accesso&lt;br&gt;2. Verifica di aver configurato almeno un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Connessione interrotta)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Condividi la cartella con SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Abbiamo compresso automaticamente il tuo registro &lt;a style="%1" href="%2"&gt;qui&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Trasferisci l'archivio con &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Condividi il link con &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Ultimo caricamento il %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>La condivisione è stata annullata</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Il registro completo esteso è attivato tramite la variabile d'ambiente KDRIVE_FORCE_EXTENDED_LOG. Impostalo a 0 per disabilitarlo.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>L'intera cartella è di grandi dimensioni (&gt; 100 MB) e potrebbe richiedere del tempo per essere condivisa. Per ridurre il tempo di condivisione, si consiglia di condividere solo l'ultima sessione di kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%2/%1/%3 alle %4:%5:%6</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Salvare le modifiche?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossibile aprire la cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Condividere</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Condivisione | passaggio 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Condivisione | passaggio 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Annullamento...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Debug</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Avviso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Irreversibile</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Impostazioni di debug</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Salva le informazioni di debug in una cartella sul mio computer (consigliato)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Queste informazioni consentono al supporto IT di determinare l&apos;origine di un incidente.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Livello di debug</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Il livello di traccia consente di scegliere l&apos;entità delle informazioni di debug registrate</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Il registro completo esteso raccoglie una cronologia dettagliata che può essere utilizzata per il debug. Abilitarla può rallentare l&apos;applicazione kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Log completo esteso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Elimina i registri più vecchi di %1 giorni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Condividi la cartella debug con il supporto di Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>L&apos;ultima sessione è il periodo trascorso dall&apos;ultimo avvio di kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Condividi solo l&apos;ultima sessione di kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Caricamento</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Impossibile condividere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Verifica di aver effettuato l&apos;accesso&lt;br&gt;2. Verifica di aver configurato almeno un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Connessione interrotta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Condividi la cartella con SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Abbiamo compresso automaticamente il tuo registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;qui&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Trasferisci l&apos;archivio con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Condividi il link con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Ultimo caricamento il %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>La condivisione è stata annullata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Il registro completo esteso è attivato tramite la variabile d&apos;ambiente KDRIVE_FORCE_EXTENDED_LOG. Impostalo a 0 per disabilitarlo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>L&apos;intera cartella è di grandi dimensioni (&gt; 100 MB) e potrebbe richiedere del tempo per essere condivisa. Per ridurre il tempo di condivisione, si consiglia di condividere solo l&apos;ultima sessione di kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%2/%1/%3 alle %4:%5:%6</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Salvare le modifiche?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossibile aprire la cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Condividere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Condivisione | passaggio 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Condivisione | passaggio 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Annullamento...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Cartelle</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Notifiche</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Verrà visualizzata una notifica appena una nuova cartella sarà sincronizzata o modificata</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Connesso a</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questa operazione &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Questa operazione può richiedere da pochi secondi a qualche minuto, a seconda delle dimensioni della cartella.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Nuova sincronizzazione delle cartelle locali non riuscita!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Attivazione Lite Sync non riuscita.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Disattivazione Lite Sync non riuscita.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>RIMUOVI CONNESSIONE DI SINC. CARTELLE</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Si è verificato un errore durante il caricamento dell'elenco delle sottocartelle.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Abilita le notifiche per questo kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>CONFERMA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Errori di sincronizzazione e informazioni.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Sincronizza una cartella locale</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Abilitare Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Disabilitare Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Non hai abbastanza spazio libero per sincronizzare tutti i file sul tuo kDrive (%1 mancanti). Se disabiliti Lite Sync dovrai scegliere quali cartelle sincronizzare sul tuo computer. Nel frattempo la sincronizzazione del tuo kDrive verrà sospesa.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Se si disattiva Lite Sync, tutti i file verranno scaricati sul computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Creazione della nuova sincronizzazione non riuscita</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Sincronizzazione Lite attivata.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync disattivato.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Questa unità è in fase di eliminazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Impossibile aprire l'articolo %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Impossibile interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Rimuovi tutte le sincronizzazioni</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Cerca nel tuo kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Ricerca</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Cartelle</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Notifiche</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Verrà visualizzata una notifica appena una nuova cartella sarà sincronizzata o modificata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Connesso a</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questa operazione &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Questa operazione può richiedere da pochi secondi a qualche minuto, a seconda delle dimensioni della cartella.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Nuova sincronizzazione delle cartelle locali non riuscita!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Attivazione Lite Sync non riuscita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Disattivazione Lite Sync non riuscita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>RIMUOVI CONNESSIONE DI SINC. CARTELLE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Si è verificato un errore durante il caricamento dell&apos;elenco delle sottocartelle.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Abilita le notifiche per questo kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>CONFERMA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Errori di sincronizzazione e informazioni.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Sincronizza una cartella locale</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Abilitare Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Disabilitare Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Non hai abbastanza spazio libero per sincronizzare tutti i file sul tuo kDrive (%1 mancanti). Se disabiliti Lite Sync dovrai scegliere quali cartelle sincronizzare sul tuo computer. Nel frattempo la sincronizzazione del tuo kDrive verrà sospesa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Se si disattiva Lite Sync, tutti i file verranno scaricati sul computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Creazione della nuova sincronizzazione non riuscita</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Sincronizzazione Lite attivata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync disattivato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Questa unità è in fase di eliminazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Impossibile aprire l&apos;articolo %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Impossibile interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Rimuovi tutte le sincronizzazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Cerca nel tuo kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Ricerca</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Sincronizza un kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Aggiungi un kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Sincronizza un kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Aggiungi un kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Risolvere</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Articoli in conflitto</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Elementi con caratteri non supportati</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Cancella cronologia</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Per risolvere</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Risolto automaticamente</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problema/i risolto/i</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>problema/i rilevato/i</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Risolvere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Articoli in conflitto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Elementi con caratteri non supportati</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Cancella cronologia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Per risolvere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Risolto automaticamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problema/i risolto/i</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>problema/i rilevato/i</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Conflitti o errori di sincronizzazione</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Errori</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Torna alle preferenze</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Conflitti o errori di sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Errori</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Torna alle preferenze</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Non è stato possibile sincronizzare alcuni file sui kDrive seguenti:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 errori)</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 informazione(i))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 errori e %2 informazioni)</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
-<numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Non è stato possibile sincronizzare alcuni file sui kDrive seguenti:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 errori)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informazione(i))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 errori e %2 informazioni)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
+            <numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>File esclusi</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Aggiungi file o cartelle che non saranno sincronizzati sul tuo computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Aggiungi</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NOME</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>AVVERTIMENTO</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>SALVA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Salvare le modifiche?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Il modello di esclusione esiste già!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Eliminare?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Impossibile salvare le modifiche!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>File esclusi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Aggiungi file o cartelle che non saranno sincronizzati sul tuo computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Aggiungi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>AVVERTIMENTO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Salvare le modifiche?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Il modello di esclusione esiste già!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Eliminare?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Impossibile salvare le modifiche!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>CONVALIDA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>CONVALIDA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Risolvere i conflitti</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Cosa vuoi fare con gli elementi in conflitto %1?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Salva le mie modifiche e sostituisci le versioni degli altri utenti.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Annulla le mie modifiche e conserva le versioni degli altri utenti.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Le tue modifiche potrebbero essere eliminate definitivamente. Non possono essere ripristinate dall'applicazione web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Le tue modifiche saranno eliminate definitivamente. Non potranno essere ripristinate dall'applicazione web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Mostra articolo(i)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>CONVALIDA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Sono state apportate modifiche a questi file da diversi utenti in diversi posti (online su kDrive, un computer o un dispositivo mobile). Le cartelle contenenti questi file potrebbero anche essere state eliminate.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>La versione locale del tuo elemento &lt;b&gt;non è sincronizzata&lt;/b&gt; con kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Ulteriori informazioni&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Risolvere i conflitti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Cosa vuoi fare con gli elementi in conflitto %1?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Salva le mie modifiche e sostituisci le versioni degli altri utenti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Annulla le mie modifiche e conserva le versioni degli altri utenti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Le tue modifiche potrebbero essere eliminate definitivamente. Non possono essere ripristinate dall&apos;applicazione web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Le tue modifiche saranno eliminate definitivamente. Non potranno essere ripristinate dall&apos;applicazione web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Mostra articolo(i)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>CONVALIDA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Sono state apportate modifiche a questi file da diversi utenti in diversi posti (online su kDrive, un computer o un dispositivo mobile). Le cartelle contenenti questi file potrebbero anche essere state eliminate.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>La versione locale del tuo elemento &lt;b&gt;non è sincronizzata&lt;/b&gt; con kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Ulteriori informazioni&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Più azioni</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Sincronizzata in &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Attiva Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Attiva Lite sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Le cartelle non selezionate verranno spostate nel cestino, a condizione che contengano elementi offline. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Le cartelle non selezionate verranno spostate nel cestino. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Le cartelle non selezionate verranno cancellate &lt;b&gt;definitivamente&lt;/b&gt; dal computer. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Annulla</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>CONVALIDA</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Sospendi sincronizzazione</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Disattiva Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Riprendi sincronizzazione</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Rimuovi sincronizzazione</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Più azioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Sincronizzata in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Attiva Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Attiva Lite sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Le cartelle non selezionate verranno spostate nel cestino, a condizione che contengano elementi offline. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Le cartelle non selezionate verranno spostate nel cestino. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Le cartelle non selezionate verranno cancellate &lt;b&gt;definitivamente&lt;/b&gt; dal computer. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Annulla</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>CONVALIDA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Sospendi sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Disattiva Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Riprendi sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Rimuovi sincronizzazione</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossibile aprire il percorso della cartella %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossibile aprire il percorso della cartella %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>ID applicazione</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Nome applicazione</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>CONVALIDA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>ID applicazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nome applicazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>CONVALIDA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Alcune app (backup, antivirus...) accedono ai tuoi file, che vengono scaricati quando sono "online". Aggiungerle nell'elenco qui sotto per evitare che questo accada.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Aggiungi</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ID APPLICAZIONE</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NOME</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>SALVA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Salvare le modifiche?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Eliminare?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Impossibile salvare le modifiche!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Alcune app (backup, antivirus...) accedono ai tuoi file, che vengono scaricati quando sono &quot;online&quot;. Aggiungerle nell&apos;elenco qui sotto per evitare che questo accada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Aggiungi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID APPLICAZIONE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Salvare le modifiche?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Eliminare?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Impossibile salvare le modifiche!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Quali cartelle del computer desideri&lt;br&gt;sincronizzare?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Il contenuto di questa cartella sarà sincronizzato sul kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Seleziona una cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Modifica cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>CONTINUA</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Quali cartelle del computer desideri&lt;br&gt;sincronizzare?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Il contenuto di questa cartella sarà sincronizzato sul kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Seleziona una cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Modifica cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
-Seleziona un'altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Seleziona cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
+Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Seleziona cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Errore</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Il file '%1'&lt;br/&gt;non può essere aperto in scrittura.&lt;br/&gt;&lt;br/&gt;Il risultato del log &lt;b&gt;non&lt;/b&gt; può essere salvato!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Errore</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Il file &apos;%1&apos;&lt;br/&gt;non può essere aperto in scrittura.&lt;br/&gt;&lt;br/&gt;Il risultato del log &lt;b&gt;non&lt;/b&gt; può essere salvato!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Preferenze</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Guida</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferenze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Guida</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Impossibile aprire il percorso della cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Invio completato!&lt;br&gt;Fai riferimento all'identificatore &lt;b&gt;%1&lt;/b&gt; nelle segnalazioni di bug.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Trasmissione fallita!
-Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Nessun kDrive configurato!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;Svuota la cronologia e, se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Sembra che la tua connessione di rete sia configurata con un timeout troppo basso perché l'applicazione funzioni correttamente (errore %1).&lt;br&gt;Verifica la configurazione di rete.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Impossibile connettersi al server kDrive (errore %1).&lt;br&gt;Tentativo di riconnessione. Controlla la tua connessione Internet e il tuo firewall.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Accedi nuovamente e se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>È disponibile una nuova versione dell'applicazione.&lt;br&gt;Aggiorna l'applicazione per continuare a utilizzarla.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Il caricamento del registro non è riuscito (errore %1).&lt;br&gt;Riprova più tardi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>La cartella di sincronizzazione non è più accessibile (errore %1).&lt;br&gt;La sincronizzazione riprenderà non appena la cartella sarà accessibile.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>La cartella di sincronizzazione è stata sostituita o spostata in modo da impedire la sincronizzazione (errore %1).&lt;br&gt;Questo può accadere dopo aver copiato, spostato o ripristinato la cartella.&lt;br&gt;Per risolvere il problema, creare una nuova sincronizzazione con una nuova cartella.&lt;br&gt;Nota: se nella vecchia cartella sono presenti modifiche non sincronizzate, è necessario copiarle manualmente nella nuova.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Memoria insufficiente sul computer.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive deve avere accesso in scrittura alla directory temporanea del tuo computer.&lt;br&gt;Riavvia l'app kDrive per risolvere il problema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Si è verificato un errore tecnico.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Il numero di osservatori inotify è insufficiente (errore %1).&lt;br&gt;È possibile aumentare questo numero modificando '/etc/sysctl.conf'.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;È necessario consentire:&lt;br&gt;- kDrive in Impostazioni di sistema &gt;&gt; Generali &gt;&gt; Elementi di accesso ed estensioni &gt;&gt; Estensioni di sicurezza degli endpoint&lt;br&gt;- Estensione kDrive LiteSync in Impostazioni di sistema &gt;&gt; Privacy e sicurezza &gt;&gt; Accesso completo al disco.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l'estensione Lite Sync sia installata e che il servizio di ricerca di Windows sia abilitato.&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l'estensione Lite Sync disponga delle autorizzazioni corrette e sia in esecuzione.&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Un file o una cartella all'interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Il kDrive è in modalità di manutenzione.&lt;br&gt;La sincronizzazione riprenderà appena possibile. Contatta il nostro team di assistenza se l'errore persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Il kDrive è bloccato.&lt;br&gt;Rinnovare kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Il kDrive è bloccato.&lt;br&gt;Contatta un amministratore per rinnovare il kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive si sta riattivando.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l'errore persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive è in modalità sospensione.&lt;br&gt;Accedi alla &lt;a style="%1" href="%2"&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive è in modalità sospensione.&lt;br&gt;
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Impossibile aprire il percorso della cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Invio completato!&lt;br&gt;Fai riferimento all&apos;identificatore &lt;b&gt;%1&lt;/b&gt; nelle segnalazioni di bug.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Trasmissione fallita!
+Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Nessun kDrive configurato!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;Svuota la cronologia e, se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Sembra che la tua connessione di rete sia configurata con un timeout troppo basso perché l&apos;applicazione funzioni correttamente (errore %1).&lt;br&gt;Verifica la configurazione di rete.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Impossibile connettersi al server kDrive (errore %1).&lt;br&gt;Tentativo di riconnessione. Controlla la tua connessione Internet e il tuo firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Accedi nuovamente e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>È disponibile una nuova versione dell&apos;applicazione.&lt;br&gt;Aggiorna l&apos;applicazione per continuare a utilizzarla.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Il caricamento del registro non è riuscito (errore %1).&lt;br&gt;Riprova più tardi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>La cartella di sincronizzazione non è più accessibile (errore %1).&lt;br&gt;La sincronizzazione riprenderà non appena la cartella sarà accessibile.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>La cartella di sincronizzazione è stata sostituita o spostata in modo da impedire la sincronizzazione (errore %1).&lt;br&gt;Questo può accadere dopo aver copiato, spostato o ripristinato la cartella.&lt;br&gt;Per risolvere il problema, creare una nuova sincronizzazione con una nuova cartella.&lt;br&gt;Nota: se nella vecchia cartella sono presenti modifiche non sincronizzate, è necessario copiarle manualmente nella nuova.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Memoria insufficiente sul computer.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive deve avere accesso in scrittura alla directory temporanea del tuo computer.&lt;br&gt;Riavvia l&apos;app kDrive per risolvere il problema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Si è verificato un errore tecnico.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Il numero di osservatori inotify è insufficiente (errore %1).&lt;br&gt;È possibile aumentare questo numero modificando &apos;/etc/sysctl.conf&apos;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;È necessario consentire:&lt;br&gt;- kDrive in Impostazioni di sistema &gt;&gt; Generali &gt;&gt; Elementi di accesso ed estensioni &gt;&gt; Estensioni di sicurezza degli endpoint&lt;br&gt;- Estensione kDrive LiteSync in Impostazioni di sistema &gt;&gt; Privacy e sicurezza &gt;&gt; Accesso completo al disco.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l&apos;estensione Lite Sync sia installata e che il servizio di ricerca di Windows sia abilitato.&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l&apos;estensione Lite Sync disponga delle autorizzazioni corrette e sia in esecuzione.&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Un file o una cartella all&apos;interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Il kDrive è in modalità di manutenzione.&lt;br&gt;La sincronizzazione riprenderà appena possibile. Contatta il nostro team di assistenza se l&apos;errore persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Il kDrive è bloccato.&lt;br&gt;Rinnovare kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Il kDrive è bloccato.&lt;br&gt;Contatta un amministratore per rinnovare il kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive si sta riattivando.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l&apos;errore persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive è in modalità sospensione.&lt;br&gt;Accedi alla &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive è in modalità sospensione.&lt;br&gt;
 Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Non sei autorizzato ad accedere a questo kDrive.&lt;br&gt;La sincronizzazione è stata sospesa. Contatta un amministratore.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l'errore persiste.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Le connessioni di rete sono state interrotte dal kernel (errore %1).&lt;br&gt;Svuota la cronologia e se l'errore persiste, contatta il nostro team di supporto.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Purtroppo la tua vecchia configurazione non può essere migrata. &lt;br&gt;L'applicazione userà una configurazione vuota.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Purtroppo la tua vecchia configurazione proxy non può essere migrata, i proxy SOCKS5 non sono supportati al momento. &lt;br&gt;L'applicazione userà invece le impostazioni del proxy di sistema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione è stata riavviata. Svuota la cronologia e se l'errore persiste, contatta il nostro team di assistenza.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Si è verificato un errore nell'accedere al database di sincronizzazione (errore %1). &lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Token non valido o revocato.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Le sincronizzazioni nidificate sono vietate (errore %1).&lt;br&gt;Conservare solo le sincronizzazioni le cui cartelle non sono nidificate.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>La cartella di sincronizzazione sul kDrive remoto non esiste più o non è più accessibile (errore %1).&lt;br&gt;È necessario ripristinarla o ridarle i diritti di accesso o cancellare/ricreare la sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Errore durante l'analisi del nome file (errore %1).&lt;br&gt;Caratteri speciali come virgolette doppie, barre rovesciate o ritorni a capo possono causare errori di analisi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Non si dispone delle autorizzazioni necessarie per creare un elemento, oppure esiste già un altro elemento con lo stesso nome. L'elemento è stato ignorato.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Non è consentito spostare l'elemento in "%1".&lt;br&gt;Verrà ripristinato nella sua cartella principale originale.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;Il download è stato annullato.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Impossibile creare il file "%1" perché non è supportato dal tuo filesystem.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Questo elemento è stato spostato altrove.&lt;br&gt;L'operazione locale è stata annullata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>In questa posizione esiste già un elemento con lo stesso nome.&lt;br&gt;L'elemento locale è stato rinominato.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Un elemento con lo stesso nome esiste già in questa posizione.&lt;br&gt;L'operazione locale è stata annullata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Il file è stato modificato contemporaneamente da un altro utente.&lt;br&gt;Le tue modifiche sono state salvate in una copia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Un altro utente ha spostato una cartella padre della destinazione.&lt;br&gt;L'operazione locale è stata annullata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Il nome dell'elemento contiene solo spazi.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Non disponi dell'autorizzazione per modificare l'elemento.&lt;br&gt;Il file contenente le tue modifiche è stato rinominato ed escluso dalla sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Non disponi dell'autorizzazione per rinominare l'elemento.&lt;br&gt;Verrà ripristinato con il suo nome originale.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Non disponi dell'autorizzazione per eliminare l'elemento.&lt;br&gt;Verrà ripristinato alla sua posizione originale.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Impossibile spostare questo elemento nel cestino, è stato inserito nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Il file è stato modificato localmente mentre veniva eliminato dal kDrive remoto.&lt;br&gt;Una copia locale è stata salvata nella cartella di recupero (rescue folder).</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>L'operazione eseguita sull'articolo è vietata.&lt;br&gt;L'articolo è stato temporaneamente inserito nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>L'operazione eseguita su questo articolo non è riuscita.&lt;br&gt;L'articolo è stato temporaneamente inserito nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Il file è troppo grande per essere caricato. È stato temporaneamente inserito nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Impossibile scaricare il file.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Hai superato la tua quota. Aumenta la tua quota di spazio per riattivare il caricamento dei file.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>L’unità contenente la cartella di sincronizzazione non è più collegata (errore %1).&lt;br&gt;Ricollegala per riprendere la sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;Il processo LiteSyncExt non è attualmente in esecuzione. La sincronizzazione riprenderà non appena verrà avviata.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Un elemento esistente ha un nome identico con le stesse opzioni di maiuscole e minuscole (stesse lettere maiuscole e minuscole).&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Il nome dell'elemento contiene un carattere non supportato.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Il nome dell'elemento termina con uno spazio, che è vietato sul tuo sistema operativo.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Il nome di questo elemento è riservato dal tuo sistema operativo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Il nome dell'elemento è troppo lungo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Il percorso dell'elemento è troppo lungo.&lt;br&gt;È stato ignorato.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Il nome dell'elemento contiene un carattere UNICODE recente non ancora supportato dal file system.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>La sincronizzazione di questo elemento è fallita. È stato temporaneamente inserito nella lista nera.&lt;br&gt;Un altro tentativo di sincronizzazione verrà effettuato tra un'ora o al successivo avvio dell'applicazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Questo elemento è stato escluso dalla sincronizzazione da un modello personalizzato. È possibile disattivare questo tipo di notifica dalle preferenze</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Questo elemento è stato escluso dalla sincronizzazione perché si tratta di un hard link.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Questo articolo è attualmente bloccato da un altro utente online.&lt;br&gt;Riproviamo a caricare le modifiche più tardi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Errore di sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Impossibile accedere all'elemento.&lt;br&gt;Si prega di correggere i permessi di lettura e scrittura.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Errore di sistema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>L'elemento esiste già dall'altra parte.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Si è verificato un errore tecnico.&lt;br&gt;Svuota la cronologia e, se l'errore persiste, contatta il nostro team di assistenza.</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Non sei autorizzato ad accedere a questo kDrive.&lt;br&gt;La sincronizzazione è stata sospesa. Contatta un amministratore.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l&apos;errore persiste.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Le connessioni di rete sono state interrotte dal kernel (errore %1).&lt;br&gt;Svuota la cronologia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Purtroppo la tua vecchia configurazione non può essere migrata. &lt;br&gt;L&apos;applicazione userà una configurazione vuota.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Purtroppo la tua vecchia configurazione proxy non può essere migrata, i proxy SOCKS5 non sono supportati al momento. &lt;br&gt;L&apos;applicazione userà invece le impostazioni del proxy di sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione è stata riavviata. Svuota la cronologia e se l&apos;errore persiste, contatta il nostro team di assistenza.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Si è verificato un errore nell&apos;accedere al database di sincronizzazione (errore %1). &lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Token non valido o revocato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Le sincronizzazioni nidificate sono vietate (errore %1).&lt;br&gt;Conservare solo le sincronizzazioni le cui cartelle non sono nidificate.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>La cartella di sincronizzazione sul kDrive remoto non esiste più o non è più accessibile (errore %1).&lt;br&gt;È necessario ripristinarla o ridarle i diritti di accesso o cancellare/ricreare la sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Errore durante l&apos;analisi del nome file (errore %1).&lt;br&gt;Caratteri speciali come virgolette doppie, barre rovesciate o ritorni a capo possono causare errori di analisi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Non si dispone delle autorizzazioni necessarie per creare un elemento, oppure esiste già un altro elemento con lo stesso nome. L&apos;elemento è stato ignorato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Non è consentito spostare l&apos;elemento in &quot;%1&quot;.&lt;br&gt;Verrà ripristinato nella sua cartella principale originale.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;Il download è stato annullato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Impossibile creare il file &quot;%1&quot; perché non è supportato dal tuo filesystem.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Questo elemento è stato spostato altrove.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>In questa posizione esiste già un elemento con lo stesso nome.&lt;br&gt;L&apos;elemento locale è stato rinominato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Un elemento con lo stesso nome esiste già in questa posizione.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Il file è stato modificato contemporaneamente da un altro utente.&lt;br&gt;Le tue modifiche sono state salvate in una copia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Un altro utente ha spostato una cartella padre della destinazione.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Il nome dell&apos;elemento contiene solo spazi.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Non disponi dell&apos;autorizzazione per modificare l&apos;elemento.&lt;br&gt;Il file contenente le tue modifiche è stato rinominato ed escluso dalla sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Non disponi dell&apos;autorizzazione per rinominare l&apos;elemento.&lt;br&gt;Verrà ripristinato con il suo nome originale.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Non disponi dell&apos;autorizzazione per eliminare l&apos;elemento.&lt;br&gt;Verrà ripristinato alla sua posizione originale.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Impossibile spostare questo elemento nel cestino, è stato inserito nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Il file è stato modificato localmente mentre veniva eliminato dal kDrive remoto.&lt;br&gt;Una copia locale è stata salvata nella cartella di recupero (rescue folder).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>L&apos;operazione eseguita sull&apos;articolo è vietata.&lt;br&gt;L&apos;articolo è stato temporaneamente inserito nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>L&apos;operazione eseguita su questo articolo non è riuscita.&lt;br&gt;L&apos;articolo è stato temporaneamente inserito nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Il file è troppo grande per essere caricato. È stato temporaneamente inserito nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Impossibile scaricare il file.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Hai superato la tua quota. Aumenta la tua quota di spazio per riattivare il caricamento dei file.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>L’unità contenente la cartella di sincronizzazione non è più collegata (errore %1).&lt;br&gt;Ricollegala per riprendere la sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;Il processo LiteSyncExt non è attualmente in esecuzione. La sincronizzazione riprenderà non appena verrà avviata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Un elemento esistente ha un nome identico con le stesse opzioni di maiuscole e minuscole (stesse lettere maiuscole e minuscole).&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Il nome dell&apos;elemento contiene un carattere non supportato.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Il nome dell&apos;elemento termina con uno spazio, che è vietato sul tuo sistema operativo.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Il nome di questo elemento è riservato dal tuo sistema operativo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Il nome dell&apos;elemento è troppo lungo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Il percorso dell&apos;elemento è troppo lungo.&lt;br&gt;È stato ignorato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Il nome dell&apos;elemento contiene un carattere UNICODE recente non ancora supportato dal file system.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>La sincronizzazione di questo elemento è fallita. È stato temporaneamente inserito nella lista nera.&lt;br&gt;Un altro tentativo di sincronizzazione verrà effettuato tra un&apos;ora o al successivo avvio dell&apos;applicazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Questo elemento è stato escluso dalla sincronizzazione da un modello personalizzato. È possibile disattivare questo tipo di notifica dalle preferenze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Questo elemento è stato escluso dalla sincronizzazione perché si tratta di un hard link.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Questo articolo è attualmente bloccato da un altro utente online.&lt;br&gt;Riproviamo a caricare le modifiche più tardi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Errore di sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Impossibile accedere all&apos;elemento.&lt;br&gt;Si prega di correggere i permessi di lettura e scrittura.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Errore di sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>L&apos;elemento esiste già dall&apos;altra parte.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Si è verificato un errore tecnico.&lt;br&gt;Svuota la cronologia e, se l&apos;errore persiste, contatta il nostro team di assistenza.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Questa sincronizzazione è in fase di eliminazione.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Questa sincronizzazione è in fase di eliminazione.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Torna all'elenco dei kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Preferenze</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Torna all&apos;elenco dei kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferenze</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Generale</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Attiva tema scuro</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Attiva icone monocolore</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Lancia kDrive all'avvio del sistema</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Olandese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avanzate</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Informazioni di debug</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Apri cartella di debug&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>File da escludere</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Server proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Svedese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portoghese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polacco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norvegese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finlandese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Danese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Greco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Impossibile aprire la cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Link %1 non valido.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Lingua</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Non è possibile eseguire alcuni processi.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Sposta i file eliminati nel cestino del mio computer</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Alcuni file o cartelle potrebbero non essere spostati nel cestino del computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Puoi sempre recuperare i file già sincronizzati dal cestino dell'applicazione web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Inglese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Francese</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Tedesco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Spagnolo</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italiano</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Predefinito</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Generale</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Attiva tema scuro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Attiva icone monocolore</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Lancia kDrive all&apos;avvio del sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Olandese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avanzate</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Informazioni di debug</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>File da escludere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Server proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Svedese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portoghese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polacco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norvegese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finlandese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Danese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Greco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Impossibile aprire la cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Link %1 non valido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Lingua</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Non è possibile eseguire alcuni processi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Sposta i file eliminati nel cestino del mio computer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Alcuni file o cartelle potrebbero non essere spostati nel cestino del computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Puoi sempre recuperare i file già sincronizzati dal cestino dell&apos;applicazione web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Inglese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Francese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Tedesco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Spagnolo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italiano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Predefinito</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 in uso</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 in uso</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>Proxy HTTP(S)</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Server proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Nessun server proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Usa parametri di sistema</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Indica un proxy manualmente</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Porta</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Indirizzo del server proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Autenticazione necessaria</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Utente</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Password</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>SALVA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Salvare le modifiche?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Impossibile salvare. Non tutti i campi obbligatori sono stati completati!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy non trovato. Salvare comunque?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Server proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Nessun server proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Usa parametri di sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Indica un proxy manualmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Porta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Indirizzo del server proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Autenticazione necessaria</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Utente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Password</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Salvare le modifiche?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Impossibile salvare. Non tutti i campi obbligatori sono stati completati!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy non trovato. Salvare comunque?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Responsabile delle risorse</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Utilizzo massimo della CPU consentito</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>SALVA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Salvare le modifiche?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Responsabile delle risorse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Utilizzo massimo della CPU consentito</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>SALVA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Salvare le modifiche?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Seleziona una cartella sul tuo kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Il contenuto della cartella selezionata sarà sincronizzato nella cartella &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>CONTINUA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Spazio disponibile nel computer per la cartella attuale: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Questa cartella è già sincronizzata.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>CONFERMA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ANNULLA</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Seleziona una cartella sul tuo kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Il contenuto della cartella selezionata sarà sincronizzato nella cartella &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Spazio disponibile nel computer per la cartella attuale: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Questa cartella è già sincronizzata.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>CONFERMA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANNULLA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; contiene sottocartelle,&lt;br&gt; seleziona quelle che desideri sincronizzare</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>CONTINUA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Attualmente non ci sono sottocartelle sul server.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; contiene sottocartelle,&lt;br&gt; seleziona quelle che desideri sincronizzare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Attualmente non ci sono sottocartelle sul server.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Riprendi la sincronizzazione di kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Riprendi la sincronizzazione di tutti i kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Sospendi la sincronizzazione di kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Sospendi sincronizzazione</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Metti in pausa tutta la sincronizzazione di kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Riprendi sincronizzazione</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Riprendi la sincronizzazione di kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Riprendi la sincronizzazione di tutti i kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Sospendi la sincronizzazione di kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Sospendi sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Metti in pausa tutta la sincronizzazione di kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Riprendi sincronizzazione</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Copiare il link di condivisione</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Visualizzazione su kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Mostra nella cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Più azioni</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Apri</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Aggiungi ai preferiti</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiare il link di condivisione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Visualizzazione su kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Mostra nella cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Più azioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Apri</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Aggiungi ai preferiti</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Mai</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Per 1 ora</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Fino alle 8:00 di domani</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Per 3 giorni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Per 1 settimana</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Sempre</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Per 1 altra ora</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Per altri 3 giorni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Per 1 altra settimana</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Impossibile aprire l'URL della cartella %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Apri nella cartella</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Apri la versione web %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Parametri unità</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Notifiche disabilitate fino al %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Disabilita notifiche</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Preferenze dell'applicazione</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Hai bisogno di aiuto</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Invia feedback</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Esci da kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Impossibile accedere al sito web %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Mostra errori e informazioni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Mostra informazioni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Più azioni</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Mai</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Per 1 ora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Fino alle 8:00 di domani</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Per 3 giorni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Per 1 settimana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Per 1 altra ora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Per altri 3 giorni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Per 1 altra settimana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Impossibile aprire l&apos;URL della cartella %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Apri nella cartella</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Apri la versione web %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parametri unità</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Notifiche disabilitate fino al %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Disabilita notifiche</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Preferenze dell&apos;applicazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Hai bisogno di aiuto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Invia feedback</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Esci da kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Impossibile accedere al sito web %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Mostra errori e informazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Mostra informazioni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Più azioni</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Aggiorna l'app kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Questa versione dell'app kDrive non è più supportata. Per accedere alle funzionalità e ai miglioramenti più recenti, aggiornare.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Aggiornamento</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Si prega di scaricare l'ultima versione dal sito web.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Download dell'aggiornamento in corso</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>In cerca di aggiornamento...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Aggiornamento manuale</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Non disponibile</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Puoi sincronizzare i file &lt;a style="%1" href="%2"&gt;dal tuo computer&lt;/a&gt; o su &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Sincronizzata</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Preferiti</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Attività</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Non implementato!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/it/applicazioni/scarica-kdrive"&gt;Clicca qui per scaricare manualmente&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Nessuna cartella sincronizzata per questo kDrive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Nessun kDrive configurato!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Impossibile aprire il link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Link %1 non valido.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Impossibile aprire l'URL della cartella %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Aggiorna l&apos;app kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Questa versione dell&apos;app kDrive non è più supportata. Per accedere alle funzionalità e ai miglioramenti più recenti, aggiornare.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Aggiornamento</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Si prega di scaricare l&apos;ultima versione dal sito web.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Download dell&apos;aggiornamento in corso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>In cerca di aggiornamento...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Aggiornamento manuale</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Non disponibile</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Puoi sincronizzare i file &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;dal tuo computer&lt;/a&gt; o su &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Sincronizzata</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Preferiti</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Attività</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Non implementato!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/it/applicazioni/scarica-kdrive&quot;&gt;Clicca qui per scaricare manualmente&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Nessuna cartella sincronizzata per questo kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Nessun kDrive configurato!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Impossibile aprire il link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Link %1 non valido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Impossibile aprire l&apos;URL della cartella %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;La nuova versione &lt;b&gt;%1&lt;/b&gt; del client %2 è disponibile ed è stata scaricata.&lt;/p&gt;&lt;p&gt;La versione installata è %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Salta questa versione</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Ricordamelo più tardi</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installa</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;La nuova versione &lt;b&gt;%1&lt;/b&gt; del client %2 è disponibile ed è stata scaricata.&lt;/p&gt;&lt;p&gt;La versione installata è %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Salta questa versione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Ricordamelo più tardi</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installa</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>È disponibile un nuovo aggiornamento.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>La versione %1 è disponibile per il download.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>È disponibile un nuovo aggiornamento.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>La versione %1 è disponibile per il download.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Aggiungi un account</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Aggiungi un account</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Mostra nota di rilascio&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Versione</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>AGGIORNAMENTO</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 è aggiornato!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Controllo dell'aggiornamento sul server...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>È disponibile un aggiornamento: %1.&lt;br&gt;Scaricalo da &lt;a style="%2" href="%3"&gt;qui&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>È disponibile un aggiornamento: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Download in corso %1. Attendere...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Impossibile verificare la presenza di nuovi aggiornamenti.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Si è verificato un errore durante l'aggiornamento.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Impossibile scaricare l'aggiornamento.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Aggiornamento disabilitato.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Beta program</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Ottenere l'accesso anticipato alle nuove versioni dell'applicazione</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Contatto</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Modificare</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Esci</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostra nota di rilascio&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Versione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>AGGIORNAMENTO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 è aggiornato!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Controllo dell&apos;aggiornamento sul server...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>È disponibile un aggiornamento: %1.&lt;br&gt;Scaricalo da &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;qui&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>È disponibile un aggiornamento: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Download in corso %1. Attendere...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Impossibile verificare la presenza di nuovi aggiornamenti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Si è verificato un errore durante l&apos;aggiornamento.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Impossibile scaricare l&apos;aggiornamento.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Aggiornamento disabilitato.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Beta program</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Ottenere l&apos;accesso anticipato alle nuove versioni dell&apos;applicazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Contatto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Modificare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Esci</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Impossibile salvare i parametri, riprova più tardi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Impossibile salvare i parametri!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>La cartella padre è una cartella di sincronizzazione o contenuta in un</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Impossibile trovare un percorso valido</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Nessuna cartella valida selezionata!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Il percorso selezionato non esiste!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Il percorso selezionato non è una cartella!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Non disponi dell'autorizzazione di scrittura per la cartella selezionata!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>La cartella locale %1 contiene una cartella già sincronizzata. Scegline un'altra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un'altra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>La cartella locale %1 è già sincronizzata. Scegline un'altra!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync (Beta) è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync (Beta) è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Rendere disponibile localmente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Libera spazio locale</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Annulla liberazione di spazio locale</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Annulla rendere disponibile localmente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Ricondivisione di questo file non consentita</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Ricondivisione di questa cartella non consentita</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Copia il collegamento di condivisione pubblica</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Copia il collegamento di condivisione privata</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Apri nel browser</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Impossibile salvare i parametri, riprova più tardi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Impossibile salvare i parametri!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>La cartella padre è una cartella di sincronizzazione o contenuta in un</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Impossibile trovare un percorso valido</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Nessuna cartella valida selezionata!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Il percorso selezionato non esiste!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Il percorso selezionato non è una cartella!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Non disponi dell&apos;autorizzazione di scrittura per la cartella selezionata!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>La cartella locale %1 contiene una cartella già sincronizzata. Scegline un&apos;altra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un&apos;altra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>La cartella locale %1 è già sincronizzata. Scegline un&apos;altra!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Rendere disponibile localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Libera spazio locale</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Annulla liberazione di spazio locale</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Annulla rendere disponibile localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Ricondivisione di questo file non consentita</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Ricondivisione di questa cartella non consentita</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Copia il collegamento di condivisione pubblica</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Copia il collegamento di condivisione privata</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Apri nel browser</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>L'applicazione kDrive si chiuderà a causa di un errore irreversibile.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>L&apos;applicazione kDrive si chiuderà a causa di un errore irreversibile.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translatorcomment>// QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate</translatorcomment>
-<translation>
-<numerusform>%n anno/i</numerusform>
-<numerusform>%n anno/i</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n mese/i</numerusform>
-<numerusform>%n mese/i</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n giorno/i</numerusform>
-<numerusform>%n giorno/i</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n ora/e</numerusform>
-<numerusform>%n ora/e</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuto/i</numerusform>
-<numerusform>%n minuto/i</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n secondo/i</numerusform>
-<numerusform>%n secondo/i</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translatorcomment>// QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate</translatorcomment>
+        <translation>
+            <numerusform>%n anno/i</numerusform>
+            <numerusform>%n anno/i</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n mese/i</numerusform>
+            <numerusform>%n mese/i</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n giorno/i</numerusform>
+            <numerusform>%n giorno/i</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n ora/e</numerusform>
+            <numerusform>%n ora/e</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuto/i</numerusform>
+            <numerusform>%n minuto/i</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n secondo/i</numerusform>
+            <numerusform>%n secondo/i</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Area di notifica non disponibile</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 richiede un’area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un’applicazione per l’area di notifica come “trayer” e riprova.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Area di notifica non disponibile</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 richiede un’area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un’applicazione per l’area di notifica come “trayer” e riprova.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Impossibile aprire il browser</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Si è verificato un errore durante l'avvio del browser per accedere all'URL %1. Forse non è configurato un browser predefinito?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Impossibile aprire il client di posta elettronica</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Si è verificato un errore durante l'avvio del client di posta per creare un nuovo messaggio. Forse non è configurato un client di posta predefinito?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Non sei più collegato. &lt;a style="%1" href="%2"&gt;Accedi&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Impossibile aprire il browser</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Si è verificato un errore durante l&apos;avvio del browser per accedere all&apos;URL %1. Forse non è configurato un browser predefinito?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Impossibile aprire il client di posta elettronica</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Si è verificato un errore durante l&apos;avvio del client di posta per creare un nuovo messaggio. Forse non è configurato un client di posta predefinito?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Non sei più collegato. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Accedi&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Nessuna cartella da sincronizzare
+        <translation>Nessuna cartella da sincronizzare
 Puoi aggiungerne uno dalle impostazioni di kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Sincronizzazione in corso (%1 di %2)
+        <translation>Sincronizzazione in corso (%1 di %2)
 %3 mancanti...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Sincronizzazione in corso (fase %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Sincronizzazione in corso.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Non è stato possibile sincronizzare alcuni file. &lt;a style="%1" href="%2"&gt;Maggiori informazioni&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Sospensione sincronizzazione in corso…</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché un'altra sincronizzazione sta utilizzando la stessa cartella.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché contiene la cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché è contenuta nella cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Si prega di selezionare un'altra cartella.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un'altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Inizio sincronizzazione</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Sincronizzazione sospesa.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Sincronizzazione in corso (%1 di %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Sistema aggiornato. Sono presenti conflitti non risolti.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Sistema aggiornato!</translation>
-</message>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Sincronizzazione in corso (fase %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Sincronizzazione in corso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Non è stato possibile sincronizzare alcuni file. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Maggiori informazioni&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Sospensione sincronizzazione in corso…</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché un&apos;altra sincronizzazione sta utilizzando la stessa cartella.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché contiene la cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché è contenuta nella cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Si prega di selezionare un&apos;altra cartella.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un&apos;altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Inizio sincronizzazione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Sincronizzazione sospesa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Sincronizzazione in corso (%1 di %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Sistema aggiornato. Sono presenti conflitti non risolti.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Sistema aggiornato!</translation>
+    </message>
 </context>
 </TS>

--- a/translations/client_it.ts
+++ b/translations/client_it.ts
@@ -1,2582 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="it_IT">
+<TS language="it_IT" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Informazioni su</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">CHIUDI</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versione %1. Per maggiori informazioni, visita &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribuito da %1 e concesso in licenza &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e il logo %2 sono marchi registrati di %1. &lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossibile aprire la cartella %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Compilato da &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;fonti Git&lt;/a&gt; il %2, alle %3 usando Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Informazioni su</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>CHIUDI</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versione %1. Per maggiori informazioni, visita &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribuito da %1 e concesso in licenza &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e il logo %2 sono marchi registrati di %1. &lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossibile aprire la cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Compilato da &lt;a style="color: #489EF3" href="%1"&gt;fonti Git&lt;/a&gt; il %2, alle %3 usando Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossibile aprire il percorso della cartella %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossibile aprire il percorso della cartella %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">La sincronizzazione sarà avviata e potrai aggiungere i file alla tua cartella %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Il tuo kDrive è pronto!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">APRI CARTELLA</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">PARAMETRI</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Sincronizza un&apos;altra unità</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>La sincronizzazione sarà avviata e potrai aggiungere i file alla tua cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Il tuo kDrive è pronto!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>APRI CARTELLA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>PARAMETRI</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Sincronizza un'altra unità</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">AVANTI</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Seleziona il kDrive che vuoi sincronizzare</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Ottieni kDrive gratuitamente</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Archivia le tue foto, documenti ed e-mail in Svizzera presso un&apos;azienda indipendente che rispetta la privacy. Maggiori informazioni</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Prova gratuita</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>AVANTI</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Seleziona il kDrive che vuoi sincronizzare</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Ottieni kDrive gratuitamente</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Archivia le tue foto, documenti ed e-mail in Svizzera presso un'azienda indipendente che rispetta la privacy. Maggiori informazioni</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Prova gratuita</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Risparmia spazio sul tuo computer</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Scegli quali file rendere disponibili online o localmente</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">PIÙ TARDI</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SÌ</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync sincronizza tutti i tuoi file senza occupare spazio sul tuo computer. Puoi sfogliare i file sul tuo kDrive e scaricarli localmente quando vuoi. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Maggiori informazioni&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Attivare Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Attivare Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Risparmia spazio sul tuo computer</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Scegli quali file rendere disponibili online o localmente</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>PIÙ TARDI</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>SÌ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync sincronizza tutti i tuoi file senza occupare spazio sul tuo computer. Puoi sfogliare i file sul tuo kDrive e scaricarli localmente quando vuoi. &lt;a style="%1" href="%2"&gt;Maggiori informazioni&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Attivare Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Attivare Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Posizione del tuo %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Modifica cartella</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FINE</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Seleziona cartella</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Il contenuto della cartella &lt;b&gt;%1&lt;/b&gt; verrà sincronizzato nel tuo kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Al termine della configurazione tutti i tuoi file saranno in questa cartella. Puoi trascinare nuovi file in questa cartella per sincronizzarli con il tuo kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Posizione del tuo %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Modifica cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>FINE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Seleziona cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Il contenuto della cartella &lt;b&gt;%1&lt;/b&gt; verrà sincronizzato nel tuo kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Al termine della configurazione tutti i tuoi file saranno in questa cartella. Puoi trascinare nuovi file in questa cartella per sincronizzarli con il tuo kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
-Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUA</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
+Seleziona un'altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>CONTINUA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Accedi dal tuo browser</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Il browser dovrebbe aprirsi automaticamente per completare la connessione. Una volta connesso, tornerai automaticamente a kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Apri la pagina di accesso</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Si è verificato un errore durante l&apos;autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Accesso non riuscito: %1 – %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Impossibile aprire la pagina di accesso nel browser web</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Accedi dal tuo browser</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Il browser dovrebbe aprirsi automaticamente per completare la connessione. Una volta connesso, tornerai automaticamente a kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Apri la pagina di accesso</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Si è verificato un errore durante l'autenticazione. Chiudi la finestra di accesso e riprova.&lt;br&gt;Se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Accesso non riuscito: %1 – %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Impossibile aprire la pagina di accesso nel browser web</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Seleziona cartelle kDrive da sincronizzare sul tuo desktop</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUA</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Spazio disponibile nel computer: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Si è verificato un errore durante il caricamento dell&apos;elenco delle sottocartelle.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Die Liste der Unterordner konnte nicht geladen werden. Ihr kDrive befindet sich möglicherweise in Wartung.&lt;br&gt;Melden Sie sich bei der &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Seleziona cartelle kDrive da sincronizzare sul tuo desktop</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>CONTINUA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Spazio disponibile nel computer: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Si è verificato un errore durante il caricamento dell'elenco delle sottocartelle.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Die Liste der Unterordner konnte nicht geladen werden. Ihr kDrive befindet sich möglicherweise in Wartung.&lt;br&gt;Melden Sie sich bei der &lt;a style="%1" href="%2"&gt;Webversion&lt;/a&gt; an, um den Status Ihres kDrive zu überprüfen, oder wenden Sie sich an Ihren Administrator.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Creazione della la cartella locale %1 non riuscita</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Creazione della nuova sincronizzazione non riuscita</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">Il kDrive %1 è già sincronizzato su questo computer. Continuare lo stesso?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Creazione della la cartella locale %1 non riuscita</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Creazione della nuova sincronizzazione non riuscita</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>Il kDrive %1 è già sincronizzato su questo computer. Continuare lo stesso?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">Il client kDrive viene eseguito con parametri errati</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">Il client kDrive è già in esecuzione!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">L&apos;utente %1 non è connesso. Effettuare nuovamente il login.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>Il client kDrive viene eseguito con parametri errati</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>Il client kDrive è già in esecuzione!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>L'utente %1 non è connesso. Effettuare nuovamente il login.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Link di condivisione copiato negli appunti</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
-            <numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 è stato rimosso.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
-            <numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 è stato aggiunto.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
-            <numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 è stato aggiornato.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
-            <numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 è stato spostato in %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Sincronizza attività</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Link di condivisione copiato negli appunti</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
+<numerusform>%1 e %n altri file sono stati rimossi.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 è stato rimosso.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
+<numerusform>%1 e %n altri file sono stati aggiunti.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 è stato aggiunto.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
+<numerusform>%1 e %n altri file sono stati aggiornati.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 è stato aggiornato.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
+<numerusform>%1 è stato spostato in %2 e %n altri file sono stati spostati.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 è stato spostato in %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Sincronizza attività</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Attualmente non ci sono sottocartelle sul server.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Attualmente non ci sono sottocartelle sul server.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Abbandonare il programma beta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Partecipare al programma beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Ottenete l&apos;accesso anticipato alle nuove versioni dell&apos;applicazione prima che vengano rilasciate al pubblico e partecipate al miglioramento dell&apos;applicazione inviandoci i vostri commenti.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Beneficiare degli aggiornamenti beta delle applicazioni</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">No</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Versione beta pubblica</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Versione beta interna</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Versione di prova</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Capisco</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Siete sicuri di voler abbandonare il programma beta?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Salva</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">La tua attuale versione dell&apos;applicazione potrebbe essere troppo recente, la tua scelta sarà effettiva dal prossimo aggiornamento disponibile.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Le versioni beta possono uscire inaspettatamente o causare instabilità.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Abbandonare il programma beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Partecipare al programma beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Ottenete l'accesso anticipato alle nuove versioni dell'applicazione prima che vengano rilasciate al pubblico e partecipate al miglioramento dell'applicazione inviandoci i vostri commenti.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Beneficiare degli aggiornamenti beta delle applicazioni</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>No</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Versione beta pubblica</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Versione beta interna</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Versione di prova</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Capisco</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Siete sicuri di voler abbandonare il programma beta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Salva</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>La tua attuale versione dell'applicazione potrebbe essere troppo recente, la tua scelta sarà effettiva dal prossimo aggiornamento disponibile.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Le versioni beta possono uscire inaspettatamente o causare instabilità.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Accedi</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Cartella %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Sintesi</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferenze</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Esci</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Stato non definito.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">In attesa di iniziare la sincronizzazione.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Sincronizzazione in corso.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">La sincronizzazione è stata completata correttamente, sono presenti conflitti non risolti.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">L&apos;ultima sincronizzazione è stata completata correttamente.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Interrotto dall&apos;utente.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Sincronizzazione sospesa.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Sincronizzazione sospesa)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vuoi davvero rimuovere le sincronizzazioni dell&apos;account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">RIMUOVERE TUTTE LE SINC</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 elementi sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Per evitare eliminazioni involontarie, la sincronizzazione è stata messa in pausa.&lt;br&gt;Vuoi propagare queste eliminazioni al tuo kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Diversi file sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. I file eliminati si trovano nel &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;cestino&lt;/a&gt; di kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Non mostrare più</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Impossibile avviare la sincronizzazione!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossibile aprire il percorso della cartella %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Impossibile inizializzare il client kDrive</translation>
-    </message>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Impossibile risolvere i conflitti su %1 elemento/i nella cartella di sincronizzazione: %2</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Sincronizzazione sospesa</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Accedi</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Cartella %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Non è stata configurata alcuna cartella per la sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Sintesi</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translation>Preferenze</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Esci</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Stato non definito.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>In attesa di iniziare la sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Sincronizzazione in corso.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>La sincronizzazione è stata completata correttamente, sono presenti conflitti non risolti.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>L'ultima sincronizzazione è stata completata correttamente.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Interrotto dall'utente.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Sincronizzazione sospesa.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Sincronizzazione sospesa)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vuoi davvero rimuovere le sincronizzazioni dell'account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questo &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>RIMUOVERE TUTTE LE SINC</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 elementi sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Per evitare eliminazioni involontarie, la sincronizzazione è stata messa in pausa.&lt;br&gt;Vuoi propagare queste eliminazioni al tuo kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Diversi file sono stati eliminati dalla cartella di sincronizzazione locale &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. I file eliminati si trovano nel &lt;a style="%1" href="%3"&gt;cestino&lt;/a&gt; di kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Non mostrare più</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Impossibile avviare la sincronizzazione!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossibile aprire il percorso della cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Impossibile inizializzare il client kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Impossibile risolvere i conflitti su %1 elemento/i nella cartella di sincronizzazione: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Sincronizzazione sospesa</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Riepilogo della sincronizzazione della cartella locale</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">I contenuti delle cartelle nel computer saranno sincronizzati con la cartella del kDrive selezionato e viceversa.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SINCRONIZZA</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Riepilogo della sincronizzazione della cartella locale</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>I contenuti delle cartelle nel computer saranno sincronizzati con la cartella del kDrive selezionato e viceversa.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SINCRONIZZA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Prima di terminare</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Esegui le fasi seguenti per assicurare che Lite Sync funzioni correttamente sul computer e per completare la configurazione del kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Aprite le &lt;b&gt;Impostazioni generali&lt;/b&gt; del vostro Mac o &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Apri le &lt;b&gt;impostazioni Privacy e sicurezza&lt;/b&gt; del tuo Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Apri le &lt;b&gt;impostazioni di sicurezza e privacy&lt;/b&gt; del tuo Mac o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Andare alla sezione &lt;b&gt;&quot;Elementi ed estensioni di accesso&quot;&lt;/b&gt; e quindi a &lt;b&gt;&quot;Estensioni di sicurezza per gli endpoint&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Autorizzare l&apos;applicazione kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Vai alla sezione &lt;b&gt;&quot;Sicurezza&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Autorizza l&apos;applicazione kDrive nella casella indicando che kDrive è stato bloccato</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Sblocca il lucchetto&lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; e autorizza l&apos;applicazione kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Andate alla sezione &lt;b&gt;&quot;Privacy e sicurezza&quot;&lt;/b&gt; e fate clic su &lt;b&gt;&quot;Accesso completo al disco&quot;&lt;/b&gt; oppure &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Sempre nelle impostazioni di Sicurezza e Privacy, apri la scheda &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; o &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fai clic qui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Seleziona la casella &quot;kDrive LiteSync Extension&quot; quindi la casella &quot;kDrive.app&quot; (se non è già selezionata)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Potrebbe essere proposto un riavvio dell&apos;app, in questo caso accettarlo</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Spunta la casella &quot;kDrive LiteSync Extension&quot; (e &quot;kDrive.app&quot; se esiste) in &lt;b&gt;&quot;Accesso completo al disco&quot;&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">FASE 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Fatto)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">FASE 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">FASI ESEGUITE</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FINE</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Prima di terminare</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Esegui le fasi seguenti per assicurare che Lite Sync funzioni correttamente sul computer e per completare la configurazione del kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Aprite le &lt;b&gt;Impostazioni generali&lt;/b&gt; del vostro Mac o &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Apri le &lt;b&gt;impostazioni Privacy e sicurezza&lt;/b&gt; del tuo Mac o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Apri le &lt;b&gt;impostazioni di sicurezza e privacy&lt;/b&gt; del tuo Mac o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Andare alla sezione &lt;b&gt;"Elementi ed estensioni di accesso"&lt;/b&gt; e quindi a &lt;b&gt;"Estensioni di sicurezza per gli endpoint"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Autorizzare l'applicazione kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Vai alla sezione &lt;b&gt;"Sicurezza"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Autorizza l'applicazione kDrive nella casella indicando che kDrive è stato bloccato</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Sblocca il lucchetto&lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorizza l'applicazione kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Andate alla sezione &lt;b&gt;"Privacy e sicurezza"&lt;/b&gt; e fate clic su &lt;b&gt;"Accesso completo al disco"&lt;/b&gt; oppure &lt;a style=%1 href=%2&gt;cliccate qui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Sempre nelle impostazioni di Sicurezza e Privacy, apri la scheda &lt;b&gt;"Privacy"&lt;/b&gt; o &lt;a style="%1" href="%2"&gt;fai clic qui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Seleziona la casella "kDrive LiteSync Extension" quindi la casella "kDrive.app" (se non è già selezionata)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Potrebbe essere proposto un riavvio dell'app, in questo caso accettarlo</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Spunta la casella "kDrive LiteSync Extension" (e "kDrive.app" se esiste) in &lt;b&gt;"Accesso completo al disco"&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>FASE 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Fatto)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>FASE 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>FASI ESEGUITE</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>FINE</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SÌ</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NO</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>SÌ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NO</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Invio di informazioni di debug in corso</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Invio di informazioni di debug in corso</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Info</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Debug</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Avviso</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Errore</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Irreversibile</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Impostazioni di debug</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Salva le informazioni di debug in una cartella sul mio computer (consigliato)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Queste informazioni consentono al supporto IT di determinare l&apos;origine di un incidente.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Livello di debug</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Il livello di traccia consente di scegliere l&apos;entità delle informazioni di debug registrate</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Il registro completo esteso raccoglie una cronologia dettagliata che può essere utilizzata per il debug. Abilitarla può rallentare l&apos;applicazione kDrive.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Log completo esteso</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Elimina i registri più vecchi di %1 giorni</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Condividi la cartella debug con il supporto di Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">L&apos;ultima sessione è il periodo trascorso dall&apos;ultimo avvio di kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Condividi solo l&apos;ultima sessione di kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Caricamento</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SALVA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Impossibile condividere</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Verifica di aver effettuato l&apos;accesso&lt;br&gt;2. Verifica di aver configurato almeno un kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Connessione interrotta)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Condividi la cartella con SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Abbiamo compresso automaticamente il tuo registro &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;qui&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Trasferisci l&apos;archivio con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Condividi il link con &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Ultimo caricamento il %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">La condivisione è stata annullata</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Il registro completo esteso è attivato tramite la variabile d&apos;ambiente KDRIVE_FORCE_EXTENDED_LOG. Impostalo a 0 per disabilitarlo.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">L&apos;intera cartella è di grandi dimensioni (&gt; 100 MB) e potrebbe richiedere del tempo per essere condivisa. Per ridurre il tempo di condivisione, si consiglia di condividere solo l&apos;ultima sessione di kDrive.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%2/%1/%3 alle %4:%5:%6</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Salvare le modifiche?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossibile aprire la cartella %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Condividere</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Condivisione | passaggio 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Condivisione | passaggio 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Annullamento...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Debug</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Avviso</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Errore</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Irreversibile</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Impostazioni di debug</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Salva le informazioni di debug in una cartella sul mio computer (consigliato)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Queste informazioni consentono al supporto IT di determinare l'origine di un incidente.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Apri cartella di debug&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Livello di debug</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Il livello di traccia consente di scegliere l'entità delle informazioni di debug registrate</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Il registro completo esteso raccoglie una cronologia dettagliata che può essere utilizzata per il debug. Abilitarla può rallentare l'applicazione kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Log completo esteso</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Elimina i registri più vecchi di %1 giorni</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Condividi la cartella debug con il supporto di Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>L'ultima sessione è il periodo trascorso dall'ultimo avvio di kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Condividi solo l'ultima sessione di kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Caricamento</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>SALVA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Impossibile condividere</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Verifica di aver effettuato l'accesso&lt;br&gt;2. Verifica di aver configurato almeno un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Connessione interrotta)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Condividi la cartella con SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Abbiamo compresso automaticamente il tuo registro &lt;a style="%1" href="%2"&gt;qui&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Trasferisci l'archivio con &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Condividi il link con &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Ultimo caricamento il %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>La condivisione è stata annullata</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Il registro completo esteso è attivato tramite la variabile d'ambiente KDRIVE_FORCE_EXTENDED_LOG. Impostalo a 0 per disabilitarlo.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>L'intera cartella è di grandi dimensioni (&gt; 100 MB) e potrebbe richiedere del tempo per essere condivisa. Per ridurre il tempo di condivisione, si consiglia di condividere solo l'ultima sessione di kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%2/%1/%3 alle %4:%5:%6</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Salvare le modifiche?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossibile aprire la cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Condividere</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Condivisione | passaggio 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Condivisione | passaggio 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Annullamento...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Cartelle</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Notifiche</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Verrà visualizzata una notifica appena una nuova cartella sarà sincronizzata o modificata</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Connesso a</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questa operazione &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Questa operazione può richiedere da pochi secondi a qualche minuto, a seconda delle dimensioni della cartella.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Nuova sincronizzazione delle cartelle locali non riuscita!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Attivazione Lite Sync non riuscita.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Disattivazione Lite Sync non riuscita.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">RIMUOVI CONNESSIONE DI SINC. CARTELLE</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Si è verificato un errore durante il caricamento dell&apos;elenco delle sottocartelle.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Abilita le notifiche per questo kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFERMA</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Errori di sincronizzazione e informazioni.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Sincronizza una cartella locale</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Abilitare Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Disabilitare Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Non hai abbastanza spazio libero per sincronizzare tutti i file sul tuo kDrive (%1 mancanti). Se disabiliti Lite Sync dovrai scegliere quali cartelle sincronizzare sul tuo computer. Nel frattempo la sincronizzazione del tuo kDrive verrà sospesa.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Se si disattiva Lite Sync, tutti i file verranno scaricati sul computer.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Creazione della nuova sincronizzazione non riuscita</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Sincronizzazione Lite attivata.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync disattivato.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Questa unità è in fase di eliminazione.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Impossibile aprire l&apos;articolo %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Impossibile interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Rimuovi tutte le sincronizzazioni</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Cerca nel tuo kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Ricerca</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Cartelle</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Notifiche</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Verrà visualizzata una notifica appena una nuova cartella sarà sincronizzata o modificata</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Connesso a</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; questa operazione &lt;b&gt;non&lt;/b&gt; eliminerà alcun file.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Questa operazione può richiedere da pochi secondi a qualche minuto, a seconda delle dimensioni della cartella.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Nuova sincronizzazione delle cartelle locali non riuscita!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Attivazione Lite Sync non riuscita.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Disattivazione Lite Sync non riuscita.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>RIMUOVI CONNESSIONE DI SINC. CARTELLE</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Si è verificato un errore durante il caricamento dell'elenco delle sottocartelle.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Abilita le notifiche per questo kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>CONFERMA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Errori di sincronizzazione e informazioni.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Sincronizza una cartella locale</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Abilitare Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Disabilitare Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Non hai abbastanza spazio libero per sincronizzare tutti i file sul tuo kDrive (%1 mancanti). Se disabiliti Lite Sync dovrai scegliere quali cartelle sincronizzare sul tuo computer. Nel frattempo la sincronizzazione del tuo kDrive verrà sospesa.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Se si disattiva Lite Sync, tutti i file verranno scaricati sul computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Creazione della nuova sincronizzazione non riuscita</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Sincronizzazione Lite attivata.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync disattivato.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Questa unità è in fase di eliminazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Impossibile aprire l'articolo %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Impossibile interrompere la sincronizzazione della cartella &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Rimuovi tutte le sincronizzazioni</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Cerca nel tuo kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Ricerca</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Sincronizza un kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Aggiungi un kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Sincronizza un kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Aggiungi un kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Risolvere</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Articoli in conflitto</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Elementi con caratteri non supportati</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Cancella cronologia</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Per risolvere</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Risolto automaticamente</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problema/i risolto/i</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">problema/i rilevato/i</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Risolvere</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Articoli in conflitto</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Elementi con caratteri non supportati</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Cancella cronologia</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Per risolvere</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Risolto automaticamente</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problema/i risolto/i</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>problema/i rilevato/i</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Conflitti o errori di sincronizzazione</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Errori</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Torna alle preferenze</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Conflitti o errori di sincronizzazione</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Errori</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Torna alle preferenze</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Non è stato possibile sincronizzare alcuni file sui kDrive seguenti:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 errori)</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 informazione(i))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 errori e %2 informazioni)</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
-            <numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Non è stato possibile sincronizzare alcuni file sui kDrive seguenti:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 errori)</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 informazione(i))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 errori e %2 informazioni)</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
+<numerusform>Errori generici (%n avviso/i o errore/i)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">File esclusi</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Aggiungi file o cartelle che non saranno sincronizzati sul tuo computer.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Aggiungi</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOME</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">AVVERTIMENTO</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SALVA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Salvare le modifiche?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Il modello di esclusione esiste già!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Eliminare?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Impossibile salvare le modifiche!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>File esclusi</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Aggiungi file o cartelle che non saranno sincronizzati sul tuo computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Aggiungi</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NOME</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>AVVERTIMENTO</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>SALVA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Salvare le modifiche?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Il modello di esclusione esiste già!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Eliminare?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Impossibile salvare le modifiche!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">CONVALIDA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>CONVALIDA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Risolvere i conflitti</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Cosa vuoi fare con gli elementi in conflitto %1?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Salva le mie modifiche e sostituisci le versioni degli altri utenti.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Annulla le mie modifiche e conserva le versioni degli altri utenti.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Le tue modifiche potrebbero essere eliminate definitivamente. Non possono essere ripristinate dall&apos;applicazione web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Le tue modifiche saranno eliminate definitivamente. Non potranno essere ripristinate dall&apos;applicazione web kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Mostra articolo(i)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">CONVALIDA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Sono state apportate modifiche a questi file da diversi utenti in diversi posti (online su kDrive, un computer o un dispositivo mobile). Le cartelle contenenti questi file potrebbero anche essere state eliminate.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">La versione locale del tuo elemento &lt;b&gt;non è sincronizzata&lt;/b&gt; con kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Ulteriori informazioni&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Risolvere i conflitti</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Cosa vuoi fare con gli elementi in conflitto %1?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Salva le mie modifiche e sostituisci le versioni degli altri utenti.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Annulla le mie modifiche e conserva le versioni degli altri utenti.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Le tue modifiche potrebbero essere eliminate definitivamente. Non possono essere ripristinate dall'applicazione web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Le tue modifiche saranno eliminate definitivamente. Non potranno essere ripristinate dall'applicazione web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Mostra articolo(i)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>CONVALIDA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Sono state apportate modifiche a questi file da diversi utenti in diversi posti (online su kDrive, un computer o un dispositivo mobile). Le cartelle contenenti questi file potrebbero anche essere state eliminate.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>La versione locale del tuo elemento &lt;b&gt;non è sincronizzata&lt;/b&gt; con kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Ulteriori informazioni&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Più azioni</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Sincronizzata in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Attiva Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Attiva Lite sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Le cartelle non selezionate verranno spostate nel cestino, a condizione che contengano elementi offline. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Le cartelle non selezionate verranno spostate nel cestino. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Le cartelle non selezionate verranno cancellate &lt;b&gt;definitivamente&lt;/b&gt; dal computer. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Annulla</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">CONVALIDA</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Sospendi sincronizzazione</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Disattiva Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Riprendi sincronizzazione</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Rimuovi sincronizzazione</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Più azioni</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Sincronizzata in &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Attiva Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Attiva Lite sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Le cartelle non selezionate verranno spostate nel cestino, a condizione che contengano elementi offline. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Le cartelle non selezionate verranno spostate nel cestino. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Le cartelle non selezionate verranno cancellate &lt;b&gt;definitivamente&lt;/b&gt; dal computer. Le cartelle sincronizzate con kDrive rimarranno disponibili online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Annulla</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>CONVALIDA</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Sospendi sincronizzazione</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Disattiva Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Riprendi sincronizzazione</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Rimuovi sincronizzazione</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Impossibile aprire il percorso della cartella %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossibile aprire il percorso della cartella %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">ID applicazione</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Nome applicazione</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">CONVALIDA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>ID applicazione</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Nome applicazione</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>CONVALIDA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Alcune app (backup, antivirus...) accedono ai tuoi file, che vengono scaricati quando sono &quot;online&quot;. Aggiungerle nell&apos;elenco qui sotto per evitare che questo accada.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Aggiungi</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ID APPLICAZIONE</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOME</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SALVA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Salvare le modifiche?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Eliminare?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Impossibile salvare le modifiche!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Alcune app (backup, antivirus...) accedono ai tuoi file, che vengono scaricati quando sono "online". Aggiungerle nell'elenco qui sotto per evitare che questo accada.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Aggiungi</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ID APPLICAZIONE</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NOME</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>SALVA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Salvare le modifiche?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Eliminare?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Impossibile salvare le modifiche!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Quali cartelle del computer desideri&lt;br&gt;sincronizzare?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Il contenuto di questa cartella sarà sincronizzato sul kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Seleziona una cartella</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Modifica cartella</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUA</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Quali cartelle del computer desideri&lt;br&gt;sincronizzare?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Il contenuto di questa cartella sarà sincronizzato sul kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Seleziona una cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Modifica cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>CONTINUA</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
-Seleziona un&apos;altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Seleziona cartella</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Questa cartella non è compatibile con Lite Sync.&lt;br&gt;
+Seleziona un'altra cartella. Se continui, Lite Sync verrà disabilitato.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Seleziona cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Errore</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Il file &apos;%1&apos;&lt;br/&gt;non può essere aperto in scrittura.&lt;br/&gt;&lt;br/&gt;Il risultato del log &lt;b&gt;non&lt;/b&gt; può essere salvato!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Errore</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Il file '%1'&lt;br/&gt;non può essere aperto in scrittura.&lt;br/&gt;&lt;br/&gt;Il risultato del log &lt;b&gt;non&lt;/b&gt; può essere salvato!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferenze</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Guida</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Preferenze</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Guida</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Impossibile aprire il percorso della cartella %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Invio completato!&lt;br&gt;Fai riferimento all&apos;identificatore &lt;b&gt;%1&lt;/b&gt; nelle segnalazioni di bug.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Trasmissione fallita!
-Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Nessun kDrive configurato!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;Svuota la cronologia e, se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Sembra che la tua connessione di rete sia configurata con un timeout troppo basso perché l&apos;applicazione funzioni correttamente (errore %1).&lt;br&gt;Verifica la configurazione di rete.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Impossibile connettersi al server kDrive (errore %1).&lt;br&gt;Tentativo di riconnessione. Controlla la tua connessione Internet e il tuo firewall.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Accedi nuovamente e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>È disponibile una nuova versione dell&apos;applicazione.&lt;br&gt;Aggiorna l&apos;applicazione per continuare a utilizzarla.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Il caricamento del registro non è riuscito (errore %1).&lt;br&gt;Riprova più tardi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>La cartella di sincronizzazione non è più accessibile (errore %1).&lt;br&gt;La sincronizzazione riprenderà non appena la cartella sarà accessibile.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>La cartella di sincronizzazione è stata sostituita o spostata in modo da impedire la sincronizzazione (errore %1).&lt;br&gt;Questo può accadere dopo aver copiato, spostato o ripristinato la cartella.&lt;br&gt;Per risolvere il problema, creare una nuova sincronizzazione con una nuova cartella.&lt;br&gt;Nota: se nella vecchia cartella sono presenti modifiche non sincronizzate, è necessario copiarle manualmente nella nuova.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Memoria insufficiente sul computer.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive deve avere accesso in scrittura alla directory temporanea del tuo computer.&lt;br&gt;Riavvia l&apos;app kDrive per risolvere il problema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Si è verificato un errore tecnico.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Il numero di osservatori inotify è insufficiente (errore %1).&lt;br&gt;È possibile aumentare questo numero modificando &apos;/etc/sysctl.conf&apos;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;È necessario consentire:&lt;br&gt;- kDrive in Impostazioni di sistema &gt;&gt; Generali &gt;&gt; Elementi di accesso ed estensioni &gt;&gt; Estensioni di sicurezza degli endpoint&lt;br&gt;- Estensione kDrive LiteSync in Impostazioni di sistema &gt;&gt; Privacy e sicurezza &gt;&gt; Accesso completo al disco.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l&apos;estensione Lite Sync sia installata e che il servizio di ricerca di Windows sia abilitato.&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l&apos;estensione Lite Sync disponga delle autorizzazioni corrette e sia in esecuzione.&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Svuota la cronologia, riavvia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Un file o una cartella all&apos;interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Il kDrive è in modalità di manutenzione.&lt;br&gt;La sincronizzazione riprenderà appena possibile. Contatta il nostro team di assistenza se l&apos;errore persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Il kDrive è bloccato.&lt;br&gt;Rinnovare kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Il kDrive è bloccato.&lt;br&gt;Contatta un amministratore per rinnovare il kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive si sta riattivando.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l&apos;errore persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive è in modalità sospensione.&lt;br&gt;Accedi alla &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive è in modalità sospensione.&lt;br&gt;
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Impossibile aprire il percorso della cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Invio completato!&lt;br&gt;Fai riferimento all'identificatore &lt;b&gt;%1&lt;/b&gt; nelle segnalazioni di bug.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Trasmissione fallita!
+Per favore, utilizza il seguente link per inviare i log al supporto: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Nessun kDrive configurato!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;Svuota la cronologia e, se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Sembra che la tua connessione di rete sia configurata con un timeout troppo basso perché l'applicazione funzioni correttamente (errore %1).&lt;br&gt;Verifica la configurazione di rete.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Impossibile connettersi al server kDrive (errore %1).&lt;br&gt;Tentativo di riconnessione. Controlla la tua connessione Internet e il tuo firewall.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Accedi nuovamente e se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>È disponibile una nuova versione dell'applicazione.&lt;br&gt;Aggiorna l'applicazione per continuare a utilizzarla.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Il caricamento del registro non è riuscito (errore %1).&lt;br&gt;Riprova più tardi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>La cartella di sincronizzazione non è più accessibile (errore %1).&lt;br&gt;La sincronizzazione riprenderà non appena la cartella sarà accessibile.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>La cartella di sincronizzazione è stata sostituita o spostata in modo da impedire la sincronizzazione (errore %1).&lt;br&gt;Questo può accadere dopo aver copiato, spostato o ripristinato la cartella.&lt;br&gt;Per risolvere il problema, creare una nuova sincronizzazione con una nuova cartella.&lt;br&gt;Nota: se nella vecchia cartella sono presenti modifiche non sincronizzate, è necessario copiarle manualmente nella nuova.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Memoria insufficiente sul computer.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive deve avere accesso in scrittura alla directory temporanea del tuo computer.&lt;br&gt;Riavvia l'app kDrive per risolvere il problema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Si è verificato un errore tecnico.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Il numero di osservatori inotify è insufficiente (errore %1).&lt;br&gt;È possibile aumentare questo numero modificando '/etc/sysctl.conf'.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;È necessario consentire:&lt;br&gt;- kDrive in Impostazioni di sistema &gt;&gt; Generali &gt;&gt; Elementi di accesso ed estensioni &gt;&gt; Estensioni di sicurezza degli endpoint&lt;br&gt;- Estensione kDrive LiteSync in Impostazioni di sistema &gt;&gt; Privacy e sicurezza &gt;&gt; Accesso completo al disco.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l'estensione Lite Sync sia installata e che il servizio di ricerca di Windows sia abilitato.&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Verifica che l'estensione Lite Sync disponga delle autorizzazioni corrette e sia in esecuzione.&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Impossibile avviare il plug-in Lite Sync (errore %1).&lt;br&gt;Svuota la cronologia, riavvia e se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Un file o una cartella all'interno della cartella di sincronizzazione sembra essere corrotto.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Il kDrive è in modalità di manutenzione.&lt;br&gt;La sincronizzazione riprenderà appena possibile. Contatta il nostro team di assistenza se l'errore persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Il kDrive è bloccato.&lt;br&gt;Rinnovare kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Il kDrive è bloccato.&lt;br&gt;Contatta un amministratore per rinnovare il kDrive. Se non si interviene, i dati verranno cancellati in modo definitivo e sarà impossibile recuperarli.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive si sta riattivando.&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l'errore persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive è in modalità sospensione.&lt;br&gt;Accedi alla &lt;a style="%1" href="%2"&gt;versione web&lt;/a&gt; per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive è in modalità sospensione.&lt;br&gt;
 Accedi alla versione web per verificare lo stato del tuo kDrive oppure contatta il tuo amministratore.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Non sei autorizzato ad accedere a questo kDrive.&lt;br&gt;La sincronizzazione è stata sospesa. Contatta un amministratore.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l&apos;errore persiste.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Le connessioni di rete sono state interrotte dal kernel (errore %1).&lt;br&gt;Svuota la cronologia e se l&apos;errore persiste, contatta il nostro team di supporto.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Purtroppo la tua vecchia configurazione non può essere migrata. &lt;br&gt;L&apos;applicazione userà una configurazione vuota.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Purtroppo la tua vecchia configurazione proxy non può essere migrata, i proxy SOCKS5 non sono supportati al momento. &lt;br&gt;L&apos;applicazione userà invece le impostazioni del proxy di sistema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione è stata riavviata. Svuota la cronologia e se l&apos;errore persiste, contatta il nostro team di assistenza.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Si è verificato un errore nell&apos;accedere al database di sincronizzazione (errore %1). &lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Token non valido o revocato.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Le sincronizzazioni nidificate sono vietate (errore %1).&lt;br&gt;Conservare solo le sincronizzazioni le cui cartelle non sono nidificate.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>La cartella di sincronizzazione sul kDrive remoto non esiste più o non è più accessibile (errore %1).&lt;br&gt;È necessario ripristinarla o ridarle i diritti di accesso o cancellare/ricreare la sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Errore durante l&apos;analisi del nome file (errore %1).&lt;br&gt;Caratteri speciali come virgolette doppie, barre rovesciate o ritorni a capo possono causare errori di analisi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Non si dispone delle autorizzazioni necessarie per creare un elemento, oppure esiste già un altro elemento con lo stesso nome. L&apos;elemento è stato ignorato.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Non è consentito spostare l&apos;elemento in &quot;%1&quot;.&lt;br&gt;Verrà ripristinato nella sua cartella principale originale.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;Il download è stato annullato.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Questo elemento è stato spostato altrove.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>In questa posizione esiste già un elemento con lo stesso nome.&lt;br&gt;L&apos;elemento locale è stato rinominato.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Un elemento con lo stesso nome esiste già in questa posizione.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Il file è stato modificato contemporaneamente da un altro utente.&lt;br&gt;Le tue modifiche sono state salvate in una copia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Un altro utente ha spostato una cartella padre della destinazione.&lt;br&gt;L&apos;operazione locale è stata annullata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Il nome dell&apos;elemento contiene solo spazi.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Non disponi dell&apos;autorizzazione per modificare l&apos;elemento.&lt;br&gt;Il file contenente le tue modifiche è stato rinominato ed escluso dalla sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Non disponi dell&apos;autorizzazione per rinominare l&apos;elemento.&lt;br&gt;Verrà ripristinato con il suo nome originale.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Non disponi dell&apos;autorizzazione per eliminare l&apos;elemento.&lt;br&gt;Verrà ripristinato alla sua posizione originale.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Impossibile spostare questo elemento nel cestino, è stato inserito nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Il file è stato modificato localmente mentre veniva eliminato dal kDrive remoto.&lt;br&gt;Una copia locale è stata salvata nella cartella di recupero (rescue folder).</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>L&apos;operazione eseguita sull&apos;articolo è vietata.&lt;br&gt;L&apos;articolo è stato temporaneamente inserito nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>L&apos;operazione eseguita su questo articolo non è riuscita.&lt;br&gt;L&apos;articolo è stato temporaneamente inserito nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Il file è troppo grande per essere caricato. È stato temporaneamente inserito nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Impossibile scaricare il file.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Hai superato la tua quota. Aumenta la tua quota di spazio per riattivare il caricamento dei file.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>L’unità contenente la cartella di sincronizzazione non è più collegata (errore %1).&lt;br&gt;Ricollegala per riprendere la sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;Il processo LiteSyncExt non è attualmente in esecuzione. La sincronizzazione riprenderà non appena verrà avviata.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Un elemento esistente ha un nome identico con le stesse opzioni di maiuscole e minuscole (stesse lettere maiuscole e minuscole).&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Il nome dell&apos;elemento contiene un carattere non supportato.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Il nome dell&apos;elemento termina con uno spazio, che è vietato sul tuo sistema operativo.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Il nome di questo elemento è riservato dal tuo sistema operativo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Il nome dell&apos;elemento è troppo lungo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Il percorso dell&apos;elemento è troppo lungo.&lt;br&gt;È stato ignorato.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Il nome dell&apos;elemento contiene un carattere UNICODE recente non ancora supportato dal file system.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>La sincronizzazione di questo elemento è fallita. È stato temporaneamente inserito nella lista nera.&lt;br&gt;Un altro tentativo di sincronizzazione verrà effettuato tra un&apos;ora o al successivo avvio dell&apos;applicazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Questo elemento è stato escluso dalla sincronizzazione da un modello personalizzato. È possibile disattivare questo tipo di notifica dalle preferenze</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Questo elemento è stato escluso dalla sincronizzazione perché si tratta di un hard link.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Questo articolo è attualmente bloccato da un altro utente online.&lt;br&gt;Riproviamo a caricare le modifiche più tardi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Errore di sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Impossibile accedere all&apos;elemento.&lt;br&gt;Si prega di correggere i permessi di lettura e scrittura.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Impossibile creare il file %1 perché non è supportato dal file system.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Errore di sistema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>L&apos;elemento esiste già dall&apos;altra parte.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Si è verificato un errore tecnico.&lt;br&gt;Svuota la cronologia e, se l&apos;errore persiste, contatta il nostro team di assistenza.</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Non sei autorizzato ad accedere a questo kDrive.&lt;br&gt;La sincronizzazione è stata sospesa. Contatta un amministratore.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione riprenderà il prima possibile. Contatta il nostro team di supporto se l'errore persiste.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Le connessioni di rete sono state interrotte dal kernel (errore %1).&lt;br&gt;Svuota la cronologia e se l'errore persiste, contatta il nostro team di supporto.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Purtroppo la tua vecchia configurazione non può essere migrata. &lt;br&gt;L'applicazione userà una configurazione vuota.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Purtroppo la tua vecchia configurazione proxy non può essere migrata, i proxy SOCKS5 non sono supportati al momento. &lt;br&gt;L'applicazione userà invece le impostazioni del proxy di sistema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Si è verificato un errore tecnico (errore %1).&lt;br&gt;La sincronizzazione è stata riavviata. Svuota la cronologia e se l'errore persiste, contatta il nostro team di assistenza.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Si è verificato un errore nell'accedere al database di sincronizzazione (errore %1). &lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Si è verificato un problema di accesso (errore %1).&lt;br&gt;Token non valido o revocato.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Le sincronizzazioni nidificate sono vietate (errore %1).&lt;br&gt;Conservare solo le sincronizzazioni le cui cartelle non sono nidificate.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>La cartella di sincronizzazione sul kDrive remoto non esiste più o non è più accessibile (errore %1).&lt;br&gt;È necessario ripristinarla o ridarle i diritti di accesso o cancellare/ricreare la sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Errore durante l'analisi del nome file (errore %1).&lt;br&gt;Caratteri speciali come virgolette doppie, barre rovesciate o ritorni a capo possono causare errori di analisi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Non si dispone delle autorizzazioni necessarie per creare un elemento, oppure esiste già un altro elemento con lo stesso nome. L'elemento è stato ignorato.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Non è consentito spostare l'elemento in "%1".&lt;br&gt;Verrà ripristinato nella sua cartella principale originale.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;Il download è stato annullato.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Impossibile creare il file "%1" perché non è supportato dal tuo filesystem.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Questo elemento è stato spostato altrove.&lt;br&gt;L'operazione locale è stata annullata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>In questa posizione esiste già un elemento con lo stesso nome.&lt;br&gt;L'elemento locale è stato rinominato.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Un elemento con lo stesso nome esiste già in questa posizione.&lt;br&gt;L'operazione locale è stata annullata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Lo spazio disponibile sul computer è insufficiente.&lt;br&gt;La sincronizzazione è stata interrotta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Il file è stato modificato contemporaneamente da un altro utente.&lt;br&gt;Le tue modifiche sono state salvate in una copia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Un altro utente ha spostato una cartella padre della destinazione.&lt;br&gt;L'operazione locale è stata annullata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Il nome dell'elemento contiene solo spazi.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Non disponi dell'autorizzazione per modificare l'elemento.&lt;br&gt;Il file contenente le tue modifiche è stato rinominato ed escluso dalla sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Non disponi dell'autorizzazione per rinominare l'elemento.&lt;br&gt;Verrà ripristinato con il suo nome originale.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Non disponi dell'autorizzazione per eliminare l'elemento.&lt;br&gt;Verrà ripristinato alla sua posizione originale.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Impossibile spostare questo elemento nel cestino, è stato inserito nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Il file è stato modificato localmente mentre veniva eliminato dal kDrive remoto.&lt;br&gt;Una copia locale è stata salvata nella cartella di recupero (rescue folder).</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>L'operazione eseguita sull'articolo è vietata.&lt;br&gt;L'articolo è stato temporaneamente inserito nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>L'operazione eseguita su questo articolo non è riuscita.&lt;br&gt;L'articolo è stato temporaneamente inserito nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Il file è troppo grande per essere caricato. È stato temporaneamente inserito nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Impossibile scaricare il file.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Hai superato la tua quota. Aumenta la tua quota di spazio per riattivare il caricamento dei file.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>L’unità contenente la cartella di sincronizzazione non è più collegata (errore %1).&lt;br&gt;Ricollegala per riprendere la sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Impossibile avviare la sincronizzazione (errore %1).&lt;br&gt;Il processo LiteSyncExt non è attualmente in esecuzione. La sincronizzazione riprenderà non appena verrà avviata.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Un elemento esistente ha un nome identico con le stesse opzioni di maiuscole e minuscole (stesse lettere maiuscole e minuscole).&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Il nome dell'elemento contiene un carattere non supportato.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Il nome dell'elemento termina con uno spazio, che è vietato sul tuo sistema operativo.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Il nome di questo elemento è riservato dal tuo sistema operativo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Il nome dell'elemento è troppo lungo.&lt;br&gt;È stato temporaneamente inserito nella blacklist.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Il percorso dell'elemento è troppo lungo.&lt;br&gt;È stato ignorato.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Il nome dell'elemento contiene un carattere UNICODE recente non ancora supportato dal file system.&lt;br&gt;È stato escluso dalla sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>La sincronizzazione di questo elemento è fallita. È stato temporaneamente inserito nella lista nera.&lt;br&gt;Un altro tentativo di sincronizzazione verrà effettuato tra un'ora o al successivo avvio dell'applicazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Questo elemento è stato escluso dalla sincronizzazione da un modello personalizzato. È possibile disattivare questo tipo di notifica dalle preferenze</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Questo elemento è stato escluso dalla sincronizzazione perché si tratta di un hard link.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Questo articolo è attualmente bloccato da un altro utente online.&lt;br&gt;Riproviamo a caricare le modifiche più tardi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Errore di sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Impossibile accedere all'elemento.&lt;br&gt;Si prega di correggere i permessi di lettura e scrittura.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Errore di sistema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>L'elemento esiste già dall'altra parte.&lt;br&gt;È stato temporaneamente messo nella lista nera.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Si è verificato un errore tecnico.&lt;br&gt;Svuota la cronologia e, se l'errore persiste, contatta il nostro team di assistenza.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Questa sincronizzazione è in fase di eliminazione.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Questa sincronizzazione è in fase di eliminazione.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Torna all&apos;elenco dei kDrive</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferenze</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Torna all'elenco dei kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Preferenze</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Generale</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Attiva tema scuro</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Attiva icone monocolore</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Lancia kDrive all&apos;avvio del sistema</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Olandese</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avanzate</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Informazioni di debug</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Apri cartella di debug&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">File da escludere</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Server proxy</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Svedese</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portoghese</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polacco</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norvegese</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finlandese</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Danese</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Greco</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Impossibile aprire la cartella %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Link %1 non valido.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Lingua</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Non è possibile eseguire alcuni processi.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Sposta i file eliminati nel cestino del mio computer</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Alcuni file o cartelle potrebbero non essere spostati nel cestino del computer.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Puoi sempre recuperare i file già sincronizzati dal cestino dell&apos;applicazione web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Scopri di più&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Inglese</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Francese</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Tedesco</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Spagnolo</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italiano</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Predefinito</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Generale</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Attiva tema scuro</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Attiva icone monocolore</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Lancia kDrive all'avvio del sistema</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Olandese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avanzate</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Informazioni di debug</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Apri cartella di debug&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>File da escludere</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Server proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Svedese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portoghese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polacco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norvegese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finlandese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Danese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Greco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Impossibile aprire la cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Link %1 non valido.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Lingua</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Non è possibile eseguire alcuni processi.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Sposta i file eliminati nel cestino del mio computer</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Alcuni file o cartelle potrebbero non essere spostati nel cestino del computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Puoi sempre recuperare i file già sincronizzati dal cestino dell'applicazione web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Scopri di più&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Inglese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Francese</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Tedesco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Spagnolo</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italiano</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Predefinito</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 in uso</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 in uso</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">Proxy HTTP(S)</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Server proxy</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Nessun server proxy</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Usa parametri di sistema</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Indica un proxy manualmente</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Porta</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Indirizzo del server proxy</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Autenticazione necessaria</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Utente</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Password</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SALVA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Salvare le modifiche?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Impossibile salvare. Non tutti i campi obbligatori sono stati completati!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy non trovato. Salvare comunque?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>Proxy HTTP(S)</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Server proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Nessun server proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Usa parametri di sistema</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Indica un proxy manualmente</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Porta</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Indirizzo del server proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Autenticazione necessaria</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Utente</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Password</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>SALVA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Salvare le modifiche?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Impossibile salvare. Non tutti i campi obbligatori sono stati completati!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy non trovato. Salvare comunque?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Responsabile delle risorse</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Utilizzo massimo della CPU consentito</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SALVA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Salvare le modifiche?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Responsabile delle risorse</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Utilizzo massimo della CPU consentito</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>SALVA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Salvare le modifiche?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Seleziona una cartella sul tuo kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Il contenuto della cartella selezionata sarà sincronizzato nella cartella &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUA</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Spazio disponibile nel computer per la cartella attuale: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Questa cartella è già sincronizzata.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFERMA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANNULLA</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Seleziona una cartella sul tuo kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Il contenuto della cartella selezionata sarà sincronizzato nella cartella &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>CONTINUA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Spazio disponibile nel computer per la cartella attuale: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Questa cartella è già sincronizzata.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>CONFERMA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ANNULLA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; contiene sottocartelle,&lt;br&gt; seleziona quelle che desideri sincronizzare</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUA</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Attualmente non ci sono sottocartelle sul server.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; contiene sottocartelle,&lt;br&gt; seleziona quelle che desideri sincronizzare</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>CONTINUA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Attualmente non ci sono sottocartelle sul server.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Riprendi la sincronizzazione di kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Riprendi la sincronizzazione di tutti i kDrive</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Sospendi la sincronizzazione di kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Sospendi sincronizzazione</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Metti in pausa tutta la sincronizzazione di kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Riprendi sincronizzazione</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Riprendi la sincronizzazione di kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Riprendi la sincronizzazione di tutti i kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Sospendi la sincronizzazione di kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Sospendi sincronizzazione</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Metti in pausa tutta la sincronizzazione di kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Riprendi sincronizzazione</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Copiare il link di condivisione</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Visualizzazione su kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Mostra nella cartella</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Più azioni</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Apri</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Aggiungi ai preferiti</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Copiare il link di condivisione</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Visualizzazione su kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Mostra nella cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Più azioni</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Apri</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Aggiungi ai preferiti</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Mai</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Per 1 ora</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Fino alle 8:00 di domani</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Per 3 giorni</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Per 1 settimana</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Sempre</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Per 1 altra ora</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Per altri 3 giorni</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Per 1 altra settimana</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Impossibile aprire l&apos;URL della cartella %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Apri nella cartella</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Apri la versione web %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Parametri unità</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Notifiche disabilitate fino al %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Disabilita notifiche</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Preferenze dell&apos;applicazione</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Hai bisogno di aiuto</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Invia feedback</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Esci da kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Impossibile accedere al sito web %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Mostra errori e informazioni</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Mostra informazioni</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Più azioni</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Mai</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Per 1 ora</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Fino alle 8:00 di domani</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Per 3 giorni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Per 1 settimana</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Per 1 altra ora</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Per altri 3 giorni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Per 1 altra settimana</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Impossibile aprire l'URL della cartella %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Apri nella cartella</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Apri la versione web %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Parametri unità</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Notifiche disabilitate fino al %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Disabilita notifiche</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Preferenze dell'applicazione</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Hai bisogno di aiuto</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Invia feedback</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Esci da kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Impossibile accedere al sito web %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Mostra errori e informazioni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Mostra informazioni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Più azioni</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Aggiorna l&apos;app kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Questa versione dell&apos;app kDrive non è più supportata. Per accedere alle funzionalità e ai miglioramenti più recenti, aggiornare.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Aggiornamento</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Si prega di scaricare l&apos;ultima versione dal sito web.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Download dell&apos;aggiornamento in corso</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">In cerca di aggiornamento...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Aggiornamento manuale</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Non disponibile</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Puoi sincronizzare i file &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;dal tuo computer&lt;/a&gt; o su &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Sincronizzata</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Preferiti</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Attività</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Non implementato!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/it/applicazioni/scarica-kdrive&quot;&gt;Clicca qui per scaricare manualmente&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Nessuna cartella sincronizzata per questo kDrive!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Nessun kDrive configurato!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Impossibile aprire il link %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Link %1 non valido.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Impossibile aprire l&apos;URL della cartella %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Aggiorna l'app kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Questa versione dell'app kDrive non è più supportata. Per accedere alle funzionalità e ai miglioramenti più recenti, aggiornare.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Aggiornamento</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Si prega di scaricare l'ultima versione dal sito web.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Download dell'aggiornamento in corso</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>In cerca di aggiornamento...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Aggiornamento manuale</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Non disponibile</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Puoi sincronizzare i file &lt;a style="%1" href="%2"&gt;dal tuo computer&lt;/a&gt; o su &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Sincronizzata</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Preferiti</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Attività</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Non implementato!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/it/applicazioni/scarica-kdrive"&gt;Clicca qui per scaricare manualmente&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Nessuna cartella sincronizzata per questo kDrive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Nessun kDrive configurato!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Impossibile aprire il link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Link %1 non valido.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Impossibile aprire l'URL della cartella %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;La nuova versione &lt;b&gt;%1&lt;/b&gt; del client %2 è disponibile ed è stata scaricata.&lt;/p&gt;&lt;p&gt;La versione installata è %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Salta questa versione</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Ricordamelo più tardi</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installa</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;La nuova versione &lt;b&gt;%1&lt;/b&gt; del client %2 è disponibile ed è stata scaricata.&lt;/p&gt;&lt;p&gt;La versione installata è %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Salta questa versione</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Ricordamelo più tardi</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installa</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">È disponibile un nuovo aggiornamento.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">La versione %1 è disponibile per il download.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>È disponibile un nuovo aggiornamento.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>La versione %1 è disponibile per il download.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Aggiungi un account</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Aggiungi un account</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostra nota di rilascio&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Versione</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">AGGIORNAMENTO</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 è aggiornato!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Controllo dell&apos;aggiornamento sul server...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">È disponibile un aggiornamento: %1.&lt;br&gt;Scaricalo da &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;qui&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">È disponibile un aggiornamento: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Download in corso %1. Attendere...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Impossibile verificare la presenza di nuovi aggiornamenti.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Si è verificato un errore durante l&apos;aggiornamento.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Impossibile scaricare l&apos;aggiornamento.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Aggiornamento disabilitato.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Beta program</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Ottenere l&apos;accesso anticipato alle nuove versioni dell&apos;applicazione</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Contatto</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Modificare</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Esci</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Mostra nota di rilascio&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Versione</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>AGGIORNAMENTO</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 è aggiornato!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Controllo dell'aggiornamento sul server...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>È disponibile un aggiornamento: %1.&lt;br&gt;Scaricalo da &lt;a style="%2" href="%3"&gt;qui&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>È disponibile un aggiornamento: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Download in corso %1. Attendere...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Impossibile verificare la presenza di nuovi aggiornamenti.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Si è verificato un errore durante l'aggiornamento.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Impossibile scaricare l'aggiornamento.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Aggiornamento disabilitato.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Beta program</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Ottenere l'accesso anticipato alle nuove versioni dell'applicazione</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Contatto</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Modificare</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Esci</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Impossibile salvare i parametri, riprova più tardi.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Impossibile salvare i parametri!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">La cartella padre è una cartella di sincronizzazione o contenuta in un</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Impossibile trovare un percorso valido</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Nessuna cartella valida selezionata!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Il percorso selezionato non esiste!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Il percorso selezionato non è una cartella!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Non disponi dell&apos;autorizzazione di scrittura per la cartella selezionata!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">La cartella locale %1 contiene una cartella già sincronizzata. Scegline un&apos;altra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un&apos;altra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">La cartella locale %1 è già sincronizzata. Scegline un&apos;altra!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync (Beta) è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync (Beta) è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Rendere disponibile localmente</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Libera spazio locale</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Annulla liberazione di spazio locale</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Annulla rendere disponibile localmente</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Ricondivisione di questo file non consentita</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Ricondivisione di questa cartella non consentita</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Copia il collegamento di condivisione pubblica</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Copia il collegamento di condivisione privata</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Apri nel browser</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Impossibile salvare i parametri, riprova più tardi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Impossibile salvare i parametri!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>La cartella padre è una cartella di sincronizzazione o contenuta in un</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Impossibile trovare un percorso valido</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Nessuna cartella valida selezionata!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Il percorso selezionato non esiste!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Il percorso selezionato non è una cartella!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Non disponi dell'autorizzazione di scrittura per la cartella selezionata!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>La cartella locale %1 contiene una cartella già sincronizzata. Scegline un'altra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>La cartella locale %1 è contenuta in una cartella già sincronizzata. Scegline un'altra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>La cartella locale %1 è già sincronizzata. Scegline un'altra!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync (Beta) è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync (Beta) è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync è abilitato. I file di kDrive rimangono nel Cloud e non utilizzano lo spazio di archiviazione del computer.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync è disabilitato. I file kDrive utilizzano lo spazio di archiviazione del tuo computer.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Rendere disponibile localmente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Libera spazio locale</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Annulla liberazione di spazio locale</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Annulla rendere disponibile localmente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Ricondivisione di questo file non consentita</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Ricondivisione di questa cartella non consentita</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Copia il collegamento di condivisione pubblica</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Copia il collegamento di condivisione privata</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Apri nel browser</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">L&apos;applicazione kDrive si chiuderà a causa di un errore irreversibile.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>L'applicazione kDrive si chiuderà a causa di un errore irreversibile.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translatorcomment>// QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate</translatorcomment>
-        <translation type="vanished">
-            <numerusform>%n anno/i</numerusform>
-            <numerusform>%n anno/i</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n mese/i</numerusform>
-            <numerusform>%n mese/i</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n giorno/i</numerusform>
-            <numerusform>%n giorno/i</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n ora/e</numerusform>
-            <numerusform>%n ora/e</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minuto/i</numerusform>
-            <numerusform>%n minuto/i</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n secondo/i</numerusform>
-            <numerusform>%n secondo/i</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translatorcomment>// QTBUG-3945 and issue #4855: QT_TRANSLATE_NOOP does not work with plural form because lupdate</translatorcomment>
+<translation>
+<numerusform>%n anno/i</numerusform>
+<numerusform>%n anno/i</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n mese/i</numerusform>
+<numerusform>%n mese/i</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n giorno/i</numerusform>
+<numerusform>%n giorno/i</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n ora/e</numerusform>
+<numerusform>%n ora/e</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuto/i</numerusform>
+<numerusform>%n minuto/i</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n secondo/i</numerusform>
+<numerusform>%n secondo/i</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Area di notifica non disponibile</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 richiede un’area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un’applicazione per l’area di notifica come “trayer” e riprova.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Area di notifica non disponibile</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 richiede un’area di notifica (system tray) funzionante. Se utilizzi XFCE, segui &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;queste istruzioni&lt;/a&gt;. In caso contrario, installa un’applicazione per l’area di notifica come “trayer” e riprova.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Impossibile aprire il browser</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Si è verificato un errore durante l&apos;avvio del browser per accedere all&apos;URL %1. Forse non è configurato un browser predefinito?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Impossibile aprire il client di posta elettronica</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Si è verificato un errore durante l&apos;avvio del client di posta per creare un nuovo messaggio. Forse non è configurato un client di posta predefinito?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Non sei più collegato. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Accedi&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Impossibile aprire il browser</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Si è verificato un errore durante l'avvio del browser per accedere all'URL %1. Forse non è configurato un browser predefinito?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Impossibile aprire il client di posta elettronica</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Si è verificato un errore durante l'avvio del client di posta per creare un nuovo messaggio. Forse non è configurato un client di posta predefinito?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Non sei più collegato. &lt;a style="%1" href="%2"&gt;Accedi&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Nessuna cartella da sincronizzare
+<translation>Nessuna cartella da sincronizzare
 Puoi aggiungerne uno dalle impostazioni di kDrive.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Sincronizzazione in corso (%1 di %2)
+<translation>Sincronizzazione in corso (%1 di %2)
 %3 mancanti...</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Sincronizzazione in corso (fase %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Sincronizzazione in corso.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Non è stato possibile sincronizzare alcuni file. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Maggiori informazioni&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Sospensione sincronizzazione in corso…</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché un&apos;altra sincronizzazione sta utilizzando la stessa cartella.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché contiene la cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché è contenuta nella cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Si prega di selezionare un&apos;altra cartella.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un&apos;altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Inizio sincronizzazione</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Sincronizzazione sospesa.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Sincronizzazione in corso (%1 di %2)</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Sistema aggiornato. Sono presenti conflitti non risolti.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Sistema aggiornato!</translation>
-    </message>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Sincronizzazione in corso (fase %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Sincronizzazione in corso.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Non è stato possibile sincronizzare alcuni file. &lt;a style="%1" href="%2"&gt;Maggiori informazioni&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Sospensione sincronizzazione in corso…</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché un'altra sincronizzazione sta utilizzando la stessa cartella.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché contiene la cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata perché è contenuta nella cartella sincronizzata &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Si prega di selezionare un'altra cartella.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>La cartella &lt;b&gt;%1&lt;/b&gt; non può essere selezionata come cartella di sincronizzazione. Selezionare un'altra cartella. Cartella suggerita: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Hai escluso più di %1 cartelle. Tieni presente che ciò influirà sulle prestazioni di sincronizzazione.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Non puoi escludere più di %1 cartelle. Deseleziona le cartelle di livello superiore.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Inizio sincronizzazione</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Sincronizzazione sospesa.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Sincronizzazione in corso (%1 di %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Sistema aggiornato. Sono presenti conflitti non risolti.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Sistema aggiornato!</translation>
+</message>
 </context>
 </TS>

--- a/translations/client_nb.ts
+++ b/translations/client_nb.ts
@@ -1,3097 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="nb_NO" version="2.1">
+<TS version="2.1" language="nb_NO">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Om</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>LUKK</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versjon %1. For mer informasjon, gå til &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribuert av %1 og lisensiert under &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke apne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style="color: #489EF3" href="%1"&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>LUKK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versjon %1. For mer informasjon, gå til &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuert av %1 og lisensiert under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke apne mappestien %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>kDrive-enheten din er klar!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>APNE MAPPE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>INNSTILLINGER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synkroniser en annen stasjon</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>kDrive-enheten din er klar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>APNE MAPPE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>INNSTILLINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkroniser en annen stasjon</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>NESTE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Velg kDrive-enheten du vil synkronisere</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Fa kDrive gratis</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Test gratis</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>NESTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Velg kDrive-enheten du vil synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Fa kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Test gratis</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Spar plass pa datamaskinen</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>SENERE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Vil du aktivere Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Vil du aktivere Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Spar plass pa datamaskinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>SENERE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Vil du aktivere Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Vil du aktivere Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Plassering av din %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Rediger mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>FULLFOR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Velg mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Plassering av din %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>FULLFOR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Velg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>FORTSETT</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Logg inn fra nettleseren din</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Åpne påloggingssiden</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Det oppstod en feil under autentisering. Lukk påloggingsvinduet og prøv igjen.&lt;br&gt;Kontakt supportteamet vårt hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Innlogging mislyktes: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Logg inn fra nettleseren din</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Åpne påloggingssiden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Det oppstod en feil under autentisering. Lukk påloggingsvinduet og prøv igjen.&lt;br&gt;Kontakt supportteamet vårt hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Innlogging mislyktes: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>FORTSETT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Ledig plass på datamaskinen din: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Ledig plass på datamaskinen din: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Det gikk ikke å opprette den lokale mappen %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Det gikk ikke å opprette ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Det gikk ikke å opprette den lokale mappen %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gikk ikke å opprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-klienten kjøres med feil parametere!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>kDrive-klienten kjører allerede!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-klienten kjøres med feil parametere!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-klienten kjører allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Del-lenken er kopiert til utklippstavlen</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
-<numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er fjernet.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
-<numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er lagt til.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
-<numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 er oppdatert.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
-<numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 er flyttet til %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synkroniseringsaktivitet</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Del-lenken er kopiert til utklippstavlen</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er fjernet.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er lagt til.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
+            <numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 er oppdatert.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
+            <numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 er flyttet til %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synkroniseringsaktivitet</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Avslutt betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Bli med i betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Dra nytte av oppdateringer til betaversjonen av appen</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Nei</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Offentlig betaversjon</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Intern betaversjon</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Testversjon</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Jeg forstår</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Lagre</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Avslutt betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Bli med i betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Dra nytte av oppdateringer til betaversjonen av appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Nei</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Offentlig betaversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Intern betaversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Testversjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Jeg forstår</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Lagre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Vennligst logg inn</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Mappe %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Det er ikke konfigurert noen synkroniseringsmapper.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Sammendrag</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translatorcomment>Préférences</translatorcomment>
-<translation>Innstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Avslutt</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Udefinert tilstand.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Venter på å starte synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synkroniseringen pågår.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Den siste synkroniseringen ble gjennomført.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Brukeravbrudd.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synkroniseringen er satt på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synkroniseringen er satt på pause)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>FJERN ALLE SYNKRONISERINGER</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 elementer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. For å unngå utilsiktede slettinger er synkroniseringen satt på pause.&lt;br&gt;Vil du spre disse slettingene til kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Flere filer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Slettede filer finnes i kDrives &lt;a style="%1" href="%3"&gt;papirkurv&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Ikke vis igjen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Det gikk ikke å starte synkroniseringen!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke apne mappestien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Kan ikke starte kDrive-klienten</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synkroniseringen er satt på pause</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Vennligst logg inn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Mappe %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Det er ikke konfigurert noen synkroniseringsmapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Sammendrag</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Avslutt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Udefinert tilstand.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Venter på å starte synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synkroniseringen pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Den siste synkroniseringen ble gjennomført.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Brukeravbrudd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synkroniseringen er satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkroniseringen er satt på pause)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>FJERN ALLE SYNKRONISERINGER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 elementer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. For å unngå utilsiktede slettinger er synkroniseringen satt på pause.&lt;br&gt;Vil du spre disse slettingene til kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Flere filer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Slettede filer finnes i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papirkurv&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Ikke vis igjen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Det gikk ikke å starte synkroniseringen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Kan ikke starte kDrive-klienten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkroniseringen er satt på pause</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Oversikt over synkroniseringen av den lokale mappen din</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNKRONISER</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Oversikt over synkroniseringen av den lokale mappen din</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONISER</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Før du avslutter</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Godkjenn kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Lås opp hengelåsen &lt;img src=":/client/resources/icons/actions/lock.png"&gt; og godkjenn kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikker her&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>TRINN 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Ferdig)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>TRINN 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>UTFØRTE TRINN</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>FULLFOR</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Før du avslutter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Godkjenn kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Lås opp hengelåsen &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkjenn kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikker her&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>TRINN 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Ferdig)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>TRINN 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>UTFØRTE TRINN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>FULLFOR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NEI</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NEI</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Overføring av feilsøkingsinformasjon</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Overføring av feilsøkingsinformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Informasjon</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Feilsøking</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Advarsel</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Feil</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Dødelig</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Feilsøkingsinnstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Feilsøkingsnivå</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Utvidet fullstendig logg</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Slett logger som er eldre enn %1 dager</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Del kun den siste kDrive-økten</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Laster</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>LAGRE</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Det gikk ikke å dele</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Forbindelsen ble brutt)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Vi har automatisk komprimert loggen din &lt;a style="%1" href="%2"&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Overfør arkivet med &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Del lenken med&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Siste opplasting av %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Delingen er avbrutt</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Den utvidede fullstendige loggen aktiveres via miljøvariabelen KDRIVE_FORCE_EXTENDED_LOG. Sett den til 0 for å deaktivere den.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du lagre endringene dine?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke apne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Del</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Deling | trinn 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Deling | trinn 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Avbryter...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Feilsøking</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Advarsel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Dødelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Feilsøkingsinnstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Feilsøkingsnivå</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Utvidet fullstendig logg</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Slett logger som er eldre enn %1 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Del kun den siste kDrive-økten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Laster</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Det gikk ikke å dele</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Forbindelsen ble brutt)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Vi har automatisk komprimert loggen din &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Del lenken med&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Siste opplasting av %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Delingen er avbrutt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Den utvidede fullstendige loggen aktiveres via miljøvariabelen KDRIVE_FORCE_EXTENDED_LOG. Sett den til 0 for å deaktivere den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Del</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Deling | trinn 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Deling | trinn 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Avbryter...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Mapper</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Varsler</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>I forbindelse med</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Synkroniseringen av den nye lokale mappen mislyktes!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Aktivering av Lite Sync mislyktes.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Deaktivering av Lite Sync mislyktes.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Slå på varslinger for denne kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synkroniseringsfeil og informasjon.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synkroniser en lokal mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Vil du virkelig slå på Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Vil du virkelig slå av Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Det gikk ikke å opprette ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync er aktivert.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync er deaktivert.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Denne stasjonen blir slettet.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Det er umulig å åpne elementet %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Fjern alle synkroniseringer</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Søk i kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Søk</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mapper</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Varsler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>I forbindelse med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Synkroniseringen av den nye lokale mappen mislyktes!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktivering av Lite Sync mislyktes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Deaktivering av Lite Sync mislyktes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Slå på varslinger for denne kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkroniseringsfeil og informasjon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkroniser en lokal mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Vil du virkelig slå på Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Vil du virkelig slå av Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gikk ikke å opprette ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync er aktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync er deaktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Denne stasjonen blir slettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Det er umulig å åpne elementet %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Fjern alle synkroniseringer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Søk i kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Søk</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synkroniser en kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Legg til en kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkroniser en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Legg til en kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Løsning</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Elementer med konflikt</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Element(er) med tegn som ikke støttes</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Slett historikk</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Å løse</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Løst automatisk</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problemer løst</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>det er oppdaget et eller flere problemer</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Løsning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elementer med konflikt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Element(er) med tegn som ikke støttes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Slett historikk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Å løse</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Løst automatisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problemer løst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>det er oppdaget et eller flere problemer</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synkroniseringskonflikter eller feil</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Feil</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Tilbake til innstillinger</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkroniseringskonflikter eller feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Tilbake til innstillinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 feil)</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 opplysning(er))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 feil og %2 opplysninger)</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
-<numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 feil)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 opplysning(er))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 feil og %2 opplysninger)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
+            <numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Ekskluderte filer</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Legg til</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NAVN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>ADVARSEL</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>LAGRE</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du lagre endringene dine?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Utelukkelsesmalen finnes allerede!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Vil du virkelig slette?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Kan ikke lagre endringene!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ekskluderte filer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Legg til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>ADVARSEL</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Utelukkelsesmalen finnes allerede!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke lagre endringene!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Løse konflikter</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Angre mine endringer og behold andre brukeres versjoner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Vis element(er)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Les mer&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Løse konflikter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Angre mine endringer og behold andre brukeres versjoner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Vis element(er)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synkronisert til &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Aktiver Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Aktiver Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Stopp synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Deaktiver Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Fortsett synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Fjern synkronisering</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkronisert til &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Aktiver Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Aktiver Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Stopp synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Deaktiver Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsett synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Fjern synkronisering</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke apne mappestien %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Applikasjons-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Programnavn</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Applikasjons-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Programnavn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Legg til</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>SØKNADS-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NAVN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>LAGRE</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du lagre endringene dine?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Vil du virkelig slette?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Kan ikke lagre endringene!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Legg til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>SØKNADS-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAVN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vil du virkelig slette?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Kan ikke lagre endringene!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Velg en mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Rediger mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>FORTSETT</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Velg en mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Rediger mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Velg mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Velg mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Feil</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Feil</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Innstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Hjelp</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hjelp</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Kan ikke apne mappestien %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>kDrive er ikke konfigurert!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Overføringen mislyktes!
-Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Du har enten ikke tillatelse til å opprette et element, eller det finnes allerede et annet element med samme navn. Elementet ble ignorert.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Det er umulig å opprette filen «%1», siden den ikke støttes i filsystemet ditt.&lt;br&gt;Den er ekskludert fra synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Det er umulig å laste ned filen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Synkroniseringsfeil.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Systemfeil.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Kan ikke apne mappestien %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive er ikke konfigurert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Overføringen mislyktes!
+Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Du har enten ikke tillatelse til å opprette et element, eller det finnes allerede et annet element med samme navn. Elementet ble ignorert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Det er umulig å opprette filen «%1», siden den ikke støttes i filsystemet ditt.&lt;br&gt;Den er ekskludert fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Det er umulig å laste ned filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Synkroniseringsfeil.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Systemfeil.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Denne synkroniseringen blir slettet.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Denne synkroniseringen blir slettet.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Tilbake til listen over stasjoner</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Innstillinger</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Tilbake til listen over stasjoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Innstillinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Generelt</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Aktiver morkt tema</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Aktiver monokrome ikoner</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Start kDrive ved oppstart</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Dansk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Gresk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Nederlandsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avansert</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Feilsokingsinformasjon</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Filer som skal utelukkes</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Svensk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugisisk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Kan ikke apne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Ugyldig lenke %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Sprak</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>En eller annen prosess kunne ikke kjøres.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Flytt slettede filer til papirkurven pa datamaskinen</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Engelsk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Fransk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Tysk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Spansk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italiensk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Standard</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Generelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Aktiver morkt tema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Aktiver monokrome ikoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Start kDrive ved oppstart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Dansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Gresk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Nederlandsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avansert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Feilsokingsinformasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Filer som skal utelukkes</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Svensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugisisk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Kan ikke apne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldig lenke %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Sprak</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>En eller annen prosess kunne ikke kjøres.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Flytt slettede filer til papirkurven pa datamaskinen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Engelsk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Fransk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Tysk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Spansk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italiensk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 i bruk</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 i bruk</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S)-proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ingen proxy-server</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Bruk systemparametere</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Angi en fullmektig manuelt</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Havn</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Adressen til proxy-serveren</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Pålogging kreves</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Bruker</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Passord</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>LAGRE</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du lagre endringene dine?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy funnet, vil du lagre likevel?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ingen proxy-server</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Bruk systemparametere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Angi en fullmektig manuelt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Havn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adressen til proxy-serveren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Pålogging kreves</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Bruker</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Passord</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy funnet, vil du lagre likevel?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Ressursansvarlig</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Maksimal tillatt CPU-bruk</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>LAGRE</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vil du lagre endringene dine?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Ressursansvarlig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maksimal tillatt CPU-bruk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>LAGRE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vil du lagre endringene dine?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Velg en mappe på kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>FORTSETT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Denne mappen synkroniseres allerede.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>BEKREFT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Velg en mappe på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Denne mappen synkroniseres allerede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BEKREFT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>FORTSETT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>FORTSETT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Gjenoppta synkroniseringen av kDrive «%1»</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Gjenoppta all synkronisering av kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Stopp synkroniseringen av kDrive «%1»</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Stopp synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Stopp all synkronisering av kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Fortsett synkroniseringen</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Gjenoppta synkroniseringen av kDrive «%1»</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Gjenoppta all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Stopp synkroniseringen av kDrive «%1»</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Stopp synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Stopp all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsett synkroniseringen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Kopier delingslenken</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Vis på kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Vis i mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Åpne</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Legg til i favoritter</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopier delingslenken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Vis på kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Vis i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Åpne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Legg til i favoritter</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Aldri</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>I løpet av 1 time</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Frem til i morgen kl. 08.00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>I løpet av 3 dager</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>I løpet av 1 uke</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Alltid</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>I én time til</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>I ytterligere 3 dager</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>I én uke til</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Det går ikke an å åpne mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Åpne i mappe</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Åpne %1-nettversjonen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Drivparametere</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Varsler er deaktivert frem til %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Deaktiver varsler</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Innstillinger for applikasjonen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Trenger du hjelp?</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Send tilbakemeldinger</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Avslutt kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Det er ikke mulig å få tilgang til nettstedet %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Vis feil og informasjon</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Vis informasjon</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Flere handlinger</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Aldri</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>I løpet av 1 time</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Frem til i morgen kl. 08.00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>I løpet av 3 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>I løpet av 1 uke</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Alltid</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>I én time til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>I ytterligere 3 dager</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>I én uke til</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går ikke an å åpne mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Åpne i mappe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Åpne %1-nettversjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drivparametere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Varsler er deaktivert frem til %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Deaktiver varsler</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Innstillinger for applikasjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Trenger du hjelp?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Send tilbakemeldinger</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Avslutt kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Det er ikke mulig å få tilgang til nettstedet %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Vis feil og informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Vis informasjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Flere handlinger</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Oppdater kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Oppdatering</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Last ned den nyeste versjonen fra nettstedet.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Oppdateringen lastes ned</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Leter etter oppdatering...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Manuell oppdatering</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Ikke tilgjengelig</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Du kan synkronisere filer &lt;a style="%1" href="%2"&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synkronisert</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoritter</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Aktivitet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Ikke implementert!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>kDrive er ikke konfigurert!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Kan ikke apne lenken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Ugyldig lenke %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Det går ikke an å åpne mappen %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Oppdater kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Last ned den nyeste versjonen fra nettstedet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Oppdateringen lastes ned</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Leter etter oppdatering...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Manuell oppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Ikke tilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synkronisert</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoritter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Ikke implementert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive er ikke konfigurert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Kan ikke apne lenken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Ugyldig lenke %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går ikke an å åpne mappen %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Hopp over denne versjonen</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Minn meg på det senere</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installer oppdatering</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Hopp over denne versjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Minn meg på det senere</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installer oppdatering</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Ny oppdatering tilgjengelig.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Versjon %1 er tilgjengelig for nedlasting.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Ny oppdatering tilgjengelig.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Versjon %1 er tilgjengelig for nedlasting.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Legg til en konto</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Legg til en konto</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Versjon</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>OPPDATERING</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 er oppdatert!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Sjekker oppdateringer på serveren...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style="%2" href="%3"&gt;her&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Det er en oppdatering tilgjengelig: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Laster ned %1. Vennligst vent...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Det oppstod en feil under oppdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Det gikk ikke an å laste ned oppdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Oppdatering deaktivert.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Betaprogram</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Få tidlig tilgang til nye versjoner av applikasjonen</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Bli med</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Endre</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Avslutt</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Versjon</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>OPPDATERING</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 er oppdatert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Sjekker oppdateringer på serveren...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Det er en oppdatering tilgjengelig: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Laster ned %1. Vennligst vent...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Det oppstod en feil under oppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Det gikk ikke an å laste ned oppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Oppdatering deaktivert.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Betaprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Få tidlig tilgang til nye versjoner av applikasjonen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Bli med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Endre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Avslutt</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Kan ikke lagre parametrene!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Finner ikke en gyldig sti</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Det er ikke valgt noen gyldig mappe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Den valgte banen finnes ikke!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Den valgte banen er ikke en mappe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Du har ikke tilgang til å skrive til den valgte mappen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Gjør tilgjengelig lokalt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Frigjør lokal lagringsplass</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Avbryt for å frigjøre lokal lagringsplass</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Avbryt lokal tilgjengeliggjøring</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Det er ikke tillatt å dele denne filen videre</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Det er ikke tillatt å dele denne mappen videre</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Kopier lenken til den offentlige delingen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Kopier lenken til privat deling</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Åpne i nettleseren</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Kan ikke lagre parametrene!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Finner ikke en gyldig sti</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Det er ikke valgt noen gyldig mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Den valgte banen finnes ikke!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Den valgte banen er ikke en mappe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Du har ikke tilgang til å skrive til den valgte mappen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Gjør tilgjengelig lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Frigjør lokal lagringsplass</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Avbryt for å frigjøre lokal lagringsplass</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Avbryt lokal tilgjengeliggjøring</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Det er ikke tillatt å dele denne filen videre</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Det er ikke tillatt å dele denne mappen videre</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Kopier lenken til den offentlige delingen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Kopier lenken til privat deling</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Åpne i nettleseren</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n ar</numerusform>
-<numerusform>%n ar</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n maned</numerusform>
-<numerusform>%n maneder</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n dag</numerusform>
-<numerusform>%n dager</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n time</numerusform>
-<numerusform>%n timer</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minutt</numerusform>
-<numerusform>%n minutter</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekund</numerusform>
-<numerusform>%n sekunder</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n ar</numerusform>
+            <numerusform>%n ar</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n maned</numerusform>
+            <numerusform>%n maneder</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dager</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n time</numerusform>
+            <numerusform>%n timer</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minutt</numerusform>
+            <numerusform>%n minutter</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Systemstatusfeltet er ikke tilgjengelig</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 krever et fungerende systemstatusfelt. Kjører du XFCE, følg &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;disse instruksjonene&lt;/a&gt;. Ellers installerer du en systemstatusfelts-applikasjon som 'trayer' og prøver igjen.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Systemstatusfeltet er ikke tilgjengelig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 krever et fungerende systemstatusfelt. Kjører du XFCE, følg &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;disse instruksjonene&lt;/a&gt;. Ellers installerer du en systemstatusfelts-applikasjon som &apos;trayer&apos; og prøver igjen.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Kunne ikke åpne nettleseren</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Kunne ikke åpne e-postprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Du er ikke lenger pålogget. &lt;a style="%1" href="%2"&gt;Logg inn&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synkronisering pågår (Trinn %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synkronisering pågår.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Noen filer kunne ikke synkroniseres. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synkronisering på pause ...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synkronisering starter</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synkroniseringen er satt på pause.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synkronisering pågår (1 % av 2 %)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Kunne ikke åpne nettleseren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Kunne ikke åpne e-postprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Du er ikke lenger pålogget. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logg inn&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronisering pågår (Trinn %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronisering pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Noen filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkronisering på pause ...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkronisering starter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkroniseringen er satt på pause.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronisering pågår (1 % av 2 %)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synkronisering pågår (%1 av %2)
+        <translation>Synkronisering pågår (%1 av %2)
 %3 igjen...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Du har uavklarte konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Du er oppdatert!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Du har uavklarte konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Du er oppdatert!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Ingen mappe å synkronisere
+        <translation>Ingen mappe å synkronisere
 Du kan legge til en i kDrive-innstillingene.</translation>
-</message>
+    </message>
 </context>
 </TS>

--- a/translations/client_nb.ts
+++ b/translations/client_nb.ts
@@ -1,2582 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="nb_NO">
+<TS language="nb_NO" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Om</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">LUKK</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versjon %1. For mer informasjon, gå til &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribuert av %1 og lisensiert under &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke apne mappen %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Om</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>LUKK</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versjon %1. For mer informasjon, gå til &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Opphavsrett 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribuert av %1 og lisensiert under &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 og %2-logoen er registrerte varemerker tilhørende %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke apne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Kompilert fra &lt;a style="color: #489EF3" href="%1"&gt;Git-kildekoden&lt;/a&gt; den %2, %3 ved hjelp av Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke apne mappestien %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke apne mappestien %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">kDrive-enheten din er klar!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">APNE MAPPE</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">INNSTILLINGER</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Synkroniser en annen stasjon</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Synkroniseringen starter, og du vil kunne legge til filer i mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>kDrive-enheten din er klar!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>APNE MAPPE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>INNSTILLINGER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synkroniser en annen stasjon</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">NESTE</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Velg kDrive-enheten du vil synkronisere</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Fa kDrive gratis</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Test gratis</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>NESTE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Velg kDrive-enheten du vil synkronisere</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Fa kDrive gratis</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Lagre bilder, dokumenter og e-poster i Sveits hos et uavhengig selskap som respekterer personvernet. Les mer</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Test gratis</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Spar plass pa datamaskinen</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">SENERE</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Vil du aktivere Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Vil du aktivere Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Spar plass pa datamaskinen</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Bestem hvilke filer som skal vaere tilgjengelige pa nettet eller lokalt</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>SENERE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synkroniserer alle filene dine uten å ta opp plass på datamaskinen din. Du kan bla gjennom filene i kDrive og laste dem ned lokalt når du vil. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Vil du aktivere Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Vil du aktivere Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Plassering av din %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Rediger mappe</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FULLFOR</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Velg mappe</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Plassering av din %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Rediger mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>FULLFOR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Velg mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Innholdet i mappen &lt;b&gt;%1&lt;/b&gt; vil bli synkronisert i kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Når konfigurasjonen er fullført, finner du alle filene dine i denne mappen. Du kan legge nye filer der for å synkronisere dem til kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt; 
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSETT</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>FORTSETT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Logg inn fra nettleseren din</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Åpne påloggingssiden</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Det oppstod en feil under autentisering. Lukk påloggingsvinduet og prøv igjen.&lt;br&gt;Kontakt supportteamet vårt hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Innlogging mislyktes: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Logg inn fra nettleseren din</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Nettleseren din bør åpne seg automatisk for å fullføre tilkoblingen. Når du er tilkoblet, kommer du automatisk tilbake til kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Åpne påloggingssiden</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Det oppstod en feil under autentisering. Lukk påloggingsvinduet og prøv igjen.&lt;br&gt;Kontakt supportteamet vårt hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Innlogging mislyktes: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Det gikk ikke an å åpne påloggingssiden i nettleseren din</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSETT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Ledig plass på datamaskinen din: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Det oppstod en feil under lasting av listen over undermapper.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Velg kDrive-mapper som skal synkroniseres på skrivebordet</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>FORTSETT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Ledig plass på datamaskinen din: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Det er ikke mulig å laste inn listen over undermapper. Det kan hende at kDrive er under vedlikehold.&lt;br&gt;Logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Det gikk ikke å opprette den lokale mappen %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Det gikk ikke å opprette ny synkronisering</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Det gikk ikke å opprette den lokale mappen %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Det gikk ikke å opprette ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>kDrive %1 er allerede synkronisert på denne datamaskinen. Vil du fortsette likevel?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-klienten kjøres med feil parametere!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">kDrive-klienten kjører allerede!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-klienten kjøres med feil parametere!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>kDrive-klienten kjører allerede!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Brukeren %1 er ikke pålogget. Vennligst logg inn på nytt.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Del-lenken er kopiert til utklippstavlen</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
-            <numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er fjernet.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
-            <numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er lagt til.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
-            <numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 er oppdatert.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
-            <numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 er flyttet til %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synkroniseringsaktivitet</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Del-lenken er kopiert til utklippstavlen</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 og %n annen fil har blitt fjernet.</numerusform>
+<numerusform>%1 og %n andre filer har blitt fjernet.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er fjernet.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 og %n annen fil har blitt lagt til.</numerusform>
+<numerusform>%1 og %n andre filer har blitt lagt til.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er lagt til.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 og %n annen fil har blitt oppdatert.</numerusform>
+<numerusform>%1 og %n andre filer har blitt oppdatert.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 er oppdatert.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 har blitt flyttet til %2, og %n annen fil har blitt flyttet.</numerusform>
+<numerusform>%1 har blitt flyttet til %2, og %n andre filer har blitt flyttet.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 er flyttet til %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synkroniseringsaktivitet</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Avslutt betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Bli med i betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Dra nytte av oppdateringer til betaversjonen av appen</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Nei</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Offentlig betaversjon</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Intern betaversjon</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Testversjon</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Jeg forstår</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Lagre</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Avslutt betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Bli med i betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Få tidlig tilgang til nye versjoner av applikasjonen før de blir gjort tilgjengelig for allmennheten, og bidra til å forbedre applikasjonen ved å sende oss dine kommentarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Dra nytte av oppdateringer til betaversjonen av appen</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Nei</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Offentlig betaversjon</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Intern betaversjon</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Testversjon</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Jeg forstår</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Er du sikker på at du vil melde deg ut av betaprogrammet?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Lagre</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Den nåværende versjonen av applikasjonen er kanskje for ny; valget ditt trer i kraft når neste oppdatering blir tilgjengelig.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Betaversjoner kan avsluttes uventet eller føre til ustabilitet.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Vennligst logg inn</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Mappe %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Det er ikke konfigurert noen synkroniseringsmapper.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Sammendrag</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation type="vanished">Innstillinger</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Avslutt</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Udefinert tilstand.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Venter på å starte synkroniseringen.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synkroniseringen pågår.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Den siste synkroniseringen ble gjennomført.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Brukeravbrudd.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synkroniseringen er satt på pause.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synkroniseringen er satt på pause)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">FJERN ALLE SYNKRONISERINGER</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 elementer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. For å unngå utilsiktede slettinger er synkroniseringen satt på pause.&lt;br&gt;Vil du spre disse slettingene til kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Flere filer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Slettede filer finnes i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papirkurv&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Ikke vis igjen</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Det gikk ikke å starte synkroniseringen!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke apne mappestien %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Kan ikke starte kDrive-klienten</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synkroniseringen er satt på pause</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Det lyktes ikke å løse konflikter på %1 element(er) i synkroniseringsmappen: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Vennligst logg inn</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Mappe %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Det er ikke konfigurert noen synkroniseringsmapper.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Sammendrag</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translatorcomment>Préférences</translatorcomment>
+<translation>Innstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Avslutt</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Udefinert tilstand.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Venter på å starte synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synkroniseringen pågår.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synkroniseringen ble fullført, men det er noen uløste konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Den siste synkroniseringen ble gjennomført.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Brukeravbrudd.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synkroniseringen er satt på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synkroniseringen er satt på pause)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vil du virkelig fjerne synkroniseringene for kontoen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>FJERN ALLE SYNKRONISERINGER</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 elementer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. For å unngå utilsiktede slettinger er synkroniseringen satt på pause.&lt;br&gt;Vil du spre disse slettingene til kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Flere filer har blitt slettet fra din lokale synkroniseringsmappe &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Slettede filer finnes i kDrives &lt;a style="%1" href="%3"&gt;papirkurv&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Ikke vis igjen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Det gikk ikke å starte synkroniseringen!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke apne mappestien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Kan ikke starte kDrive-klienten</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synkroniseringen er satt på pause</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Oversikt over synkroniseringen av den lokale mappen din</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNKRONISER</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Oversikt over synkroniseringen av den lokale mappen din</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Innholdet i mappen på datamaskinen din vil bli synkronisert med mappen på den valgte kDrive-enheten, og omvendt.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNKRONISER</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Før du avslutter</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Godkjenn kDrive-appen</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Lås opp hengelåsen &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; og godkjenn kDrive-appen</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikk her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klikker her&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">TRINN 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Ferdig)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">TRINN 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">UTFØRTE TRINN</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">FULLFOR</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Før du avslutter</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Følg disse trinnene for å sikre at Lite Sync fungerer som det skal på datamaskinen din og for å fullføre konfigurasjonen av kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åpne &lt;b&gt;innstillingene under «Generelt»&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åpne &lt;b&gt;innstillingene for personvern og sikkerhet&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Åpne &lt;b&gt;innstillingene for Sikkerhet og personvern&lt;/b&gt; på Mac-en din, eller  &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Gå til delen &lt;b&gt;«Påloggingselementer og utvidelser»&lt;/b&gt; og deretter til &lt;b&gt;«Utvidelser for endepunktsikkerhet»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Godkjenn kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Gå til avsnittet &lt;b&gt;«Sikkerhet»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Godkjenn kDrive-appen i boksen der det står at kDrive er blokkert</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Lås opp hengelåsen &lt;img src=":/client/resources/icons/actions/lock.png"&gt; og godkjenn kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Gå til delen &lt;b&gt;«Personvern og sikkerhet»&lt;/b&gt; og klikk på &lt;b&gt;«Full disktilgang»,&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikk her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Mens du fortsatt er i innstillingene for Sikkerhet og personvern, åpner du fanen &lt;b&gt;«Personvern»&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klikker her&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Merk av i boksen «kDrive LiteSync Extension» og deretter i boksen «kDrive.app» (hvis den ikke allerede er merket av)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Det kan bli foreslått å starte appen på nytt; i så fall må du godta dette</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Merk av for «kDrive LiteSync Extension» (og «kDrive.app» hvis den finnes) under &lt;b&gt;«Full diskadgang»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>TRINN 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Ferdig)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>TRINN 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>UTFØRTE TRINN</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>FULLFOR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NEI</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NEI</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Overføring av feilsøkingsinformasjon</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Overføring av feilsøkingsinformasjon</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Informasjon</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Feilsøking</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Advarsel</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Feil</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Dødelig</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Feilsøkingsinnstillinger</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Feilsøkingsnivå</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Utvidet fullstendig logg</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Slett logger som er eldre enn %1 dager</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Del kun den siste kDrive-økten</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Laster</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">LAGRE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Det gikk ikke å dele</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Forbindelsen ble brutt)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Del mappen med SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Vi har automatisk komprimert loggen din &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Overfør arkivet med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Del lenken med&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Siste opplasting av %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Delingen er avbrutt</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Den utvidede fullstendige loggen aktiveres via miljøvariabelen KDRIVE_FORCE_EXTENDED_LOG. Sett den til 0 for å deaktivere den.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du lagre endringene dine?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke apne mappen %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Del</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Deling | trinn 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Deling | trinn 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Avbryter...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Informasjon</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Feilsøking</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Advarsel</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Feil</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Dødelig</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Feilsøkingsinnstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Lagre feilsøkingsinformasjon i en mappe på datamaskinen min (anbefalt)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Denne informasjonen gjør det mulig for IT-supporten å fastslå årsaken til en hendelse.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Feilsøkingsnivå</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Med sporingsnivået kan du velge omfanget av feilsøkingsinformasjonen som skal loggføres</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Den utvidede fullstendige loggen samler inn en detaljert historikk som kan brukes til feilsøking. Hvis du aktiverer den, kan det føre til at kDrive-programmet går tregere.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Utvidet fullstendig logg</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Slett logger som er eldre enn %1 dager</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Del feilsøkingsmappen med Infomaniaks kundestøtte.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Den siste økten er tidsperioden siden kDrive sist ble startet.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Del kun den siste kDrive-økten</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Laster</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>LAGRE</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Det gikk ikke å dele</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Sjekk at du er logget inn &lt;br&gt;2. Sjekk at du har konfigurert minst én kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Forbindelsen ble brutt)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Del mappen med SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Vi har automatisk komprimert loggen din &lt;a style="%1" href="%2"&gt;her&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Overfør arkivet med &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Del lenken med&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Siste opplasting av %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Delingen er avbrutt</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Den utvidede fullstendige loggen aktiveres via miljøvariabelen KDRIVE_FORCE_EXTENDED_LOG. Sett den til 0 for å deaktivere den.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Hele mappen er stor (&amp;gt; 100 MB) og det kan ta litt tid å dele den. For å redusere delingstiden anbefaler vi at du bare deler den siste kDrive-økten.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 kl. %4:%5 og %6 sek.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du lagre endringene dine?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke apne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Del</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Deling | trinn 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Deling | trinn 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Avbryter...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Mapper</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Varsler</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">I forbindelse med</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Synkroniseringen av den nye lokale mappen mislyktes!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Aktivering av Lite Sync mislyktes.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Deaktivering av Lite Sync mislyktes.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Det oppstod en feil under lasting av listen over undermapper.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Slå på varslinger for denne kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synkroniseringsfeil og informasjon.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Synkroniser en lokal mappe</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Vil du virkelig slå på Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Vil du virkelig slå av Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Det gikk ikke å opprette ny synkronisering</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync er aktivert.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync er deaktivert.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Denne stasjonen blir slettet.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Det er umulig å åpne elementet %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Fjern alle synkroniseringer</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Søk i kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Søk</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Mapper</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Varsler</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Det vises en melding så snart en ny mappe er synkronisert eller endret</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>I forbindelse med</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vil du virkelig slutte å synkronisere mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Merk:&lt;/b&gt; Dette vil &lt;b&gt;ikke&lt;/b&gt; slette noen filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Denne operasjonen kan ta alt fra noen sekunder til noen minutter, avhengig av mappens størrelse.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Synkroniseringen av den nye lokale mappen mislyktes!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Aktivering av Lite Sync mislyktes.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Deaktivering av Lite Sync mislyktes.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>FJERN SYNKRONISERINGSTILKOBLING FOR MAPPEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Det oppstod en feil under lasting av listen over undermapper.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Slå på varslinger for denne kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synkroniseringsfeil og informasjon.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synkroniser en lokal mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Vil du virkelig slå på Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Vil du virkelig slå av Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Du har ikke nok plass til å synkronisere alle filene på kDrive (%1 mangler). Hvis du deaktiverer Lite Sync, må du velge hvilke mapper som skal synkroniseres på datamaskinen din. I mellomtiden vil synkroniseringen av kDrive bli satt på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Hvis du deaktiverer Lite Sync, vil alle filene lastes ned til datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Det gikk ikke å opprette ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync er aktivert.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync er deaktivert.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Denne stasjonen blir slettet.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Det er umulig å åpne elementet %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Det gikk ikke å stoppe synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Fjern alle synkroniseringer</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Søk i kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Søk</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Synkroniser en kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Legg til en kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synkroniser en kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Legg til en kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Løsning</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Elementer med konflikt</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Element(er) med tegn som ikke støttes</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Slett historikk</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Å løse</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Løst automatisk</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problemer løst</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">det er oppdaget et eller flere problemer</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Løsning</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Elementer med konflikt</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Element(er) med tegn som ikke støttes</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Slett historikk</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Å løse</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Løst automatisk</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problemer løst</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>det er oppdaget et eller flere problemer</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synkroniseringskonflikter eller feil</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Feil</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Tilbake til innstillinger</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synkroniseringskonflikter eller feil</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Feil</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Tilbake til innstillinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 feil)</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 opplysning(er))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 feil og %2 opplysninger)</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
-            <numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Noen filer kunne ikke synkroniseres på følgende kDrive(r):</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 feil)</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 opplysning(er))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 feil og %2 opplysninger)</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Generelle feil (%n advarsel eller feil)</numerusform>
+<numerusform>Generelle feil (%n advarsler eller feil)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Ekskluderte filer</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Legg til</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAVN</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">ADVARSEL</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">LAGRE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du lagre endringene dine?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Utelukkelsesmalen finnes allerede!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vil du virkelig slette?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Kan ikke lagre endringene!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Ekskluderte filer</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Legg til filer eller mapper som ikke skal synkroniseres på datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Legg til</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NAVN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>ADVARSEL</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>LAGRE</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du lagre endringene dine?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Utelukkelsesmalen finnes allerede!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Vil du virkelig slette?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Kan ikke lagre endringene!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Løse konflikter</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Angre mine endringer og behold andre brukeres versjoner.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Vis element(er)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Løse konflikter</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Hva vil du gjøre med det/de %1 elementet/elementene som er i konflikt?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Lagre endringene mine og erstatt andre brukeres versjoner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Angre mine endringer og behold andre brukeres versjoner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Endringene dine kan bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Endringene dine vil bli slettet permanent. De kan ikke gjenopprettes fra kDrive-nettapplikasjonen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Vis element(er)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Flere brukere har gjort endringer i disse filene på flere steder (på nettet via kDrive, på en datamaskin eller på en mobil). Mapper som inneholder disse filene kan også ha blitt slettet.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Den lokale versjonen av elementet ditt &lt;b&gt;er ikke synkronisert&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Les mer&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synkronisert til &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Aktiver Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Aktiver Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Stopp synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Deaktiver Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Fortsett synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Fjern synkronisering</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synkronisert til &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Aktiver Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Aktiver Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Mapper som ikke er valgt, flyttes til papirkurven dersom de inneholder elementer som er tilgjengelige uten nettilgang. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Mapper som ikke er valgt, flyttes til papirkurven. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Mapper som ikke er valgt, vil bli slettet &lt;b&gt;permanent&lt;/b&gt; fra datamaskinen. Mapper som er synkronisert med kDrive, vil fortsatt være tilgjengelige på nettet.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Stopp synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Deaktiver Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Fortsett synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Fjern synkronisering</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan ikke apne mappestien %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke apne mappestien %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Applikasjons-ID</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Programnavn</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Applikasjons-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Programnavn</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Legg til</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">SØKNADS-ID</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAVN</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">LAGRE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du lagre endringene dine?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vil du virkelig slette?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Kan ikke lagre endringene!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Noen apper (sikkerhetskopiering, antivirusprogrammer osv.) får tilgang til filene dine, noe som fører til at de lastes ned når de er «online». Legg dem til i listen nedenfor for å unngå dette.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Legg til</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>SØKNADS-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NAVN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>LAGRE</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du lagre endringene dine?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Vil du virkelig slette?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Kan ikke lagre endringene!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Velg en mappe</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Rediger mappe</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSETT</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Hvilken mappe på datamaskinen din ønsker du å&lt;br&gt;synkronisere?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Innholdet i denne mappen vil bli synkronisert på kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Velg en mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Rediger mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>FORTSETT</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Denne mappen er ikke kompatibel med Lite Sync.&lt;br&gt;
 Velg en annen mappe. Hvis du fortsetter, vil Lite Sync bli deaktivert.&lt;br&gt;
 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Velg mappe</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Velg mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Feil</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Feil</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Filen «%1»&lt;br/&gt;kan ikke åpnes for skriving.&lt;br/&gt;&lt;br/&gt;Loggutskriften kan &lt;b&gt;ikke&lt;/b&gt; lagres!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Innstillinger</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Hjelp</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Innstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Hjelp</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Kan ikke apne mappestien %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive er ikke konfigurert!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Overføringen mislyktes!
-Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Du har enten ikke tillatelse til å opprette et element, eller det finnes allerede et annet element med samme navn. Elementet ble ignorert.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Det er umulig å laste ned filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Synkroniseringsfeil.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Kan ikke opprette filen %1 fordi den ikke støttes av filsystemet ditt.&lt;br&gt;Den er ekskludert fra synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Systemfeil.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Kan ikke apne mappestien %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Overføringen er fullført!&lt;br&gt;Vennligst oppgi identifikatoren &lt;b&gt;%1&lt;/b&gt; i feilmeldinger.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>kDrive er ikke konfigurert!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Overføringen mislyktes!
+Bruk følgende lenke for å sende loggfilene til kundestøtte: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Det ser ut til at tidsavbruddet i nettverkstilkoblingen din er satt for lavt til at programmet skal fungere som det skal (feil %1).&lt;br&gt;Vennligst sjekk nettverksinnstillingene dine.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Kan ikke koble til kDrive-serveren (feil %1).&lt;br&gt;Forsøker å koble til på nytt. Kontroller internettforbindelsen og brannmuren din.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Vennligst logg inn på nytt, og kontakt vår kundestøtte dersom feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Det er en ny versjon av appen tilgjengelig.&lt;br&gt;Oppdater appen for å kunne fortsette å bruke den.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Opplastingen av loggen mislyktes (feil %1).&lt;br&gt;Prøv igjen senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Synkroniseringsmappen er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Synkroniseringen fortsetter så snart mappen er tilgjengelig.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Synkroniseringsmappen er erstattet eller flyttet på en måte som forhindrer synkronisering (feil %1).&lt;br&gt;Dette kan skje etter at mappen er kopiert, flyttet eller gjenopprettet.&lt;br&gt;For å løse dette må du opprette en ny synkronisering med en ny mappe.&lt;br&gt;Merk: Hvis du har endringer i den gamle mappen som ikke er synkronisert, må du kopiere dem manuelt over til den nye mappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Det er ikke nok ledig minne på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive må ha skrivetilgang til datamaskinens midlertidige mappe. Start kDrive-appen&lt;br&gt;på nytt for å løse dette problemet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Det har oppstått en teknisk feil.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Antallet inotify-overvåkninger er for lavt (feil %1).&lt;br&gt;Du kan øke dette antallet ved å redigere «/etc/sysctl.conf».</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Det går ikke an å starte synkroniseringen (feil %1).&lt;br&gt;Du må gi tillatelse til&lt;br&gt;:– kDrive i Systeminnstillinger &amp;gt;&amp;gt; Generelt &amp;gt;&amp;gt; Påloggingselementer og utvidelser &amp;gt;&amp;gt;&lt;br&gt;Utvidelser for endepunktsikkerhet– kDrive LiteSync-utvidelsen i Systeminnstillinger &amp;gt;&amp;gt; Personvern og sikkerhet &amp;gt;&amp;gt; Full disktilgang.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Kontroller at Lite Sync-utvidelsen er installert og at Windows Search-tjenesten er aktivert.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går ikke an å starte Lite Sync-tillegget (feil %1).&lt;br&gt;Sjekk at Lite Sync-utvidelsen har riktige tillatelser og at den kjører.&lt;br&gt;Tøm historikken, start på nytt, og hvis feilen vedvarer, kan du kontakte vår kundestøtte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går ikke an å starte Lite Sync-pluginen (feil %1).&lt;br&gt;Tøm historikken, start på nytt, og kontakt kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være ødelagt.&lt;br&gt;Synkroniseringen er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive er i vedlikeholdsmodus.&lt;br&gt;Synkroniseringen vil starte igjen så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive er blokkert.&lt;br&gt;Vennligst oppdater kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive er sperret.&lt;br&gt;Ta kontakt med en administrator for å fornye kDrive. Hvis du ikke gjør noe, vil dataene bli slettet permanent, og det vil være umulig å gjenopprette dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive er i ferd med å starte opp.&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive er inaktiv.&lt;br&gt;Vennligst logg inn på nettversjonen for å sjekke statusen til kDrive, eller kontakt administratoren din.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Du har ikke tilgang til denne kDrive-kontoen.&lt;br&gt;Synkroniseringen er satt på pause. Ta kontakt med en administrator.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen vil gjenopptas så snart som mulig. Ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Nettverkstilkoblingene er blitt avbrutt av kjernen (feil %1).&lt;br&gt;Tøm historikken, og ta kontakt med vår kundestøtte hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Dessverre kunne ikke den gamle konfigurasjonen overføres.&lt;br&gt;Programmet vil bruke en tom konfigurasjon.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Dessverre kunne ikke den gamle proxykonfigurasjonen din overføres, da SOCKS5-proxyer foreløpig ikke støttes.&lt;br&gt;Programmet vil i stedet bruke systemets proxyinnstillinger.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Det har oppstått en teknisk feil (feil %1).&lt;br&gt;Synkroniseringen har blitt startet på nytt. Tøm historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Det har oppstått en feil ved tilgang til synkroniseringsdatabasen (feil %1).&lt;br&gt;Synkroniseringen er stoppet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Det har oppstått et innloggingsproblem (feil %1).&lt;br&gt;Tokenet er ugyldig eller tilbakekalt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Innebygde synkroniseringer er ikke tillatt (feil %1).&lt;br&gt;Du bør kun beholde synkroniseringer der mappene ikke er innebygde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Synkroniseringsmappen på den eksterne kDrive-enheten finnes ikke lenger eller er ikke lenger tilgjengelig (feil %1).&lt;br&gt;Du må gjenopprette den, gi den tilgang igjen eller slette og opprette synkroniseringen på nytt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Feil ved tolkning av filnavn (feil %1).&lt;br&gt;Spesialtegn som doble anførselstegn, tilbakeslag eller linjeskift kan føre til feil ved tolkningen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Du har enten ikke tillatelse til å opprette et element, eller det finnes allerede et annet element med samme navn. Elementet ble ignorert.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Du har ikke tillatelse til å flytte elementet til «%1».&lt;br&gt;Det vil bli gjenopprettet i den opprinnelige overordnede mappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Nedlastingen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Det er umulig å opprette filen «%1», siden den ikke støttes i filsystemet ditt.&lt;br&gt;Den er ekskludert fra synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Dette elementet er flyttet til et annet sted.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Det lokale elementet har fått nytt navn.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Det finnes allerede et element med samme navn på dette stedet.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Det er ikke nok ledig plass på datamaskinen din.&lt;br&gt;Synkroniseringen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Filen ble redigert samtidig av en annen bruker.&lt;br&gt;Endringene dine er lagret i en kopi.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>En annen bruker har flyttet en overordnet mappe for målmappen.&lt;br&gt;Den lokale operasjonen er avbrutt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Varenavnet inneholder kun mellomrom.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Du har ikke rett til å redigere elementet.&lt;br&gt;Filen som inneholder endringene dine, har blitt omdøpt og ekskludert fra synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Du har ikke lov til å endre navnet på elementet.&lt;br&gt;Det vil bli gjenopprettet med sitt opprinnelige navn.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Du har ikke tillatelse til å slette elementet.&lt;br&gt;Det vil bli gjenopprettet til sin opprinnelige plassering.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Det gikk ikke å flytte dette elementet til papirkurven; det er blitt svartelistet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Filen er endret lokalt, mens den er slettet på den eksterne kDrive-enheten. Den&lt;br&gt;lokale kopien er lagret i redningsmappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Handlingen som ble utført på elementet, er forbudt.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Operasjonen som ble utført på dette elementet mislyktes.&lt;br&gt;Elementet er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Filen er for stor til å kunne lastes opp. Den er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Det er umulig å laste ned filen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Du har overskredet kvoten din. Øk lagringsplasskvoten din for å aktivere filopplasting igjen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Stasjonen som inneholder synkroniseringsmappen din, er ikke lenger tilkoblet (feil %1).&lt;br&gt;Koble den til igjen for å fortsette synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Det er ikke mulig å starte synkroniseringen (feil %1).&lt;br&gt;LiteSyncExt-prosessen kjører ikke for øyeblikket. Synkroniseringen vil fortsette så snart prosessen er startet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Et eksisterende element har et identisk navn med samme bruk av store og små bokstaver.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Varenavnet inneholder et tegn som ikke støttes.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Navnet på elementet slutter med et mellomrom, noe som er forbudt i operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Dette elementnavnet er reservert av operativsystemet ditt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Varenavnet er for langt.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Elementstien er for lang.&lt;br&gt;Den er blitt ignorert.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Navnet på elementet inneholder et nytt Unicode-tegn som filsystemet ditt ennå ikke støtter.&lt;br&gt;Det er utelatt fra synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Det gikk ikke å synkronisere dette elementet. Det er midlertidig satt på svartelisten. Det vil bli&lt;br&gt;gjort et nytt forsøk på å synkronisere det om en time eller ved neste oppstart av applikasjonen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Dette elementet er ekskludert fra synkroniseringen av en tilpasset mal.&lt;br&gt;Du kan deaktivere denne typen varsler under Innstillinger</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Dette elementet er utelatt fra synkroniseringen fordi det er en hardlenke.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Denne varen er for øyeblikket låst av en annen bruker som er online.&lt;br&gt;Vi prøver å laste opp endringene dine senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Synkroniseringsfeil.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Kan ikke få tilgang til elementet.&lt;br&gt;Vennligst korriger lese- og skrivetillatelsene.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Systemfeil.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Elementet finnes allerede på den andre siden.&lt;br&gt;Det er midlertidig satt på svartelisten.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Det har oppstått en teknisk feil. Tøm&lt;br&gt;historikken, og ta kontakt med kundestøtten vår hvis feilen vedvarer.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Denne synkroniseringen blir slettet.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Denne synkroniseringen blir slettet.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Tilbake til listen over stasjoner</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Innstillinger</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Tilbake til listen over stasjoner</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Innstillinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Generelt</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Aktiver morkt tema</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Aktiver monokrome ikoner</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Start kDrive ved oppstart</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finsk</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Dansk</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Gresk</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Nederlandsk</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avansert</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Feilsokingsinformasjon</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Filer som skal utelukkes</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Svensk</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugisisk</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polsk</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norsk</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan ikke apne mappen %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ugyldig lenke %1.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Sprak</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">En eller annen prosess kunne ikke kjøres.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Flytt slettede filer til papirkurven pa datamaskinen</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Engelsk</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Fransk</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Tysk</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Spansk</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italiensk</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Standard</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Generelt</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Aktiver morkt tema</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Aktiver monokrome ikoner</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Start kDrive ved oppstart</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Dansk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Gresk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Nederlandsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avansert</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Feilsokingsinformasjon</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Åpne feilsøkingsmappen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Filer som skal utelukkes</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Svensk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugisisk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Kan ikke apne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Ugyldig lenke %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Sprak</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>En eller annen prosess kunne ikke kjøres.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Flytt slettede filer til papirkurven pa datamaskinen</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Noen filer eller mapper kan ikke flyttes til datamaskinens papirkurv.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Du kan alltid gjenopprette allerede synkroniserte filer fra papirkurven i kDrive-nettappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Engelsk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Fransk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Tysk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Spansk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italiensk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Standard</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 i bruk</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 i bruk</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S)-proxy</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Ingen proxy-server</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Bruk systemparametere</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Angi en fullmektig manuelt</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Havn</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Adressen til proxy-serveren</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Pålogging kreves</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Bruker</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Passord</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">LAGRE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du lagre endringene dine?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy funnet, vil du lagre likevel?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S)-proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ingen proxy-server</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Bruk systemparametere</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Angi en fullmektig manuelt</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Havn</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Adressen til proxy-serveren</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Pålogging kreves</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Bruker</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Passord</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>LAGRE</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du lagre endringene dine?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Det er ikke mulig å lagre, da alle obligatoriske felt ikke er fylt ut!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy funnet, vil du lagre likevel?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Ressursansvarlig</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Maksimal tillatt CPU-bruk</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">LAGRE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vil du lagre endringene dine?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Ressursansvarlig</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Maksimal tillatt CPU-bruk</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>LAGRE</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vil du lagre endringene dine?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Velg en mappe på kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSETT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Denne mappen synkroniseres allerede.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKREFT</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Velg en mappe på kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Innholdet i den valgte mappen vil bli synkronisert til mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>FORTSETT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Ledig plass på datamaskinen din for den aktuelle mappen: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Denne mappen synkroniseres allerede.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>BEKREFT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSETT</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Det finnes for øyeblikket ingen undermapper på serveren.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; inneholder undermapper.&lt;br&gt; Velg de du ønsker å synkronisere</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>FORTSETT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Det finnes for øyeblikket ingen undermapper på serveren.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Gjenoppta synkroniseringen av kDrive «%1»</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Gjenoppta all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Stopp synkroniseringen av kDrive «%1»</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Stopp synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Stopp all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Fortsett synkroniseringen</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Gjenoppta synkroniseringen av kDrive «%1»</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Gjenoppta all synkronisering av kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Stopp synkroniseringen av kDrive «%1»</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Stopp synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Stopp all synkronisering av kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Fortsett synkroniseringen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Kopier delingslenken</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Vis på kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Vis i mappe</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Åpne</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Legg til i favoritter</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Kopier delingslenken</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Vis på kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Vis i mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Åpne</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Legg til i favoritter</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Aldri</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">I løpet av 1 time</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Frem til i morgen kl. 08.00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">I løpet av 3 dager</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">I løpet av 1 uke</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Alltid</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">I én time til</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">I ytterligere 3 dager</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">I én uke til</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Det går ikke an å åpne mappen %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Åpne i mappe</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Åpne %1-nettversjonen</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Drivparametere</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Varsler er deaktivert frem til %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Deaktiver varsler</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Innstillinger for applikasjonen</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Trenger du hjelp?</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Send tilbakemeldinger</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Avslutt kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Det er ikke mulig å få tilgang til nettstedet %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Vis feil og informasjon</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Vis informasjon</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Flere handlinger</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Aldri</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>I løpet av 1 time</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Frem til i morgen kl. 08.00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>I løpet av 3 dager</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>I løpet av 1 uke</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Alltid</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>I én time til</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>I ytterligere 3 dager</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>I én uke til</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Det går ikke an å åpne mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Åpne i mappe</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Åpne %1-nettversjonen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Drivparametere</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Varsler er deaktivert frem til %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Deaktiver varsler</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Innstillinger for applikasjonen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Trenger du hjelp?</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Send tilbakemeldinger</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Avslutt kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Det er ikke mulig å få tilgang til nettstedet %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Vis feil og informasjon</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Vis informasjon</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Flere handlinger</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Oppdater kDrive-appen</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Oppdatering</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Last ned den nyeste versjonen fra nettstedet.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Oppdateringen lastes ned</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Leter etter oppdatering...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Manuell oppdatering</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Ikke tilgjengelig</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Du kan synkronisere filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synkronisert</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoritter</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Aktivitet</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Ikke implementert!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">kDrive er ikke konfigurert!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan ikke apne lenken %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ugyldig lenke %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Det går ikke an å åpne mappen %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Oppdater kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Denne versjonen av kDrive-appen støttes ikke lenger. Oppdater appen for å få tilgang til de nyeste funksjonene og forbedringene.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Oppdatering</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Last ned den nyeste versjonen fra nettstedet.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Oppdateringen lastes ned</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Leter etter oppdatering...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Manuell oppdatering</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Ikke tilgjengelig</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Du kan synkronisere filer &lt;a style="%1" href="%2"&gt;fra datamaskinen din&lt;/a&gt; eller fra &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synkronisert</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoritter</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Aktivitet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Ikke implementert!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klikk her for å laste ned manuelt&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Det finnes ingen synkronisert mappe for denne Drive-kontoen!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>kDrive er ikke konfigurert!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Kan ikke apne lenken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Ugyldig lenke %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Det går ikke an å åpne mappen %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Hopp over denne versjonen</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Minn meg på det senere</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installer oppdatering</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Den nye versjonen &lt;b&gt;%1&lt;/b&gt; av %2-klienten er tilgjengelig og er lastet ned.&lt;/p&gt;&lt;p&gt;Den installerte versjonen er %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Hopp over denne versjonen</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Minn meg på det senere</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installer oppdatering</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Ny oppdatering tilgjengelig.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Versjon %1 er tilgjengelig for nedlasting.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Ny oppdatering tilgjengelig.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Versjon %1 er tilgjengelig for nedlasting.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Legg til en konto</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Legg til en konto</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Versjon</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">OPPDATERING</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 er oppdatert!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Sjekker oppdateringer på serveren...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;her&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Det er en oppdatering tilgjengelig: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Laster ned %1. Vennligst vent...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Det oppstod en feil under oppdateringen.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Det gikk ikke an å laste ned oppdateringen.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Oppdatering deaktivert.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Betaprogram</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Få tidlig tilgang til nye versjoner av applikasjonen</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Bli med</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Endre</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Avslutt</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Vis utgivelsesnotat&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Versjon</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>OPPDATERING</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 er oppdatert!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Sjekker oppdateringer på serveren...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Det er en oppdatering tilgjengelig: %1. Last&lt;br&gt;den ned &lt;a style="%2" href="%3"&gt;her&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Det er en oppdatering tilgjengelig: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Laster ned %1. Vennligst vent...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Det var ikke mulig å sjekke om det var nye oppdateringer.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Det oppstod en feil under oppdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Det gikk ikke an å laste ned oppdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Oppdatering deaktivert.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Betaprogram</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Få tidlig tilgang til nye versjoner av applikasjonen</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Bli med</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Endre</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Avslutt</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Kan ikke lagre parametrene!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Finner ikke en gyldig sti</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Det er ikke valgt noen gyldig mappe!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Den valgte banen finnes ikke!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Den valgte banen er ikke en mappe!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Du har ikke tilgang til å skrive til den valgte mappen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Gjør tilgjengelig lokalt</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Frigjør lokal lagringsplass</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Avbryt for å frigjøre lokal lagringsplass</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Avbryt lokal tilgjengeliggjøring</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Det er ikke tillatt å dele denne filen videre</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Det er ikke tillatt å dele denne mappen videre</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Kopier lenken til den offentlige delingen</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Kopier lenken til privat deling</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Åpne i nettleseren</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Det gikk ikke an å lagre parametrene. Prøv igjen senere.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Kan ikke lagre parametrene!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Overordnet mappe er en synkroniseringsmappe eller ligger i en slik</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Finner ikke en gyldig sti</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Det er ikke valgt noen gyldig mappe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Den valgte banen finnes ikke!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Den valgte banen er ikke en mappe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Du har ikke tilgang til å skrive til den valgte mappen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Den lokale mappen %1 inneholder en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Den lokale mappen %1 ligger i en mappe som allerede er synkronisert. Vennligst velg en annen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Den lokale mappen %1 er allerede synkronisert. Velg en annen!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync (Beta) er aktivert. Filer fra kDrive forblir i skyen og bruker ikke lagringsplassen på datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync (Beta) er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite-synkronisering er aktivert. Filer fra kDrive forblir i skyen og opptar ikke lagringsplass på datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync er deaktivert. kDrive-filene bruker lagringsplassen på datamaskinen din.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Gjør tilgjengelig lokalt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Frigjør lokal lagringsplass</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Avbryt for å frigjøre lokal lagringsplass</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Avbryt lokal tilgjengeliggjøring</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Det er ikke tillatt å dele denne filen videre</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Det er ikke tillatt å dele denne mappen videre</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Kopier lenken til den offentlige delingen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Kopier lenken til privat deling</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Åpne i nettleseren</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>kDrive-programmet vil lukkes på grunn av en alvorlig feil.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n ar</numerusform>
-            <numerusform>%n ar</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n maned</numerusform>
-            <numerusform>%n maneder</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n dag</numerusform>
-            <numerusform>%n dager</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n time</numerusform>
-            <numerusform>%n timer</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minutt</numerusform>
-            <numerusform>%n minutter</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n sekund</numerusform>
-            <numerusform>%n sekunder</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n ar</numerusform>
+<numerusform>%n ar</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n maned</numerusform>
+<numerusform>%n maneder</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n dag</numerusform>
+<numerusform>%n dager</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n time</numerusform>
+<numerusform>%n timer</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minutt</numerusform>
+<numerusform>%n minutter</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekund</numerusform>
+<numerusform>%n sekunder</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Systemstatusfeltet er ikke tilgjengelig</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 krever et fungerende systemstatusfelt. Kjører du XFCE, følg &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;disse instruksjonene&lt;/a&gt;. Ellers installerer du en systemstatusfelts-applikasjon som &apos;trayer&apos; og prøver igjen.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Systemstatusfeltet er ikke tilgjengelig</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 krever et fungerende systemstatusfelt. Kjører du XFCE, følg &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;disse instruksjonene&lt;/a&gt;. Ellers installerer du en systemstatusfelts-applikasjon som 'trayer' og prøver igjen.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Kunne ikke åpne nettleseren</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Kunne ikke åpne e-postprogrammet</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Du er ikke lenger pålogget. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logg inn&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synkronisering pågår (Trinn %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synkronisering pågår.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Noen filer kunne ikke synkroniseres. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Les mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synkronisering på pause ...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Synkronisering starter</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synkroniseringen er satt på pause.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synkronisering pågår (1 % av 2 %)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Kunne ikke åpne nettleseren</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Det oppstod en feil da nettleseren ble startet for å gå til URL-adressen %1. Kanskje er det ikke konfigurert noen standard nettleser?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Kunne ikke åpne e-postprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Det oppstod en feil da e-postklienten ble startet for å opprette en ny melding. Kanskje er det ikke konfigurert noen standard e-postklient?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Du er ikke lenger pålogget. &lt;a style="%1" href="%2"&gt;Logg inn&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synkronisering pågår (Trinn %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synkronisering pågår.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Noen filer kunne ikke synkroniseres. &lt;a style="%1" href="%2"&gt;Les mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synkronisering på pause ...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi en annen synkronisering bruker den samme mappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den inneholder den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges fordi den ligger i den synkroniserte mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan ikke velges som synkroniseringsmappe. Vennligst velg en annen mappe. Forslag til mappe: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Du har ekskludert mer enn %1 mapper. Vær oppmerksom på at dette vil påvirke synkroniseringsytelsen.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Du kan ikke ekskludere mer enn 1 % av mappene. Fjern merket for mapper på høyere nivå.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synkronisering starter</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synkroniseringen er satt på pause.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synkronisering pågår (1 % av 2 %)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synkronisering pågår (%1 av %2)
+<translation>Synkronisering pågår (%1 av %2)
 %3 igjen...</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Du har uavklarte konflikter.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Du er oppdatert!</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Du har uavklarte konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Du er oppdatert!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Ingen mappe å synkronisere
+<translation>Ingen mappe å synkronisere
 Du kan legge til en i kDrive-innstillingene.</translation>
-    </message>
+</message>
 </context>
 </TS>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -620,7 +620,7 @@ Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&g
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
         <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Open de &lt;b&gt;Algemene instellingen&lt;/b&gt; van uw Mac of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Open de &lt;b&gt;Algemene instellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -660,7 +660,7 @@ Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&g
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
         <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation>Ga naar de sectie &lt;b&gt;&quot;Privacy en beveiliging&quot;&lt;/b&gt; en klik op &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt; of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Privacy en beveiliging&quot;&lt;/b&gt; en klik op &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt; of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -1793,7 +1793,7 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="818"/>
         <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Het is onmogelijk om het bestand „%1“ aan te maken, omdat dit niet wordt ondersteund op uw bestandssysteem.&lt;br&gt;Het is uitgesloten van synchronisatie.</translation>
+        <translation>Het is onmogelijk om het bestand &quot;%1&quot; aan te maken, omdat dit niet wordt ondersteund op uw bestandssysteem.&lt;br&gt;Het is uitgesloten van synchronisatie.</translation>
     </message>
     <message>
         <location filename="../src/gui/parametersdialog.cpp" line="609"/>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -4,971 +4,1206 @@
 <context>
     <name>KDC::AboutDialog</name>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
         <source>About</source>
-        <translation type="vanished">Over</translation>
+        <translation>Over</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
         <source>CLOSE</source>
-        <translation type="vanished">SLUITEN</translation>
+        <translation>SLUITEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
         <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versie %1. Voor meer informatie, bezoek &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Versie %1. Voor meer informatie, bezoek &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
         <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
         <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Gedistribueerd door %1 en gelicentieerd onder de &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 en het %2-logo zijn gedeponeerde handelsmerken van %1.&lt;br&gt;&lt;br&gt;</translation>
+        <translation>Gedistribueerd door %1 en gelicentieerd onder de &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 en het %2-logo zijn gedeponeerde handelsmerken van %1.&lt;br&gt;&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
         <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan map %1 niet openen.</translation>
+        <translation>Kan map %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
         <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Gecompileerd vanuit &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-bronnen&lt;/a&gt; op %2, %3 met Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;&lt;small&gt;Gecompileerd vanuit &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-bronnen&lt;/a&gt; op %2, %3 met Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
     <name>KDC::AbstractFileItemWidget</name>
     <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
         <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan debugmap %1 niet openen.</translation>
+        <translation>Kan debugmap %1 niet openen.</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveConfirmationWidget</name>
     <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
         <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">De synchronisatie begint en u kunt bestanden aan uw %1-map toevoegen.</translation>
+        <translation>De synchronisatie begint en u kunt bestanden aan uw %1-map toevoegen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
         <source>Your kDrive is ready!</source>
-        <translation type="vanished">Uw kDrive is klaar!</translation>
+        <translation>Uw kDrive is klaar!</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
         <source>OPEN FOLDER</source>
-        <translation type="vanished">LOKALE MAP OPENEN</translation>
+        <translation>LOKALE MAP OPENEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
         <source>PARAMETERS</source>
-        <translation type="vanished">INSTELLINGEN</translation>
+        <translation>INSTELLINGEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
         <source>Synchronize another drive</source>
-        <translation type="vanished">Een andere kDrive synchroniseren</translation>
+        <translation>Een andere kDrive synchroniseren</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveListWidget</name>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
         <source>NEXT</source>
-        <translation type="vanished">VOLGENDE</translation>
+        <translation>VOLGENDE</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
         <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Selecteer de kDrive die u wilt synchroniseren</translation>
+        <translation>Selecteer de kDrive die u wilt synchroniseren</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
         <source>Get kDrive for free</source>
-        <translation type="vanished">Ontvang kDrive gratis</translation>
+        <translation>Ontvang kDrive gratis</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
         <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Sla uw foto&apos;s, documenten en e-mails op in Zwitserland bij een onafhankelijk bedrijf dat de privacy respecteert. Meer informatie</translation>
+        <translation>Sla uw foto&apos;s, documenten en e-mails op in Zwitserland bij een onafhankelijk bedrijf dat de privacy respecteert. Meer informatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
         <source>Test for free</source>
-        <translation type="vanished">Gratis testen</translation>
+        <translation>Gratis testen</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveLiteSyncWidget</name>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
         <source>Conserve your computer space</source>
-        <translation type="vanished">Bespaar ruimte op uw computer</translation>
+        <translation>Bespaar ruimte op uw computer</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
         <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Bepaal welke bestanden online of lokaal beschikbaar moeten zijn</translation>
+        <translation>Bepaal welke bestanden online of lokaal beschikbaar moeten zijn</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
         <source>LATER</source>
-        <translation type="vanished">LATER</translation>
+        <translation>LATER</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
         <source>YES</source>
-        <translation type="vanished">JA</translation>
+        <translation>JA</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
         <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synchroniseert al uw bestanden zonder de ruimte op uw computer te gebruiken. U kunt door de bestanden in uw kDrive bladeren en ze downloaden wanneer u wilt. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>Lite Sync synchroniseert al uw bestanden zonder de ruimte op uw computer te gebruiken. U kunt door de bestanden in uw kDrive bladeren en ze downloaden wanneer u wilt. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
         <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Wilt u Lite Sync (Beta) activeren?</translation>
+        <translation>Wilt u Lite Sync (Beta) activeren?</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
         <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Wilt u Lite Sync activeren?</translation>
+        <translation>Wilt u Lite Sync activeren?</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveLocalFolderWidget</name>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
         <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Locatie van uw %1 kDrive</translation>
+        <translation>Locatie van uw %1 kDrive</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
         <source>Edit folder</source>
-        <translation type="vanished">Map bewerken</translation>
+        <translation>Map bewerken</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
         <source>END</source>
-        <translation type="vanished">VOLTOOIEN</translation>
+        <translation>VOLTOOIEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Deze map is niet compatibel met Lite Sync.&lt;br&gt; 
+        <translation>Deze map is niet compatibel met Lite Sync.&lt;br&gt; 
 Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&gt; 
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
         <source>Select folder</source>
-        <translation type="vanished">Map selecteren</translation>
+        <translation>Map selecteren</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
         <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">De inhoud van de map &lt;b&gt;%1&lt;/b&gt; wordt gesynchroniseerd met uw kDrive</translation>
+        <translation>De inhoud van de map &lt;b&gt;%1&lt;/b&gt; wordt gesynchroniseerd met uw kDrive</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
         <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">U vindt al uw bestanden in deze map wanneer de configuratie voltooid is. U kunt nieuwe bestanden hier naartoe slepen om ze te synchroniseren met uw kDrive.</translation>
+        <translation>U vindt al uw bestanden in deze map wanneer de configuratie voltooid is. U kunt nieuwe bestanden hier naartoe slepen om ze te synchroniseren met uw kDrive.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
         <source>CONTINUE</source>
-        <translation type="vanished">DOORGAAN</translation>
+        <translation>DOORGAAN</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveLoginWidget</name>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
         <source>Log in from your browser</source>
-        <translation type="vanished">Log in via uw browser</translation>
+        <translation>Log in via uw browser</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
         <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Uw browser zou automatisch moeten openen om de verbinding te voltooien. Eenmaal verbonden, keert u automatisch terug naar kDrive.</translation>
+        <translation>Uw browser zou automatisch moeten openen om de verbinding te voltooien. Eenmaal verbonden, keert u automatisch terug naar kDrive.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
         <source>Open the login page</source>
-        <translation type="vanished">Open de inlogpagina</translation>
+        <translation>Open de inlogpagina</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
         <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Er is een fout opgetreden tijdens de verificatie. Sluit het aanmeldvenster en probeer het opnieuw.&lt;br&gt;Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
+        <translation>Er is een fout opgetreden tijdens de verificatie. Sluit het aanmeldvenster en probeer het opnieuw.&lt;br&gt;Neem contact op met ons ondersteuningsteam als de fout aanhoudt.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
         <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Inloggen mislukt: %1 - %2</translation>
+        <translation>Inloggen mislukt: %1 - %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
         <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Kan de inlogpagina niet openen in uw webbrowser</translation>
+        <translation>Kan de inlogpagina niet openen in uw webbrowser</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveServerFoldersWidget</name>
     <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
         <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Selecteer kDrive-mappen om te synchroniseren op uw computer</translation>
+        <translation>Selecteer kDrive-mappen om te synchroniseren op uw computer</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
         <source>CONTINUE</source>
-        <translation type="vanished">DOORGAAN</translation>
+        <translation>DOORGAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
         <source>Space available on your computer : %1</source>
-        <translation type="vanished">Beschikbare ruimte op uw computer: %1</translation>
+        <translation>Beschikbare ruimte op uw computer: %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
         <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
+        <translation>Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
         <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Kan de lijst met submappen niet laden. Uw kDrive is mogelijk in onderhoud.&lt;br&gt;Log in op de &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversie&lt;/a&gt; om de status van uw kDrive te controleren, of neem contact op met uw beheerder.</translation>
+        <translation>Kan de lijst met submappen niet laden. Uw kDrive is mogelijk in onderhoud.&lt;br&gt;Log in op de &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webversie&lt;/a&gt; om de status van uw kDrive te controleren, of neem contact op met uw beheerder.</translation>
     </message>
 </context>
 <context>
     <name>KDC::AddDriveWizard</name>
     <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
         <source>Failed to create local folder %1</source>
-        <translation type="vanished">Kan lokale map %1 niet aanmaken</translation>
+        <translation>Kan lokale map %1 niet aanmaken</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
         <source>Failed to create new synchronization</source>
-        <translation type="vanished">Kan geen nieuwe synchronisatie aanmaken</translation>
+        <translation>Kan geen nieuwe synchronisatie aanmaken</translation>
     </message>
     <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
         <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">De kDrive %1 is al gesynchroniseerd op deze computer. Toch doorgaan?</translation>
+        <translation>De kDrive %1 is al gesynchroniseerd op deze computer. Toch doorgaan?</translation>
     </message>
 </context>
 <context>
     <name>KDC::AppClient</name>
     <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
         <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-client wordt uitgevoerd met ongeldige parameters!</translation>
+        <translation>kDrive-client wordt uitgevoerd met ongeldige parameters!</translation>
     </message>
     <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
         <source>kDrive client is already running!</source>
-        <translation type="vanished">kDrive-client draait al!</translation>
+        <translation>kDrive-client draait al!</translation>
     </message>
     <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
         <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Gebruiker %1 is niet verbonden. Log opnieuw in.</translation>
+        <translation>Gebruiker %1 is niet verbonden. Log opnieuw in.</translation>
     </message>
 </context>
 <context>
     <name>KDC::AppServer</name>
     <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
         <source>Share link copied to clipboard</source>
-        <translation type="vanished">Deellink gekopieerd naar klembord</translation>
+        <translation>Deellink gekopieerd naar klembord</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
         <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%1 is verwijderd.</numerusform>
             <numerusform>%1 en %n andere bestanden zijn verwijderd.</numerusform>
         </translation>
     </message>
     <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
         <source>%1 has been removed.</source>
         <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 is verwijderd.</translation>
+        <translation>%1 is verwijderd.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
         <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%1 en %n ander(e) bestand(en) zijn toegevoegd.</numerusform>
             <numerusform>%1 en %n andere bestanden zijn toegevoegd.</numerusform>
         </translation>
     </message>
     <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
         <source>%1 has been added.</source>
         <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 is toegevoegd.</translation>
+        <translation>%1 is toegevoegd.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
         <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%1 is bijgewerkt.</numerusform>
             <numerusform>%1 en %n andere bestanden zijn bijgewerkt.</numerusform>
         </translation>
     </message>
     <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
         <source>%1 has been updated.</source>
         <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 is bijgewerkt.</translation>
+        <translation>%1 is bijgewerkt.</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
         <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%1 is verplaatst naar %2.</numerusform>
             <numerusform>%1 is verplaatst naar %2 en %n andere bestanden zijn verplaatst.</numerusform>
         </translation>
     </message>
     <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
         <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 is verplaatst naar %2.</translation>
+        <translation>%1 is verplaatst naar %2.</translation>
     </message>
     <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
         <source>Sync Activity</source>
-        <translation type="vanished">Synchronisatieactiviteit</translation>
+        <translation>Synchronisatieactiviteit</translation>
     </message>
 </context>
 <context>
     <name>KDC::BaseFolderTreeItemWidget</name>
     <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
         <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Geen submappen op de server.</translation>
+        <translation>Geen submappen op de server.</translation>
     </message>
 </context>
 <context>
     <name>KDC::BetaProgramDialog</name>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
         <source>Quit the beta program</source>
-        <translation type="vanished">Bètaprogramma verlaten</translation>
+        <translation>Bètaprogramma verlaten</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
         <source>Join the beta program</source>
-        <translation type="vanished">Deelnemen aan het bètaprogramma</translation>
+        <translation>Deelnemen aan het bètaprogramma</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
         <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Krijg vroeg toegang tot nieuwe versies van de applicatie voordat ze voor het grote publiek worden vrijgegeven, en help mee de applicatie te verbeteren door ons uw opmerkingen te sturen.</translation>
+        <translation>Krijg vroeg toegang tot nieuwe versies van de applicatie voordat ze voor het grote publiek worden vrijgegeven, en help mee de applicatie te verbeteren door ons uw opmerkingen te sturen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
         <source>Benefit from application beta updates</source>
-        <translation type="vanished">Profiteer van bèta-updates van de applicatie</translation>
+        <translation>Profiteer van bèta-updates van de applicatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
         <source>No</source>
-        <translation type="vanished">Nee</translation>
+        <translation>Nee</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
         <source>Public beta version</source>
-        <translation type="vanished">Openbare bètaversie</translation>
+        <translation>Openbare bètaversie</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
         <source>Internal beta version</source>
-        <translation type="vanished">Interne bètaversie</translation>
+        <translation>Interne bètaversie</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
         <source>Test version</source>
-        <translation type="vanished">Testversie</translation>
+        <translation>Testversie</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
         <source>I understand</source>
-        <translation type="vanished">Ik begrijp het</translation>
+        <translation>Ik begrijp het</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
         <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Weet u zeker dat u het bètaprogramma wilt verlaten?</translation>
+        <translation>Weet u zeker dat u het bètaprogramma wilt verlaten?</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
         <source>Save</source>
-        <translation type="vanished">Opslaan</translation>
+        <translation>Opslaan</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
         <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Uw huidige versie van de applicatie is mogelijk te recent, uw keuze wordt effectief wanneer de volgende update beschikbaar is.</translation>
+        <translation>Uw huidige versie van de applicatie is mogelijk te recent, uw keuze wordt effectief wanneer de volgende update beschikbaar is.</translation>
     </message>
     <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
         <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Bètaversies kunnen onverwacht stoppen of instabiliteit veroorzaken.</translation>
+        <translation>Bètaversies kunnen onverwacht stoppen of instabiliteit veroorzaken.</translation>
     </message>
 </context>
 <context>
     <name>KDC::ClientGui</name>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
         <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Kan conflict(en) niet oplossen voor %1 item(s) in synchronisatiemap: %2</translation>
+        <translation>Kan conflict(en) niet oplossen voor %1 item(s) in synchronisatiemap: %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
         <source>Please sign in</source>
-        <translation type="vanished">Log alstublieft in</translation>
+        <translation>Log alstublieft in</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
         <source>Folder %1: %2</source>
-        <translation type="vanished">Map %1: %2</translation>
+        <translation>Map %1: %2</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
         <source>There are no sync folders configured.</source>
-        <translation type="vanished">Er zijn geen synchronisatiemappen geconfigureerd.</translation>
+        <translation>Er zijn geen synchronisatiemappen geconfigureerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
         <source>Synthesis</source>
-        <translation type="vanished">Overzicht</translation>
+        <translation>Overzicht</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
         <source>Preferences</source>
         <translatorcomment>Voorkeuren</translatorcomment>
-        <translation type="vanished">Voorkeuren</translation>
+        <translation>Voorkeuren</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
         <source>Quit</source>
-        <translation type="vanished">Afsluiten</translation>
+        <translation>Afsluiten</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
         <source>Undefined State.</source>
-        <translation type="vanished">Ongedefinieerde status.</translation>
+        <translation>Ongedefinieerde status.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
         <source>Waiting to start syncing.</source>
-        <translation type="vanished">Wachten om synchronisatie te starten.</translation>
+        <translation>Wachten om synchronisatie te starten.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
         <source>Sync is running.</source>
-        <translation type="vanished">Synchronisatie wordt uitgevoerd.</translation>
+        <translation>Synchronisatie wordt uitgevoerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
         <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synchronisatie gelukt, niet-opgeloste conflicten.</translation>
+        <translation>Synchronisatie gelukt, niet-opgeloste conflicten.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
         <source>Last Sync was successful.</source>
-        <translation type="vanished">Laatste synchronisatie was succesvol.</translation>
+        <translation>Laatste synchronisatie was succesvol.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
         <source>User Abort.</source>
-        <translation type="vanished">Afgebroken door gebruiker.</translation>
+        <translation>Afgebroken door gebruiker.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
         <source>Sync is paused.</source>
-        <translation type="vanished">Synchronisatie is gepauzeerd.</translation>
+        <translation>Synchronisatie is gepauzeerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
         <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synchronisatie gepauzeerd)</translation>
+        <translation>%1 (Synchronisatie gepauzeerd)</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
         <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Weet u zeker dat u de synchronisaties van het account &lt;i&gt;%1&lt;/i&gt; wilt verwijderen?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Dit zal &lt;b&gt;geen&lt;/b&gt; bestanden verwijderen.</translation>
+        <translation>Weet u zeker dat u de synchronisaties van het account &lt;i&gt;%1&lt;/i&gt; wilt verwijderen?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Dit zal &lt;b&gt;geen&lt;/b&gt; bestanden verwijderen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
         <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">ALLE SYNCHRONISATIES VERWIJDEREN</translation>
+        <translation>ALLE SYNCHRONISATIES VERWIJDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
         <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 items zijn verwijderd uit uw lokale synchronisatiemap &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Om onbedoelde verwijderingen te voorkomen, is de synchronisatie onderbroken.&lt;br&gt;Wilt u deze verwijderingen doorzetten naar uw kDrive?</translation>
+        <translation>%1 items zijn verwijderd uit uw lokale synchronisatiemap &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Om onbedoelde verwijderingen te voorkomen, is de synchronisatie onderbroken.&lt;br&gt;Wilt u deze verwijderingen doorzetten naar uw kDrive?</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
         <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Meerdere bestanden zijn verwijderd uit uw lokale synchronisatiemap &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Verwijderde bestanden zijn te vinden in de &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;prullenbak&lt;/a&gt; van kDrive.</translation>
+        <translation>Meerdere bestanden zijn verwijderd uit uw lokale synchronisatiemap &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Verwijderde bestanden zijn te vinden in de &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;prullenbak&lt;/a&gt; van kDrive.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
         <source>Don&apos;t show again</source>
-        <translation type="vanished">Niet meer weergeven</translation>
+        <translation>Niet meer weergeven</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
         <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Kan synchronisaties niet starten!</translation>
+        <translation>Kan synchronisaties niet starten!</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
         <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan debugmap %1 niet openen.</translation>
+        <translation>Kan debugmap %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
         <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Kan kDrive-client niet initialiseren</translation>
+        <translation>Kan kDrive-client niet initialiseren</translation>
     </message>
     <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
         <source>Synchronization is paused</source>
-        <translation type="vanished">Synchronisatie is gepauzeerd</translation>
+        <translation>Synchronisatie is gepauzeerd</translation>
     </message>
 </context>
 <context>
     <name>KDC::ConfirmSynchronizationDialog</name>
     <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
         <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Samenvatting van uw lokale mapsynchronisatie</translation>
+        <translation>Samenvatting van uw lokale mapsynchronisatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
         <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">De inhoud van de map op uw computer wordt gesynchroniseerd met de map van de geselecteerde kDrive en omgekeerd.</translation>
+        <translation>De inhoud van de map op uw computer wordt gesynchroniseerd met de map van de geselecteerde kDrive en omgekeerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
         <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNCHRONISEREN</translation>
+        <translation>SYNCHRONISEREN</translation>
     </message>
 </context>
 <context>
     <name>KDC::CustomExtensionSetupWidget</name>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
         <source>Before finishing</source>
-        <translation type="vanished">Voordat u voltooit</translation>
+        <translation>Voordat u voltooit</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
         <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Voer de volgende stappen uit om ervoor te zorgen dat Lite Sync correct werkt op uw computer en om de configuratie van de kDrive te voltooien.</translation>
+        <translation>Voer de volgende stappen uit om ervoor te zorgen dat Lite Sync correct werkt op uw computer en om de configuratie van de kDrive te voltooien.</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
         <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Open de &lt;b&gt;Algemene instellingen&lt;/b&gt; van uw Mac of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Open de &lt;b&gt;Algemene instellingen&lt;/b&gt; van uw Mac of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
         <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Open de &lt;b&gt;Privacy- en beveiligingsinstellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Open de &lt;b&gt;Privacy- en beveiligingsinstellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
         <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Open de &lt;b&gt;Beveiligings- en privacy-instellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Open de &lt;b&gt;Beveiligings- en privacy-instellingen&lt;/b&gt; van uw Mac of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
         <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Ga naar de sectie &lt;b&gt;&quot;Inlogitems en extensies&quot;&lt;/b&gt; en vervolgens naar &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Inlogitems en extensies&quot;&lt;/b&gt; en vervolgens naar &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
         <source>Authorize the kDrive application</source>
-        <translation type="vanished">Authoriseer de kDrive-applicatie</translation>
+        <translation>Authoriseer de kDrive-applicatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
         <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Ga naar de sectie &lt;b&gt;&quot;Beveiliging&quot;&lt;/b&gt;</translation>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Beveiliging&quot;&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
         <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Authoriseer de kDrive-applicatie in het vak dat aangeeft dat kDrive is geblokkeerd</translation>
+        <translation>Authoriseer de kDrive-applicatie in het vak dat aangeeft dat kDrive is geblokkeerd</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
         <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Ontgrendel het hangslot &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; en authoriseer de kDrive-applicatie</translation>
+        <translation>Ontgrendel het hangslot &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; en authoriseer de kDrive-applicatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
         <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ga naar de sectie &lt;b&gt;&quot;Privacy en beveiliging&quot;&lt;/b&gt; en klik op &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt; of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Ga naar de sectie &lt;b&gt;&quot;Privacy en beveiliging&quot;&lt;/b&gt; en klik op &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt; of &lt;a style=%1 href=%2&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
         <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Nog steeds in de Beveiliging- en Privacy-instellingen, open het tabblad &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
+        <translation>Nog steeds in de Beveiliging- en Privacy-instellingen, open het tabblad &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; of &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klik hier&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Vink het vakje &quot;kDrive LiteSync Extension&quot; aan en vervolgens het vakje &quot;kDrive.app&quot; (indien nog niet aangevinkt)</translation>
+        <translation>Vink het vakje &quot;kDrive LiteSync Extension&quot; aan en vervolgens het vakje &quot;kDrive.app&quot; (indien nog niet aangevinkt)</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
         <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Een herstart van de app kan worden voorgesteld, accepteer dit in dat geval</translation>
+        <translation>Een herstart van de app kan worden voorgesteld, accepteer dit in dat geval</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
         <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Vink het vakje &quot;kDrive LiteSync Extension&quot; aan (en &quot;kDrive.app&quot; als het bestaat) bij &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt;</translation>
+        <translation>Vink het vakje &quot;kDrive LiteSync Extension&quot; aan (en &quot;kDrive.app&quot; als het bestaat) bij &lt;b&gt;&quot;Volledige schijftoegang&quot;&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
         <source>STEP 1</source>
-        <translation type="vanished">STAP 1</translation>
+        <translation>STAP 1</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
         <source>(Done)</source>
-        <translation type="vanished">(Uitgevoerd)</translation>
+        <translation>(Uitgevoerd)</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
         <source>STEP 2</source>
-        <translation type="vanished">STAP 2</translation>
+        <translation>STAP 2</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
         <source>STEPS PERFORMED</source>
-        <translation type="vanished">UITGEVOERDE STAPPEN</translation>
+        <translation>UITGEVOERDE STAPPEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
         <source>END</source>
-        <translation type="vanished">VOLTOOIEN</translation>
+        <translation>VOLTOOIEN</translation>
     </message>
 </context>
 <context>
     <name>KDC::CustomMessageBox</name>
     <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
         <source>OK</source>
-        <translation type="vanished">OK</translation>
+        <translation>OK</translation>
     </message>
     <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
         <source>YES</source>
-        <translation type="vanished">JA</translation>
+        <translation>JA</translation>
     </message>
     <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
         <source>NO</source>
-        <translation type="vanished">NEE</translation>
+        <translation>NEE</translation>
     </message>
 </context>
 <context>
     <name>KDC::DebugReporter</name>
     <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Sending of debugging information</source>
-        <translation type="vanished">Verzenden van debuginformatie</translation>
+        <translation>Verzenden van debuginformatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
 </context>
 <context>
     <name>KDC::DebuggingDialog</name>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
         <source>Info</source>
-        <translation type="vanished">Informatie</translation>
+        <translation>Informatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
         <source>Debug</source>
-        <translation type="vanished">Debuggen</translation>
+        <translation>Debuggen</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
         <source>Warning</source>
-        <translation type="vanished">Waarschuwing</translation>
+        <translation>Waarschuwing</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
         <source>Error</source>
-        <translation type="vanished">Fout</translation>
+        <translation>Fout</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
         <source>Fatal</source>
-        <translation type="vanished">Fataal</translation>
+        <translation>Fataal</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
         <source>Debugging settings</source>
-        <translation type="vanished">Debug-instellingen</translation>
+        <translation>Debug-instellingen</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
         <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Debuginformatie opslaan in een map op mijn computer (aanbevolen)</translation>
+        <translation>Debuginformatie opslaan in een map op mijn computer (aanbevolen)</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
         <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Deze informatie stelt IT-ondersteuning in staat de oorzaak van een incident te bepalen.</translation>
+        <translation>Deze informatie stelt IT-ondersteuning in staat de oorzaak van een incident te bepalen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
         <source>Debug level</source>
-        <translation type="vanished">Debug-niveau</translation>
+        <translation>Debug-niveau</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
         <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Het trace-niveau laat u de omvang van de vastgelegde debuginformatie kiezen</translation>
+        <translation>Het trace-niveau laat u de omvang van de vastgelegde debuginformatie kiezen</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
         <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Het uitgebreide volledige logboek verzamelt een gedetailleerde geschiedenis die kan worden gebruikt voor debugging. Het activeren ervan kan de kDrive-applicatie vertragen.</translation>
+        <translation>Het uitgebreide volledige logboek verzamelt een gedetailleerde geschiedenis die kan worden gebruikt voor debugging. Het activeren ervan kan de kDrive-applicatie vertragen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
         <source>Extended Full Log</source>
-        <translation type="vanished">Uitgebreid volledig logboek</translation>
+        <translation>Uitgebreid volledig logboek</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
         <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Logboeken ouder dan %1 dagen verwijderen</translation>
+        <translation>Logboeken ouder dan %1 dagen verwijderen</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
         <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Deel de debugmap met Infomaniak-ondersteuning.</translation>
+        <translation>Deel de debugmap met Infomaniak-ondersteuning.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
         <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">De laatste sessie is de periode sinds de laatste kDrive-start.</translation>
+        <translation>De laatste sessie is de periode sinds de laatste kDrive-start.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
         <source>Share only the last kDrive session</source>
-        <translation type="vanished">Deel alleen de laatste kDrive-sessie</translation>
+        <translation>Deel alleen de laatste kDrive-sessie</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
         <source>  Loading</source>
-        <translation type="vanished">  Laden</translation>
+        <translation>  Laden</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
         <source>SAVE</source>
-        <translation type="vanished">OPSLAAN</translation>
+        <translation>OPSLAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
         <source>Failed to share</source>
-        <translation type="vanished">Delen mislukt</translation>
+        <translation>Delen mislukt</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
         <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Controleer of u bent ingelogd &lt;br&gt;2. Controleer of u ten minste één kDrive heeft geconfigureerd</translation>
+        <translation>1. Controleer of u bent ingelogd &lt;br&gt;2. Controleer of u ten minste één kDrive heeft geconfigureerd</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
         <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Verbinding onderbroken)</translation>
+        <translation> (Verbinding onderbroken)</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
         <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Deel de map met SwissTransfer &lt;br&gt;</translation>
+        <translation>Deel de map met SwissTransfer &lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
         <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. We hebben uw logboek automatisch gecomprimeerd &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt;.&lt;br&gt;</translation>
+        <translation> 1. We hebben uw logboek automatisch gecomprimeerd &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;hier&lt;/a&gt;.&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
         <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Verstuur het archief met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+        <translation> 2. Verstuur het archief met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
         <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Deel de link met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+        <translation> 3. Deel de link met &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
         <source>Last upload the %1</source>
-        <translation type="vanished">Laatste upload op %1</translation>
+        <translation>Laatste upload op %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
         <source>Sharing has been cancelled</source>
-        <translation type="vanished">Het delen is geannuleerd</translation>
+        <translation>Het delen is geannuleerd</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
         <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Het uitgebreide volledige logboek wordt geactiveerd via de omgevingsvariabele KDRIVE_FORCE_EXTENDED_LOG. Stel deze in op 0 om het uit te schakelen.</translation>
+        <translation>Het uitgebreide volledige logboek wordt geactiveerd via de omgevingsvariabele KDRIVE_FORCE_EXTENDED_LOG. Stel deze in op 0 om het uit te schakelen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
         <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">De hele map is groot (&gt; 100 MB) en het delen kan enige tijd duren. Om de deeltijd te verkorten, raden we aan alleen de laatste kDrive-sessie te delen.</translation>
+        <translation>De hele map is groot (&gt; 100 MB) en het delen kan enige tijd duren. Om de deeltijd te verkorten, raden we aan alleen de laatste kDrive-sessie te delen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
         <source>%1/%2/%3 at %4h%5m and %6s</source>
         <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%2/%1/%3 om %4u%5 en %6s</translation>
+        <translation>%2/%1/%3 om %4u%5 en %6s</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
         <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wilt u uw wijzigingen opslaan?</translation>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
         <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan map %1 niet openen.</translation>
+        <translation>Kan map %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
         <source>  Share</source>
-        <translation type="vanished">  Delen</translation>
+        <translation>  Delen</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
         <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Delen | stap 1/2 %1%</translation>
+        <translation>  Delen | stap 1/2 %1%</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
         <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Delen | stap 2/2 %1%</translation>
+        <translation>  Delen | stap 2/2 %1%</translation>
     </message>
     <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
         <source>  Canceling...</source>
-        <translation type="vanished">  Annuleren...</translation>
+        <translation>  Annuleren...</translation>
     </message>
 </context>
 <context>
     <name>KDC::DrivePreferencesWidget</name>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
         <source>Folders</source>
-        <translation type="vanished">Mappen</translation>
+        <translation>Mappen</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
         <source>Notifications</source>
-        <translation type="vanished">Meldingen</translation>
+        <translation>Meldingen</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
         <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Een melding wordt weergegeven zodra een nieuwe map is gesynchroniseerd of gewijzigd</translation>
+        <translation>Een melding wordt weergegeven zodra een nieuwe map is gesynchroniseerd of gewijzigd</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
         <source>Connected with</source>
-        <translation type="vanished">Verbonden met</translation>
+        <translation>Verbonden met</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
         <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Weet u zeker dat u wilt stoppen met het synchroniseren van de map &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Hierdoor worden &lt;b&gt;geen&lt;/b&gt; bestanden verwijderd.</translation>
+        <translation>Weet u zeker dat u wilt stoppen met het synchroniseren van de map &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Opmerking:&lt;/b&gt; Hierdoor worden &lt;b&gt;geen&lt;/b&gt; bestanden verwijderd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
         <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Deze bewerking kan enkele seconden tot enkele minuten duren, afhankelijk van de grootte van de map.</translation>
+        <translation>Deze bewerking kan enkele seconden tot enkele minuten duren, afhankelijk van de grootte van de map.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
         <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Synchronisatie van nieuwe lokale map mislukt!</translation>
+        <translation>Synchronisatie van nieuwe lokale map mislukt!</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
         <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Activering van Lite Sync mislukt.</translation>
+        <translation>Activering van Lite Sync mislukt.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
         <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Deactivering van Lite Sync mislukt.</translation>
+        <translation>Deactivering van Lite Sync mislukt.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
         <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">MAP-SYNCHRONISATIE VERWIJDEREN</translation>
+        <translation>MAP-SYNCHRONISATIE VERWIJDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
         <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
+        <translation>Er is een fout opgetreden bij het laden van de lijst met submappen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
         <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Meldingen voor deze kDrive inschakelen</translation>
+        <translation>Meldingen voor deze kDrive inschakelen</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
         <source>CONFIRM</source>
-        <translation type="vanished">BEVESTIGEN</translation>
+        <translation>BEVESTIGEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
         <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synchronisatiefouten en informatie.</translation>
+        <translation>Synchronisatiefouten en informatie.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
         <source>Synchronize a local folder</source>
-        <translation type="vanished">Een lokale map synchroniseren</translation>
+        <translation>Een lokale map synchroniseren</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
         <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Weet u zeker dat u Lite Sync wilt inschakelen?</translation>
+        <translation>Weet u zeker dat u Lite Sync wilt inschakelen?</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
         <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Weet u zeker dat u Lite Sync wilt uitschakelen?</translation>
+        <translation>Weet u zeker dat u Lite Sync wilt uitschakelen?</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
         <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">U heeft niet genoeg ruimte om alle bestanden op uw kDrive te synchroniseren (%1 ontbreekt). Als u Lite Sync uitschakelt, moet u selecteren welke mappen op uw computer moeten worden gesynchroniseerd. In de tussentijd wordt de synchronisatie van uw kDrive gepauzeerd.</translation>
+        <translation>U heeft niet genoeg ruimte om alle bestanden op uw kDrive te synchroniseren (%1 ontbreekt). Als u Lite Sync uitschakelt, moet u selecteren welke mappen op uw computer moeten worden gesynchroniseerd. In de tussentijd wordt de synchronisatie van uw kDrive gepauzeerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
         <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Als u Lite Sync uitschakelt, worden alle bestanden naar uw computer gedownload.</translation>
+        <translation>Als u Lite Sync uitschakelt, worden alle bestanden naar uw computer gedownload.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
         <source>Failed to create new synchronization</source>
-        <translation type="vanished">Kan geen nieuwe synchronisatie aanmaken</translation>
+        <translation>Kan geen nieuwe synchronisatie aanmaken</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
         <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync geactiveerd.</translation>
+        <translation>Lite Sync geactiveerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
         <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync gedeactiveerd.</translation>
+        <translation>Lite Sync gedeactiveerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
         <source>This drive is being deleted.</source>
-        <translation type="vanished">Dit station wordt verwijderd.</translation>
+        <translation>Dit station wordt verwijderd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
         <source>Impossible to open item %1</source>
-        <translation type="vanished">Kan item %1 niet openen</translation>
+        <translation>Kan item %1 niet openen</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
         <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Kan stoppen met synchroniseren van map &lt;i&gt;%1&lt;/i&gt; niet uitvoeren.</translation>
+        <translation>Kan stoppen met synchroniseren van map &lt;i&gt;%1&lt;/i&gt; niet uitvoeren.</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
         <source>Remove all synchronizations</source>
-        <translation type="vanished">Alle synchronisaties verwijderen</translation>
+        <translation>Alle synchronisaties verwijderen</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
         <source>Search in your kDrive</source>
-        <translation type="vanished">Zoeken in uw kDrive</translation>
+        <translation>Zoeken in uw kDrive</translation>
     </message>
     <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
         <source>Search</source>
-        <translation type="vanished">Zoeken</translation>
+        <translation>Zoeken</translation>
     </message>
 </context>
 <context>
     <name>KDC::DriveSelectionWidget</name>
     <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
         <source>Synchronize a kDrive</source>
-        <translation type="vanished">Een kDrive synchroniseren</translation>
+        <translation>Een kDrive synchroniseren</translation>
     </message>
     <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
         <source>Add a kDrive</source>
-        <translation type="vanished">Een kDrive toevoegen</translation>
+        <translation>Een kDrive toevoegen</translation>
     </message>
 </context>
 <context>
     <name>KDC::ErrorTabWidget</name>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
         <source>Resolve</source>
-        <translation type="vanished">Oplossen</translation>
+        <translation>Oplossen</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
         <source>Conflicted item(s)</source>
-        <translation type="vanished">Item(s) met conflict</translation>
+        <translation>Item(s) met conflict</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
         <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Item(s) met niet-ondersteunde tekens</translation>
+        <translation>Item(s) met niet-ondersteunde tekens</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
         <source>Clear history</source>
-        <translation type="vanished">Geschiedenis wissen</translation>
+        <translation>Geschiedenis wissen</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
         <source>To Resolve</source>
-        <translation type="vanished">Op te lossen</translation>
+        <translation>Op te lossen</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
         <source>Automatically resolved</source>
-        <translation type="vanished">Automatisch opgelost</translation>
+        <translation>Automatisch opgelost</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
         <source>problem(s) solved</source>
-        <translation type="vanished">probleem(en) opgelost</translation>
+        <translation>probleem(en) opgelost</translation>
     </message>
     <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
         <source>problem(s) detected</source>
-        <translation type="vanished">probleem(en) gedetecteerd</translation>
+        <translation>probleem(en) gedetecteerd</translation>
     </message>
 </context>
 <context>
     <name>KDC::ErrorsMenuBarWidget</name>
     <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
         <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synchronisatieconflicten of fouten</translation>
+        <translation>Synchronisatieconflicten of fouten</translation>
     </message>
     <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
         <source>Errors</source>
-        <translation type="vanished">Fouten</translation>
+        <translation>Fouten</translation>
     </message>
     <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
         <source>Back to preferences</source>
-        <translation type="vanished">Terug naar voorkeuren</translation>
+        <translation>Terug naar voorkeuren</translation>
     </message>
 </context>
 <context>
     <name>KDC::ErrorsPopup</name>
     <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
         <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Sommige bestanden konden niet worden gesynchroniseerd op de volgende kDrive(s):</translation>
+        <translation>Sommige bestanden konden niet worden gesynchroniseerd op de volgende kDrive(s):</translation>
     </message>
     <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
         <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 fout(en))</translation>
+        <translation> (%1 fout(en))</translation>
     </message>
     <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
         <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 informatie(s))</translation>
+        <translation> (%1 informatie(s))</translation>
     </message>
     <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
         <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 fout(en) en %2 informatie(s))</translation>
+        <translation> (%1 fout(en) en %2 informatie(s))</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
         <source>Generic errors (%n warning(s) or error(s))</source>
         <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
+        <translation>
             <numerusform>Algemene fouten (%n waarschuwing of fout)</numerusform>
             <numerusform>Algemene fouten (%n waarschuwingen of fouten)</numerusform>
         </translation>
@@ -977,299 +1212,367 @@ Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&g
 <context>
     <name>KDC::FileExclusionDialog</name>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
         <source>Excluded files</source>
-        <translation type="vanished">Uitgesloten bestanden</translation>
+        <translation>Uitgesloten bestanden</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
         <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Voeg bestanden of mappen toe die niet op uw computer worden gesynchroniseerd.</translation>
+        <translation>Voeg bestanden of mappen toe die niet op uw computer worden gesynchroniseerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
         <source>Add</source>
-        <translation type="vanished">Toevoegen</translation>
+        <translation>Toevoegen</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
         <source>NAME</source>
-        <translation type="vanished">NAAM</translation>
+        <translation>NAAM</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
         <source>WARNING</source>
-        <translation type="vanished">WAARSCHUWING</translation>
+        <translation>WAARSCHUWING</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
         <source>SAVE</source>
-        <translation type="vanished">OPSLAAN</translation>
+        <translation>OPSLAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
         <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wilt u uw wijzigingen opslaan?</translation>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
         <source>Exclusion template already exists!</source>
-        <translation type="vanished">Uitsluitingssjabloon bestaat al!</translation>
+        <translation>Uitsluitingssjabloon bestaat al!</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
         <source>Do you really want to delete?</source>
-        <translation type="vanished">Weet u zeker dat u wilt verwijderen?</translation>
+        <translation>Weet u zeker dat u wilt verwijderen?</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
         <source>Cannot save changes!</source>
-        <translation type="vanished">Kan wijzigingen niet opslaan!</translation>
+        <translation>Kan wijzigingen niet opslaan!</translation>
     </message>
 </context>
 <context>
     <name>KDC::FileExclusionNameDialog</name>
     <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
         <source>VALIDATE</source>
-        <translation type="vanished">VALIDEREN</translation>
+        <translation>VALIDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
 </context>
 <context>
     <name>KDC::FixConflictingFilesDialog</name>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
         <source>Solve conflict(s)</source>
-        <translation type="vanished">Conflict(en) oplossen</translation>
+        <translation>Conflict(en) oplossen</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
         <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Wat wilt u doen met de %1 item(s) met een conflict?&lt;/b&gt;</translation>
+        <translation>&lt;b&gt;Wat wilt u doen met de %1 item(s) met een conflict?&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
         <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Mijn wijzigingen opslaan en de versies van andere gebruikers vervangen.</translation>
+        <translation>Mijn wijzigingen opslaan en de versies van andere gebruikers vervangen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
         <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Mijn wijzigingen ongedaan maken en de versies van andere gebruikers behouden.</translation>
+        <translation>Mijn wijzigingen ongedaan maken en de versies van andere gebruikers behouden.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
         <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Uw wijzigingen kunnen permanent worden verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
+        <translation>Uw wijzigingen kunnen permanent worden verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
         <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
         <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Uw wijzigingen worden permanent verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
+        <translation>Uw wijzigingen worden permanent verwijderd. Ze kunnen niet worden hersteld vanuit de kDrive webapplicatie.</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
         <source>Show item(s)</source>
-        <translation type="vanished">Item(s) tonen</translation>
+        <translation>Item(s) tonen</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
         <source>VALIDATE</source>
-        <translation type="vanished">VALIDEREN</translation>
+        <translation>VALIDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
         <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Er zijn wijzigingen aangebracht in deze bestanden door meerdere gebruikers op verschillende plaatsen (online op kDrive, een computer of een mobiel apparaat). Mappen die deze bestanden bevatten, kunnen ook zijn verwijderd.&lt;br&gt;</translation>
+        <translation>Er zijn wijzigingen aangebracht in deze bestanden door meerdere gebruikers op verschillende plaatsen (online op kDrive, een computer of een mobiel apparaat). Mappen die deze bestanden bevatten, kunnen ook zijn verwijderd.&lt;br&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
         <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">De lokale versie van uw item &lt;b&gt;is niet gesynchroniseerd&lt;/b&gt; met kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>De lokale versie van uw item &lt;b&gt;is niet gesynchroniseerd&lt;/b&gt; met kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
 </context>
 <context>
     <name>KDC::FolderItemWidget</name>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
         <source>More actions</source>
-        <translation type="vanished">Meer acties</translation>
+        <translation>Meer acties</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
         <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Gesynchroniseerd in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+        <translation>Gesynchroniseerd in &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
         <source>Activate Lite Sync</source>
-        <translation type="vanished">Lite Sync activeren</translation>
+        <translation>Lite Sync activeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
         <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Lite Sync (Beta) activeren</translation>
+        <translation>Lite Sync (Beta) activeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
         <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Niet-geselecteerde mappen worden naar de prullenbak verplaatst als ze offline items bevatten. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+        <translation>Niet-geselecteerde mappen worden naar de prullenbak verplaatst als ze offline items bevatten. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
         <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Niet-geselecteerde mappen worden naar de prullenbak verplaatst. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+        <translation>Niet-geselecteerde mappen worden naar de prullenbak verplaatst. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
         <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Niet-geselecteerde mappen worden &lt;b&gt;permanent&lt;/b&gt; van de computer verwijderd. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
+        <translation>Niet-geselecteerde mappen worden &lt;b&gt;permanent&lt;/b&gt; van de computer verwijderd. Mappen die met kDrive zijn gesynchroniseerd, blijven online beschikbaar.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
         <source>Cancel</source>
-        <translation type="vanished">Annuleren</translation>
+        <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
         <source>VALIDATE</source>
-        <translation type="vanished">VALIDEREN</translation>
+        <translation>VALIDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
         <source>Pause synchronization</source>
-        <translation type="vanished">Synchronisatie pauzeren</translation>
+        <translation>Synchronisatie pauzeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
         <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Lite Sync deactiveren</translation>
+        <translation>Lite Sync deactiveren</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
         <source>Resume synchronization</source>
-        <translation type="vanished">Synchronisatie hervatten</translation>
+        <translation>Synchronisatie hervatten</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
         <source>Remove synchronization</source>
-        <translation type="vanished">Synchronisatie verwijderen</translation>
+        <translation>Synchronisatie verwijderen</translation>
     </message>
 </context>
 <context>
     <name>KDC::GenericErrorItemWidget</name>
     <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
         <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Kan mappad %1 niet openen.</translation>
+        <translation>Kan mappad %1 niet openen.</translation>
     </message>
 </context>
 <context>
     <name>KDC::LiteSyncAppDialog</name>
     <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
         <source>Application Id</source>
-        <translation type="vanished">Applicatie-ID</translation>
+        <translation>Applicatie-ID</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
         <source>Application Name</source>
-        <translation type="vanished">Applicatienaam</translation>
+        <translation>Applicatienaam</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
         <source>VALIDATE</source>
-        <translation type="vanished">VALIDEREN</translation>
+        <translation>VALIDEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
 </context>
 <context>
     <name>KDC::LiteSyncDialog</name>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
         <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Sommige apps (back-up, antivirus...) krijgen toegang tot uw bestanden, wat leidt tot hun download wanneer ze &quot;online&quot; zijn. Voeg ze toe aan de onderstaande lijst om dit gedrag te voorkomen.</translation>
+        <translation>Sommige apps (back-up, antivirus...) krijgen toegang tot uw bestanden, wat leidt tot hun download wanneer ze &quot;online&quot; zijn. Voeg ze toe aan de onderstaande lijst om dit gedrag te voorkomen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
         <source>Add</source>
-        <translation type="vanished">Toevoegen</translation>
+        <translation>Toevoegen</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
         <source>APPLICATION ID</source>
-        <translation type="vanished">APPLICATIE-ID</translation>
+        <translation>APPLICATIE-ID</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
         <source>NAME</source>
-        <translation type="vanished">NAAM</translation>
+        <translation>NAAM</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
         <source>SAVE</source>
-        <translation type="vanished">OPSLAAN</translation>
+        <translation>OPSLAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
         <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wilt u uw wijzigingen opslaan?</translation>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
         <source>Do you really want to delete?</source>
-        <translation type="vanished">Weet u zeker dat u wilt verwijderen?</translation>
+        <translation>Weet u zeker dat u wilt verwijderen?</translation>
     </message>
     <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
         <source>Cannot save changes!</source>
-        <translation type="vanished">Kan wijzigingen niet opslaan!</translation>
+        <translation>Kan wijzigingen niet opslaan!</translation>
     </message>
 </context>
 <context>
     <name>KDC::LocalFolderDialog</name>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
         <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Welke map op uw computer wilt u&lt;br&gt;synchroniseren?</translation>
+        <translation>Welke map op uw computer wilt u&lt;br&gt;synchroniseren?</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
         <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">De inhoud van deze map wordt gesynchroniseerd met de kDrive</translation>
+        <translation>De inhoud van deze map wordt gesynchroniseerd met de kDrive</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
         <source>Select a folder</source>
-        <translation type="vanished">Selecteer een map</translation>
+        <translation>Selecteer een map</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
         <source>Edit folder</source>
-        <translation type="vanished">Map bewerken</translation>
+        <translation>Map bewerken</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
         <source>CONTINUE</source>
-        <translation type="vanished">DOORGAAN</translation>
+        <translation>DOORGAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
         <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Deze map is niet compatibel met Lite Sync.&lt;br&gt;
+        <translation>Deze map is niet compatibel met Lite Sync.&lt;br&gt;
 Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&gt;
 &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
         <source>Select folder</source>
-        <translation type="vanished">Map selecteren</translation>
+        <translation>Map selecteren</translation>
     </message>
     <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
 </context>
 <context>
     <name>KDC::Logger</name>
     <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
         <source>Error</source>
-        <translation type="vanished">Fout</translation>
+        <translation>Fout</translation>
     </message>
     <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
         <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Bestand &apos;%1&apos;&lt;br/&gt;kan niet worden geopend om te schrijven.&lt;br/&gt;&lt;br/&gt;De loguitvoer kan &lt;b&gt;niet&lt;/b&gt; worden opgeslagen!&lt;/nobr&gt;</translation>
+        <translation>&lt;nobr&gt;Bestand &apos;%1&apos;&lt;br/&gt;kan niet worden geopend om te schrijven.&lt;br/&gt;&lt;br/&gt;De loguitvoer kan &lt;b&gt;niet&lt;/b&gt; worden opgeslagen!&lt;/nobr&gt;</translation>
     </message>
 </context>
 <context>
     <name>KDC::MainMenuBarWidget</name>
     <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
         <source>Preferences</source>
-        <translation type="vanished">Voorkeuren</translation>
+        <translation>Voorkeuren</translation>
     </message>
     <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
         <source>Help</source>
-        <translation type="vanished">Help</translation>
+        <translation>Help</translation>
     </message>
 </context>
 <context>
@@ -1488,6 +1791,11 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
         <translation>Er is niet genoeg ruimte over op uw computer.&lt;br&gt;De download is geannuleerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Het is onmogelijk om het bestand „%1“ aan te maken, omdat dit niet wordt ondersteund op uw bestandssysteem.&lt;br&gt;Het is uitgesloten van synchronisatie.</translation>
+    </message>
+    <message>
         <location filename="../src/gui/parametersdialog.cpp" line="609"/>
         <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
         <translation>Dit element is ergens anders naartoe verplaatst.&lt;br&gt;De lokale bewerking is geannuleerd.</translation>
@@ -1649,11 +1957,6 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
         <translation>Kan geen toegang krijgen tot item.&lt;br&gt;Corrigeer de lees- en schrijfrechten.</translation>
     </message>
     <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Kan bestand %1 niet aanmaken omdat het niet wordt ondersteund door uw bestandssysteem.&lt;br&gt;Het is uitgesloten van synchronisatie.</translation>
-    </message>
-    <message>
         <location filename="../src/gui/parametersdialog.cpp" line="821"/>
         <source>System error.</source>
         <translation>Systeemfout.</translation>
@@ -1672,797 +1975,984 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
 <context>
     <name>KDC::PreferencesBlocWidget</name>
     <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
         <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Deze synchronisatie wordt verwijderd.</translation>
+        <translation>Deze synchronisatie wordt verwijderd.</translation>
     </message>
 </context>
 <context>
     <name>KDC::PreferencesMenuBarWidget</name>
     <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
         <source>Back to drive list</source>
-        <translation type="vanished">Terug naar de drivelijst</translation>
+        <translation>Terug naar de drivelijst</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
         <source>Preferences</source>
-        <translation type="vanished">Voorkeuren</translation>
+        <translation>Voorkeuren</translation>
     </message>
 </context>
 <context>
     <name>KDC::PreferencesWidget</name>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
         <source>General</source>
-        <translation type="vanished">Algemeen</translation>
+        <translation>Algemeen</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
         <source>Activate dark theme</source>
-        <translation type="vanished">Donker thema activeren</translation>
+        <translation>Donker thema activeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
         <source>Activate monochrome icons</source>
-        <translation type="vanished">Monochrome pictogrammen activeren</translation>
+        <translation>Monochrome pictogrammen activeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
         <source>Launch kDrive at startup</source>
-        <translation type="vanished">kDrive starten bij het opstarten</translation>
+        <translation>kDrive starten bij het opstarten</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
         <source>Swedish</source>
-        <translation type="vanished">Zweeds</translation>
+        <translation>Zweeds</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
         <source>Portuguese</source>
-        <translation type="vanished">Portugees</translation>
+        <translation>Portugees</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
         <source>Polish</source>
-        <translation type="vanished">Pools</translation>
+        <translation>Pools</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
         <source>Norwegian</source>
-        <translation type="vanished">Noors</translation>
+        <translation>Noors</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
         <source>Finnish</source>
-        <translation type="vanished">Fins</translation>
+        <translation>Fins</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
         <source>Danish</source>
-        <translation type="vanished">Deens</translation>
+        <translation>Deens</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
         <source>Greek</source>
-        <translation type="vanished">Grieks</translation>
+        <translation>Grieks</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
         <source>Dutch</source>
-        <translation type="vanished">Nederlands</translation>
+        <translation>Nederlands</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
         <source>Advanced</source>
-        <translation type="vanished">Geavanceerd</translation>
+        <translation>Geavanceerd</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
         <source>Debugging information</source>
-        <translation type="vanished">Debuginformatie</translation>
+        <translation>Debuginformatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Debugmap openen&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
         <source>Files to exclude</source>
-        <translation type="vanished">Bestanden om uit te sluiten</translation>
+        <translation>Bestanden om uit te sluiten</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
         <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
+        <translation>Proxyserver</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
         <source>Unable to open folder %1.</source>
-        <translation type="vanished">Kan map %1 niet openen.</translation>
+        <translation>Kan map %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
         <source>Invalid link %1.</source>
-        <translation type="vanished">Ongeldige link %1.</translation>
+        <translation>Ongeldige link %1.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
         <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
+        <translation>Lite Sync</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
         <source>Language</source>
-        <translation type="vanished">Taal</translation>
+        <translation>Taal</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
         <source>Some process failed to run.</source>
-        <translation type="vanished">Sommige processen konden niet worden uitgevoerd.</translation>
+        <translation>Sommige processen konden niet worden uitgevoerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
         <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Verwijderde bestanden naar de prullenbak van mijn computer verplaatsen</translation>
+        <translation>Verwijderde bestanden naar de prullenbak van mijn computer verplaatsen</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
         <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Sommige bestanden of mappen kunnen mogelijk niet naar de prullenbak van de computer worden verplaatst.</translation>
+        <translation>Sommige bestanden of mappen kunnen mogelijk niet naar de prullenbak van de computer worden verplaatst.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
         <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">U kunt altijd reeds gesynchroniseerde bestanden ophalen uit de prullenbak van de kDrive webapplicatie.</translation>
+        <translation>U kunt altijd reeds gesynchroniseerde bestanden ophalen uit de prullenbak van de kDrive webapplicatie.</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
         <source>English</source>
-        <translation type="vanished">Engels</translation>
+        <translation>Engels</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
         <source>French</source>
-        <translation type="vanished">Frans</translation>
+        <translation>Frans</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
         <source>German</source>
-        <translation type="vanished">Duits</translation>
+        <translation>Duits</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
         <source>Spanish</source>
-        <translation type="vanished">Spaans</translation>
+        <translation>Spaans</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
         <source>Italian</source>
-        <translation type="vanished">Italiaans</translation>
+        <translation>Italiaans</translation>
     </message>
     <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
         <source>Default</source>
-        <translation type="vanished">Standaard</translation>
+        <translation>Standaard</translation>
     </message>
 </context>
 <context>
     <name>KDC::ProgressBarWidget</name>
     <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
         <source>%1 in use</source>
-        <translation type="vanished">%1 in gebruik</translation>
+        <translation>%1 in gebruik</translation>
     </message>
 </context>
 <context>
     <name>KDC::ProxyServerDialog</name>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
         <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S) Proxy</translation>
+        <translation>HTTP(S) Proxy</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
         <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
+        <translation>Proxyserver</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
         <source>No proxy server</source>
-        <translation type="vanished">Geen proxyserver</translation>
+        <translation>Geen proxyserver</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
         <source>Use system parameters</source>
-        <translation type="vanished">Systeeminstellingen gebruiken</translation>
+        <translation>Systeeminstellingen gebruiken</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
         <source>Indicate a proxy manually</source>
-        <translation type="vanished">Proxy handmatig opgeven</translation>
+        <translation>Proxy handmatig opgeven</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
         <source>Port</source>
-        <translation type="vanished">Poort</translation>
+        <translation>Poort</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
         <source>Address of the proxy server</source>
-        <translation type="vanished">Adres van de proxyserver</translation>
+        <translation>Adres van de proxyserver</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
         <source>Authentication needed</source>
-        <translation type="vanished">Authenticatie vereist</translation>
+        <translation>Authenticatie vereist</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
         <source>User</source>
-        <translation type="vanished">Gebruiker</translation>
+        <translation>Gebruiker</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
         <source>Password</source>
-        <translation type="vanished">Wachtwoord</translation>
+        <translation>Wachtwoord</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
         <source>SAVE</source>
-        <translation type="vanished">OPSLAAN</translation>
+        <translation>OPSLAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
         <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wilt u uw wijzigingen opslaan?</translation>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
         <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Opslaan niet mogelijk, niet alle verplichte velden zijn ingevuld!</translation>
+        <translation>Opslaan niet mogelijk, niet alle verplichte velden zijn ingevuld!</translation>
     </message>
     <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
         <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy niet gevonden, toch opslaan?</translation>
+        <translation>Proxy niet gevonden, toch opslaan?</translation>
     </message>
 </context>
 <context>
     <name>KDC::ResourcesManagerDialog</name>
     <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
         <source>Resources Manager</source>
-        <translation type="vanished">Resources Beheer</translation>
+        <translation>Resources Beheer</translation>
     </message>
     <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
         <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Maximaal toegestaan CPU-gebruik</translation>
+        <translation>Maximaal toegestaan CPU-gebruik</translation>
     </message>
     <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
         <source>SAVE</source>
-        <translation type="vanished">OPSLAAN</translation>
+        <translation>OPSLAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
     <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
         <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Wilt u uw wijzigingen opslaan?</translation>
+        <translation>Wilt u uw wijzigingen opslaan?</translation>
     </message>
 </context>
 <context>
     <name>KDC::ServerBaseFolderDialog</name>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
         <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Selecteer een map op uw kDrive</translation>
+        <translation>Selecteer een map op uw kDrive</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
         <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">De inhoud van de geselecteerde map wordt gesynchroniseerd naar de map &lt;b&gt;%1&lt;/b&gt;.</translation>
+        <translation>De inhoud van de geselecteerde map wordt gesynchroniseerd naar de map &lt;b&gt;%1&lt;/b&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
         <source>CONTINUE</source>
-        <translation type="vanished">DOORGAAN</translation>
+        <translation>DOORGAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
         <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Beschikbare ruimte op uw computer voor de huidige map: %1</translation>
+        <translation>Beschikbare ruimte op uw computer voor de huidige map: %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
         <source>This folder is already being synced.</source>
-        <translation type="vanished">Deze map wordt al gesynchroniseerd.</translation>
+        <translation>Deze map wordt al gesynchroniseerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
         <source>CONFIRM</source>
-        <translation type="vanished">BEVESTIGEN</translation>
+        <translation>BEVESTIGEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
         <source>CANCEL</source>
-        <translation type="vanished">ANNULEREN</translation>
+        <translation>ANNULEREN</translation>
     </message>
 </context>
 <context>
     <name>KDC::ServerFoldersDialog</name>
     <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
         <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">De map &lt;b&gt;%1&lt;/b&gt; bevat submappen,&lt;br&gt; selecteer degene die u wilt synchroniseren</translation>
+        <translation>De map &lt;b&gt;%1&lt;/b&gt; bevat submappen,&lt;br&gt; selecteer degene die u wilt synchroniseren</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
         <source>CONTINUE</source>
-        <translation type="vanished">DOORGAAN</translation>
+        <translation>DOORGAAN</translation>
     </message>
     <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
         <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Geen submappen op de server.</translation>
+        <translation>Geen submappen op de server.</translation>
     </message>
 </context>
 <context>
     <name>KDC::StatusBarWidget</name>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
         <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Hervat kDrive &quot;%1&quot; synchronisatie</translation>
+        <translation>Hervat kDrive &quot;%1&quot; synchronisatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
         <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Hervat alle kDrives synchronisatie</translation>
+        <translation>Hervat alle kDrives synchronisatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
         <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Pauzeer kDrive &quot;%1&quot; synchronisatie</translation>
+        <translation>Pauzeer kDrive &quot;%1&quot; synchronisatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
         <source>Pause synchronization</source>
-        <translation type="vanished">Synchronisatie pauzeren</translation>
+        <translation>Synchronisatie pauzeren</translation>
     </message>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
         <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Pauzeer alle kDrives synchronisatie</translation>
+        <translation>Pauzeer alle kDrives synchronisatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
         <source>Resume synchronization</source>
-        <translation type="vanished">Synchronisatie hervatten</translation>
+        <translation>Synchronisatie hervatten</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynchronizedItemWidget</name>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
         <source>Copy share link</source>
-        <translation type="vanished">Deellink kopiëren</translation>
+        <translation>Deellink kopiëren</translation>
     </message>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
         <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Weergeven op kdrive.infomaniak.com</translation>
+        <translation>Weergeven op kdrive.infomaniak.com</translation>
     </message>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
         <source>Show in folder</source>
-        <translation type="vanished">Tonen in map</translation>
+        <translation>Tonen in map</translation>
     </message>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
         <source>More actions</source>
-        <translation type="vanished">Meer acties</translation>
+        <translation>Meer acties</translation>
     </message>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
         <source>Open</source>
-        <translation type="vanished">Openen</translation>
+        <translation>Openen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
         <source>Add to favorites</source>
-        <translation type="vanished">Toevoegen aan favorieten</translation>
+        <translation>Toevoegen aan favorieten</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisBar</name>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
         <source>Never</source>
-        <translation type="vanished">Nooit</translation>
+        <translation>Nooit</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
         <source>During 1 hour</source>
-        <translation type="vanished">Gedurende 1 uur</translation>
+        <translation>Gedurende 1 uur</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
         <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Tot morgen 08:00</translation>
+        <translation>Tot morgen 08:00</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
         <source>During 3 days</source>
-        <translation type="vanished">Gedurende 3 dagen</translation>
+        <translation>Gedurende 3 dagen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
         <source>During 1 week</source>
-        <translation type="vanished">Gedurende 1 week</translation>
+        <translation>Gedurende 1 week</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
         <source>Always</source>
-        <translation type="vanished">Altijd</translation>
+        <translation>Altijd</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
         <source>For 1 more hour</source>
-        <translation type="vanished">Voor 1 uur extra</translation>
+        <translation>Voor 1 uur extra</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
         <source>For 3 more days</source>
-        <translation type="vanished">Voor 3 dagen extra</translation>
+        <translation>Voor 3 dagen extra</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
         <source>For 1 more week</source>
-        <translation type="vanished">Voor 1 week extra</translation>
+        <translation>Voor 1 week extra</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
         <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kan map-URL %1 niet openen.</translation>
+        <translation>Kan map-URL %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
         <source>Open in folder</source>
-        <translation type="vanished">Openen in map</translation>
+        <translation>Openen in map</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
         <source>Open %1 web version</source>
-        <translation type="vanished">Open %1 webversie</translation>
+        <translation>Open %1 webversie</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
         <source>Drive parameters</source>
-        <translation type="vanished">Drive-instellingen</translation>
+        <translation>Drive-instellingen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
         <source>Notifications disabled until %1</source>
-        <translation type="vanished">Meldingen uitgeschakeld tot %1</translation>
+        <translation>Meldingen uitgeschakeld tot %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
         <source>Disable Notifications</source>
-        <translation type="vanished">Meldingen uitschakelen</translation>
+        <translation>Meldingen uitschakelen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
         <source>Application preferences</source>
-        <translation type="vanished">Applicatievoorkeuren</translation>
+        <translation>Applicatievoorkeuren</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
         <source>Need help</source>
-        <translation type="vanished">Hulp nodig</translation>
+        <translation>Hulp nodig</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
         <source>Send feedbacks</source>
-        <translation type="vanished">Feedback sturen</translation>
+        <translation>Feedback sturen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
         <source>Quit kDrive</source>
-        <translation type="vanished">kDrive afsluiten</translation>
+        <translation>kDrive afsluiten</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
         <source>Unable to access web site %1.</source>
-        <translation type="vanished">Kan geen toegang krijgen tot website %1.</translation>
+        <translation>Kan geen toegang krijgen tot website %1.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
         <source>Show errors and informations</source>
-        <translation type="vanished">Fouten en informatie tonen</translation>
+        <translation>Fouten en informatie tonen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
         <source>Show informations</source>
-        <translation type="vanished">Informatie tonen</translation>
+        <translation>Informatie tonen</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
         <source>More actions</source>
-        <translation type="vanished">Meer acties</translation>
+        <translation>Meer acties</translation>
     </message>
 </context>
 <context>
     <name>KDC::SynthesisPopover</name>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
         <source>Update kDrive App</source>
-        <translation type="vanished">kDrive App bijwerken</translation>
+        <translation>kDrive App bijwerken</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
         <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Deze versie van de kDrive-app wordt niet meer ondersteund. Update om toegang te krijgen tot de nieuwste functies en verbeteringen.</translation>
+        <translation>Deze versie van de kDrive-app wordt niet meer ondersteund. Update om toegang te krijgen tot de nieuwste functies en verbeteringen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
         <source>Update</source>
-        <translation type="vanished">Bijwerken</translation>
+        <translation>Bijwerken</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
         <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Download de nieuwste versie op de website.</translation>
+        <translation>Download de nieuwste versie op de website.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
         <source>Update download in progress</source>
-        <translation type="vanished">Update-download bezig</translation>
+        <translation>Update-download bezig</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
         <source>Looking for update...</source>
-        <translation type="vanished">Zoeken naar update...</translation>
+        <translation>Zoeken naar update...</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
         <source>Manual update</source>
-        <translation type="vanished">Handmatige update</translation>
+        <translation>Handmatige update</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
         <source>Unavailable</source>
-        <translation type="vanished">Niet beschikbaar</translation>
+        <translation>Niet beschikbaar</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
         <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">U kunt bestanden synchroniseren &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;vanaf uw computer&lt;/a&gt; of op &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+        <translation>U kunt bestanden synchroniseren &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;vanaf uw computer&lt;/a&gt; of op &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
         <source>Synchronized</source>
-        <translation type="vanished">Gesynchroniseerd</translation>
+        <translation>Gesynchroniseerd</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
         <source>Favorites</source>
-        <translation type="vanished">Favorieten</translation>
+        <translation>Favorieten</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
         <source>Activity</source>
-        <translation type="vanished">Activiteit</translation>
+        <translation>Activiteit</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
         <source>Not implemented!</source>
-        <translation type="vanished">Niet geïmplementeerd!</translation>
+        <translation>Niet geïmplementeerd!</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
         <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klik hier om handmatig te downloaden&lt;/a&gt;</translation>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klik hier om handmatig te downloaden&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
         <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Geen gesynchroniseerde map voor deze Drive!</translation>
+        <translation>Geen gesynchroniseerde map voor deze Drive!</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
         <source>No kDrive configured!</source>
-        <translation type="vanished">Geen kDrive geconfigureerd!</translation>
+        <translation>Geen kDrive geconfigureerd!</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
         <source>Unable to open link %1.</source>
-        <translation type="vanished">Kan link %1 niet openen.</translation>
+        <translation>Kan link %1 niet openen.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
         <source>Invalid link %1.</source>
-        <translation type="vanished">Ongeldige link %1.</translation>
+        <translation>Ongeldige link %1.</translation>
     </message>
     <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
         <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Kan map-URL %1 niet openen.</translation>
+        <translation>Kan map-URL %1 niet openen.</translation>
     </message>
 </context>
 <context>
     <name>KDC::UpdateDialog</name>
     <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
         <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;De nieuwe versie &lt;b&gt;%1&lt;/b&gt; van de %2 Client is beschikbaar en is gedownload.&lt;/p&gt;&lt;p&gt;De geïnstalleerde versie is %3.&lt;/p&gt;</translation>
+        <translation>&lt;p&gt;De nieuwe versie &lt;b&gt;%1&lt;/b&gt; van de %2 Client is beschikbaar en is gedownload.&lt;/p&gt;&lt;p&gt;De geïnstalleerde versie is %3.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
         <source>Skip this version</source>
-        <translation type="vanished">Deze versie overslaan</translation>
+        <translation>Deze versie overslaan</translation>
     </message>
     <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
         <source>Remind me later</source>
-        <translation type="vanished">Herinner me later</translation>
+        <translation>Herinner me later</translation>
     </message>
     <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
         <source>Install update</source>
-        <translation type="vanished">Update installeren</translation>
+        <translation>Update installeren</translation>
     </message>
 </context>
 <context>
     <name>KDC::UpdateManager</name>
     <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
         <source>New update available.</source>
-        <translation type="vanished">Nieuwe update beschikbaar.</translation>
+        <translation>Nieuwe update beschikbaar.</translation>
     </message>
     <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
         <source>Version %1 is available for download.</source>
-        <translation type="vanished">Versie %1 is beschikbaar om te downloaden.</translation>
+        <translation>Versie %1 is beschikbaar om te downloaden.</translation>
     </message>
 </context>
 <context>
     <name>KDC::UserSelectionWidget</name>
     <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
         <source>Add an account</source>
-        <translation type="vanished">Een account toevoegen</translation>
+        <translation>Een account toevoegen</translation>
     </message>
 </context>
 <context>
     <name>KDC::VersionWidget</name>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Release-opmerking tonen&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Release-opmerking tonen&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
         <source>Version</source>
-        <translation type="vanished">Versie</translation>
+        <translation>Versie</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
         <source>UPDATE</source>
-        <translation type="vanished">BIJWERKEN</translation>
+        <translation>BIJWERKEN</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
         <source>%1 is up to date!</source>
-        <translation type="vanished">%1 is up-to-date!</translation>
+        <translation>%1 is up-to-date!</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
         <source>Checking update on server...</source>
-        <translation type="vanished">Controleren op update op server...</translation>
+        <translation>Controleren op update op server...</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
         <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Een update is beschikbaar: %1.&lt;br&gt;Download het van &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt;.</translation>
+        <translation>Een update is beschikbaar: %1.&lt;br&gt;Download het van &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;hier&lt;/a&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
         <source>An update is available: %1</source>
-        <translation type="vanished">Een update is beschikbaar: %1</translation>
+        <translation>Een update is beschikbaar: %1</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
         <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">%1 downloaden. Even geduld...</translation>
+        <translation>%1 downloaden. Even geduld...</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
         <source>Could not check for new updates.</source>
-        <translation type="vanished">Kon niet controleren op nieuwe updates.</translation>
+        <translation>Kon niet controleren op nieuwe updates.</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
         <source>An error occurred during update.</source>
-        <translation type="vanished">Er is een fout opgetreden tijdens de update.</translation>
+        <translation>Er is een fout opgetreden tijdens de update.</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
         <source>Could not download update.</source>
-        <translation type="vanished">Kon update niet downloaden.</translation>
+        <translation>Kon update niet downloaden.</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
         <source>Update disabled.</source>
-        <translation type="vanished">Update uitgeschakeld.</translation>
+        <translation>Update uitgeschakeld.</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
         <source>Beta program</source>
-        <translation type="vanished">Bètaprogramma</translation>
+        <translation>Bètaprogramma</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
         <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Krijg vroeg toegang tot nieuwe versies van de applicatie</translation>
+        <translation>Krijg vroeg toegang tot nieuwe versies van de applicatie</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
         <source>Join</source>
-        <translation type="vanished">Deelnemen</translation>
+        <translation>Deelnemen</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
         <source>Modify</source>
-        <translation type="vanished">Wijzigen</translation>
+        <translation>Wijzigen</translation>
     </message>
     <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
         <source>Quit</source>
-        <translation type="vanished">Verlaten</translation>
+        <translation>Verlaten</translation>
     </message>
 </context>
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
         <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Kan parameters niet opslaan, probeer het later opnieuw.</translation>
+        <translation>Kan parameters niet opslaan, probeer het later opnieuw.</translation>
     </message>
     <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
         <source>Unable to save parameters!</source>
-        <translation type="vanished">Kan parameters niet opslaan!</translation>
+        <translation>Kan parameters niet opslaan!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
         <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">De bovenliggende map is een synchronisatiemap of zit erin</translation>
+        <translation>De bovenliggende map is een synchronisatiemap of zit erin</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
         <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Kan geen geldig pad vinden</translation>
+        <translation>Kan geen geldig pad vinden</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
         <source>No valid folder selected!</source>
-        <translation type="vanished">Geen geldige map geselecteerd!</translation>
+        <translation>Geen geldige map geselecteerd!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
         <source>The selected path does not exist!</source>
-        <translation type="vanished">Het geselecteerde pad bestaat niet!</translation>
+        <translation>Het geselecteerde pad bestaat niet!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
         <source>The selected path is not a folder!</source>
-        <translation type="vanished">Het geselecteerde pad is geen map!</translation>
+        <translation>Het geselecteerde pad is geen map!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
         <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">U heeft geen schrijfrechten voor de geselecteerde map!</translation>
+        <translation>U heeft geen schrijfrechten voor de geselecteerde map!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
         <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">De lokale map %1 bevat een map die al gesynchroniseerd is. Kies een andere!</translation>
+        <translation>De lokale map %1 bevat een map die al gesynchroniseerd is. Kies een andere!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
         <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">De lokale map %1 zit in een map die al gesynchroniseerd is. Kies een andere!</translation>
+        <translation>De lokale map %1 zit in een map die al gesynchroniseerd is. Kies een andere!</translation>
     </message>
     <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
         <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">De lokale map %1 is al gesynchroniseerd. Kies een andere!</translation>
+        <translation>De lokale map %1 is al gesynchroniseerd. Kies een andere!</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
         <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync (Beta) is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
+        <translation>Lite sync (Beta) is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
         <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync (Beta) is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
+        <translation>Lite sync (Beta) is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
         <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
+        <translation>Lite sync is ingeschakeld. Bestanden van kDrive blijven in de Cloud en gebruiken geen opslagruimte op uw computer.</translation>
     </message>
     <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
         <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
+        <translation>Lite sync is uitgeschakeld. De kDrive-bestanden gebruiken de opslagruimte van uw computer.</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
         <source>Make available locally</source>
-        <translation type="vanished">Lokaal beschikbaar maken</translation>
+        <translation>Lokaal beschikbaar maken</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
         <source>Free up local space</source>
-        <translation type="vanished">Lokale ruimte vrijmaken</translation>
+        <translation>Lokale ruimte vrijmaken</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
         <source>Cancel free up local space</source>
-        <translation type="vanished">Annuleer lokale ruimte vrijmaken</translation>
+        <translation>Annuleer lokale ruimte vrijmaken</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
         <source>Cancel make available locally</source>
-        <translation type="vanished">Annuleer lokaal beschikbaar maken</translation>
+        <translation>Annuleer lokaal beschikbaar maken</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
         <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Opnieuw delen van dit bestand is niet toegestaan</translation>
+        <translation>Opnieuw delen van dit bestand is niet toegestaan</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
         <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Opnieuw delen van deze map is niet toegestaan</translation>
+        <translation>Opnieuw delen van deze map is niet toegestaan</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
         <source>Copy public share link</source>
-        <translation type="vanished">Openbare deellink kopiëren</translation>
+        <translation>Openbare deellink kopiëren</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
         <source>Copy private share link</source>
-        <translation type="vanished">Privé deellink kopiëren</translation>
+        <translation>Privé deellink kopiëren</translation>
     </message>
     <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
         <source>Open in browser</source>
-        <translation type="vanished">Openen in browser</translation>
+        <translation>Openen in browser</translation>
     </message>
 </context>
 <context>
     <name>SharedTools::QtSingleApplication</name>
     <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
         <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">kDrive-applicatie wordt afgesloten vanwege een fatale fout.</translation>
+        <translation>kDrive-applicatie wordt afgesloten vanwege een fatale fout.</translation>
     </message>
 </context>
 <context>
     <name>Utility</name>
     <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
         <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
+        <translation>%L1 GB</translation>
     </message>
     <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
         <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
+        <translation>%L1 MB</translation>
     </message>
     <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
         <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
+        <translation>%L1 KB</translation>
     </message>
     <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
         <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
+        <translation>%L1 B</translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
         <source>%n year(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n jaar</numerusform>
             <numerusform>%n jaar</numerusform>
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
         <source>%n month(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n maand</numerusform>
             <numerusform>%n maanden</numerusform>
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
         <source>%n day(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n dag</numerusform>
             <numerusform>%n dagen</numerusform>
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
         <source>%n hour(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n uur</numerusform>
             <numerusform>%n uur</numerusform>
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
         <source>%n minute(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n minuut</numerusform>
             <numerusform>%n minuten</numerusform>
         </translation>
     </message>
     <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
         <source>%n second(s)</source>
-        <translation type="vanished">
+        <translation>
             <numerusform>%n seconde</numerusform>
             <numerusform>%n seconden</numerusform>
         </translation>
@@ -2471,110 +2961,135 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
 <context>
     <name>main.cpp</name>
     <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
         <source>System Tray not available</source>
-        <translation type="vanished">Systeemvak niet beschikbaar</translation>
+        <translation>Systeemvak niet beschikbaar</translation>
     </message>
     <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
         <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 vereist een werkend systeemvak. Als u XFCE gebruikt, volg dan &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;deze instructies&lt;/a&gt;. Installeer anders een systeemvak-toepassing zoals &apos;trayer&apos; en probeer het opnieuw.</translation>
+        <translation>%1 vereist een werkend systeemvak. Als u XFCE gebruikt, volg dan &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;deze instructies&lt;/a&gt;. Installeer anders een systeemvak-toepassing zoals &apos;trayer&apos; en probeer het opnieuw.</translation>
     </message>
 </context>
 <context>
     <name>utility</name>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
         <source>Could not open browser</source>
-        <translation type="vanished">Kon browser niet openen</translation>
+        <translation>Kon browser niet openen</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
         <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Er trad een fout op bij het starten van de browser om naar URL %1 te gaan. Misschien is er geen standaardbrowser geconfigureerd?</translation>
+        <translation>Er trad een fout op bij het starten van de browser om naar URL %1 te gaan. Misschien is er geen standaardbrowser geconfigureerd?</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
         <source>Could not open email client</source>
-        <translation type="vanished">Kon e-mailclient niet openen</translation>
+        <translation>Kon e-mailclient niet openen</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
         <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Er trad een fout op bij het starten van de e-mailclient om een nieuw bericht te maken. Misschien is er geen standaard e-mailclient geconfigureerd?</translation>
+        <translation>Er trad een fout op bij het starten van de e-mailclient om een nieuw bericht te maken. Misschien is er geen standaard e-mailclient geconfigureerd?</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
         <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">U bent niet meer verbonden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inloggen&lt;/a&gt;</translation>
+        <translation>U bent niet meer verbonden. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inloggen&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
         <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synchronisatie bezig (Stap %1/%2).</translation>
+        <translation>Synchronisatie bezig (Stap %1/%2).</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
         <source>Sync in progress.</source>
-        <translation type="vanished">Synchronisatie bezig.</translation>
+        <translation>Synchronisatie bezig.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
         <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Sommige bestanden konden niet worden gesynchroniseerd. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>Sommige bestanden konden niet worden gesynchroniseerd. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
         <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synchronisatie wordt gepauzeerd...</translation>
+        <translation>Synchronisatie wordt gepauzeerd...</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat een andere synchronisatie dezelfde map gebruikt.</translation>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat een andere synchronisatie dezelfde map gebruikt.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt; bevat.</translation>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt; bevat.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze bevat is in de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt;.</translation>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd omdat deze bevat is in de gesynchroniseerde map &lt;b&gt;%2&lt;/b&gt;.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map.</translation>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
         <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map. Voorgestelde map: &lt;b&gt;%2&lt;/b&gt;</translation>
+        <translation>Map &lt;b&gt;%1&lt;/b&gt; kan niet worden geselecteerd als synchronisatiemap. Selecteer een andere map. Voorgestelde map: &lt;b&gt;%2&lt;/b&gt;</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
         <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">U heeft meer dan %1 mappen uitgesloten, houd er rekening mee dat dit de synchronisatieprestaties beïnvloedt.</translation>
+        <translation>U heeft meer dan %1 mappen uitgesloten, houd er rekening mee dat dit de synchronisatieprestaties beïnvloedt.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
         <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">U kunt niet meer dan %1 mappen uitsluiten. Vink mappen op een hoger niveau uit.</translation>
+        <translation>U kunt niet meer dan %1 mappen uitsluiten. Vink mappen op een hoger niveau uit.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
         <source>Synchronization starting</source>
-        <translation type="vanished">Synchronisatie start</translation>
+        <translation>Synchronisatie start</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
         <source>Synchronization paused.</source>
-        <translation type="vanished">Synchronisatie gepauzeerd.</translation>
+        <translation>Synchronisatie gepauzeerd.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
         <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synchronisatie bezig (%1 van %2)</translation>
+        <translation>Synchronisatie bezig (%1 van %2)</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
         <source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synchronisatie bezig (%1 van %2)
+        <translation>Synchronisatie bezig (%1 van %2)
 %3 resterend...</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
         <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">U bent up-to-date, niet-opgeloste conflicten.</translation>
+        <translation>U bent up-to-date, niet-opgeloste conflicten.</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
         <source>You are up to date!</source>
-        <translation type="vanished">U bent up-to-date!</translation>
+        <translation>U bent up-to-date!</translation>
     </message>
     <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
         <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Geen map om te synchroniseren
+        <translation>Geen map om te synchroniseren
 U kunt er een toevoegen via de kDrive-instellingen.</translation>
     </message>
 </context>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -1316,7 +1316,7 @@ Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&g
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
         <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -567,7 +567,7 @@ Selecteer een andere map. Als u doorgaat, wordt Lite Sync uitgeschakeld.&lt;br&g
     <message>
         <location filename="../src/gui/clientgui.cpp" line="850"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Kan debugmap %1 niet openen.</translation>
+        <translation>Kan mappad %1 niet openen.</translation>
     </message>
     <message>
         <location filename="../src/gui/clientgui.cpp" line="117"/>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -46,7 +46,7 @@
     <message>
         <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
         <source>Unable to open folder path %1.</source>
-        <translation>Kan debugmap %1 niet openen.</translation>
+        <translation>Kan mappad %1 niet openen.</translation>
     </message>
 </context>
 <context>

--- a/translations/client_nl.ts
+++ b/translations/client_nl.ts
@@ -2128,7 +2128,7 @@ Gebruik de volgende link om de logs naar de ondersteuning te sturen: &lt;a style
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
         <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Meer informatie&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../src/gui/preferenceswidget.cpp" line="500"/>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -1,3108 +1,3108 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="pl_PL" version="2.1">
+<TS version="2.1" language="pl_PL">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Informacje</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>ZAMKNIJ</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Dystrybucja: %1; na licencji &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Nie można otworzyć folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style="color: #489EF3" href="%1"&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>ZAMKNIJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Dystrybucja: %1; na licencji &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Nie można otworzyć ścieżki folderu %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Twój kDrive jest gotowy!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>OTWÓRZ FOLDER</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>USTAWIENIA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Zsynchronizuj inny dysk</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Twój kDrive jest gotowy!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>OTWÓRZ FOLDER</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>USTAWIENIA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Zsynchronizuj inny dysk</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Anuluj</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>DALEJ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Pobierz kDrive za darmo</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Wypróbuj za darmo</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>DALEJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Pobierz kDrive za darmo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Wypróbuj za darmo</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Oszczędzaj miejsce na komputerze</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>PÓŹNIEJ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>TAK</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Oszczędzaj miejsce na komputerze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>PÓŹNIEJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>TAK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Lokalizacja dysku %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Edytuj folder</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>ZAKOŃCZ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Wybierz folder</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Lokalizacja dysku %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Edytuj folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>ZAKOŃCZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
 Wybierz inny folder. Jeśli kontynuujesz, funkcja Lite Sync zostanie wyłączona.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>KONTYNUUJ</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Zaloguj się w przeglądarce</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Otwórz stronę logowania</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Wystąpił błąd podczas uwierzytelniania. Zamknij okno logowania i spróbuj ponownie.&lt;br&gt;Jeśli błąd będzie się powtarzał, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Nie udało się zalogować: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Zaloguj się w przeglądarce</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Otwórz stronę logowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Wystąpił błąd podczas uwierzytelniania. Zamknij okno logowania i spróbuj ponownie.&lt;br&gt;Jeśli błąd będzie się powtarzał, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Nie udało się zalogować: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>KONTYNUUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Wolne miejsce na komputerze: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Wolne miejsce na komputerze: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Nie udało się utworzyć folderu lokalnego %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Nie udało się utworzyć nowej synchronizacji</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Nie udało się utworzyć folderu lokalnego %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Nie udało się utworzyć nowej synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>Klient kDrive już działa!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>Klient kDrive już działa!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Link do udostępnienia skopiowano do schowka</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
-<numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 został usunięty.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
-<numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>Dodano %1.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
-<numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 zostało zaktualizowane.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
-<numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 zostało przeniesione do %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synchronizacja działań</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Link do udostępnienia skopiowano do schowka</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 został usunięty.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>Dodano %1.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
+            <numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 zostało zaktualizowane.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
+            <numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 zostało przeniesione do %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synchronizacja działań</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Wyjdź z programu beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Dołącz do programu beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Nie</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Publiczna wersja beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Wewnętrzna wersja beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Wersja testowa</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Rozumiem</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Czy na pewno chcesz opuścić program beta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Zapisz</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Anuluj</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Wyjdź z programu beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Dołącz do programu beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Nie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Publiczna wersja beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Wewnętrzna wersja beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Wersja testowa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Rozumiem</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Czy na pewno chcesz opuścić program beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Zapisz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Zaloguj się</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Folder %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Podsumowanie</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translatorcomment>Préférences</translatorcomment>
-<translation>Preferencje</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Zakończ</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Stan nieokreślony.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synchronizacja trwa.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Anulowanie przez użytkownika.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synchronizacja została wstrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synchronizacja została wstrzymana)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 elementów zostało usuniętych z lokalnego folderu synchronizacji &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Aby uniknąć niezamierzonych usunięć, synchronizacja została wstrzymana.&lt;br&gt;Czy chcesz przenieść te usunięcia do swojego kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Kilka plików zostało usuniętych z lokalnego folderu synchronizacji &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Usunięte pliki można znaleźć w &lt;a style="%1" href="%3"&gt;koszu&lt;/a&gt; kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Nie pokazuj ponownie</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Nie udało się uruchomić synchronizacji!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Nie można otworzyć ścieżki folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Nie można zainicjować klienta kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synchronizacja została wstrzymana</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Zaloguj się</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Folder %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Podsumowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Preferencje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Zakończ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Stan nieokreślony.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synchronizacja trwa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Anulowanie przez użytkownika.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synchronizacja została wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synchronizacja została wstrzymana)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 elementów zostało usuniętych z lokalnego folderu synchronizacji &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Aby uniknąć niezamierzonych usunięć, synchronizacja została wstrzymana.&lt;br&gt;Czy chcesz przenieść te usunięcia do swojego kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Kilka plików zostało usuniętych z lokalnego folderu synchronizacji &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Usunięte pliki można znaleźć w &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;koszu&lt;/a&gt; kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Nie pokazuj ponownie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Nie udało się uruchomić synchronizacji!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Nie można zainicjować klienta kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synchronizacja została wstrzymana</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Podsumowanie synchronizacji folderów lokalnych</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNCHRONIZUJ</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Podsumowanie synchronizacji folderów lokalnych</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNCHRONIZUJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Zanim skończymy</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Zezwól aplikacji kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Odblokuj kłódkę &lt;img src=":/client/resources/icons/actions/lock.png"&gt; i autoryzuj aplikację kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>KROK 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Gotowe)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>KROK 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>WYKONANE CZYNNOŚCI</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>ZAKOŃCZ</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Zanim skończymy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Zezwól aplikacji kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Odblokuj kłódkę &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; i autoryzuj aplikację kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>KROK 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Gotowe)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>KROK 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>WYKONANE CZYNNOŚCI</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>ZAKOŃCZ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>TAK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NIE</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>TAK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NIE</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Wysyłanie informacji dotyczących debugowania</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Anuluj</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Wysyłanie informacji dotyczących debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Informacje</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Debugowanie</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Ostrzeżenie</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Błąd</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Śmiertelny</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Ustawienia debugowania</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Poziom debugowania</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Rozszerzony pełny dziennik</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Usuń logi starsze niż %1 dni</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Udostępnij tylko ostatnią sesję kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Ładowanie</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Anuluj</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>ZAPISZ</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Nie udało się udostępnić</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Przerwano połączenie)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Automatycznie skompresowaliśmy &lt;a style="%1" href="%2"&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Prześlij link na adres&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Ostatnie przesłanie: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Udostępnianie zostało anulowane</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Rozszerzony pełny dziennik jest aktywowany przez zmienną środowiskową KDRIVE_FORCE_EXTENDED_LOG. Ustaw ją na 0, aby ją wyłączyć.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Nie można otworzyć folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Udostępnij</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Udostępnianie | krok 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Udostępnianie | krok 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Anulowanie...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Debugowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Ostrzeżenie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Śmiertelny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Ustawienia debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Poziom debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Rozszerzony pełny dziennik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Usuń logi starsze niż %1 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Udostępnij tylko ostatnią sesję kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Ładowanie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Nie udało się udostępnić</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Przerwano połączenie)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Automatycznie skompresowaliśmy &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Prześlij link na adres&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Ostatnie przesłanie: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Udostępnianie zostało anulowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Rozszerzony pełny dziennik jest aktywowany przez zmienną środowiskową KDRIVE_FORCE_EXTENDED_LOG. Ustaw ją na 0, aby ją wyłączyć.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Udostępnij</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Udostępnianie | krok 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Udostępnianie | krok 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Anulowanie...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Foldery</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Powiadomienia</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Związane z</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Włącz powiadomienia dla tego kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>POTWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Błędy synchronizacji i informacje.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Zsynchronizuj folder lokalny</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Nie udało się utworzyć nowej synchronizacji</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Włączono funkcję Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Funkcja Lite Sync została wyłączona.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Ten dysk jest właśnie usuwany.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Nie można otworzyć elementu %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Usuń wszystkie synchronizacje</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Wyszukaj w swoim kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Wyszukaj</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Foldery</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Powiadomienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Związane z</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Włącz powiadomienia dla tego kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>POTWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Błędy synchronizacji i informacje.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Zsynchronizuj folder lokalny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Nie udało się utworzyć nowej synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Włączono funkcję Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Funkcja Lite Sync została wyłączona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Ten dysk jest właśnie usuwany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Nie można otworzyć elementu %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Usuń wszystkie synchronizacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Wyszukaj w swoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Wyszukaj</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Zsynchronizuj kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Dodaj kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Zsynchronizuj kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Dodaj kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Rozwiązać</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Elementy powodujące konflikt</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Elementy zawierające znaki nieobsługiwane</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Wyczyść historię</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Aby rozwiązać</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Rozwiązano automatycznie</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>rozwiązane problemy</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>wykryto problem(y)</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Rozwiązać</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elementy powodujące konflikt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Elementy zawierające znaki nieobsługiwane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Wyczyść historię</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Aby rozwiązać</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Rozwiązano automatycznie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>rozwiązane problemy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>wykryto problem(y)</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Konflikty lub błędy synchronizacji</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Błędy</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Powrót do ustawień</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Konflikty lub błędy synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Błędy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Powrót do ustawień</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 błąd(ów))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 informacja(i))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 błąd(ów) i %2 informacja(i))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
-<numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
-<numerusform/>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 błąd(ów))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informacja(i))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 błąd(ów) i %2 informacja(i))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
+            <numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Pliki wykluczone</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Dodaj</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>IMIĘ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>OSTRZEŻENIE</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>ZAPISZ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Szablon wykluczenia już istnieje!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Czy na pewno chcesz usunąć?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Nie można zapisać zmian!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Pliki wykluczone</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>IMIĘ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>OSTRZEŻENIE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Szablon wykluczenia już istnieje!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Czy na pewno chcesz usunąć?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Nie można zapisać zmian!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>ZATWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Rozwiązywanie konfliktów</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Pokaż produkty</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>ZATWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Rozwiązywanie konfliktów</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Pokaż produkty</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Więcej działań</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Zsynchronizowano do &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Włącz Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Włącz Lite Sync (wersja beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Anuluj</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>ZATWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Wstrzymaj synchronizację</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Wyłącz Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Wznowienie synchronizacji</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Wyłącz synchronizację</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Zsynchronizowano do &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Włącz Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Włącz Lite Sync (wersja beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Anuluj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Wstrzymaj synchronizację</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Wyłącz Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Wznowienie synchronizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Wyłącz synchronizację</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Nie można otworzyć ścieżki folderu %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Identyfikator aplikacji</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Nazwa aplikacji</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>ZATWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Identyfikator aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nazwa aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>ZATWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Dodaj</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ID WNIOSKU</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>IMIĘ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>ZAPISZ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Czy na pewno chcesz usunąć?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Nie można zapisać zmian!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Dodaj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID WNIOSKU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>IMIĘ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Czy na pewno chcesz usunąć?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Nie można zapisać zmian!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Wybierz folder</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Edytuj folder</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>KONTYNUUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Edytuj folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
 Wybierz inny folder. Jeśli kontynuujesz, aplikacja Lite Sync zostanie wyłączona.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Wybierz folder</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Wybierz folder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Błąd</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Błąd</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Preferencje</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Pomoc</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferencje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Pomoc</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Nie można otworzyć ścieżki folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>Nie skonfigurowano programu kDrive!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Przesyłanie nie powiodło się!
-Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Nie masz uprawnień do tworzenia elementu lub istnieje już inny element o tej samej nazwie. Element został zignorowany.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Nie można utworzyć pliku „%1”, ponieważ nie jest on obsługiwany w Twoim systemie plików.&lt;br&gt;Został on wykluczony z synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Nie można pobrać pliku.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Błąd synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Błąd systemu.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>Nie skonfigurowano programu kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Przesyłanie nie powiodło się!
+Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Nie masz uprawnień do tworzenia elementu lub istnieje już inny element o tej samej nazwie. Element został zignorowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Nie można utworzyć pliku „%1”, ponieważ nie jest on obsługiwany w Twoim systemie plików.&lt;br&gt;Został on wykluczony z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Nie można pobrać pliku.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Błąd synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Błąd systemu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Ta synchronizacja zostanie usunięta.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Ta synchronizacja zostanie usunięta.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Powrót do listy dysków</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Preferencje</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Powrót do listy dysków</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferencje</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Ogólne</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Włącz ciemny motyw</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Włącz monochromatyczne ikony</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Uruchamiaj kDrive przy starcie systemu</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Fiński</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Duński</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Grecki</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Niderlandzki</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Zaawansowane</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Informacje debugowania</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Pliki do wykluczenia</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Serwer proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Szwedzki</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugalski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norweski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Nie można otworzyć folderu %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Nieprawidłowy link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Język</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Nie udało się uruchomić jakiegoś procesu.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Przenoś usunięte pliki do kosza na komputerze</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Angielski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Francuski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Niemiecki</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Hiszpański</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Włoski</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Domyślny</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Ogólne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Włącz ciemny motyw</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Włącz monochromatyczne ikony</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Uruchamiaj kDrive przy starcie systemu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Fiński</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Duński</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Grecki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Niderlandzki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Zaawansowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Informacje debugowania</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Pliki do wykluczenia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Serwer proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Szwedzki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugalski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norweski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Nie można otworzyć folderu %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Nieprawidłowy link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Język</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Nie udało się uruchomić jakiegoś procesu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Przenoś usunięte pliki do kosza na komputerze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Angielski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Francuski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Niemiecki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Hiszpański</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Włoski</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Domyślny</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 w użyciu</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 w użyciu</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>Serwer proxy HTTP(S)</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Serwer proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Brak serwera proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Użyj parametrów systemowych</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Wprowadź pełnomocnika ręcznie</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Port</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Adres serwera proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Wymagane uwierzytelnienie</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Użytkownik</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Hasło</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>ZAPISZ</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Serwer proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Serwer proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Brak serwera proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Użyj parametrów systemowych</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Wprowadź pełnomocnika ręcznie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Port</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Adres serwera proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Wymagane uwierzytelnienie</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Użytkownik</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Hasło</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Kierownik ds. zasobów</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Maksymalne dopuszczalne obciążenie procesora</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>ZAPISZ</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Kierownik ds. zasobów</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Maksymalne dopuszczalne obciążenie procesora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>ZAPISZ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Wybierz folder na swoim kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>KONTYNUUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Ten folder jest już synchronizowany.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>POTWIERDŹ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>ANULUJ</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Wybierz folder na swoim kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Ten folder jest już synchronizowany.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>POTWIERDŹ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>ANULUJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>KONTYNUUJ</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>KONTYNUUJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Wznowić synchronizację kDrive „%1”</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Wstrzymaj synchronizację kDrive „%1”</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Wstrzymaj synchronizację</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Wznowienie synchronizacji</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Wznowić synchronizację kDrive „%1”</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Wstrzymaj synchronizację kDrive „%1”</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Wstrzymaj synchronizację</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Wznowienie synchronizacji</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Skopiuj link do udostępnienia</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Pokaż w folderze</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Więcej działań</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Otwórz</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Dodaj do ulubionych</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Skopiuj link do udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Pokaż w folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Otwórz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Dodaj do ulubionych</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Nigdy</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>W ciągu godziny</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Do jutra do godziny 8:00 rano</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Przez 3 dni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>W ciągu tygodnia</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Zawsze</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Jeszcze przez 1 godzinę</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Jeszcze przez 3 dni</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Jeszcze przez 1 tydzień</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Nie można otworzyć folderu o adresie URL %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Otwórz w folderze</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Otwórz wersję internetową %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Parametry napędu</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Powiadomienia wyłączone do %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Wyłącz powiadomienia</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Ustawienia aplikacji</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Potrzebujesz pomocy?</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Prześlij opinię</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Zamknij kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Pokaż błędy i informacje</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Pokaż informacje</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Więcej działań</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nigdy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>W ciągu godziny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Do jutra do godziny 8:00 rano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Przez 3 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>W ciągu tygodnia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Zawsze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Jeszcze przez 1 godzinę</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Jeszcze przez 3 dni</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Jeszcze przez 1 tydzień</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Otwórz w folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Otwórz wersję internetową %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parametry napędu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Powiadomienia wyłączone do %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Wyłącz powiadomienia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Ustawienia aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Potrzebujesz pomocy?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Prześlij opinię</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Zamknij kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Pokaż błędy i informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Pokaż informacje</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Więcej działań</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Zaktualizuj aplikację kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Aktualizacja</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Trwa pobieranie aktualizacji</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Czekam na aktualizację...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Ręczna aktualizacja</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Niedostępne</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Możesz zsynchronizować pliki &lt;a style="%1" href="%2"&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Zsynchronizowane</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Ulubione</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Zajęcia</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Nie zaimplementowano!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>Nie skonfigurowano programu kDrive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Nie można otworzyć linku %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Nieprawidłowy link %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Nie można otworzyć folderu o adresie URL %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Zaktualizuj aplikację kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Aktualizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Trwa pobieranie aktualizacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Czekam na aktualizację...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Ręczna aktualizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Niedostępne</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Możesz zsynchronizować pliki &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Zsynchronizowane</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Ulubione</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Zajęcia</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Nie zaimplementowano!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>Nie skonfigurowano programu kDrive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Nie można otworzyć linku %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Nieprawidłowy link %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Pomiń tę wersję</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Przypomnij mi później</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Zainstaluj aktualizację</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Pomiń tę wersję</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Przypomnij mi później</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Zainstaluj aktualizację</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Dostępna jest nowa aktualizacja.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Wersja %1 jest dostępna do pobrania.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Dostępna jest nowa aktualizacja.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Wersja %1 jest dostępna do pobrania.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Dodaj konto</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Dodaj konto</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Wersja</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>AKTUALIZACJA</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 jest aktualne!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Sprawdzam aktualizacje na serwerze...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Dostępna jest aktualizacja: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Pobieranie %1. Proszę czekać...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Podczas aktualizacji wystąpił błąd.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Nie udało się pobrać aktualizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Funkcja aktualizacji została wyłączona.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Program beta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Dołącz</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Zmodyfikuj</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Zakończ</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Wersja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>AKTUALIZACJA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 jest aktualne!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Sprawdzam aktualizacje na serwerze...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Dostępna jest aktualizacja: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Pobieranie %1. Proszę czekać...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Podczas aktualizacji wystąpił błąd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Nie udało się pobrać aktualizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Funkcja aktualizacji została wyłączona.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Program beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Dołącz</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Zmodyfikuj</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Zakończ</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Nie można zapisać parametrów!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Nie można znaleźć prawidłowej ścieżki</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Nie wybrano żadnego prawidłowego folderu!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Wybrana ścieżka nie istnieje!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Wybrana ścieżka nie jest folderem!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Udostępnij lokalnie</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Zwolnij miejsce na dysku lokalnym</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Anuluj, aby zwolnić miejsce na dysku</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Anuluj udostępnianie lokalne</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Skopiuj link do publicznego udostępnienia</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Skopiuj prywatny link do udostępnienia</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Otwórz w przeglądarce</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Nie można zapisać parametrów!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Nie można znaleźć prawidłowej ścieżki</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Nie wybrano żadnego prawidłowego folderu!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Wybrana ścieżka nie istnieje!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Wybrana ścieżka nie jest folderem!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Udostępnij lokalnie</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Zwolnij miejsce na dysku lokalnym</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Anuluj, aby zwolnić miejsce na dysku</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Anuluj udostępnianie lokalne</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Skopiuj link do publicznego udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Skopiuj prywatny link do udostępnienia</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Otwórz w przeglądarce</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n rok</numerusform>
-<numerusform>%n lat</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n miesiąc</numerusform>
-<numerusform>%n miesięcy</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n dzień</numerusform>
-<numerusform>%n dni</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n godzina</numerusform>
-<numerusform>%n godzin</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuta</numerusform>
-<numerusform>%n minut</numerusform>
-<numerusform/>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekunda</numerusform>
-<numerusform>%n sekund</numerusform>
-<numerusform/>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n rok</numerusform>
+            <numerusform>%n lat</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n miesiąc</numerusform>
+            <numerusform>%n miesięcy</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dzień</numerusform>
+            <numerusform>%n dni</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n godzina</numerusform>
+            <numerusform>%n godzin</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuta</numerusform>
+            <numerusform>%n minut</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekunda</numerusform>
+            <numerusform>%n sekund</numerusform>
+            <numerusform></numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Zasobnik systemowy niedostępny</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 wymaga działającego zasobnika systemowego. Jeśli używasz XFCE, postępuj zgodnie z &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;tymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację zasobnika systemowego, taką jak 'trayer', i spróbuj ponownie.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Zasobnik systemowy niedostępny</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 wymaga działającego zasobnika systemowego. Jeśli używasz XFCE, postępuj zgodnie z &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;tymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację zasobnika systemowego, taką jak &apos;trayer&apos;, i spróbuj ponownie.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Nie udało się otworzyć przeglądarki</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Nie masz już połączenia. &lt;a style="%1" href="%2"&gt;Zaloguj się&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Trwa synchronizacja (Krok %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Trwa synchronizacja.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Niektórych plików nie udało się zsynchronizować. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Wstrzymywanie synchronizacji...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Rozpoczyna się synchronizacja</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synchronizacja została wstrzymana.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Trwa synchronizacja (%1 z %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Nie udało się otworzyć przeglądarki</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Nie masz już połączenia. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Zaloguj się&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Trwa synchronizacja (Krok %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Trwa synchronizacja.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Niektórych plików nie udało się zsynchronizować. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Wstrzymywanie synchronizacji...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Rozpoczyna się synchronizacja</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synchronizacja została wstrzymana.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Trwa synchronizacja (%1 z %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Trwa synchronizacja (%1 z %2)
+        <translation>Trwa synchronizacja (%1 z %2)
 Zostało %3...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Jesteś na bieżąco!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Jesteś na bieżąco!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Brak folderu do synchronizacji
+        <translation>Brak folderu do synchronizacji
 Możesz dodać folder w ustawieniach kDrive.</translation>
-</message>
+    </message>
 </context>
 </TS>

--- a/translations/client_pl.ts
+++ b/translations/client_pl.ts
@@ -1,2593 +1,3108 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pl_PL">
+<TS language="pl_PL" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Informacje</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">ZAMKNIJ</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Dystrybucja: %1; na licencji &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Nie można otworzyć folderu %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Informacje</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>ZAMKNIJ</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Wersja %1. Więcej informacji można znaleźć na stronie &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Prawa autorskie 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Dystrybucja: %1; na licencji &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 oraz logo %2 są zastrzeżonymi znakami towarowymi firmy %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Nie można otworzyć folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Skompilowano ze &lt;a style="color: #489EF3" href="%1"&gt;źródeł Git&lt;/a&gt; w dniu %2, %3 przy użyciu Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Nie można otworzyć ścieżki folderu %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Nie można otworzyć ścieżki folderu %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Twój kDrive jest gotowy!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">OTWÓRZ FOLDER</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">USTAWIENIA</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Zsynchronizuj inny dysk</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Rozpocznie się synchronizacja i będzie można dodawać pliki do folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Twój kDrive jest gotowy!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>OTWÓRZ FOLDER</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>USTAWIENIA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Zsynchronizuj inny dysk</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anuluj</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">DALEJ</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Pobierz kDrive za darmo</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Wypróbuj za darmo</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>DALEJ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Wybierz urządzenie kDrive, które chcesz zsynchronizować</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Pobierz kDrive za darmo</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Przechowuj swoje zdjęcia, dokumenty i wiadomości e-mail w Szwajcarii, korzystając z usług niezależnej firmy, która szanuje prywatność. Dowiedz się więcej</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Wypróbuj za darmo</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Oszczędzaj miejsce na komputerze</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">PÓŹNIEJ</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">TAK</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Czy chcesz włączyć funkcję Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Oszczędzaj miejsce na komputerze</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Zdecyduj, które pliki mają być dostępne online lub lokalnie</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>PÓŹNIEJ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>TAK</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synchronizuje wszystkie Twoje pliki bez zajmowania miejsca na komputerze. Możesz przeglądać pliki w kDrive i pobierać je lokalnie w dowolnym momencie. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Czy chcesz włączyć funkcję Lite Sync (wersja beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Czy chcesz włączyć funkcję Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Lokalizacja dysku %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Edytuj folder</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ZAKOŃCZ</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Wybierz folder</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Lokalizacja dysku %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Edytuj folder</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>ZAKOŃCZ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Wybierz folder</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Zawartość folderu &lt;b&gt;%1&lt;/b&gt; zostanie zsynchronizowana w Twoim kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Po zakończeniu konfiguracji wszystkie pliki znajdziesz w tym folderze. Możesz wrzucić tam nowe pliki, aby zsynchronizować je z usługą kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Ten folder nie jest zgodny z Lite Sync.&lt;br&gt; 
 Wybierz inny folder. Jeśli kontynuujesz, funkcja Lite Sync zostanie wyłączona.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">KONTYNUUJ</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>KONTYNUUJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Zaloguj się w przeglądarce</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Otwórz stronę logowania</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Wystąpił błąd podczas uwierzytelniania. Zamknij okno logowania i spróbuj ponownie.&lt;br&gt;Jeśli błąd będzie się powtarzał, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Nie udało się zalogować: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Zaloguj się w przeglądarce</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Przeglądarka powinna otworzyć się automatycznie, aby nawiązać połączenie. Po nawiązaniu połączenia nastąpi automatyczny powrót do serwisu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Otwórz stronę logowania</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Wystąpił błąd podczas uwierzytelniania. Zamknij okno logowania i spróbuj ponownie.&lt;br&gt;Jeśli błąd będzie się powtarzał, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Nie udało się zalogować: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Nie udało się otworzyć strony logowania w przeglądarce internetowej</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">KONTYNUUJ</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Wolne miejsce na komputerze: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Wybierz foldery kDrive, które chcesz zsynchronizować na pulpicie</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>KONTYNUUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Wolne miejsce na komputerze: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Nie można załadować listy podfolderów. Być może Twoje konto kDrive jest obecnie w trakcie konserwacji.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan swojego konta kDrive, lub skontaktuj się z administratorem.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Nie udało się utworzyć folderu lokalnego %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Nie udało się utworzyć nowej synchronizacji</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Nie udało się utworzyć folderu lokalnego %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Nie udało się utworzyć nowej synchronizacji</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>Aplikacja kDrive %1 jest już zsynchronizowana na tym komputerze. Czy mimo to chcesz kontynuować?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">Klient kDrive już działa!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>Program kDrive został uruchomiony z nieprawidłowymi parametrami!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>Klient kDrive już działa!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Użytkownik %1 nie jest zalogowany. Zaloguj się ponownie.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Link do udostępnienia skopiowano do schowka</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
-            <numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 został usunięty.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
-            <numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">Dodano %1.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
-            <numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 zostało zaktualizowane.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
-            <numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 zostało przeniesione do %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synchronizacja działań</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Link do udostępnienia skopiowano do schowka</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 oraz %n inny plik zostały usunięte.</numerusform>
+<numerusform>%1 oraz %n innych plików zostało usuniętych.</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 został usunięty.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 oraz %n inny plik zostały dodane.</numerusform>
+<numerusform>%1 oraz %n innych plików zostało dodanych.</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>Dodano %1.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 oraz %n inny plik zostały zaktualizowane.</numerusform>
+<numerusform>%1 oraz %n innych plików zostało zaktualizowanych.</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 zostało zaktualizowane.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 został przeniesiony do %2, a %n inny plik został przeniesiony.</numerusform>
+<numerusform>%1 został przeniesiony do %2, a %n innych plików zostało przeniesionych.</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 zostało przeniesione do %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synchronizacja działań</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Wyjdź z programu beta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Dołącz do programu beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Skorzystaj z aktualizacji wersji beta aplikacji</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Nie</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Publiczna wersja beta</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Wewnętrzna wersja beta</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Wersja testowa</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Rozumiem</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Czy na pewno chcesz opuścić program beta?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Zapisz</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anuluj</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Wyjdź z programu beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Dołącz do programu beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Zyskaj wczesny dostęp do nowych wersji aplikacji, zanim zostaną one udostępnione szerokiej publiczności, i pomóż nam ulepszać aplikację, przesyłając nam swoje uwagi.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Skorzystaj z aktualizacji wersji beta aplikacji</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Nie</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Publiczna wersja beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Wewnętrzna wersja beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Wersja testowa</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Rozumiem</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Czy na pewno chcesz opuścić program beta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Zapisz</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Obecna wersja aplikacji może być zbyt nowa; wybrane ustawienia zaczną obowiązywać po udostępnieniu kolejnej aktualizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Wersje beta mogą się niespodziewanie zamknąć lub powodować niestabilność działania.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Zaloguj się</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Folder %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Nie skonfigurowano żadnych folderów synchronizacji.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Podsumowanie</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation type="vanished">Preferencje</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Zakończ</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Stan nieokreślony.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Oczekiwanie na rozpoczęcie synchronizacji.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synchronizacja trwa.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Anulowanie przez użytkownika.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synchronizacja została wstrzymana.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synchronizacja została wstrzymana)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 elementów zostało usuniętych z lokalnego folderu synchronizacji &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Aby uniknąć niezamierzonych usunięć, synchronizacja została wstrzymana.&lt;br&gt;Czy chcesz przenieść te usunięcia do swojego kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Kilka plików zostało usuniętych z lokalnego folderu synchronizacji &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Usunięte pliki można znaleźć w &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;koszu&lt;/a&gt; kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Nie pokazuj ponownie</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Nie udało się uruchomić synchronizacji!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Nie można otworzyć ścieżki folderu %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Nie można zainicjować klienta kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synchronizacja została wstrzymana</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Nie udało się rozwiązać konfliktu(-ów) dotyczących %1 elementu(-ów) w folderze synchronizacji: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Zaloguj się</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Folder %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Nie skonfigurowano żadnych folderów synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Podsumowanie</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translatorcomment>Préférences</translatorcomment>
+<translation>Preferencje</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Zakończ</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Stan nieokreślony.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Oczekiwanie na rozpoczęcie synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synchronizacja trwa.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synchronizacja przebiegła pomyślnie, pozostały nierozwiązane konflikty.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Ostatnia synchronizacja zakończyła się powodzeniem.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Anulowanie przez użytkownika.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synchronizacja została wstrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synchronizacja została wstrzymana)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Czy na pewno chcesz usunąć synchronizacje konta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>USUŃ WSZYSTKIE SYNCHRONIZACJE</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 elementów zostało usuniętych z lokalnego folderu synchronizacji &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Aby uniknąć niezamierzonych usunięć, synchronizacja została wstrzymana.&lt;br&gt;Czy chcesz przenieść te usunięcia do swojego kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Kilka plików zostało usuniętych z lokalnego folderu synchronizacji &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Usunięte pliki można znaleźć w &lt;a style="%1" href="%3"&gt;koszu&lt;/a&gt; kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Nie pokazuj ponownie</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Nie udało się uruchomić synchronizacji!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Nie można otworzyć ścieżki folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Nie można zainicjować klienta kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synchronizacja została wstrzymana</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Podsumowanie synchronizacji folderów lokalnych</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNCHRONIZUJ</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Podsumowanie synchronizacji folderów lokalnych</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Zawartość folderu na Twoim komputerze zostanie zsynchronizowana z folderem na wybranym serwerze kDrive i odwrotnie.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNCHRONIZUJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Zanim skończymy</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Zezwól aplikacji kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Odblokuj kłódkę &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; i autoryzuj aplikację kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;kliknij tutaj&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">KROK 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Gotowe)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">KROK 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">WYKONANE CZYNNOŚCI</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">ZAKOŃCZ</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Zanim skończymy</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Wykonaj poniższe czynności, aby upewnić się, że program Lite Sync działa poprawnie na Twoim komputerze, oraz aby zakończyć konfigurację serwisu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Otwórz &lt;b&gt;ustawienia ogólne&lt;/b&gt; komputera Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Otwórz &lt;b&gt;ustawienia prywatności i bezpieczeństwa&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Otwórz &lt;b&gt;ustawienia „Bezpieczeństwo i prywatność”&lt;/b&gt; na komputerze Mac lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Przejdź do sekcji &lt;b&gt;„Elementy logowania i rozszerzenia”,&lt;/b&gt; a następnie do &lt;b&gt;„Rozszerzenia Endpoint Security”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Zezwól aplikacji kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Przejdź do sekcji &lt;b&gt;„Bezpieczeństwo”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Zezwól aplikacji kDrive w oknie informującym, że kDrive zostało zablokowane</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Odblokuj kłódkę &lt;img src=":/client/resources/icons/actions/lock.png"&gt; i autoryzuj aplikację kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Przejdź do sekcji &lt;b&gt;„Prywatność i bezpieczeństwo”&lt;/b&gt; i kliknij opcję &lt;b&gt;„Pełny dostęp do dysku”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Wciąż w ustawieniach „Bezpieczeństwo i prywatność” otwórz zakładkę &lt;b&gt;„Prywatność”&lt;/b&gt; lub &lt;a style="%1" href="%2"&gt;kliknij tutaj&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Zaznacz pole „kDrive LiteSync Extension”, a następnie pole „kDrive.app” (jeśli nie jest jeszcze zaznaczone)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Może pojawić się propozycja ponownego uruchomienia aplikacji; w takim przypadku należy ją zaakceptować</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Zaznacz pole „kDrive LiteSync Extension” (oraz „kDrive.app”, jeśli istnieje) w &lt;b&gt;sekcji „Pełny dostęp do dysku”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>KROK 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Gotowe)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>KROK 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>WYKONANE CZYNNOŚCI</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>ZAKOŃCZ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">TAK</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NIE</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>TAK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NIE</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Wysyłanie informacji dotyczących debugowania</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anuluj</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Wysyłanie informacji dotyczących debugowania</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Informacje</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Debugowanie</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Ostrzeżenie</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Błąd</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Śmiertelny</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Ustawienia debugowania</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Poziom debugowania</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Rozszerzony pełny dziennik</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Usuń logi starsze niż %1 dni</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Udostępnij tylko ostatnią sesję kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Ładowanie</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anuluj</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ZAPISZ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Nie udało się udostępnić</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Przerwano połączenie)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Automatycznie skompresowaliśmy &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Prześlij archiwum za pomocą serwisu &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Prześlij link na adres&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Ostatnie przesłanie: %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Udostępnianie zostało anulowane</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Rozszerzony pełny dziennik jest aktywowany przez zmienną środowiskową KDRIVE_FORCE_EXTENDED_LOG. Ustaw ją na 0, aby ją wyłączyć.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 o godz. %4:%5 i %6 s</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Czy chcesz zapisać wprowadzone zmiany?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Nie można otworzyć folderu %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Udostępnij</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Udostępnianie | krok 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Udostępnianie | krok 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Anulowanie...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Informacje</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Debugowanie</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Ostrzeżenie</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Błąd</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Śmiertelny</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Ustawienia debugowania</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Zapisz informacje dotyczące debugowania w folderze na moim komputerze (zalecane)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Informacje te pozwalają działowi wsparcia IT ustalić przyczynę incydentu.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Poziom debugowania</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Poziom śledzenia pozwala wybrać zakres rejestrowanych informacji dotyczących debugowania</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Rozszerzony dziennik pełny gromadzi szczegółową historię, którą można wykorzystać do debugowania. Jego włączenie może spowolnić działanie aplikacji kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Rozszerzony pełny dziennik</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Usuń logi starsze niż %1 dni</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Prześlij folder debugowania do działu pomocy technicznej Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Ostatnia sesja to okres od ostatniego uruchomienia programu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Udostępnij tylko ostatnią sesję kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Ładowanie</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>ZAPISZ</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Nie udało się udostępnić</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Sprawdź, czy jesteś zalogowany &lt;br&gt;2. Sprawdź, czy skonfigurowałeś co najmniej jeden serwer kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Przerwano połączenie)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Udostępnij folder za pomocą SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Automatycznie skompresowaliśmy &lt;a style="%1" href="%2"&gt;tutaj&lt;/a&gt; Twój plik dziennika.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Prześlij archiwum za pomocą serwisu &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Prześlij link na adres&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Ostatnie przesłanie: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Udostępnianie zostało anulowane</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Rozszerzony pełny dziennik jest aktywowany przez zmienną środowiskową KDRIVE_FORCE_EXTENDED_LOG. Ustaw ją na 0, aby ją wyłączyć.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Cały folder jest duży (&gt; 100 MB) i udostępnienie go może zająć trochę czasu. Aby skrócić czas udostępniania, zalecamy udostępnienie tylko ostatniej sesji kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 o godz. %4:%5 i %6 s</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Nie można otworzyć folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Udostępnij</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Udostępnianie | krok 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Udostępnianie | krok 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Anulowanie...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Foldery</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Powiadomienia</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Związane z</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Aktywacja funkcji Lite Sync nie powiodła się.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Nie udało się wyłączyć funkcji Lite Sync.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Wystąpił błąd podczas ładowania listy podfolderów.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Włącz powiadomienia dla tego kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">POTWIERDŹ</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Błędy synchronizacji i informacje.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Zsynchronizuj folder lokalny</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Nie udało się utworzyć nowej synchronizacji</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Włączono funkcję Lite Sync.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Funkcja Lite Sync została wyłączona.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Ten dysk jest właśnie usuwany.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Nie można otworzyć elementu %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Usuń wszystkie synchronizacje</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Wyszukaj w swoim kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Wyszukaj</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Foldery</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Powiadomienia</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Gdy tylko nowy folder zostanie zsynchronizowany lub zmodyfikowany, pojawi się powiadomienie</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Związane z</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Czy na pewno chcesz przerwać synchronizację folderu &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Uwaga: Nie&lt;/b&gt; spowoduje to usunięcia żadnych plików.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Operacja ta może potrwać od kilku sekund do kilku minut, w zależności od rozmiaru folderu.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Nie udało się zsynchronizować nowego folderu lokalnego!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Aktywacja funkcji Lite Sync nie powiodła się.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Nie udało się wyłączyć funkcji Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>USUŃ POŁĄCZENIE SYNCHRONIZACJI FOLDERÓW</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Wystąpił błąd podczas ładowania listy podfolderów.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Włącz powiadomienia dla tego kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>POTWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Błędy synchronizacji i informacje.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Zsynchronizuj folder lokalny</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Czy na pewno chcesz włączyć funkcję Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Czy na pewno chcesz wyłączyć funkcję Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Nie masz wystarczającej ilości miejsca, aby zsynchronizować wszystkie pliki z kDrive (brakuje %1). Jeśli wyłączysz funkcję Lite Sync, musisz wybrać foldery, które chcesz zsynchronizować na swoim komputerze. W międzyczasie synchronizacja kDrive zostanie wstrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Jeśli wyłączysz funkcję Lite Sync, wszystkie pliki zostaną pobrane na Twój komputer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Nie udało się utworzyć nowej synchronizacji</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Włączono funkcję Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Funkcja Lite Sync została wyłączona.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Ten dysk jest właśnie usuwany.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Nie można otworzyć elementu %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Nie udało się zatrzymać synchronizacji folderu &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Usuń wszystkie synchronizacje</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Wyszukaj w swoim kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Wyszukaj</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Zsynchronizuj kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Dodaj kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Zsynchronizuj kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Dodaj kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Rozwiązać</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Elementy powodujące konflikt</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Elementy zawierające znaki nieobsługiwane</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Wyczyść historię</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Aby rozwiązać</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Rozwiązano automatycznie</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">rozwiązane problemy</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">wykryto problem(y)</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Rozwiązać</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Elementy powodujące konflikt</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Elementy zawierające znaki nieobsługiwane</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Wyczyść historię</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Aby rozwiązać</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Rozwiązano automatycznie</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>rozwiązane problemy</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>wykryto problem(y)</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Konflikty lub błędy synchronizacji</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Błędy</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Powrót do ustawień</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Konflikty lub błędy synchronizacji</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Błędy</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Powrót do ustawień</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 błąd(ów))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 informacja(i))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 błąd(ów) i %2 informacja(i))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
-            <numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Nie udało się zsynchronizować niektórych plików na następujących urządzeniach kDrive:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 błąd(ów))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 informacja(i))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 błąd(ów) i %2 informacja(i))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Błędy ogólne (%n ostrzeżenie lub błąd)</numerusform>
+<numerusform>Błędy ogólne (%n ostrzeżenia lub błędy)</numerusform>
+<numerusform/>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Pliki wykluczone</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Dodaj</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">IMIĘ</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">OSTRZEŻENIE</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ZAPISZ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Czy chcesz zapisać wprowadzone zmiany?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Szablon wykluczenia już istnieje!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Czy na pewno chcesz usunąć?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Nie można zapisać zmian!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Pliki wykluczone</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Dodaj pliki lub foldery, które nie będą synchronizowane na Twoim komputerze.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Dodaj</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>IMIĘ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>OSTRZEŻENIE</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>ZAPISZ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Szablon wykluczenia już istnieje!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Czy na pewno chcesz usunąć?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Nie można zapisać zmian!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ZATWIERDŹ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>ZATWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Rozwiązywanie konfliktów</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Pokaż produkty</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ZATWIERDŹ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Rozwiązywanie konfliktów</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Co chcesz zrobić z %1 elementem (elementami) powodującym konflikt?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Zapisz moje zmiany i zastąp wersje innych użytkowników.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Cofnij moje zmiany i zachowaj wersje innych użytkowników.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Twoje zmiany mogą zostać trwale usunięte. Nie da się ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Twoje zmiany zostaną trwale usunięte. Nie będzie można ich przywrócić za pomocą aplikacji internetowej kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Pokaż produkty</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>ZATWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Pliki te zostały zmodyfikowane przez kilku użytkowników w różnych miejscach (online w serwisie kDrive, na komputerze lub urządzeniu mobilnym). Foldery zawierające te pliki mogły również zostać usunięte.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lokalna wersja Twojego elementu &lt;b&gt;nie jest zsynchronizowana&lt;/b&gt; z kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Więcej działań</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Zsynchronizowano do &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Włącz Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Włącz Lite Sync (wersja beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Anuluj</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ZATWIERDŹ</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Wstrzymaj synchronizację</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Wyłącz Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Wznowienie synchronizacji</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Wyłącz synchronizację</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Więcej działań</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Zsynchronizowano do &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Włącz Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Włącz Lite Sync (wersja beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza, o ile zawierają elementy dostępne w trybie offline. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Foldery, które nie zostały zaznaczone, zostaną przeniesione do kosza. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Foldery, które nie zostały zaznaczone, zostaną &lt;b&gt;trwale&lt;/b&gt; usunięte z komputera. Foldery zsynchronizowane z kDrive pozostaną dostępne online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Anuluj</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>ZATWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Wstrzymaj synchronizację</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Wyłącz Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Wznowienie synchronizacji</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Wyłącz synchronizację</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Nie można otworzyć ścieżki folderu %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Nie można otworzyć ścieżki folderu %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Identyfikator aplikacji</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Nazwa aplikacji</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">ZATWIERDŹ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Identyfikator aplikacji</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Nazwa aplikacji</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>ZATWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Dodaj</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ID WNIOSKU</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">IMIĘ</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ZAPISZ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Czy chcesz zapisać wprowadzone zmiany?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Czy na pewno chcesz usunąć?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Nie można zapisać zmian!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Niektóre aplikacje (do tworzenia kopii zapasowych, antywirusowe...) uzyskują dostęp do Twoich plików, co powoduje ich pobieranie, gdy są one „online”. Dodaj je do poniższej listy, aby uniknąć tego zjawiska.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Dodaj</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ID WNIOSKU</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>IMIĘ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>ZAPISZ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Czy na pewno chcesz usunąć?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Nie można zapisać zmian!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Wybierz folder</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Edytuj folder</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">KONTYNUUJ</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Który folder na komputerze chcesz&lt;br&gt;zsynchronizować?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Zawartość tego folderu zostanie zsynchronizowana w usłudze kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Wybierz folder</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Edytuj folder</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>KONTYNUUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Ten folder nie jest zgodny z aplikacją Lite Sync.&lt;br&gt;
 Wybierz inny folder. Jeśli kontynuujesz, aplikacja Lite Sync zostanie wyłączona.&lt;br&gt;
 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Wybierz folder</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Wybierz folder</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Błąd</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Błąd</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Nie można otworzyć&lt;br/&gt;pliku „%1” w trybie zapisu. &lt;b&gt;Nie&lt;/b&gt;&lt;br/&gt;&lt;br/&gt;można zapisać danych dziennika!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferencje</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Pomoc</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Preferencje</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Pomoc</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Nie można otworzyć ścieżki folderu %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>Nie skonfigurowano programu kDrive!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Przesyłanie nie powiodło się!
-Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;wersji&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Nie masz uprawnień do tworzenia elementu lub istnieje już inny element o tej samej nazwie. Element został zignorowany.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Nie można pobrać pliku.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Błąd synchronizacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Nie można utworzyć pliku %1, ponieważ nie jest on obsługiwany przez system plików.&lt;br&gt;Został wyłączony z synchronizacji.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Błąd systemu.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Nie można otworzyć ścieżki folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Przesłanie zakończone! W&lt;br&gt;zgłoszeniach błędów proszę podać identyfikator &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>Nie skonfigurowano programu kDrive!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Przesyłanie nie powiodło się!
+Proszę skorzystać z poniższego linku, aby przesłać logi do działu pomocy technicznej: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Wygląda na to, że limit czasu połączenia sieciowego jest ustawiony na zbyt niską wartość, co uniemożliwia prawidłowe działanie aplikacji (błąd %1).&lt;br&gt;Sprawdź ustawienia sieciowe.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Nie można połączyć się z serwerem kDrive (błąd %1).&lt;br&gt;Próbuję ponownie nawiązać połączenie. Sprawdź połączenie internetowe i ustawienia zapory sieciowej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Zaloguj się ponownie, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Dostępna jest nowa wersja aplikacji. Aby móc nadal z&lt;br&gt;niej korzystać, należy ją zaktualizować.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Przesyłanie dziennika nie powiodło się (błąd %1).&lt;br&gt;Spróbuj ponownie później.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Nie ma już dostępu do folderu synchronizacji (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona, gdy tylko folder będzie ponownie dostępny.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Folder synchronizacji został zastąpiony lub przeniesiony w sposób uniemożliwiający synchronizację (błąd %1). Może&lt;br&gt;się to zdarzyć po skopiowaniu, przeniesieniu lub przywróceniu folderu.&lt;br&gt;Aby to naprawić, należy utworzyć nową synchronizację z nowym folderem.&lt;br&gt;Uwaga: jeśli w starym folderze znajdują się niezsynchronizowane zmiany, należy je ręcznie skopiować do nowego folderu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Na komputerze zabrakło pamięci.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>Aplikacja kDrive musi mieć uprawnienia do zapisu w katalogu tymczasowym komputera.&lt;br&gt;Aby rozwiązać ten problem, uruchom ponownie aplikację kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Wystąpił błąd techniczny.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Liczba obserwacji inotify jest niewystarczająca (błąd %1).&lt;br&gt;Można zwiększyć tę liczbę, edytując plik „/etc/sysctl.conf”.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Należy zezwolić na&lt;br&gt;:- kDrive w Ustawieniach systemu &gt;&gt; Ogólne &gt;&gt; Elementy logowania i rozszerzenia &gt;&gt; Rozszerzenia zabezpieczeń punktów&lt;br&gt;końcowych - Rozszerzenie kDrive LiteSync w Ustawieniach systemu &gt;&gt; Prywatność i bezpieczeństwo &gt;&gt; Pełny dostęp do dysku.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync jest zainstalowane, a usługa Windows Search włączona.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Sprawdź, czy rozszerzenie Lite Sync ma odpowiednie uprawnienia i czy jest uruchomione.&lt;br&gt;Wyczyść historię, uruchom ponownie przeglądarkę, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Nie można uruchomić wtyczki Lite Sync (błąd %1).&lt;br&gt;Proszę wyczyścić historię, ponownie uruchomić program, a jeśli błąd nadal występuje, skontaktować się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Wygląda na to, że plik lub folder w folderze synchronizacji jest uszkodzony.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Serwer kDrive znajduje się w trybie konserwacji.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Usługa kDrive została zablokowana.&lt;br&gt;Proszę odnowić subskrypcję kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>Konto kDrive zostało zablokowane.&lt;br&gt;Skontaktuj się z administratorem w celu odblokowania konta kDrive. Jeśli nie podejmiesz żadnych działań, dane zostaną trwale usunięte i nie będzie możliwości ich odzyskania.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Usługa kDrive się uruchamia.&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do &lt;a style="%1" href="%2"&gt;wersji&lt;/a&gt; &lt;a style="%1" href="%2"&gt;internetowej&lt;/a&gt;, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>Usługa kDrive jest wyłączona.&lt;br&gt;Zaloguj się do wersji internetowej, aby sprawdzić stan usługi kDrive, lub skontaktuj się z administratorem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Nie masz uprawnień dostępu do tego konta kDrive.&lt;br&gt;Synchronizacja została wstrzymana. Skontaktuj się z administratorem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja zostanie wznowiona tak szybko, jak to możliwe. Jeśli błąd nie ustąpi, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Jądro systemu przerwało połączenia sieciowe (błąd %1).&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Niestety nie udało się przenieść starej konfiguracji.&lt;br&gt;Aplikacja będzie korzystać z pustej konfiguracji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Niestety nie udało się przenieść Twojej poprzedniej konfiguracji proxy; serwery proxy SOCKS5 nie są obecnie obsługiwane.&lt;br&gt;Aplikacja będzie korzystać z ustawień proxy systemu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Wystąpił błąd techniczny (błąd %1).&lt;br&gt;Synchronizacja została wznowiona. Proszę wyczyścić historię, a jeśli błąd nadal występuje, prosimy o kontakt z naszym zespołem pomocy technicznej.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Wystąpił błąd podczas uzyskiwania dostępu do bazy danych synchronizacji (błąd %1).&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Wystąpił problem z logowaniem (błąd %1).&lt;br&gt;Token jest nieprawidłowy lub został unieważniony.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Zabronione jest zagnieżdżanie synchronizacji (błąd %1).&lt;br&gt;Należy zachować wyłącznie te synchronizacje, których foldery nie są zagnieżdżone.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Folder synchronizacji na zdalnym serwerze kDrive nie istnieje już lub nie ma do niego dostępu (błąd %1).&lt;br&gt;Należy go przywrócić, przywrócić do niego uprawnienia dostępu lub usunąć i utworzyć synchronizację od nowa.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Błąd analizy nazwy pliku (błąd %1). Znaki&lt;br&gt;specjalne, takie jak cudzysłowy, ukośniki odwrotne lub znaki końca linii, mogą powodować błędy analizy.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Nie masz uprawnień do tworzenia elementu lub istnieje już inny element o tej samej nazwie. Element został zignorowany.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Nie można przenieść elementu do folderu „%1”. Zostanie&lt;br&gt;on przywrócony do pierwotnego folderu nadrzędnego.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Na komputerze zabrakło miejsca.&lt;br&gt;Pobieranie zostało przerwane.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Nie można utworzyć pliku „%1”, ponieważ nie jest on obsługiwany w Twoim systemie plików.&lt;br&gt;Został on wykluczony z synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Ten element został przeniesiony w inne miejsce.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Nazwa lokalnego elementu została zmieniona.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>W tej lokalizacji istnieje już element o tej samej nazwie.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Na komputerze zabrakło miejsca.&lt;br&gt;Synchronizacja została zatrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Plik został zmieniony w tym samym czasie przez innego użytkownika.&lt;br&gt;Twoje zmiany zostały zapisane w kopii.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Inny użytkownik przeniósł folder nadrzędny miejsca docelowego.&lt;br&gt;Operacja lokalna została anulowana.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Nazwa pozycji zawiera wyłącznie spacje.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Nie masz uprawnień do edycji tego elementu.&lt;br&gt;Plik zawierający wprowadzone zmiany został przemianowany i wykluczony z synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Nie można zmienić nazwy tego elementu. Zostanie&lt;br&gt;on przywrócony pod pierwotną nazwą.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Nie można usunąć tego elementu. Zostanie&lt;br&gt;on przywrócony do pierwotnej lokalizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Nie udało się przenieść tego elementu do kosza; został on dodany do czarnej listy.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Plik został zmodyfikowany lokalnie, podczas gdy na zdalnym serwerze kDrive został usunięty.&lt;br&gt;Lokalna kopia została zapisana w folderze awaryjnym.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Wykonanie tej operacji na tym elemencie jest zabronione.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Operacja wykonana na tym elemencie nie powiodła się.&lt;br&gt;Element został tymczasowo umieszczony na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Plik jest zbyt duży, aby można go było przesłać. Został tymczasowo zablokowany.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Nie można pobrać pliku.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Przekroczyłeś limit miejsca. Zwiększ limit miejsca, aby ponownie umożliwić przesyłanie plików.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Dysk zawierający folder synchronizacji nie jest już podłączony (błąd %1).&lt;br&gt;Podłącz go ponownie, aby wznowić synchronizację.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Nie można rozpocząć synchronizacji (błąd %1).&lt;br&gt;Proces LiteSyncExt nie jest obecnie uruchomiony. Synchronizacja zostanie wznowiona zaraz po jego uruchomieniu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Istniejący element ma identyczną nazwę z zachowaniem tej samej wielkości liter (wszystkie litery są wielkie lub małe).&lt;br&gt;Został on tymczasowo umieszczony na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Nazwa pozycji zawiera znak, który nie jest obsługiwany.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Nazwa elementu kończy się spacją, co jest niedozwolone w Twoim systemie operacyjnym.&lt;br&gt;Została ona tymczasowo umieszczona na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Ta nazwa elementu jest zarezerwowana przez system operacyjny.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Nazwa produktu jest zbyt długa.&lt;br&gt;Została tymczasowo umieszczona na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Ścieżka do elementu jest zbyt długa.&lt;br&gt;Została pominięta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Nazwa elementu zawiera znak Unicode, który nie jest jeszcze obsługiwany przez system plików.&lt;br&gt;Została ona wykluczona z synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Nie udało się zsynchronizować tego elementu. Został on tymczasowo umieszczony na czarnej liście.&lt;br&gt;Kolejna próba synchronizacji zostanie podjęta za godzinę lub przy następnym uruchomieniu aplikacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Ten element został wykluczony z synchronizacji przez szablon niestandardowy.&lt;br&gt;Możesz wyłączyć tego typu powiadomienia w ustawieniach</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Ten element został wykluczony z synchronizacji, ponieważ jest to dowiązanie twarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Ten element jest obecnie zablokowany przez innego użytkownika online.&lt;br&gt;Spróbujemy ponownie przesłać Twoje zmiany później.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Błąd synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Nie można uzyskać dostępu do elementu.&lt;br&gt;Proszę poprawić uprawnienia do odczytu i zapisu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Błąd systemu.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Ten element istnieje już po drugiej stronie.&lt;br&gt;Został tymczasowo umieszczony na czarnej liście.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Wystąpił błąd techniczny.&lt;br&gt;Proszę wyczyścić historię, a jeśli błąd nadal występuje, skontaktuj się z naszym zespołem pomocy technicznej.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Ta synchronizacja zostanie usunięta.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Ta synchronizacja zostanie usunięta.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Powrót do listy dysków</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferencje</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Powrót do listy dysków</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Preferencje</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Ogólne</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Włącz ciemny motyw</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Włącz monochromatyczne ikony</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Uruchamiaj kDrive przy starcie systemu</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Fiński</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Duński</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Grecki</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Niderlandzki</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Zaawansowane</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Informacje debugowania</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Pliki do wykluczenia</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Serwer proxy</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Szwedzki</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugalski</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polski</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norweski</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Nie można otworzyć folderu %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Nieprawidłowy link %1.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Język</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Nie udało się uruchomić jakiegoś procesu.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Przenoś usunięte pliki do kosza na komputerze</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Angielski</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Francuski</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Niemiecki</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Hiszpański</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Włoski</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Domyślny</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Ogólne</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Włącz ciemny motyw</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Włącz monochromatyczne ikony</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Uruchamiaj kDrive przy starcie systemu</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Fiński</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Duński</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Grecki</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Niderlandzki</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Zaawansowane</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Informacje debugowania</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Otwórz folder debugowania&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Pliki do wykluczenia</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Serwer proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Szwedzki</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugalski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norweski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Nie można otworzyć folderu %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Nieprawidłowy link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Język</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Nie udało się uruchomić jakiegoś procesu.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Przenoś usunięte pliki do kosza na komputerze</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Niektórych plików lub folderów nie da się przenieść do kosza komputera.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Zawsze możesz odzyskać wcześniej zsynchronizowane pliki z kosza aplikacji webowej kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Angielski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Francuski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Niemiecki</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Hiszpański</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Włoski</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Domyślny</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 w użyciu</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 w użyciu</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">Serwer proxy HTTP(S)</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Serwer proxy</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Brak serwera proxy</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Użyj parametrów systemowych</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Wprowadź pełnomocnika ręcznie</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Port</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Adres serwera proxy</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Wymagane uwierzytelnienie</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Użytkownik</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Hasło</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ZAPISZ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Czy chcesz zapisać wprowadzone zmiany?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>Serwer proxy HTTP(S)</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Serwer proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Brak serwera proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Użyj parametrów systemowych</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Wprowadź pełnomocnika ręcznie</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Port</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Adres serwera proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Wymagane uwierzytelnienie</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Użytkownik</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Hasło</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>ZAPISZ</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Nie można zapisać danych, ponieważ nie wszystkie pola obowiązkowe zostały wypełnione!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Nie znaleziono serwera proxy. Czy chcesz zapisać mimo to?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Kierownik ds. zasobów</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Maksymalne dopuszczalne obciążenie procesora</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">ZAPISZ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Czy chcesz zapisać wprowadzone zmiany?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Kierownik ds. zasobów</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Maksymalne dopuszczalne obciążenie procesora</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>ZAPISZ</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Czy chcesz zapisać wprowadzone zmiany?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Wybierz folder na swoim kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">KONTYNUUJ</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Ten folder jest już synchronizowany.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">POTWIERDŹ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">ANULUJ</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Wybierz folder na swoim kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Zawartość wybranego folderu zostanie zsynchronizowana z folderem &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>KONTYNUUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Miejsce dostępne na komputerze dla bieżącego folderu: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Ten folder jest już synchronizowany.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>POTWIERDŹ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>ANULUJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">KONTYNUUJ</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Obecnie na serwerze nie ma żadnych podfolderów.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Folder &lt;b&gt;%1&lt;/b&gt; zawiera podfoldery;&lt;br&gt; wybierz te, które chcesz zsynchronizować</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>KONTYNUUJ</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Obecnie na serwerze nie ma żadnych podfolderów.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Wznowić synchronizację kDrive „%1”</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Wznowić synchronizację wszystkich dysków kDrive</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Wstrzymaj synchronizację kDrive „%1”</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Wstrzymaj synchronizację</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Wstrzymaj synchronizację wszystkich kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Wznowienie synchronizacji</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Wznowić synchronizację kDrive „%1”</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Wznowić synchronizację wszystkich dysków kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Wstrzymaj synchronizację kDrive „%1”</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Wstrzymaj synchronizację</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Wstrzymaj synchronizację wszystkich kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Wznowienie synchronizacji</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Skopiuj link do udostępnienia</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Wyświetl na stronie kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Pokaż w folderze</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Więcej działań</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Otwórz</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Dodaj do ulubionych</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Skopiuj link do udostępnienia</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Wyświetl na stronie kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Pokaż w folderze</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Więcej działań</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Otwórz</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Dodaj do ulubionych</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Nigdy</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">W ciągu godziny</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Do jutra do godziny 8:00 rano</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Przez 3 dni</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">W ciągu tygodnia</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Zawsze</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Jeszcze przez 1 godzinę</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Jeszcze przez 3 dni</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Jeszcze przez 1 tydzień</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Nie można otworzyć folderu o adresie URL %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Otwórz w folderze</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Otwórz wersję internetową %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Parametry napędu</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Powiadomienia wyłączone do %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Wyłącz powiadomienia</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Ustawienia aplikacji</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Potrzebujesz pomocy?</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Prześlij opinię</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Zamknij kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Nie można uzyskać dostępu do strony internetowej %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Pokaż błędy i informacje</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Pokaż informacje</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Więcej działań</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Nigdy</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>W ciągu godziny</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Do jutra do godziny 8:00 rano</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Przez 3 dni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>W ciągu tygodnia</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Zawsze</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Jeszcze przez 1 godzinę</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Jeszcze przez 3 dni</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Jeszcze przez 1 tydzień</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Otwórz w folderze</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Otwórz wersję internetową %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Parametry napędu</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Powiadomienia wyłączone do %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Wyłącz powiadomienia</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Ustawienia aplikacji</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Potrzebujesz pomocy?</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Prześlij opinię</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Zamknij kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Nie można uzyskać dostępu do strony internetowej %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Pokaż błędy i informacje</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Pokaż informacje</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Więcej działań</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Zaktualizuj aplikację kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Aktualizacja</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Trwa pobieranie aktualizacji</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Czekam na aktualizację...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Ręczna aktualizacja</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Niedostępne</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Możesz zsynchronizować pliki &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Zsynchronizowane</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Ulubione</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Zajęcia</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Nie zaimplementowano!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Brak zsynchronizowanego folderu dla tego dysku!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">Nie skonfigurowano programu kDrive!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Nie można otworzyć linku %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Nieprawidłowy link %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Nie można otworzyć folderu o adresie URL %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Zaktualizuj aplikację kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Ta wersja aplikacji kDrive nie jest już obsługiwana. Aby uzyskać dostęp do najnowszych funkcji i ulepszeń, zaktualizuj aplikację.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Aktualizacja</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Proszę pobrać najnowszą wersję ze strony internetowej.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Trwa pobieranie aktualizacji</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Czekam na aktualizację...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Ręczna aktualizacja</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Niedostępne</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Możesz zsynchronizować pliki &lt;a style="%1" href="%2"&gt;z komputera&lt;/a&gt; lub ze strony &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Zsynchronizowane</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Ulubione</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Zajęcia</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Nie zaimplementowano!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Kliknij tutaj, aby pobrać plik ręcznie&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Brak zsynchronizowanego folderu dla tego dysku!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>Nie skonfigurowano programu kDrive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Nie można otworzyć linku %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Nieprawidłowy link %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Nie można otworzyć folderu o adresie URL %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Pomiń tę wersję</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Przypomnij mi później</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Zainstaluj aktualizację</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Nowa wersja &lt;b&gt;%1&lt;/b&gt; klienta %2 jest już dostępna i została pobrana.&lt;/p&gt;&lt;p&gt;Zainstalowana wersja to %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Pomiń tę wersję</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Przypomnij mi później</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Zainstaluj aktualizację</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Dostępna jest nowa aktualizacja.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Wersja %1 jest dostępna do pobrania.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Dostępna jest nowa aktualizacja.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Wersja %1 jest dostępna do pobrania.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Dodaj konto</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Dodaj konto</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Wersja</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">AKTUALIZACJA</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 jest aktualne!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Sprawdzam aktualizacje na serwerze...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Dostępna jest aktualizacja: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Pobieranie %1. Proszę czekać...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Podczas aktualizacji wystąpił błąd.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Nie udało się pobrać aktualizacji.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Funkcja aktualizacji została wyłączona.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Program beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Dołącz</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Zmodyfikuj</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Zakończ</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Pokaż informacje o aktualizacji&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Wersja</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>AKTUALIZACJA</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 jest aktualne!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Sprawdzam aktualizacje na serwerze...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Dostępna jest aktualizacja: %1.&lt;br&gt;Pobierz ją stąd.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Dostępna jest aktualizacja: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Pobieranie %1. Proszę czekać...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Nie udało się sprawdzić dostępności nowych aktualizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Podczas aktualizacji wystąpił błąd.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Nie udało się pobrać aktualizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Funkcja aktualizacji została wyłączona.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Program beta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Zyskaj wczesny dostęp do nowych wersji aplikacji</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Dołącz</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Zmodyfikuj</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Zakończ</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Nie można zapisać parametrów!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Nie można znaleźć prawidłowej ścieżki</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Nie wybrano żadnego prawidłowego folderu!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Wybrana ścieżka nie istnieje!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Wybrana ścieżka nie jest folderem!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Nie masz uprawnień do zapisu w wybranym folderze!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Udostępnij lokalnie</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Zwolnij miejsce na dysku lokalnym</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Anuluj, aby zwolnić miejsce na dysku</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Anuluj udostępnianie lokalne</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Ponowne udostępnianie tego pliku jest zabronione</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Ponowne udostępnianie tego folderu jest zabronione</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Skopiuj link do publicznego udostępnienia</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Skopiuj prywatny link do udostępnienia</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Otwórz w przeglądarce</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Nie można zapisać parametrów. Spróbuj ponownie później.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Nie można zapisać parametrów!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Folder nadrzędny jest folderem synchronizacji lub znajduje się w takim folderze</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Nie można znaleźć prawidłowej ścieżki</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Nie wybrano żadnego prawidłowego folderu!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Wybrana ścieżka nie istnieje!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Wybrana ścieżka nie jest folderem!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Nie masz uprawnień do zapisu w wybranym folderze!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Folder lokalny %1 zawiera folder, który został już zsynchronizowany. Wybierz inny!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Folder lokalny %1 znajduje się w folderze, który został już zsynchronizowany. Wybierz inny!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Lokalny folder %1 został już zsynchronizowany. Wybierz inny!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Włączono funkcję Lite sync (wersja beta). Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Funkcja Lite sync (wersja beta) jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Włączono funkcję Lite Sync. Pliki z serwisu kDrive pozostają w chmurze i nie zajmują miejsca na dysku komputera.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Funkcja Lite Sync jest wyłączona. Pliki kDrive zajmują miejsce na dysku komputera.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Udostępnij lokalnie</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Zwolnij miejsce na dysku lokalnym</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Anuluj, aby zwolnić miejsce na dysku</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Anuluj udostępnianie lokalne</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Ponowne udostępnianie tego pliku jest zabronione</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Ponowne udostępnianie tego folderu jest zabronione</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Skopiuj link do publicznego udostępnienia</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Skopiuj prywatny link do udostępnienia</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Otwórz w przeglądarce</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>Aplikacja kDrive zostanie zamknięta z powodu poważnego błędu.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n rok</numerusform>
-            <numerusform>%n lat</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n miesiąc</numerusform>
-            <numerusform>%n miesięcy</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n dzień</numerusform>
-            <numerusform>%n dni</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n godzina</numerusform>
-            <numerusform>%n godzin</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minuta</numerusform>
-            <numerusform>%n minut</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n sekunda</numerusform>
-            <numerusform>%n sekund</numerusform>
-            <numerusform></numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n rok</numerusform>
+<numerusform>%n lat</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n miesiąc</numerusform>
+<numerusform>%n miesięcy</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n dzień</numerusform>
+<numerusform>%n dni</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n godzina</numerusform>
+<numerusform>%n godzin</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuta</numerusform>
+<numerusform>%n minut</numerusform>
+<numerusform/>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekunda</numerusform>
+<numerusform>%n sekund</numerusform>
+<numerusform/>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Zasobnik systemowy niedostępny</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 wymaga działającego zasobnika systemowego. Jeśli używasz XFCE, postępuj zgodnie z &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;tymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację zasobnika systemowego, taką jak &apos;trayer&apos;, i spróbuj ponownie.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Zasobnik systemowy niedostępny</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 wymaga działającego zasobnika systemowego. Jeśli używasz XFCE, postępuj zgodnie z &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;tymi instrukcjami&lt;/a&gt;. W przeciwnym razie zainstaluj aplikację zasobnika systemowego, taką jak 'trayer', i spróbuj ponownie.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Nie udało się otworzyć przeglądarki</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Nie udało się uruchomić klienta poczty elektronicznej</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Nie masz już połączenia. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Zaloguj się&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Trwa synchronizacja (Krok %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Trwa synchronizacja.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Niektórych plików nie udało się zsynchronizować. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Dowiedz się więcej&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Wstrzymywanie synchronizacji...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Rozpoczyna się synchronizacja</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synchronizacja została wstrzymana.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Trwa synchronizacja (%1 z %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Nie udało się otworzyć przeglądarki</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Wystąpił błąd podczas uruchamiania przeglądarki w celu przejścia do adresu URL %1. Być może nie skonfigurowano domyślnej przeglądarki?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Nie udało się uruchomić klienta poczty elektronicznej</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Wystąpił błąd podczas uruchamiania klienta poczty e-mail w celu utworzenia nowej wiadomości. Być może nie skonfigurowano domyślnego klienta poczty e-mail?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Nie masz już połączenia. &lt;a style="%1" href="%2"&gt;Zaloguj się&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Trwa synchronizacja (Krok %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Trwa synchronizacja.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Niektórych plików nie udało się zsynchronizować. &lt;a style="%1" href="%2"&gt;Dowiedz się więcej&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Wstrzymywanie synchronizacji...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Nie można wybrać folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ inna synchronizacja korzysta z tego samego folderu.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ zawiera on zsynchronizowany folder &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Nie można zaznaczyć folderu &lt;b&gt;%1,&lt;/b&gt; ponieważ znajduje się on w folderze synchronizowanym &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Folderu &lt;b&gt;%1&lt;/b&gt; nie można wybrać jako folderu do synchronizacji. Wybierz inny folder.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Folder &lt;b&gt;%1&lt;/b&gt; nie może zostać wybrany jako folder synchronizacji. Wybierz inny folder. Sugerowany folder: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Wykluczyłeś ponad %1 folderów. Pamiętaj, że wpłynie to na wydajność synchronizacji.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Nie można wykluczyć więcej niż %1 folderów. Proszę odznaczyć foldery wyższego poziomu.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Rozpoczyna się synchronizacja</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synchronizacja została wstrzymana.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Trwa synchronizacja (%1 z %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Trwa synchronizacja (%1 z %2)
+<translation>Trwa synchronizacja (%1 z %2)
 Zostało %3...</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Jesteś na bieżąco!</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Masz zaległości w postaci nierozwiązanych konfliktów.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Jesteś na bieżąco!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Brak folderu do synchronizacji
+<translation>Brak folderu do synchronizacji
 Możesz dodać folder w ustawieniach kDrive.</translation>
-    </message>
+</message>
 </context>
 </TS>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -1,3097 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="pt_PT" version="2.1">
+<TS version="2.1" language="pt_PT">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Sobre</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>FECHAR</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Versão %1. Para mais informações, visite &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Não foi possível abrir a pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style="color: #489EF3" href="%1"&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Sobre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>FECHAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Versão %1. Para mais informações, visite &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Não foi possível abrir o caminho da pasta %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>O seu kDrive está pronto!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ABRIR PASTA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>PARÂMETROS</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Sincronizar outra unidade</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>O seu kDrive está pronto!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ABRIR PASTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>PARÂMETROS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Sincronizar outra unidade</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>SEGUINTE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Selecione o kDrive que pretende sincronizar</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Obter o kDrive gratuitamente</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Experimentar gratuitamente</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>SEGUINTE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Selecione o kDrive que pretende sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Obter o kDrive gratuitamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Experimentar gratuitamente</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Poupe espaco no seu computador</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>MAIS TARDE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>SIM</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Gostaria de ativar o Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Poupe espaco no seu computador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>MAIS TARDE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>SIM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Gostaria de ativar o Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Localização do seu %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Editar pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>CONCLUIR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Selecionar pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Localização do seu %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Editar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>CONCLUIR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Selecionar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Inicie sessao no seu navegador</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Abrir a página de início de sessão</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Ocorreu um erro durante a autenticação. Feche a janela de início de sessão e tente novamente.&lt;br&gt;Se o erro persistir, contacte a nossa equipa de suporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Falha no início de sessão: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Inicie sessao no seu navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Abrir a página de início de sessão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Ocorreu um erro durante a autenticação. Feche a janela de início de sessão e tente novamente.&lt;br&gt;Se o erro persistir, contacte a nossa equipa de suporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Falha no início de sessão: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Espaço disponível no seu computador: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Espaço disponível no seu computador: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Não foi possível criar a pasta local %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Não foi possível criar uma nova sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Não foi possível criar a pasta local %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Não foi possível criar uma nova sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>O cliente kDrive já está em execução!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>O cliente kDrive já está em execução!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>O link para partilhar foi copiado para a área de transferência</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
-<numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>O %1 foi removido.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
-<numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>O %1 foi adicionado.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
-<numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>O %1 foi atualizado.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
-<numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>O %1 foi transferido para o %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Atividade de sincronização</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>O link para partilhar foi copiado para a área de transferência</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi removido.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi adicionado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
+            <numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>O %1 foi atualizado.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
+            <numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>O %1 foi transferido para o %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Atividade de sincronização</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Não existem subpastas no servidor neste momento.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Não existem subpastas no servidor neste momento.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Sair do programa beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Participe no programa beta</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Aproveite as atualizações da versão beta da aplicação</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Não</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Versão beta pública</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Versão beta interna</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Versão de teste</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Eu compreendo</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Tem a certeza de que quer sair do programa beta?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Guardar</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Sair do programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Participe no programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Aproveite as atualizações da versão beta da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Não</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Versão beta pública</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Versão beta interna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Versão de teste</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Eu compreendo</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Tem a certeza de que quer sair do programa beta?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Guardar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Por favor, inicie sessão</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Pasta %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Não há pastas de sincronização configuradas.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Síntese</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translatorcomment>Préférences</translatorcomment>
-<translation>Preferências</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Sair</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Estado indefinido.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>A aguardar o início da sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>A sincronização está em curso.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>A última sincronização foi bem-sucedida.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Interrupção pelo utilizador.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>A sincronização está em pausa.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (A sincronização está em pausa)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 itens foram eliminados da sua pasta de sincronização local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Para evitar eliminações não pretendidas, a sincronização foi pausada.&lt;br&gt;Deseja propagar essas eliminações para o seu kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Vários ficheiros foram eliminados da sua pasta de sincronização local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Os ficheiros eliminados podem ser encontrados no &lt;a style="%1" href="%3"&gt;lixo&lt;/a&gt; do kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Não mostrar novamente</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Não foi possível iniciar as sincronizações!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Não foi possível abrir o caminho da pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Não foi possível inicializar o cliente kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>A sincronização está em pausa</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Por favor, inicie sessão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Pasta %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Não há pastas de sincronização configuradas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Síntese</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Estado indefinido.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>A aguardar o início da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>A sincronização está em curso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>A última sincronização foi bem-sucedida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Interrupção pelo utilizador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>A sincronização está em pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (A sincronização está em pausa)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 itens foram eliminados da sua pasta de sincronização local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Para evitar eliminações não pretendidas, a sincronização foi pausada.&lt;br&gt;Deseja propagar essas eliminações para o seu kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Vários ficheiros foram eliminados da sua pasta de sincronização local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Os ficheiros eliminados podem ser encontrados no &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;lixo&lt;/a&gt; do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Não mostrar novamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Não foi possível iniciar as sincronizações!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Não foi possível inicializar o cliente kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>A sincronização está em pausa</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Resumo da sincronização da sua pasta local</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SINCRONIZAR</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Resumo da sincronização da sua pasta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SINCRONIZAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Antes de terminar</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Autorizar a aplicação kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Desbloqueie o cadeado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorize a aplicação kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>PASSO 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Concluído)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>PASSO 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>ETAPAS REALIZADAS</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>CONCLUIR</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Antes de terminar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Autorizar a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Desbloqueie o cadeado &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; e autorize a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>PASSO 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Concluído)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>PASSO 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>ETAPAS REALIZADAS</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>CONCLUIR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OK</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>SIM</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NAO</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OK</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>SIM</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NAO</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Envio de informações de depuração</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Envio de informações de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Informações</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Depuração</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Aviso</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Erro</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Fatal</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Configurações de depuração</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Nível de depuração</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Registo completo alargado</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Eliminar registos com mais de %1 dias</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Partilhar apenas a última sessão do kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  A carregar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Não foi possível partilhar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Conexão interrompida)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Comprimimos automaticamente o seu registo &lt;a style="%1" href="%2"&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Transfira o arquivo através do &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Partilhe o link com&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Último envio: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>A partilha foi cancelada</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>O log completo estendido é ativado pela variável de ambiente KDRIVE_FORCE_EXTENDED_LOG. Defina-a como 0 para desativá-lo.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 às %4h%5m e %6s</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Quer guardar as suas alterações?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Não foi possível abrir a pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Partilhar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Partilha | passo 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Partilha | passo 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  A cancelar...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Aviso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Fatal</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Configurações de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Nível de depuração</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Registo completo alargado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Eliminar registos com mais de %1 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Partilhar apenas a última sessão do kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  A carregar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Não foi possível partilhar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Conexão interrompida)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Comprimimos automaticamente o seu registo &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Transfira o arquivo através do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Partilhe o link com&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Último envio: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>A partilha foi cancelada</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>O log completo estendido é ativado pela variável de ambiente KDRIVE_FORCE_EXTENDED_LOG. Defina-a como 0 para desativá-lo.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 às %4h%5m e %6s</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Partilhar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Partilha | passo 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Partilha | passo 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  A cancelar...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Pastas</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Notificações</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>Relacionado com</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>A sincronização da nova pasta local falhou!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>A ativação do Lite Sync falhou.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Falha na desativação do Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Ativar as notificações para este kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>CONFIRMAR</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Erros de sincronização e informações.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Sincronizar uma pasta local</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Quer mesmo ativar o Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Quer mesmo desativar o Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Não foi possível criar uma nova sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync ativado.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>O Lite Sync está desativado.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Esta unidade está a ser eliminada.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Não é possível abrir o item %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Remover todas as sincronizações</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Pesquisar no seu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Pesquisar</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Pastas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Notificações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>Relacionado com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>A sincronização da nova pasta local falhou!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>A ativação do Lite Sync falhou.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Falha na desativação do Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Ativar as notificações para este kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Erros de sincronização e informações.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Sincronizar uma pasta local</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Quer mesmo ativar o Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Quer mesmo desativar o Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Não foi possível criar uma nova sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync ativado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>O Lite Sync está desativado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Esta unidade está a ser eliminada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Não é possível abrir o item %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Remover todas as sincronizações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Pesquisar no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Pesquisar</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Sincronizar um kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Adicionar um kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Sincronizar um kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Adicionar um kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Resolução</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Elemento(s) em conflito</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Item(s) com caracteres não suportados</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Limpar histórico</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Para resolver</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Resolvido automaticamente</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problema(s) resolvido(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>foram detetados problemas</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Resolução</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Elemento(s) em conflito</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Item(s) com caracteres não suportados</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Limpar histórico</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Para resolver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Resolvido automaticamente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problema(s) resolvido(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>foram detetados problemas</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Conflitos ou erros de sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Erros</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Voltar às preferências</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Conflitos ou erros de sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Erros</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Voltar às preferências</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 erro(s))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 informação(s))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 erro(s) e %2 informação(ões))</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Erros genericos (%n aviso ou erro)</numerusform>
-<numerusform>Erros genericos (%n avisos ou erros)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 erro(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 informação(s))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 erro(s) e %2 informação(ões))</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Erros genericos (%n aviso ou erro)</numerusform>
+            <numerusform>Erros genericos (%n avisos ou erros)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Ficheiros excluídos</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Adicionar</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NOME</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>AVISO</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Quer guardar as suas alterações?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>O modelo de exclusão já existe!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Quer mesmo eliminar?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Não é possível guardar as alterações!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Ficheiros excluídos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>AVISO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>O modelo de exclusão já existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Quer mesmo eliminar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Não é possível guardar as alterações!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Resolver conflitos</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Mostrar item(s)</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Resolver conflitos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Mostrar item(s)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Mais ações</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Sincronizado em &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Ativar o Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Ativar o Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Cancelar</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Pausar a sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Desativar o Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Retomar a sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Desativar a sincronização</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Sincronizado em &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Ativar o Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Ativar o Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Cancelar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Desativar o Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Retomar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Desativar a sincronização</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Não foi possível abrir o caminho da pasta %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>ID da aplicação</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Nome da aplicação</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>VALIDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>ID da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Nome da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>VALIDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Adicionar</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>ID DA APLICAÇÃO</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NOME</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Quer guardar as suas alterações?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Quer mesmo eliminar?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Não é possível guardar as alterações!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>ID DA APLICAÇÃO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NOME</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Quer mesmo eliminar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Não é possível guardar as alterações!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Selecione uma pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Editar pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Selecione uma pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Editar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Selecionar pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Selecionar pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Erro</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Erro</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Preferências</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Ajuda</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Ajuda</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Não foi possível abrir o caminho da pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>O kDrive não está configurado!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Falha na transmissão!
-Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Não tem permissão para criar um elemento ou já existe outro elemento com o mesmo nome. O elemento foi ignorado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Não é possível criar o ficheiro «%1», uma vez que não é suportado no seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Não é possível descarregar o ficheiro.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Este item foi excluído da sincronização porque é um link físico.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Erro de sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Erro do sistema.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>O kDrive não está configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Falha na transmissão!
+Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Não tem permissão para criar um elemento ou já existe outro elemento com o mesmo nome. O elemento foi ignorado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Não é possível criar o ficheiro «%1», uma vez que não é suportado no seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Não é possível descarregar o ficheiro.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Este item foi excluído da sincronização porque é um link físico.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Erro de sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Erro do sistema.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Esta sincronização está a ser eliminada.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Esta sincronização está a ser eliminada.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Voltar à lista de unidades</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Preferências</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Voltar à lista de unidades</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Preferências</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Geral</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Ativar tema escuro</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Ativar icones monocromaticos</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Iniciar o kDrive no arranque</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finlandês</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Dinamarquês</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Grego</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Neerlandês</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avancado</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Informacoes de depuracao</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Ficheiros a excluir</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Sueco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Português</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polaco</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norueguês</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Não foi possível abrir a pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Ligacao invalida %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Idioma</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Algum processo não foi executado.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Ingles</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Frances</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Alemao</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Espanhol</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italiano</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Predefinido</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Geral</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Ativar tema escuro</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Ativar icones monocromaticos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Iniciar o kDrive no arranque</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finlandês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Dinamarquês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Grego</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Neerlandês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avancado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Informacoes de depuracao</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Ficheiros a excluir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Sueco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Português</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polaco</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norueguês</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Não foi possível abrir a pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Ligacao invalida %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Idioma</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Algum processo não foi executado.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Ingles</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Frances</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Alemao</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Espanhol</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italiano</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Predefinido</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 em uso</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 em uso</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>Proxy HTTP(S)</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Sem servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Utilizar parâmetros do sistema</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Indicar um representante manualmente</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Porto</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Endereço do servidor proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>É necessária autenticação</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Utilizador</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Palavra-passe</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Quer guardar as suas alterações?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>Proxy HTTP(S)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Sem servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Utilizar parâmetros do sistema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Indicar um representante manualmente</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Porto</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Endereço do servidor proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>É necessária autenticação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Utilizador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Palavra-passe</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Gestor de Recursos</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Utilização máxima permitida da CPU</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>GUARDAR</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Quer guardar as suas alterações?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Gestor de Recursos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Utilização máxima permitida da CPU</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>GUARDAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Quer guardar as suas alterações?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Selecione uma pasta no seu kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Esta pasta já está a ser sincronizada.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>CONFIRMAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>CANCELAR</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Selecione uma pasta no seu kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Esta pasta já está a ser sincronizada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>CONFIRMAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>CANCELAR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>CONTINUAR</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Não existem subpastas no servidor neste momento.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>CONTINUAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Não existem subpastas no servidor neste momento.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Retomar a sincronização do kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Retomar toda a sincronização do kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Suspender a sincronização do kDrive "%1"</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Pausar a sincronização</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Suspender toda a sincronização do kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Retomar a sincronização</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Retomar a sincronização do kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Retomar toda a sincronização do kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Suspender a sincronização do kDrive &quot;%1&quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Pausar a sincronização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Suspender toda a sincronização do kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Retomar a sincronização</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Copiar link de partilha</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Exibir em kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Mostrar na pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Mais ações</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Abrir</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Adicionar aos favoritos</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Copiar link de partilha</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Exibir em kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Mostrar na pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Abrir</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Adicionar aos favoritos</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Nunca</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Durante 1 hora</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Até amanhã às 8h00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Durante 3 dias</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Durante uma semana</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Sempre</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>Por mais 1 hora</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>Ainda por mais 3 dias</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Por mais uma semana</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Não foi possível abrir a URL da pasta %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Abrir na pasta</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Abrir a versão web do %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Parâmetros do acionamento</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Notificações desativadas até %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Desativar notificações</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Preferências da aplicação</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Precisa de ajuda</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Enviar comentários</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Sair do kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Não é possível aceder ao site %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Mostrar erros e informações</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Mostrar informações</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Mais ações</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Nunca</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Durante 1 hora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Até amanhã às 8h00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Durante 3 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Durante uma semana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Sempre</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>Por mais 1 hora</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>Ainda por mais 3 dias</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Por mais uma semana</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Não foi possível abrir a URL da pasta %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Abrir na pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Abrir a versão web do %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Parâmetros do acionamento</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Notificações desativadas até %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Desativar notificações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Preferências da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Precisa de ajuda</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Enviar comentários</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Sair do kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Não é possível aceder ao site %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Mostrar erros e informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Mostrar informações</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Mais ações</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Atualizar a aplicação kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Atualização</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Por favor, descarregue a versão mais recente no site.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Download da atualização em curso</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>À procura de atualizações...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Atualização manual</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Indisponível</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Pode sincronizar ficheiros &lt;a style="%1" href="%2"&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Sincronizado</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoritos</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Atividade</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Não implementado!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>O kDrive não está configurado!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Não foi possível abrir a ligação %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Ligacao invalida %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Não foi possível abrir a URL da pasta %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Atualizar a aplicação kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Atualização</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Por favor, descarregue a versão mais recente no site.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Download da atualização em curso</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>À procura de atualizações...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Atualização manual</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Indisponível</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Pode sincronizar ficheiros &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Sincronizado</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoritos</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Atividade</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Não implementado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>O kDrive não está configurado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Não foi possível abrir a ligação %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Ligacao invalida %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Não foi possível abrir a URL da pasta %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Ignorar esta versão</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Lembra-me mais tarde</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Instalar atualização</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Ignorar esta versão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Lembra-me mais tarde</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Instalar atualização</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>Está disponível uma nova atualização.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>A versão %1 está disponível para download.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>Está disponível uma nova atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>A versão %1 está disponível para download.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Adicionar uma conta</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Adicionar uma conta</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Versão</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>ATUALIZAÇÃO</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>O %1 está atualizado!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>A verificar se há atualizações no servidor...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style="%2" href="%3"&gt;aqui&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>Está disponível uma atualização: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>A descarregar %1. Por favor, aguarde...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Não foi possível verificar se existem novas atualizações.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Ocorreu um erro durante a atualização.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Não foi possível descarregar a atualização.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Atualização desativada.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Programa beta</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Junte-se a nós</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Modificar</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Sair</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Versão</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>ATUALIZAÇÃO</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>O %1 está atualizado!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>A verificar se há atualizações no servidor...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aqui&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>Está disponível uma atualização: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>A descarregar %1. Por favor, aguarde...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Não foi possível verificar se existem novas atualizações.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Ocorreu um erro durante a atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Não foi possível descarregar a atualização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Atualização desativada.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Programa beta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Junte-se a nós</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Modificar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Sair</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Não é possível guardar os parâmetros!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Não é possível encontrar um caminho válido</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Não foi selecionada nenhuma pasta válida!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>O caminho selecionado não existe!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>O caminho selecionado não é uma pasta!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Não tem permissão para gravar na pasta selecionada!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Disponibilizar localmente</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Liberte espaço no disco local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Cancelar para libertar espaço local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Cancelar disponibilização local</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Não é permitido partilhar novamente este ficheiro</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Não é permitido partilhar novamente esta pasta</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Copiar link de partilha pública</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Copiar link de partilha privada</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Abrir no navegador</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Não é possível guardar os parâmetros!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Não é possível encontrar um caminho válido</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Não foi selecionada nenhuma pasta válida!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>O caminho selecionado não existe!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>O caminho selecionado não é uma pasta!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Não tem permissão para gravar na pasta selecionada!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Disponibilizar localmente</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Liberte espaço no disco local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Cancelar para libertar espaço local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Cancelar disponibilização local</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Não é permitido partilhar novamente este ficheiro</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Não é permitido partilhar novamente esta pasta</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Copiar link de partilha pública</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Copiar link de partilha privada</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Abrir no navegador</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n ano</numerusform>
-<numerusform>%n anos</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n mes</numerusform>
-<numerusform>%n meses</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n dia</numerusform>
-<numerusform>%n dias</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n hora</numerusform>
-<numerusform>%n horas</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minuto</numerusform>
-<numerusform>%n minutos</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n segundo</numerusform>
-<numerusform>%n segundos</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n ano</numerusform>
+            <numerusform>%n anos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n mes</numerusform>
+            <numerusform>%n meses</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dia</numerusform>
+            <numerusform>%n dias</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n hora</numerusform>
+            <numerusform>%n horas</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minuto</numerusform>
+            <numerusform>%n minutos</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n segundo</numerusform>
+            <numerusform>%n segundos</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Bandeja do sistema não disponível</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 requer uma bandeja do sistema funcional. Se estiver a executar o XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema como 'trayer' e tente novamente.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Bandeja do sistema não disponível</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 requer uma bandeja do sistema funcional. Se estiver a executar o XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema como &apos;trayer&apos; e tente novamente.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Não foi possível abrir o navegador</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Não foi possível abrir o cliente de e-mail</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Já não está conectado. &lt;a style="%1" href="%2"&gt;Inicie sessão&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Sincronização em curso (Passo %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Sincronização em curso.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>A sincronização está em pausa...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>A sincronização está a começar</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>A sincronização foi interrompida.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Sincronização em curso (%1 de %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Não foi possível abrir o navegador</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Não foi possível abrir o cliente de e-mail</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Já não está conectado. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inicie sessão&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Sincronização em curso (Passo %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Sincronização em curso.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>A sincronização está em pausa...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>A sincronização está a começar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>A sincronização foi interrompida.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Sincronização em curso (%1 de %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Sincronização em curso (%1 de %2)
+        <translation>Sincronização em curso (%1 de %2)
 Faltam %3...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Estás em dia com os conflitos pendentes.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Já está tudo em dia!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Estás em dia com os conflitos pendentes.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Já está tudo em dia!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Não existe nenhuma pasta para sincronizar
+        <translation>Não existe nenhuma pasta para sincronizar
 Pode adicionar uma nas definições do kDrive.</translation>
-</message>
+    </message>
 </context>
 </TS>

--- a/translations/client_pt.ts
+++ b/translations/client_pt.ts
@@ -1,2582 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="pt_PT">
+<TS language="pt_PT" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Sobre</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">FECHAR</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Versão %1. Para mais informações, visite &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribuído por %1 e licenciado ao abrigo da &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Não foi possível abrir a pasta %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Sobre</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>FECHAR</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Versão %1. Para mais informações, visite &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Direitos de autor 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribuído por %1 e licenciado ao abrigo da &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 e o logótipo %2 são marcas registadas da %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Não foi possível abrir a pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Compilado a partir &lt;a style="color: #489EF3" href="%1"&gt;das fontes do Git&lt;/a&gt; em %2, %3 utilizando o Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Não foi possível abrir o caminho da pasta %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Não foi possível abrir o caminho da pasta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">O seu kDrive está pronto!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ABRIR PASTA</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">PARÂMETROS</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Sincronizar outra unidade</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>A sincronização irá iniciar e poderá adicionar ficheiros à sua pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>O seu kDrive está pronto!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ABRIR PASTA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>PARÂMETROS</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Sincronizar outra unidade</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">SEGUINTE</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Selecione o kDrive que pretende sincronizar</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Obter o kDrive gratuitamente</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Experimentar gratuitamente</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>SEGUINTE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Selecione o kDrive que pretende sincronizar</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Obter o kDrive gratuitamente</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Guarde as suas fotografias, documentos e e-mails na Suíça, através de uma empresa independente que respeita a privacidade. Saiba mais</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Experimentar gratuitamente</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Poupe espaco no seu computador</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Decida que ficheiros devem estar disponiveis online ou localmente</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">MAIS TARDE</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SIM</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Gostaria de ativar o Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Gostaria de ativar o Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Poupe espaco no seu computador</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Decida que ficheiros devem estar disponiveis online ou localmente</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>MAIS TARDE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>SIM</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>O Lite Sync sincroniza todos os seus ficheiros sem ocupar espaço no seu computador. Pode navegar pelos ficheiros no seu kDrive e descarregá-los para o seu computador sempre que quiser. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Gostaria de ativar o Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Gostaria de ativar o Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Localização do seu %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Editar pasta</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">CONCLUIR</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Selecionar pasta</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Localização do seu %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Editar pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>CONCLUIR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Selecionar pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>O conteúdo da pasta &lt;b&gt;%1&lt;/b&gt; será sincronizado no seu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>Encontrará todos os seus ficheiros nesta pasta quando a configuração estiver concluída. Pode colocar novos ficheiros nessa pasta para os sincronizar com o seu kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt; 
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Inicie sessao no seu navegador</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Abrir a página de início de sessão</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Ocorreu um erro durante a autenticação. Feche a janela de início de sessão e tente novamente.&lt;br&gt;Se o erro persistir, contacte a nossa equipa de suporte.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Falha no início de sessão: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Não foi possível abrir a página de início de sessão no seu navegador</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Inicie sessao no seu navegador</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>O seu navegador deverá abrir automaticamente para concluir a ligação. Assim que estiver ligado, voltará automaticamente ao kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Abrir a página de início de sessão</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Ocorreu um erro durante a autenticação. Feche a janela de início de sessão e tente novamente.&lt;br&gt;Se o erro persistir, contacte a nossa equipa de suporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Falha no início de sessão: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Não foi possível abrir a página de início de sessão no seu navegador</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Espaço disponível no seu computador: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Ocorreu um erro ao carregar a lista de subpastas.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Selecione as pastas do kDrive que pretende sincronizar no seu ambiente de trabalho</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Espaço disponível no seu computador: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Não foi possível carregar a lista de subpastas. O seu kDrive poderá estar em manutenção.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Não foi possível criar a pasta local %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Não foi possível criar uma nova sincronização</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Não foi possível criar a pasta local %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Não foi possível criar uma nova sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>O kDrive %1 já está sincronizado neste computador. Deseja continuar na mesma?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">O cliente kDrive já está em execução!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>O cliente kDrive está a ser executado com parâmetros incorretos!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>O cliente kDrive já está em execução!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>O utilizador %1 não está conectado. Por favor, inicie sessão novamente.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">O link para partilhar foi copiado para a área de transferência</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
-            <numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">O %1 foi removido.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
-            <numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">O %1 foi adicionado.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
-            <numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">O %1 foi atualizado.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
-            <numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">O %1 foi transferido para o %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Atividade de sincronização</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>O link para partilhar foi copiado para a área de transferência</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 e mais %n ficheiro foram removidos.</numerusform>
+<numerusform>%1 e mais %n ficheiros foram removidos.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>O %1 foi removido.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 e mais %n ficheiro foram adicionados.</numerusform>
+<numerusform>%1 e mais %n ficheiros foram adicionados.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>O %1 foi adicionado.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 e mais %n ficheiro foram atualizados.</numerusform>
+<numerusform>%1 e mais %n ficheiros foram atualizados.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>O %1 foi atualizado.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 foi movido para %2 e mais %n ficheiro foi movido.</numerusform>
+<numerusform>%1 foi movido para %2 e mais %n ficheiros foram movidos.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>O %1 foi transferido para o %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Atividade de sincronização</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Não existem subpastas no servidor neste momento.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Não existem subpastas no servidor neste momento.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Sair do programa beta</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Participe no programa beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Aproveite as atualizações da versão beta da aplicação</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Não</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Versão beta pública</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Versão beta interna</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Versão de teste</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Eu compreendo</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Tem a certeza de que quer sair do programa beta?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Guardar</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Sair do programa beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Participe no programa beta</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Tenha acesso antecipado às novas versões da aplicação antes do seu lançamento ao público em geral e contribua para a sua melhoria enviando-nos os seus comentários.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Aproveite as atualizações da versão beta da aplicação</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Não</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Versão beta pública</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Versão beta interna</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Versão de teste</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Eu compreendo</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Tem a certeza de que quer sair do programa beta?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Guardar</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>A versão atual da aplicação pode ser demasiado recente; a sua escolha entrará em vigor assim que estiver disponível a próxima atualização.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>As versões beta podem encerrar inesperadamente ou causar instabilidades.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Por favor, inicie sessão</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Pasta %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Não há pastas de sincronização configuradas.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Síntese</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation type="vanished">Preferências</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Sair</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Estado indefinido.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">A aguardar o início da sincronização.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">A sincronização está em curso.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">A última sincronização foi bem-sucedida.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Interrupção pelo utilizador.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">A sincronização está em pausa.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (A sincronização está em pausa)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">REMOVER TODAS AS SINCRONIZAÇÕES</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 itens foram eliminados da sua pasta de sincronização local &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. Para evitar eliminações não pretendidas, a sincronização foi pausada.&lt;br&gt;Deseja propagar essas eliminações para o seu kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Vários ficheiros foram eliminados da sua pasta de sincronização local &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Os ficheiros eliminados podem ser encontrados no &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;lixo&lt;/a&gt; do kDrive.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Não mostrar novamente</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Não foi possível iniciar as sincronizações!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Não foi possível abrir o caminho da pasta %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Não foi possível inicializar o cliente kDrive</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">A sincronização está em pausa</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Não foi possível resolver o(s) conflito(s) em %1 item(ns) na pasta de sincronização: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Por favor, inicie sessão</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Pasta %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Não há pastas de sincronização configuradas.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Síntese</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translatorcomment>Préférences</translatorcomment>
+<translation>Preferências</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Sair</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Estado indefinido.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>A aguardar o início da sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>A sincronização está em curso.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>A sincronização foi bem-sucedida, mas existem conflitos por resolver.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>A última sincronização foi bem-sucedida.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Interrupção pelo utilizador.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>A sincronização está em pausa.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (A sincronização está em pausa)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Quer mesmo remover as sincronizações da conta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar quaisquer ficheiros.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>REMOVER TODAS AS SINCRONIZAÇÕES</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 itens foram eliminados da sua pasta de sincronização local &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. Para evitar eliminações não pretendidas, a sincronização foi pausada.&lt;br&gt;Deseja propagar essas eliminações para o seu kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Vários ficheiros foram eliminados da sua pasta de sincronização local &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Os ficheiros eliminados podem ser encontrados no &lt;a style="%1" href="%3"&gt;lixo&lt;/a&gt; do kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Não mostrar novamente</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Não foi possível iniciar as sincronizações!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Não foi possível abrir o caminho da pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Não foi possível inicializar o cliente kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>A sincronização está em pausa</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Resumo da sincronização da sua pasta local</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SINCRONIZAR</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Resumo da sincronização da sua pasta local</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>O conteúdo da pasta no seu computador será sincronizado com a pasta do kDrive selecionado e vice-versa.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SINCRONIZAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Antes de terminar</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Autorizar a aplicação kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Desbloqueie o cadeado &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; e autorize a aplicação kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;clique aqui&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">PASSO 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Concluído)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">PASSO 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">ETAPAS REALIZADAS</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">CONCLUIR</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Antes de terminar</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Siga os passos abaixo para garantir que o Lite Sync funcione corretamente no seu computador e para concluir a configuração do kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abra &lt;b&gt;as definições gerais&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abra &lt;b&gt;as definições de Privacidade e Segurança&lt;/b&gt; do seu Mac ou  &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Abra &lt;b&gt;as definições de&lt;/b&gt; &lt;b&gt;Segurança e Privacidade&lt;/b&gt; do seu Mac ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Vá à secção &lt;b&gt;«Itens de início de sessão e extensões»&lt;/b&gt; e, em seguida, a &lt;b&gt;«Extensões de segurança de terminais»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Autorizar a aplicação kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Vá para a secção &lt;b&gt;«Segurança»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Autorize a aplicação kDrive na janela que indica que o kDrive foi bloqueado</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Desbloqueie o cadeado &lt;img src=":/client/resources/icons/actions/lock.png"&gt; e autorize a aplicação kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Vá à secção &lt;b&gt;«Privacidade e Segurança»&lt;/b&gt; e clique em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Ainda nas definições de Segurança e Privacidade, abra o separador &lt;b&gt;«Privacidade»&lt;/b&gt; ou &lt;a style="%1" href="%2"&gt;clique aqui&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Marque a caixa «kDrive LiteSync Extension» e, em seguida, a caixa «kDrive.app» (se ainda não estiver marcada)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Pode ser sugerido que reinicie a aplicação; nesse caso, aceite</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Marque a caixa «kDrive LiteSync Extension» (e «kDrive.app», se existir) em &lt;b&gt;«Acesso total ao disco»&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>PASSO 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Concluído)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>PASSO 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>ETAPAS REALIZADAS</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>CONCLUIR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OK</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">SIM</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NAO</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OK</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>SIM</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NAO</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Envio de informações de depuração</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Envio de informações de depuração</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Informações</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Depuração</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Aviso</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Erro</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Fatal</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Configurações de depuração</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Nível de depuração</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Registo completo alargado</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Eliminar registos com mais de %1 dias</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Partilhar apenas a última sessão do kDrive</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  A carregar</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Não foi possível partilhar</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Conexão interrompida)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Comprimimos automaticamente o seu registo &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Transfira o arquivo através do &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Partilhe o link com&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Último envio: %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">A partilha foi cancelada</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">O log completo estendido é ativado pela variável de ambiente KDRIVE_FORCE_EXTENDED_LOG. Defina-a como 0 para desativá-lo.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 às %4h%5m e %6s</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Quer guardar as suas alterações?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Não foi possível abrir a pasta %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Partilhar</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Partilha | passo 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Partilha | passo 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  A cancelar...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Informações</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Depuração</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Aviso</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Erro</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Fatal</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Configurações de depuração</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Guardar as informações de depuração numa pasta no meu computador (Recomendado)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Essas informações permitem que o suporte de TI determine a origem de uma incidência.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Nível de depuração</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>O nível de rastreio permite-lhe escolher a extensão das informações de depuração registadas</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>O registo completo alargado recolhe um histórico detalhado que pode ser utilizado para depuração. A sua ativação pode tornar a aplicação kDrive mais lenta.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Registo completo alargado</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Eliminar registos com mais de %1 dias</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Partilhe a pasta de depuração com o apoio técnico da Infomaniak.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>A última sessão corresponde ao período decorrido desde o último arranque do kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Partilhar apenas a última sessão do kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  A carregar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Não foi possível partilhar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Verifique se está com a sessão iniciada &lt;br&gt;2. Verifique se configurou pelo menos um kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Conexão interrompida)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Partilhe a pasta com o SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Comprimimos automaticamente o seu registo &lt;a style="%1" href="%2"&gt;aqui&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Transfira o arquivo através do &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Partilhe o link com&lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Último envio: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>A partilha foi cancelada</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>O log completo estendido é ativado pela variável de ambiente KDRIVE_FORCE_EXTENDED_LOG. Defina-a como 0 para desativá-lo.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>A pasta completa é grande (&gt; 100 MB) e pode demorar algum tempo a partilhar. Para reduzir o tempo de partilha, recomendamos que partilhe apenas a última sessão do kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 às %4h%5m e %6s</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Quer guardar as suas alterações?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Não foi possível abrir a pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Partilhar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Partilha | passo 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Partilha | passo 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  A cancelar...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Pastas</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Notificações</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">Relacionado com</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">A sincronização da nova pasta local falhou!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">A ativação do Lite Sync falhou.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Falha na desativação do Lite Sync.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Ocorreu um erro ao carregar a lista de subpastas.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Ativar as notificações para este kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMAR</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Erros de sincronização e informações.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Sincronizar uma pasta local</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Quer mesmo ativar o Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Quer mesmo desativar o Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Não foi possível criar uma nova sincronização</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync ativado.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">O Lite Sync está desativado.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Esta unidade está a ser eliminada.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Não é possível abrir o item %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Remover todas as sincronizações</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Pesquisar no seu kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Pesquisar</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Pastas</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Notificações</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Será exibida uma notificação assim que uma nova pasta for sincronizada ou alterada</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>Relacionado com</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Quer mesmo deixar de sincronizar a pasta &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Nota:&lt;/b&gt; Isto &lt;b&gt;não&lt;/b&gt; irá eliminar nenhum ficheiro.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Esta operação pode demorar entre alguns segundos e alguns minutos, dependendo do tamanho da pasta.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>A sincronização da nova pasta local falhou!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>A ativação do Lite Sync falhou.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Falha na desativação do Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>REMOVER A LIGAÇÃO DE SINCRONIZAÇÃO DA PASTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Ocorreu um erro ao carregar a lista de subpastas.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Ativar as notificações para este kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>CONFIRMAR</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Erros de sincronização e informações.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Sincronizar uma pasta local</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Quer mesmo ativar o Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Quer mesmo desativar o Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Não tem espaço suficiente para sincronizar todos os ficheiros do seu kDrive (faltam %1). Se desativar o Lite Sync, terá de selecionar as pastas que pretende sincronizar no seu computador. Entretanto, a sincronização do seu kDrive ficará em pausa.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Se desativar o Lite Sync, todos os ficheiros serão transferidos para o seu computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Não foi possível criar uma nova sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync ativado.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>O Lite Sync está desativado.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Esta unidade está a ser eliminada.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Não é possível abrir o item %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Não foi possível interromper a sincronização da pasta &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Remover todas as sincronizações</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Pesquisar no seu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Pesquisar</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Sincronizar um kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Adicionar um kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Sincronizar um kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Adicionar um kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Resolução</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Elemento(s) em conflito</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Item(s) com caracteres não suportados</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Limpar histórico</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Para resolver</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Resolvido automaticamente</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problema(s) resolvido(s)</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">foram detetados problemas</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Resolução</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Elemento(s) em conflito</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Item(s) com caracteres não suportados</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Limpar histórico</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Para resolver</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Resolvido automaticamente</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problema(s) resolvido(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>foram detetados problemas</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Conflitos ou erros de sincronização</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Erros</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Voltar às preferências</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Conflitos ou erros de sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Erros</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Voltar às preferências</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 erro(s))</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 informação(s))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 erro(s) e %2 informação(ões))</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Erros genericos (%n aviso ou erro)</numerusform>
-            <numerusform>Erros genericos (%n avisos ou erros)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Não foi possível sincronizar alguns ficheiros nos seguintes kDrive(s):</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 erro(s))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 informação(s))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 erro(s) e %2 informação(ões))</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Erros genericos (%n aviso ou erro)</numerusform>
+<numerusform>Erros genericos (%n avisos ou erros)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Ficheiros excluídos</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Adicionar</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOME</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">AVISO</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Quer guardar as suas alterações?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">O modelo de exclusão já existe!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Quer mesmo eliminar?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Não é possível guardar as alterações!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Ficheiros excluídos</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Adicione ficheiros ou pastas que não serão sincronizados no seu computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Adicionar</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NOME</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>AVISO</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Quer guardar as suas alterações?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>O modelo de exclusão já existe!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Quer mesmo eliminar?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Não é possível guardar as alterações!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Resolver conflitos</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Mostrar item(s)</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Resolver conflitos</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;O que pretende fazer com o(s) item(ns) em conflito %1?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Guardar as minhas alterações e substituir as versões dos outros utilizadores.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Anular as minhas alterações e manter as versões dos outros utilizadores.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>As suas alterações podem ser eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>As suas alterações serão eliminadas definitivamente. Não é possível recuperá-las a partir da aplicação web do kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Mostrar item(s)</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Vários utilizadores introduziram alterações nestes ficheiros em vários locais (online no kDrive, num computador ou num dispositivo móvel). As pastas que contêm estes ficheiros também podem ter sido eliminadas.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>A versão local do seu item &lt;b&gt;não está sincronizada&lt;/b&gt; com o kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Mais ações</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Sincronizado em &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Ativar o Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Ativar o Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Cancelar</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausar a sincronização</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Desativar o Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Retomar a sincronização</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Desativar a sincronização</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Mais ações</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Sincronizado em &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Ativar o Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Ativar o Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>As pastas não selecionadas serão movidas para a lixeira, desde que contenham itens offline. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>As pastas não selecionadas serão movidas para a lixeira. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>As pastas não selecionadas serão eliminadas &lt;b&gt;definitivamente&lt;/b&gt; do computador. As pastas sincronizadas com o kDrive permanecerão disponíveis online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Cancelar</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Pausar a sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Desativar o Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Retomar a sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Desativar a sincronização</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Não foi possível abrir o caminho da pasta %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Não foi possível abrir o caminho da pasta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">ID da aplicação</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Nome da aplicação</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">VALIDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>ID da aplicação</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Nome da aplicação</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>VALIDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Adicionar</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">ID DA APLICAÇÃO</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NOME</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Quer guardar as suas alterações?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Quer mesmo eliminar?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Não é possível guardar as alterações!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Algumas aplicações (de cópia de segurança, antivírus...) acedem aos seus ficheiros, o que leva à sua transferência quando estão «online». Adicione-as à lista abaixo para evitar este comportamento.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Adicionar</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>ID DA APLICAÇÃO</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NOME</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Quer guardar as suas alterações?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Quer mesmo eliminar?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Não é possível guardar as alterações!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">O conteúdo desta pasta será sincronizado no kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Selecione uma pasta</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Editar pasta</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Que pasta do seu computador gostaria de&lt;br&gt;sincronizar?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>O conteúdo desta pasta será sincronizado no kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Selecione uma pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Editar pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Esta pasta não é compatível com o Lite Sync.&lt;br&gt;
 Selecione outra pasta. Se continuar, o Lite Sync será desativado.&lt;br&gt;
 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Selecionar pasta</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Selecionar pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Erro</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Erro</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Não é possível abrir o&lt;br/&gt;ficheiro «%1» para gravação. &lt;b&gt;Não&lt;/b&gt; é&lt;br/&gt;&lt;br/&gt;possível guardar o registo!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferências</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Ajuda</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Preferências</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Ajuda</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Não foi possível abrir o caminho da pasta %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>O kDrive não está configurado!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Falha na transmissão!
-Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;versão&lt;/a&gt; &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Não tem permissão para criar um elemento ou já existe outro elemento com o mesmo nome. O elemento foi ignorado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Não é possível descarregar o ficheiro.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Este item foi excluído da sincronização porque é um link físico.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Erro de sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Impossível criar o ficheiro %1 porque não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Erro do sistema.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Não foi possível abrir o caminho da pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Envio concluído!&lt;br&gt;Por favor, indique o identificador &lt;b&gt;%1&lt;/b&gt; nos relatórios de erros.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>O kDrive não está configurado!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Falha na transmissão!
+Por favor, utilize o seguinte link para enviar os registos para o apoio técnico: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Parece que a sua ligação de rede está configurada com um tempo de espera demasiado curto para que a aplicação funcione corretamente (erro %1).&lt;br&gt;Verifique a sua configuração de rede.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Não é possível estabelecer ligação ao servidor kDrive (erro %1).&lt;br&gt;A tentar restabelecer a ligação. Verifique a sua ligação à Internet e a sua firewall.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Por favor, inicie sessão novamente e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>Está disponível uma nova versão da aplicação.&lt;br&gt;Por favor, atualize a aplicação para continuar a utilizá-la.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>A publicação do registo falhou (erro %1).&lt;br&gt;Por favor, tente novamente mais tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Já não é possível aceder à pasta de sincronização (erro %1).&lt;br&gt;A sincronização será retomada assim que for possível aceder à pasta.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>A pasta de sincronização foi substituída ou movida de forma a impedir a sincronização (erro %1).&lt;br&gt;Isto pode acontecer após copiar, mover ou restaurar a pasta.&lt;br&gt;Para resolver este problema, crie uma nova sincronização com uma nova pasta.&lt;br&gt;Nota: se houver alterações não sincronizadas na pasta antiga, terá de as copiar manualmente para a nova.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Não há memória suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>O kDrive precisa de ter acesso de escrita ao diretório temporário do seu computador.&lt;br&gt;Reinicie a aplicação kDrive para resolver este problema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Ocorreu um erro técnico.&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>O número de observações inotify é insuficiente (erro %1).&lt;br&gt;Pode aumentar este número editando o ficheiro «/etc/sysctl.conf».</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;Deve autorizar: - o kDrive em «Definições do sistema» &gt;&gt; «Geral» &gt;&gt; «Itens de&lt;br&gt;início de sessão e extensões» &gt;&gt; «Extensões de segurança de terminais»&lt;br&gt;; - a extensão kDrive LiteSync em «Definições do sistema» &gt;&gt; «Privacidade e segurança» &gt;&gt; «Acesso total ao disco».</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync está instalada e se o serviço Windows Search está ativado.&lt;br&gt;Limpe o histórico, reinicie o computador e, se o erro persistir, contacte a nossa equipa de suporte.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Verifique se a extensão Lite Sync tem as permissões corretas e se está em execução.&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Não foi possível iniciar o plugin Lite Sync (erro %1).&lt;br&gt;Limpe o histórico, reinicie e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Parece que um ficheiro ou pasta dentro da sua pasta de sincronização está corrompido.&lt;br&gt;A sincronização foi interrompida.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>O kDrive está em modo de manutenção.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>O kDrive está bloqueado.&lt;br&gt;Por favor, atualize o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>O kDrive está bloqueado.&lt;br&gt;Contacte um administrador para renovar o kDrive. Se não forem tomadas medidas, os dados serão eliminados definitivamente e será impossível recuperá-los.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>O kDrive está a iniciar-se.&lt;br&gt;A sincronização será reiniciada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na &lt;a style="%1" href="%2"&gt;versão&lt;/a&gt; &lt;a style="%1" href="%2"&gt;web&lt;/a&gt; para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>O kDrive está inativo.&lt;br&gt;Por favor, inicie sessão na versão web para verificar o estado do seu kDrive ou contacte o seu administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Não tem autorização para aceder a este kDrive.&lt;br&gt;A sincronização foi suspensa. Contacte um administrador.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização será retomada assim que possível. Se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>As ligações de rede foram interrompidas pelo kernel (erro %1).&lt;br&gt;Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Infelizmente, não foi possível migrar a sua configuração anterior.&lt;br&gt;A aplicação irá utilizar uma configuração em branco.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Infelizmente, não foi possível migrar a sua configuração de proxy anterior; os proxies SOCKS5 não são suportados neste momento.&lt;br&gt;A aplicação utilizará, em vez disso, as definições de proxy do sistema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Ocorreu um erro técnico (erro %1).&lt;br&gt;A sincronização foi reiniciada. Por favor, limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Ocorreu um erro ao aceder à base de dados de sincronização (erro %1).&lt;br&gt;A sincronização foi interrompida.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Ocorreu um problema ao iniciar sessão (erro %1).&lt;br&gt;Token inválido ou revogado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Não são permitidas sincronizações aninhadas (erro %1).&lt;br&gt;Deve manter apenas as sincronizações cujas pastas não estejam aninhadas.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>A pasta de sincronização no kDrive remoto já não existe ou já não está acessível (erro %1).&lt;br&gt;É necessário restaurá-la, restabelecer os direitos de acesso ou eliminar/recriar a sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Erro na análise do nome do ficheiro (erro %1).&lt;br&gt;Caracteres especiais, como aspas duplas, barras invertidas ou retornos de linha, podem causar falhas na análise.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Não tem permissão para criar um elemento ou já existe outro elemento com o mesmo nome. O elemento foi ignorado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Não é permitido mover o item para «%1».&lt;br&gt;O item será restaurado na sua pasta principal original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Não há espaço suficiente no seu computador.&lt;br&gt;O download foi cancelado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Não é possível criar o ficheiro «%1», uma vez que não é suportado no seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Este elemento foi movido para outro local.&lt;br&gt;A operação local foi cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;O elemento local foi renomeado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Já existe um elemento com o mesmo nome neste local.&lt;br&gt;A operação local foi cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Não há espaço suficiente no seu computador.&lt;br&gt;A sincronização foi interrompida.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>O ficheiro foi modificado ao mesmo tempo por outro utilizador.&lt;br&gt;As suas alterações foram guardadas numa cópia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Outro utilizador moveu uma pasta pai do destino.&lt;br&gt;A operação local foi cancelada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>O nome do artigo contém apenas espaços.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Não tem permissão para editar este item.&lt;br&gt;O ficheiro que contém as suas alterações foi renomeado e excluído da sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Não é permitido renomear o item.&lt;br&gt;Este será restaurado com o seu nome original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Não é permitido eliminar este item.&lt;br&gt;Será restaurado na sua localização original.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Não foi possível mover este item para a lixeira; foi colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>O ficheiro foi alterado localmente, embora tenha sido eliminado no kDrive remoto. A&lt;br&gt;cópia local foi guardada na pasta de recuperação.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>A operação realizada no item está proibida.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>A operação realizada neste item falhou.&lt;br&gt;O item foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>O ficheiro é demasiado grande para ser carregado. Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Não é possível descarregar o ficheiro.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Excedeste a tua quota. Aumenta a tua quota de espaço para reativar o envio de ficheiros.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>A unidade que contém a sua pasta de sincronização já não está ligada (erro %1).&lt;br&gt;Volte a ligá-la para retomar a sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Não foi possível iniciar a sincronização (erro %1).&lt;br&gt;O processo LiteSyncExt não está a ser executado neste momento. A sincronização será retomada assim que for iniciado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Existe um item com um nome idêntico, com as mesmas opções de maiúsculas e minúsculas.&lt;br&gt;Esse item foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>O nome do artigo contém um caractere não suportado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>O nome do item termina com um espaço, o que é proibido no seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Este nome de item está reservado pelo seu sistema operativo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>O nome do artigo é demasiado longo.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>O caminho do item é demasiado longo.&lt;br&gt;Foi ignorado.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>O nome do item contém um caractere Unicode recente que ainda não é suportado pelo seu sistema de ficheiros.&lt;br&gt;Foi excluído da sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Não foi possível sincronizar este item. Foi temporariamente colocado na lista negra. Será feita&lt;br&gt;uma nova tentativa de sincronização dentro de uma hora ou na próxima vez que a aplicação for iniciada.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Este item foi excluído da sincronização por um modelo personalizado.&lt;br&gt;Pode desativar este tipo de notificação nas Preferências</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Este item foi excluído da sincronização porque é um link físico.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Este item está atualmente bloqueado por outro utilizador online.&lt;br&gt;Voltaremos a tentar carregar as suas alterações mais tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Erro de sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Não é possível aceder ao item.&lt;br&gt;Por favor, corrija as permissões de leitura e escrita.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Erro do sistema.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>O item já existe no outro lado.&lt;br&gt;Foi temporariamente colocado na lista negra.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Ocorreu um erro técnico.&lt;br&gt;Limpe o histórico e, se o erro persistir, contacte a nossa equipa de apoio.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Esta sincronização está a ser eliminada.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Esta sincronização está a ser eliminada.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Voltar à lista de unidades</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Preferências</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Voltar à lista de unidades</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Preferências</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Geral</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Ativar tema escuro</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Ativar icones monocromaticos</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Iniciar o kDrive no arranque</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finlandês</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Dinamarquês</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Grego</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Neerlandês</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avancado</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Informacoes de depuracao</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Ficheiros a excluir</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Servidor proxy</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Sueco</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Português</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polaco</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norueguês</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Não foi possível abrir a pasta %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ligacao invalida %1.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Idioma</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Algum processo não foi executado.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Mover os ficheiros eliminados para o Lixo do meu computador</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Ingles</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Frances</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Alemao</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Espanhol</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italiano</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Predefinido</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Geral</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Ativar tema escuro</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Ativar icones monocromaticos</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Iniciar o kDrive no arranque</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finlandês</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Dinamarquês</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Grego</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Neerlandês</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avancado</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Informacoes de depuracao</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Abrir a pasta de depuração&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Ficheiros a excluir</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Sueco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Português</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polaco</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norueguês</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Não foi possível abrir a pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Ligacao invalida %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Idioma</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Algum processo não foi executado.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Mover os ficheiros eliminados para o Lixo do meu computador</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Alguns ficheiros ou pastas podem nao ser movidos para o Lixo do computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Pode sempre recuperar ficheiros ja sincronizados no Lixo da aplicacao web kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Ingles</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Frances</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Alemao</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Espanhol</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italiano</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Predefinido</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 em uso</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 em uso</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">Proxy HTTP(S)</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Servidor proxy</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Sem servidor proxy</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Utilizar parâmetros do sistema</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Indicar um representante manualmente</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Porto</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Endereço do servidor proxy</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">É necessária autenticação</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Utilizador</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Palavra-passe</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Quer guardar as suas alterações?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>Proxy HTTP(S)</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Sem servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Utilizar parâmetros do sistema</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Indicar um representante manualmente</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Porto</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Endereço do servidor proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>É necessária autenticação</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Utilizador</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Palavra-passe</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Quer guardar as suas alterações?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Não é possível guardar, pois nem todos os campos obrigatórios foram preenchidos!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Não foi encontrado nenhum proxy. Deseja guardar na mesma?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Gestor de Recursos</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Utilização máxima permitida da CPU</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">GUARDAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Quer guardar as suas alterações?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Gestor de Recursos</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Utilização máxima permitida da CPU</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>GUARDAR</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Quer guardar as suas alterações?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Selecione uma pasta no seu kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Espaço disponível no seu computador para a pasta atual: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Esta pasta já está a ser sincronizada.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">CONFIRMAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">CANCELAR</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Selecione uma pasta no seu kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>O conteúdo da pasta selecionada será sincronizado com a pasta &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Espaço disponível no seu computador para a pasta atual: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Esta pasta já está a ser sincronizada.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>CONFIRMAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>CANCELAR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">CONTINUAR</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Não existem subpastas no servidor neste momento.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; contém subpastas;&lt;br&gt; selecione as que deseja sincronizar</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>CONTINUAR</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Não existem subpastas no servidor neste momento.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Retomar a sincronização do kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Retomar toda a sincronização do kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Suspender a sincronização do kDrive &quot;%1&quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausar a sincronização</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Suspender toda a sincronização do kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Retomar a sincronização</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Retomar a sincronização do kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Retomar toda a sincronização do kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Suspender a sincronização do kDrive "%1"</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Pausar a sincronização</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Suspender toda a sincronização do kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Retomar a sincronização</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Copiar link de partilha</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Exibir em kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Mostrar na pasta</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Mais ações</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Abrir</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Adicionar aos favoritos</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Copiar link de partilha</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Exibir em kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Mostrar na pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Mais ações</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Abrir</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Adicionar aos favoritos</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Nunca</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Durante 1 hora</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Até amanhã às 8h00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Durante 3 dias</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Durante uma semana</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Sempre</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">Por mais 1 hora</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">Ainda por mais 3 dias</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Por mais uma semana</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Não foi possível abrir a URL da pasta %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Abrir na pasta</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Abrir a versão web do %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Parâmetros do acionamento</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Notificações desativadas até %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Desativar notificações</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Preferências da aplicação</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Precisa de ajuda</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Enviar comentários</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Sair do kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Não é possível aceder ao site %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Mostrar erros e informações</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Mostrar informações</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Mais ações</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Nunca</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Durante 1 hora</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Até amanhã às 8h00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Durante 3 dias</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Durante uma semana</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Sempre</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>Por mais 1 hora</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>Ainda por mais 3 dias</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Por mais uma semana</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Não foi possível abrir a URL da pasta %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Abrir na pasta</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Abrir a versão web do %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Parâmetros do acionamento</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Notificações desativadas até %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Desativar notificações</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Preferências da aplicação</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Precisa de ajuda</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Enviar comentários</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Sair do kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Não é possível aceder ao site %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Mostrar erros e informações</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Mostrar informações</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Mais ações</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Atualizar a aplicação kDrive</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Atualização</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Por favor, descarregue a versão mais recente no site.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Download da atualização em curso</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">À procura de atualizações...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Atualização manual</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Indisponível</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Pode sincronizar ficheiros &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Sincronizado</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoritos</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Atividade</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Não implementado!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Não existe nenhuma pasta sincronizada para este Drive!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">O kDrive não está configurado!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Não foi possível abrir a ligação %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ligacao invalida %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Não foi possível abrir a URL da pasta %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Atualizar a aplicação kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Esta versão da aplicação kDrive já não é suportada. Para aceder às funcionalidades e melhorias mais recentes, atualize a aplicação.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Atualização</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Por favor, descarregue a versão mais recente no site.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Download da atualização em curso</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>À procura de atualizações...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Atualização manual</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Indisponível</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Pode sincronizar ficheiros &lt;a style="%1" href="%2"&gt;a partir do seu computador&lt;/a&gt; ou em &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Sincronizado</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoritos</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Atividade</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Não implementado!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Clique aqui para fazer o download manualmente&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Não existe nenhuma pasta sincronizada para este Drive!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>O kDrive não está configurado!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Não foi possível abrir a ligação %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Ligacao invalida %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Não foi possível abrir a URL da pasta %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Ignorar esta versão</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Lembra-me mais tarde</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Instalar atualização</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;A nova versão &lt;b&gt;%1&lt;/b&gt; do Cliente %2 está disponível e já foi descarregada.&lt;/p&gt;&lt;p&gt;A versão instalada é a %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Ignorar esta versão</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Lembra-me mais tarde</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Instalar atualização</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">Está disponível uma nova atualização.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">A versão %1 está disponível para download.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>Está disponível uma nova atualização.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>A versão %1 está disponível para download.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Adicionar uma conta</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Adicionar uma conta</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Versão</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">ATUALIZAÇÃO</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">O %1 está atualizado!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">A verificar se há atualizações no servidor...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;aqui&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">Está disponível uma atualização: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">A descarregar %1. Por favor, aguarde...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Não foi possível verificar se existem novas atualizações.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Ocorreu um erro durante a atualização.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Não foi possível descarregar a atualização.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Atualização desativada.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Programa beta</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Obtenha acesso antecipado às novas versões da aplicação</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Junte-se a nós</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Modificar</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Sair</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Mostrar notas de lançamento&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Versão</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>ATUALIZAÇÃO</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>O %1 está atualizado!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>A verificar se há atualizações no servidor...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>Está disponível uma atualização: %1.&lt;br&gt;Faça o download &lt;a style="%2" href="%3"&gt;aqui&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>Está disponível uma atualização: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>A descarregar %1. Por favor, aguarde...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Não foi possível verificar se existem novas atualizações.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Ocorreu um erro durante a atualização.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Não foi possível descarregar a atualização.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Atualização desativada.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Programa beta</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Obtenha acesso antecipado às novas versões da aplicação</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Junte-se a nós</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Modificar</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Sair</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Não é possível guardar os parâmetros!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Não é possível encontrar um caminho válido</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Não foi selecionada nenhuma pasta válida!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">O caminho selecionado não existe!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">O caminho selecionado não é uma pasta!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Não tem permissão para gravar na pasta selecionada!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">A pasta local %1 já está sincronizada. Escolha outra!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Disponibilizar localmente</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Liberte espaço no disco local</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Cancelar para libertar espaço local</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Cancelar disponibilização local</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Não é permitido partilhar novamente este ficheiro</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Não é permitido partilhar novamente esta pasta</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Copiar link de partilha pública</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Copiar link de partilha privada</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Abrir no navegador</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Não foi possível guardar os parâmetros. Por favor, tente novamente mais tarde.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Não é possível guardar os parâmetros!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>A pasta principal é uma pasta de sincronização ou está incluída numa</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Não é possível encontrar um caminho válido</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Não foi selecionada nenhuma pasta válida!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>O caminho selecionado não existe!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>O caminho selecionado não é uma pasta!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Não tem permissão para gravar na pasta selecionada!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>A pasta local %1 contém uma pasta que já está sincronizada. Por favor, escolha outra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>A pasta local %1 está incluída numa pasta já sincronizada. Por favor, escolha outra!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>A pasta local %1 já está sincronizada. Escolha outra!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>A sincronização Lite (Beta) está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>O Lite sync (Beta) está desativado. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>A sincronização Lite está ativada. Os ficheiros do kDrive permanecem na nuvem e não ocupam espaço de armazenamento no seu computador.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>A sincronização Lite está desativada. Os ficheiros do kDrive ocupam espaço de armazenamento no seu computador.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Disponibilizar localmente</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Liberte espaço no disco local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Cancelar para libertar espaço local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Cancelar disponibilização local</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Não é permitido partilhar novamente este ficheiro</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Não é permitido partilhar novamente esta pasta</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Copiar link de partilha pública</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Copiar link de partilha privada</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Abrir no navegador</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">A aplicação kDrive irá fechar devido a um erro grave.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>A aplicação kDrive irá fechar devido a um erro grave.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n ano</numerusform>
-            <numerusform>%n anos</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n mes</numerusform>
-            <numerusform>%n meses</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n dia</numerusform>
-            <numerusform>%n dias</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n hora</numerusform>
-            <numerusform>%n horas</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minuto</numerusform>
-            <numerusform>%n minutos</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n segundo</numerusform>
-            <numerusform>%n segundos</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n ano</numerusform>
+<numerusform>%n anos</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n mes</numerusform>
+<numerusform>%n meses</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n dia</numerusform>
+<numerusform>%n dias</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n hora</numerusform>
+<numerusform>%n horas</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minuto</numerusform>
+<numerusform>%n minutos</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n segundo</numerusform>
+<numerusform>%n segundos</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Bandeja do sistema não disponível</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 requer uma bandeja do sistema funcional. Se estiver a executar o XFCE, siga &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema como &apos;trayer&apos; e tente novamente.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Bandeja do sistema não disponível</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 requer uma bandeja do sistema funcional. Se estiver a executar o XFCE, siga &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;estas instruções&lt;/a&gt;. Caso contrário, instale uma aplicação de bandeja do sistema como 'trayer' e tente novamente.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Não foi possível abrir o navegador</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Não foi possível abrir o cliente de e-mail</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Já não está conectado. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Inicie sessão&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Sincronização em curso (Passo %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Sincronização em curso.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Alguns ficheiros não puderam ser sincronizados. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Saiba mais&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">A sincronização está em pausa...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">A sincronização está a começar</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">A sincronização foi interrompida.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Sincronização em curso (%1 de %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Não foi possível abrir o navegador</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Ocorreu um erro ao iniciar o navegador para aceder ao URL %1. Será que não está configurado nenhum navegador predefinido?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Não foi possível abrir o cliente de e-mail</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Ocorreu um erro ao iniciar o cliente de e-mail para criar uma nova mensagem. Será que não está configurado nenhum cliente de e-mail predefinido?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Já não está conectado. &lt;a style="%1" href="%2"&gt;Inicie sessão&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Sincronização em curso (Passo %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Sincronização em curso.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Alguns ficheiros não puderam ser sincronizados. &lt;a style="%1" href="%2"&gt;Saiba mais&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>A sincronização está em pausa...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque outra sincronização está a utilizar a mesma pasta.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque contém a pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada porque está incluída na pasta sincronizada &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>A pasta &lt;b&gt;%1&lt;/b&gt; não pode ser selecionada como pasta de sincronização. Por favor, selecione outra pasta. Pasta sugerida: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Excluiu mais de %1 pastas; tenha em atenção que isto irá afetar o desempenho da sincronização.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Não é possível excluir mais do que %1 pastas. Desmarque as pastas de nível superior.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>A sincronização está a começar</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>A sincronização foi interrompida.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Sincronização em curso (%1 de %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Sincronização em curso (%1 de %2)
+<translation>Sincronização em curso (%1 de %2)
 Faltam %3...</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Estás em dia com os conflitos pendentes.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Já está tudo em dia!</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Estás em dia com os conflitos pendentes.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Já está tudo em dia!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Não existe nenhuma pasta para sincronizar
+<translation>Não existe nenhuma pasta para sincronizar
 Pode adicionar uma nas definições do kDrive.</translation>
-    </message>
+</message>
 </context>
 </TS>

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -1,3097 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS language="sv_SE" version="2.1">
+<TS version="2.1" language="sv_SE">
 <context>
-<name>KDC::AboutDialog</name>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="73"/>
-<source>About</source>
-<translation>Om</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="112"/>
-<source>CLOSE</source>
-<translation>STÄNG</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="123"/>
-<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-<translation>Version %1. För mer information, besök &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="126"/>
-<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-<translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="127"/>
-<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-<translation>Distribueras av %1 och licensieras enligt &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="151"/>
-<location filename="../src/gui/aboutdialog.cpp" line="162"/>
-<location filename="../src/gui/aboutdialog.cpp" line="171"/>
-<source>Unable to open folder %1.</source>
-<translation>Det går inte att öppna mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/aboutdialog.cpp" line="132"/>
-<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-<translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style="color: #489EF3" href="%1"&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-</message>
+    <name>KDC::AboutDialog</name>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="73"/>
+        <source>About</source>
+        <translation>Om</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="112"/>
+        <source>CLOSE</source>
+        <translation>STÄNG</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="123"/>
+        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+        <translation>Version %1. För mer information, besök &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="126"/>
+        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+        <translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="127"/>
+        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+        <translation>Distribueras av %1 och licensieras enligt &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="151"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="162"/>
+        <location filename="../src/gui/aboutdialog.cpp" line="171"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Det går inte att öppna mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/aboutdialog.cpp" line="132"/>
+        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+        <translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AbstractFileItemWidget</name>
-<message>
-<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
-<source>Unable to open folder path %1.</source>
-<translation>Det går inte att öppna mappsökvägen %1.</translation>
-</message>
+    <name>KDC::AbstractFileItemWidget</name>
+    <message>
+        <location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveConfirmationWidget</name>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
-<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-<translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
-<source>Your kDrive is ready!</source>
-<translation>Din kDrive är klar!</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
-<source>OPEN FOLDER</source>
-<translation>ÖPPNA MAPP</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
-<source>PARAMETERS</source>
-<translation>INSTÄLLNINGAR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
-<source>Synchronize another drive</source>
-<translation>Synkronisera en annan enhet</translation>
-</message>
+    <name>KDC::AddDriveConfirmationWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+        <translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+        <source>Your kDrive is ready!</source>
+        <translation>Din kDrive är klar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+        <source>OPEN FOLDER</source>
+        <translation>ÖPPNA MAPP</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+        <source>PARAMETERS</source>
+        <translation>INSTÄLLNINGAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+        <source>Synchronize another drive</source>
+        <translation>Synkronisera en annan enhet</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveListWidget</name>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
-<source>NEXT</source>
-<translation>NÄSTA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
-<source>Select the kDrive you want to synchronize</source>
-<translation>Välj den kDrive du vill synkronisera</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
-<source>Get kDrive for free</source>
-<translation>Skaffa kDrive gratis</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
-<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-<translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
-<source>Test for free</source>
-<translation>Testa gratis</translation>
-</message>
+    <name>KDC::AddDriveListWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+        <source>NEXT</source>
+        <translation>NÄSTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+        <source>Select the kDrive you want to synchronize</source>
+        <translation>Välj den kDrive du vill synkronisera</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+        <source>Get kDrive for free</source>
+        <translation>Skaffa kDrive gratis</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+        <translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+        <source>Test for free</source>
+        <translation>Testa gratis</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLiteSyncWidget</name>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
-<source>Conserve your computer space</source>
-<translation>Spara utrymme på datorn</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
-<source>Decide which files should be available online or locally</source>
-<translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
-<source>LATER</source>
-<translation>SENARE</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
-<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
-<source>Would you like to activate Lite Sync (Beta) ?</source>
-<translation>Vill du aktivera Lite Sync (Beta)?</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
-<source>Would you like to activate Lite Sync ?</source>
-<translation>Vill du aktivera Lite Sync?</translation>
-</message>
+    <name>KDC::AddDriveLiteSyncWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+        <source>Conserve your computer space</source>
+        <translation>Spara utrymme på datorn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+        <source>Decide which files should be available online or locally</source>
+        <translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+        <source>LATER</source>
+        <translation>SENARE</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+        <source>Would you like to activate Lite Sync (Beta) ?</source>
+        <translation>Vill du aktivera Lite Sync (Beta)?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+        <source>Would you like to activate Lite Sync ?</source>
+        <translation>Vill du aktivera Lite Sync?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLocalFolderWidget</name>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
-<source>Location of your %1 kDrive</source>
-<translation>Plats för din %1 kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
-<source>Edit folder</source>
-<translation>Ändra mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>END</source>
-<translation>SLUTFÖR</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
-<source>Select folder</source>
-<translation>Välj mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
-<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-<translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
-<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-<translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+    <name>KDC::AddDriveLocalFolderWidget</name>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+        <source>Location of your %1 kDrive</source>
+        <translation>Plats för din %1 kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+        <source>Edit folder</source>
+        <translation>Ändra mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>END</source>
+        <translation>SLUTFÖR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+        <source>Select folder</source>
+        <translation>Välj mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+        <translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+        <translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
 Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
-<source>CONTINUE</source>
-<translation>FORTSÄTT</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÄTT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveLoginWidget</name>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
-<source>Log in from your browser</source>
-<translation>Logga in från din webbläsare</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
-<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-<translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
-<source>Open the login page</source>
-<translation>Öppna inloggningssidan</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
-<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-<translation>Ett fel uppstod under autentiseringen. Stäng inloggningsfönstret och försök igen.&lt;br&gt;Om felet kvarstår, kontakta vårt supportteam.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
-<source>Login failed: %1 - %2</source>
-<translation>Inloggningen misslyckades: %1 - %2</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
-<source>Failed to open the login page in your web browser</source>
-<translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
-</message>
+    <name>KDC::AddDriveLoginWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+        <source>Log in from your browser</source>
+        <translation>Logga in från din webbläsare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+        <translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+        <source>Open the login page</source>
+        <translation>Öppna inloggningssidan</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+        <translation>Ett fel uppstod under autentiseringen. Stäng inloggningsfönstret och försök igen.&lt;br&gt;Om felet kvarstår, kontakta vårt supportteam.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+        <source>Login failed: %1 - %2</source>
+        <translation>Inloggningen misslyckades: %1 - %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+        <source>Failed to open the login page in your web browser</source>
+        <translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveServerFoldersWidget</name>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
-<source>Select kDrive folders to synchronize on your desktop</source>
-<translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
-<source>CONTINUE</source>
-<translation>FORTSÄTT</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
-<source>Space available on your computer : %1</source>
-<translation>Ledigt utrymme på din dator: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-</message>
-<message>
-<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
-<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
-</message>
+    <name>KDC::AddDriveServerFoldersWidget</name>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+        <source>Select kDrive folders to synchronize on your desktop</source>
+        <translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÄTT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+        <source>Space available on your computer : %1</source>
+        <translation>Ledigt utrymme på din dator: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AddDriveWizard</name>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
-<source>Failed to create local folder %1</source>
-<translation>Det gick inte att skapa den lokala mappen %1</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
-<source>Failed to create new synchronization</source>
-<translation>Det gick inte att skapa en ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
-<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-<translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
-</message>
+    <name>KDC::AddDriveWizard</name>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+        <source>Failed to create local folder %1</source>
+        <translation>Det gick inte att skapa den lokala mappen %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gick inte att skapa en ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+        <translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppClient</name>
-<message>
-<location filename="../src/gui/appclient.cpp" line="100"/>
-<source>kDrive client is run with bad parameters!</source>
-<translation>kDrive-klienten körs med felaktiga parametrar!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="109"/>
-<source>kDrive client is already running!</source>
-<translation>kDrive-klienten är redan igång!</translation>
-</message>
-<message>
-<location filename="../src/gui/appclient.cpp" line="724"/>
-<source>The user %1 is not connected. Please log in again.</source>
-<translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
-</message>
+    <name>KDC::AppClient</name>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="100"/>
+        <source>kDrive client is run with bad parameters!</source>
+        <translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="109"/>
+        <source>kDrive client is already running!</source>
+        <translation>kDrive-klienten är redan igång!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/appclient.cpp" line="724"/>
+        <source>The user %1 is not connected. Please log in again.</source>
+        <translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::AppServer</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="1691"/>
-<source>Share link copied to clipboard</source>
-<translation>Delningslänken har kopierats till urklipp</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3848"/>
-<source>%1 and %n other file(s) have been removed.</source>
-<translation>
-<numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-<numerusform>%1 och %n andra filer har tagits bort.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3850"/>
-<source>%1 has been removed.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 har tagits bort.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3855"/>
-<source>%1 and %n other file(s) have been added.</source>
-<translation>
-<numerusform>%1 och %n annan fil har lagts till.</numerusform>
-<numerusform>%1 och %n andra filer har lagts till.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3857"/>
-<source>%1 has been added.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 har lagts till.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3862"/>
-<source>%1 and %n other file(s) have been updated.</source>
-<translation>
-<numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-<numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3864"/>
-<source>%1 has been updated.</source>
-<comment>%1 names a file.</comment>
-<translation>%1 har uppdaterats.</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/server/appserver.cpp" line="3869"/>
-<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-<translation>
-<numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-<numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
-</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3872"/>
-<source>%1 has been moved to %2.</source>
-<translation>%1 har flyttats till %2.</translation>
-</message>
-<message>
-<location filename="../src/server/appserver.cpp" line="3880"/>
-<source>Sync Activity</source>
-<translation>Synkroniseringsaktivitet</translation>
-</message>
+    <name>KDC::AppServer</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="1691"/>
+        <source>Share link copied to clipboard</source>
+        <translation>Delningslänken har kopierats till urklipp</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3848"/>
+        <source>%1 and %n other file(s) have been removed.</source>
+        <translation>
+            <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
+            <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3850"/>
+        <source>%1 has been removed.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 har tagits bort.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3855"/>
+        <source>%1 and %n other file(s) have been added.</source>
+        <translation>
+            <numerusform>%1 och %n annan fil har lagts till.</numerusform>
+            <numerusform>%1 och %n andra filer har lagts till.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3857"/>
+        <source>%1 has been added.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 har lagts till.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3862"/>
+        <source>%1 and %n other file(s) have been updated.</source>
+        <translation>
+            <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
+            <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3864"/>
+        <source>%1 has been updated.</source>
+        <comment>%1 names a file.</comment>
+        <translation>%1 har uppdaterats.</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/server/appserver.cpp" line="3869"/>
+        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+        <translation>
+            <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
+            <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3872"/>
+        <source>%1 has been moved to %2.</source>
+        <translation>%1 har flyttats till %2.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="3880"/>
+        <source>Sync Activity</source>
+        <translation>Synkroniseringsaktivitet</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BaseFolderTreeItemWidget</name>
-<message>
-<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
-<source>No subfolders currently on the server.</source>
-<translation>Det finns för närvarande inga undermappar på servern.</translation>
-</message>
+    <name>KDC::BaseFolderTreeItemWidget</name>
+    <message>
+        <location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::BetaProgramDialog</name>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Quit the beta program</source>
-<translation>Avsluta betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
-<source>Join the beta program</source>
-<translation>Anmäl dig till betaprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
-<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-<translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
-<source>Benefit from application beta updates</source>
-<translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
-<source>No</source>
-<translation>Nej</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
-<source>Public beta version</source>
-<translation>Offentlig betaversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
-<source>Internal beta version</source>
-<translation>Intern betaversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
-<source>Test version</source>
-<translation>Testversion</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
-<source>I understand</source>
-<translation>Jag förstår</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
-<source>Are you sure you want to leave the beta program?</source>
-<translation>Är du säker på att du vill lämna betaprogrammet?</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
-<source>Save</source>
-<translation>Spara</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
-<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-<translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
-</message>
-<message>
-<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
-<source>Beta versions may leave unexpectedly or cause instabilities.</source>
-<translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
-</message>
+    <name>KDC::BetaProgramDialog</name>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Quit the beta program</source>
+        <translation>Avsluta betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+        <source>Join the beta program</source>
+        <translation>Anmäl dig till betaprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+        <translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+        <source>Benefit from application beta updates</source>
+        <translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+        <source>No</source>
+        <translation>Nej</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+        <source>Public beta version</source>
+        <translation>Offentlig betaversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+        <source>Internal beta version</source>
+        <translation>Intern betaversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+        <source>Test version</source>
+        <translation>Testversion</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+        <source>I understand</source>
+        <translation>Jag förstår</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+        <source>Are you sure you want to leave the beta program?</source>
+        <translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+        <source>Save</source>
+        <translation>Spara</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+        <translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
+        <translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ClientGui</name>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="190"/>
-<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-<translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="243"/>
-<source>Please sign in</source>
-<translation>Logga in</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="293"/>
-<source>Folder %1: %2</source>
-<translation>Mappen %1: %2</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="299"/>
-<source>There are no sync folders configured.</source>
-<translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1508"/>
-<source>Synthesis</source>
-<translation>Sammanfattning</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1509"/>
-<source>Preferences</source>
-<translatorcomment>Préférences</translatorcomment>
-<translation>Inställningar</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1510"/>
-<source>Quit</source>
-<translation>Avsluta</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="674"/>
-<source>Undefined State.</source>
-<translation>Odefinierat tillstånd.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="677"/>
-<source>Waiting to start syncing.</source>
-<translation>Väntar på att synkroniseringen ska starta.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="680"/>
-<source>Sync is running.</source>
-<translation>Synkroniseringen pågår.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="684"/>
-<source>Sync was successful, unresolved conflicts.</source>
-<translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="686"/>
-<source>Last Sync was successful.</source>
-<translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="693"/>
-<source>User Abort.</source>
-<translation>Användaren avbryter.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="697"/>
-<source>Sync is paused.</source>
-<translation>Synkroniseringen är pausad.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="706"/>
-<source>%1 (Sync is paused)</source>
-<translation>%1 (Synkroniseringen är pausad)</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1250"/>
-<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1254"/>
-<source>REMOVE ALL SYNCHRONIZATIONS</source>
-<translation>TA BORT ALLA SYNKRONISERINGAR</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1255"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1382"/>
-<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-<translation>%1 objekt har tagits bort från din lokala synkmapp &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. För att undvika oavsiktliga borttagningar har synkroniseringen pausats.&lt;br&gt;Vill du sprida dessa borttagningar till ditt kDrive?</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1420"/>
-<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
-<translation>Flera filer har tagits bort från din lokala synkmapp &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Borttagna filer finns i kDrives &lt;a style="%1" href="%3"&gt;papperskorg&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1426"/>
-<source>Don't show again</source>
-<translation>Visa inte igen</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="1676"/>
-<source>Failed to start synchronizations!</source>
-<translation>Det gick inte att starta synkroniseringarna!</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="850"/>
-<source>Unable to open folder path %1.</source>
-<translation>Det går inte att öppna mappsökvägen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="117"/>
-<source>Unable to initialize kDrive client</source>
-<translation>Det går inte att starta kDrive-klienten</translation>
-</message>
-<message>
-<location filename="../src/gui/clientgui.cpp" line="256"/>
-<source>Synchronization is paused</source>
-<translation>Synkroniseringen är pausad</translation>
-</message>
+    <name>KDC::ClientGui</name>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="190"/>
+        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+        <translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="243"/>
+        <source>Please sign in</source>
+        <translation>Logga in</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="293"/>
+        <source>Folder %1: %2</source>
+        <translation>Mappen %1: %2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="299"/>
+        <source>There are no sync folders configured.</source>
+        <translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1508"/>
+        <source>Synthesis</source>
+        <translation>Sammanfattning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1509"/>
+        <source>Preferences</source>
+        <translatorcomment>Préférences</translatorcomment>
+        <translation>Inställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1510"/>
+        <source>Quit</source>
+        <translation>Avsluta</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="674"/>
+        <source>Undefined State.</source>
+        <translation>Odefinierat tillstånd.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="677"/>
+        <source>Waiting to start syncing.</source>
+        <translation>Väntar på att synkroniseringen ska starta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="680"/>
+        <source>Sync is running.</source>
+        <translation>Synkroniseringen pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="684"/>
+        <source>Sync was successful, unresolved conflicts.</source>
+        <translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="686"/>
+        <source>Last Sync was successful.</source>
+        <translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="693"/>
+        <source>User Abort.</source>
+        <translation>Användaren avbryter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="697"/>
+        <source>Sync is paused.</source>
+        <translation>Synkroniseringen är pausad.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="706"/>
+        <source>%1 (Sync is paused)</source>
+        <translation>%1 (Synkroniseringen är pausad)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1250"/>
+        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1254"/>
+        <source>REMOVE ALL SYNCHRONIZATIONS</source>
+        <translation>TA BORT ALLA SYNKRONISERINGAR</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1255"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1382"/>
+        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+        <translation>%1 objekt har tagits bort från din lokala synkmapp &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. För att undvika oavsiktliga borttagningar har synkroniseringen pausats.&lt;br&gt;Vill du sprida dessa borttagningar till ditt kDrive?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1420"/>
+        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
+        <translation>Flera filer har tagits bort från din lokala synkmapp &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Borttagna filer finns i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papperskorg&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1426"/>
+        <source>Don&apos;t show again</source>
+        <translation>Visa inte igen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="1676"/>
+        <source>Failed to start synchronizations!</source>
+        <translation>Det gick inte att starta synkroniseringarna!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="850"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="117"/>
+        <source>Unable to initialize kDrive client</source>
+        <translation>Det går inte att starta kDrive-klienten</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/clientgui.cpp" line="256"/>
+        <source>Synchronization is paused</source>
+        <translation>Synkroniseringen är pausad</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ConfirmSynchronizationDialog</name>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
-<source>Summary of your local folder synchronization</source>
-<translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
-<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-<translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
-<source>SYNCHRONIZE</source>
-<translation>SYNKRONISERA</translation>
-</message>
+    <name>KDC::ConfirmSynchronizationDialog</name>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+        <source>Summary of your local folder synchronization</source>
+        <translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+        <translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+        <source>SYNCHRONIZE</source>
+        <translation>SYNKRONISERA</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomExtensionSetupWidget</name>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
-<source>Before finishing</source>
-<translation>Innan du avslutar</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
-<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-<translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
-<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
-<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
-<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
-<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
-<translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
-<source>Authorize the kDrive application</source>
-<translation>Godkänn appen kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
-<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
-<translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
-<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-<translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
-<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
-<translation>Lås upp hänglåset &lt;img src=":/client/resources/icons/actions/lock.png"&gt; och godkänn kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
-<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
-<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
-<translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
-<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
-<translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
-<source>A restart of the app might be proposed, in this case accept it</source>
-<translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
-<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
-<translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<source>STEP 1</source>
-<translation>STEG 1</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>(Done)</source>
-<translation>(Klart)</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
-<source>STEP 2</source>
-<translation>STEG 2</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
-<source>STEPS PERFORMED</source>
-<translation>UTFÖRDA STEG</translation>
-</message>
-<message>
-<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
-<source>END</source>
-<translation>SLUTFÖR</translation>
-</message>
+    <name>KDC::CustomExtensionSetupWidget</name>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+        <source>Before finishing</source>
+        <translation>Innan du avslutar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+        <translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
+        <translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+        <source>Authorize the kDrive application</source>
+        <translation>Godkänn appen kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
+        <translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+        <translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
+        <translation>Lås upp hänglåset &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; och godkänn kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
+        <translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
+        <translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+        <source>A restart of the app might be proposed, in this case accept it</source>
+        <translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
+        <translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <source>STEP 1</source>
+        <translation>STEG 1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>(Done)</source>
+        <translation>(Klart)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+        <source>STEP 2</source>
+        <translation>STEG 2</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+        <source>STEPS PERFORMED</source>
+        <translation>UTFÖRDA STEG</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+        <source>END</source>
+        <translation>SLUTFÖR</translation>
+    </message>
 </context>
 <context>
-<name>KDC::CustomMessageBox</name>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="105"/>
-<source>OK</source>
-<translation>OKEJ</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="115"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="125"/>
-<source>YES</source>
-<translation>JA</translation>
-</message>
-<message>
-<location filename="../src/gui/custommessagebox.cpp" line="135"/>
-<source>NO</source>
-<translation>NEJ</translation>
-</message>
+    <name>KDC::CustomMessageBox</name>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="105"/>
+        <source>OK</source>
+        <translation>OKEJ</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="115"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="125"/>
+        <source>YES</source>
+        <translation>JA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/custommessagebox.cpp" line="135"/>
+        <source>NO</source>
+        <translation>NEJ</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebugReporter</name>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Sending of debugging information</source>
-<translation>Översändning av felsökningsinformation</translation>
-</message>
-<message>
-<location filename="../src/gui/debugreporter.cpp" line="37"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
+    <name>KDC::DebugReporter</name>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Sending of debugging information</source>
+        <translation>Översändning av felsökningsinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debugreporter.cpp" line="37"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DebuggingDialog</name>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
-<source>Info</source>
-<translation>Info</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
-<source>Debug</source>
-<translation>Felsökning</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
-<source>Warning</source>
-<translation>Varning</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
-<source>Error</source>
-<translation>Fel</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
-<source>Fatal</source>
-<translation>Dödlig</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
-<source>Debugging settings</source>
-<translation>Felsökningsinställningar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
-<source>Save debugging information in a folder on my computer (Recommended)</source>
-<translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
-<source>This information enables IT support to determine the origin of an incident.</source>
-<translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
-<source>Debug level</source>
-<translation>Felsökningsnivå</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
-<source>The trace level lets you choose the extent of the debugging information recorded</source>
-<translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
-<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-<translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
-<source>Extended Full Log</source>
-<translation>Utökad fullständig logg</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
-<source>Delete logs older than %1 days</source>
-<translation>Ta bort loggar som är äldre än %1 dagar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
-<source>Share the debug folder with Infomaniak support.</source>
-<translation>Skicka debug-mappen till Infomaniaks support.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
-<source>The last session is the periode since the last kDrive start.</source>
-<translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
-<source>Share only the last kDrive session</source>
-<translation>Dela endast den senaste kDrive-sessionen</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
-<source>  Loading</source>
-<translation>  Laddar</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
-<source>SAVE</source>
-<translation>SPARA</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
-<source>Failed to share</source>
-<translation>Det gick inte att dela</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
-<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-<translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
-<source> (Connexion interrupted)</source>
-<translation> (Anslutningen avbröts)</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
-<source>Share the folder with SwissTransfer &lt;br&gt;</source>
-<translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
-<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-<translation> 1. Vi har automatiskt komprimerat din logg &lt;a style="%1" href="%2"&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
-<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-<translation> 2. Skicka arkivet via &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
-<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-<translation> 3. Dela länken med &lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
-<source>Last upload the %1</source>
-<translation>Senaste uppladdning: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
-<source>Sharing has been cancelled</source>
-<translation>Delningen har avbrutits</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
-<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-<translation>Den utökade fullständiga loggen aktiveras via miljövariabeln KDRIVE_FORCE_EXTENDED_LOG. Sätt den till 0 för att inaktivera den.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.h" line="70"/>
-<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-<translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
-<source>%1/%2/%3 at %4h%5m and %6s</source>
-<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-<translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vill du spara dina ändringar?</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
-<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
-<source>Unable to open folder %1.</source>
-<translation>Det går inte att öppna mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
-<source>  Share</source>
-<translation>  Dela</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
-<source>  Sharing | step 1/2 %1%</source>
-<translation>  Dela | steg 1/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
-<source>  Sharing | step 2/2 %1%</source>
-<translation>  Dela | steg 2/2 %1%</translation>
-</message>
-<message>
-<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
-<source>  Canceling...</source>
-<translation>  Avbryter...</translation>
-</message>
+    <name>KDC::DebuggingDialog</name>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+        <source>Info</source>
+        <translation>Info</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+        <source>Debug</source>
+        <translation>Felsökning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>Varning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+        <source>Error</source>
+        <translation>Fel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+        <source>Fatal</source>
+        <translation>Dödlig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+        <source>Debugging settings</source>
+        <translation>Felsökningsinställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+        <source>Save debugging information in a folder on my computer (Recommended)</source>
+        <translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+        <source>This information enables IT support to determine the origin of an incident.</source>
+        <translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+        <source>Debug level</source>
+        <translation>Felsökningsnivå</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+        <source>The trace level lets you choose the extent of the debugging information recorded</source>
+        <translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+        <translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+        <source>Extended Full Log</source>
+        <translation>Utökad fullständig logg</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+        <source>Delete logs older than %1 days</source>
+        <translation>Ta bort loggar som är äldre än %1 dagar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+        <source>Share the debug folder with Infomaniak support.</source>
+        <translation>Skicka debug-mappen till Infomaniaks support.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+        <source>The last session is the periode since the last kDrive start.</source>
+        <translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+        <source>Share only the last kDrive session</source>
+        <translation>Dela endast den senaste kDrive-sessionen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+        <source>  Loading</source>
+        <translation>  Laddar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+        <source>SAVE</source>
+        <translation>SPARA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+        <source>Failed to share</source>
+        <translation>Det gick inte att dela</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+        <translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+        <source> (Connexion interrupted)</source>
+        <translation> (Anslutningen avbröts)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
+        <translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+        <translation> 1. Vi har automatiskt komprimerat din logg &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+        <translation> 2. Skicka arkivet via &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+        <translation> 3. Dela länken med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+        <source>Last upload the %1</source>
+        <translation>Senaste uppladdning: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+        <source>Sharing has been cancelled</source>
+        <translation>Delningen har avbrutits</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+        <translation>Den utökade fullständiga loggen aktiveras via miljövariabeln KDRIVE_FORCE_EXTENDED_LOG. Sätt den till 0 för att inaktivera den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.h" line="70"/>
+        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+        <translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+        <source>%1/%2/%3 at %4h%5m and %6s</source>
+        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+        <translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vill du spara dina ändringar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+        <location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Det går inte att öppna mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+        <source>  Share</source>
+        <translation>  Dela</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+        <source>  Sharing | step 1/2 %1%</source>
+        <translation>  Dela | steg 1/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+        <source>  Sharing | step 2/2 %1%</source>
+        <translation>  Dela | steg 2/2 %1%</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+        <source>  Canceling...</source>
+        <translation>  Avbryter...</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DrivePreferencesWidget</name>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
-<source>Folders</source>
-<translation>Mappar</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
-<source>Notifications</source>
-<translation>Meddelanden</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
-<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-<translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
-<source>Connected with</source>
-<translation>I samband med</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
-<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-<translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
-<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-<translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
-<source>New local folder synchronization failed!</source>
-<translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
-<source>Lite Sync activation failed.</source>
-<translation>Aktiveringen av Lite Sync misslyckades.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
-<source>Lite Sync deactivation failed.</source>
-<translation>Det gick inte att inaktivera Lite Sync.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
-<source>REMOVE FOLDER SYNC CONNECTION</source>
-<translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
-<source>An error occurred while loading the list of subfolders.</source>
-<translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
-<source>Enable the notifications for this kDrive</source>
-<translation>Aktivera aviseringar för denna kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
-<source>CONFIRM</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
-<source>Synchronization errors and information.</source>
-<translation>Synkroniseringsfel och information.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
-<source>Synchronize a local folder</source>
-<translation>Synkronisera en lokal mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
-<source>Do you really want to turn on Lite Sync?</source>
-<translation>Vill du verkligen aktivera Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
-<source>Do you really want to turn off Lite Sync?</source>
-<translation>Vill du verkligen stänga av Lite Sync?</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
-<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-<translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
-<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-<translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
-<source>Failed to create new synchronization</source>
-<translation>Det gick inte att skapa en ny synkronisering</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
-<source>Lite Sync activated.</source>
-<translation>Lite Sync är aktiverat.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
-<source>Lite Sync deactivated.</source>
-<translation>Lite Sync är inaktiverat.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
-<source>This drive is being deleted.</source>
-<translation>Den här enheten raderas.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
-<source>Impossible to open item %1</source>
-<translation>Det går inte att öppna objekt %1</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
-<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-<translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
-<source>Remove all synchronizations</source>
-<translation>Ta bort alla synkroniseringar</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
-<source>Search in your kDrive</source>
-<translation>Sök i din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
-<source>Search</source>
-<translation>Sök</translation>
-</message>
+    <name>KDC::DrivePreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+        <source>Folders</source>
+        <translation>Mappar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+        <source>Notifications</source>
+        <translation>Meddelanden</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+        <translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+        <source>Connected with</source>
+        <translation>I samband med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+        <translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+        <translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+        <source>New local folder synchronization failed!</source>
+        <translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+        <source>Lite Sync activation failed.</source>
+        <translation>Aktiveringen av Lite Sync misslyckades.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+        <source>Lite Sync deactivation failed.</source>
+        <translation>Det gick inte att inaktivera Lite Sync.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+        <source>REMOVE FOLDER SYNC CONNECTION</source>
+        <translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+        <source>An error occurred while loading the list of subfolders.</source>
+        <translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+        <source>Enable the notifications for this kDrive</source>
+        <translation>Aktivera aviseringar för denna kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+        <source>CONFIRM</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+        <source>Synchronization errors and information.</source>
+        <translation>Synkroniseringsfel och information.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+        <source>Synchronize a local folder</source>
+        <translation>Synkronisera en lokal mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+        <source>Do you really want to turn on Lite Sync?</source>
+        <translation>Vill du verkligen aktivera Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+        <source>Do you really want to turn off Lite Sync?</source>
+        <translation>Vill du verkligen stänga av Lite Sync?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+        <translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+        <translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+        <source>Failed to create new synchronization</source>
+        <translation>Det gick inte att skapa en ny synkronisering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+        <source>Lite Sync activated.</source>
+        <translation>Lite Sync är aktiverat.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+        <source>Lite Sync deactivated.</source>
+        <translation>Lite Sync är inaktiverat.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+        <source>This drive is being deleted.</source>
+        <translation>Den här enheten raderas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+        <source>Impossible to open item %1</source>
+        <translation>Det går inte att öppna objekt %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+        <translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+        <source>Remove all synchronizations</source>
+        <translation>Ta bort alla synkroniseringar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+        <source>Search in your kDrive</source>
+        <translation>Sök i din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+        <source>Search</source>
+        <translation>Sök</translation>
+    </message>
 </context>
 <context>
-<name>KDC::DriveSelectionWidget</name>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
-<source>Synchronize a kDrive</source>
-<translation>Synkronisera en kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
-<source>Add a kDrive</source>
-<translation>Lägg till en kDrive</translation>
-</message>
+    <name>KDC::DriveSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+        <source>Synchronize a kDrive</source>
+        <translation>Synkronisera en kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+        <source>Add a kDrive</source>
+        <translation>Lägg till en kDrive</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorTabWidget</name>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="179"/>
-<source>Resolve</source>
-<translation>Lösa</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="180"/>
-<source>Conflicted item(s)</source>
-<translation>Konflikterande objekt</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="181"/>
-<source>Item(s) with unsupported characters</source>
-<translation>Objekt med tecken som inte stöds</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="92"/>
-<location filename="../src/gui/errortabwidget.cpp" line="135"/>
-<location filename="../src/gui/errortabwidget.cpp" line="178"/>
-<location filename="../src/gui/errortabwidget.cpp" line="186"/>
-<source>Clear history</source>
-<translation>Rensa historiken</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="176"/>
-<source>To Resolve</source>
-<translation>Att lösa</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="184"/>
-<source>Automatically resolved</source>
-<translation>Löst automatiskt</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="185"/>
-<source>problem(s) solved</source>
-<translation>problem löst</translation>
-</message>
-<message>
-<location filename="../src/gui/errortabwidget.cpp" line="177"/>
-<source>problem(s) detected</source>
-<translation>problem har upptäckts</translation>
-</message>
+    <name>KDC::ErrorTabWidget</name>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="179"/>
+        <source>Resolve</source>
+        <translation>Lösa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="180"/>
+        <source>Conflicted item(s)</source>
+        <translation>Konflikterande objekt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="181"/>
+        <source>Item(s) with unsupported characters</source>
+        <translation>Objekt med tecken som inte stöds</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="92"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="135"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="178"/>
+        <location filename="../src/gui/errortabwidget.cpp" line="186"/>
+        <source>Clear history</source>
+        <translation>Rensa historiken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="176"/>
+        <source>To Resolve</source>
+        <translation>Att lösa</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="184"/>
+        <source>Automatically resolved</source>
+        <translation>Löst automatiskt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="185"/>
+        <source>problem(s) solved</source>
+        <translation>problem löst</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errortabwidget.cpp" line="177"/>
+        <source>problem(s) detected</source>
+        <translation>problem har upptäckts</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsMenuBarWidget</name>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
-<source>Synchronization conflicts or errors</source>
-<translation>Synkroniseringskonflikter eller fel</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
-<source>Errors</source>
-<translation>Fel</translation>
-</message>
-<message>
-<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
-<source>Back to preferences</source>
-<translation>Tillbaka till inställningar</translation>
-</message>
+    <name>KDC::ErrorsMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+        <source>Synchronization conflicts or errors</source>
+        <translation>Synkroniseringskonflikter eller fel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+        <source>Errors</source>
+        <translation>Fel</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+        <source>Back to preferences</source>
+        <translation>Tillbaka till inställningar</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ErrorsPopup</name>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="73"/>
-<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
-<translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="95"/>
-<source> (%1 error(s))</source>
-<translation> (%1 fel)</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="101"/>
-<source> (%1 information(s))</source>
-<translation> (%1 uppgift(er))</translation>
-</message>
-<message>
-<location filename="../src/gui/errorspopup.cpp" line="107"/>
-<source> (%1 error(s) and %2 information(s))</source>
-<translation> (%1 fel och %2 uppgifter)</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/gui/errorspopup.cpp" line="147"/>
-<source>Generic errors (%n warning(s) or error(s))</source>
-<comment>Number of warnings or errors</comment>
-<translation>
-<numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-<numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
-</translation>
-</message>
+    <name>KDC::ErrorsPopup</name>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="73"/>
+        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
+        <translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="95"/>
+        <source> (%1 error(s))</source>
+        <translation> (%1 fel)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="101"/>
+        <source> (%1 information(s))</source>
+        <translation> (%1 uppgift(er))</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/errorspopup.cpp" line="107"/>
+        <source> (%1 error(s) and %2 information(s))</source>
+        <translation> (%1 fel och %2 uppgifter)</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/gui/errorspopup.cpp" line="147"/>
+        <source>Generic errors (%n warning(s) or error(s))</source>
+        <comment>Number of warnings or errors</comment>
+        <translation>
+            <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
+            <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionDialog</name>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
-<source>Excluded files</source>
-<translation>Undantagna filer</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
-<source>Add files or folders that will not be synchronized on your computer.</source>
-<translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
-<source>Add</source>
-<translation>Lägg till</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
-<source>NAME</source>
-<translation>NAMN</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
-<source>WARNING</source>
-<translation>VARNING</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
-<source>SAVE</source>
-<translation>SPARA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vill du spara dina ändringar?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
-<source>Exclusion template already exists!</source>
-<translation>Mallen för uteslutning finns redan!</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
-<source>Do you really want to delete?</source>
-<translation>Vill du verkligen ta bort det?</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
-<source>Cannot save changes!</source>
-<translation>Det går inte att spara ändringarna!</translation>
-</message>
+    <name>KDC::FileExclusionDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+        <source>Excluded files</source>
+        <translation>Undantagna filer</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+        <source>Add files or folders that will not be synchronized on your computer.</source>
+        <translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+        <source>Add</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+        <source>NAME</source>
+        <translation>NAMN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+        <source>WARNING</source>
+        <translation>VARNING</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+        <source>SAVE</source>
+        <translation>SPARA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vill du spara dina ändringar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+        <source>Exclusion template already exists!</source>
+        <translation>Mallen för uteslutning finns redan!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vill du verkligen ta bort det?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+        <source>Cannot save changes!</source>
+        <translation>Det går inte att spara ändringarna!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FileExclusionNameDialog</name>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
-<source>VALIDATE</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::FileExclusionNameDialog</name>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+        <source>VALIDATE</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FixConflictingFilesDialog</name>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
-<source>Solve conflict(s)</source>
-<translation>Lösa konflikter</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
-<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-<translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
-<source>Save my changes and replace other users' versions.</source>
-<translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
-<source>Undo my changes and keep other users' versions.</source>
-<translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
-<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
-<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style=%1 href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
-<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-<translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
-<source>Show item(s)</source>
-<translation>Visa objekt</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
-<source>VALIDATE</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
-<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-<translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
-<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
-<translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
+    <name>KDC::FixConflictingFilesDialog</name>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+        <source>Solve conflict(s)</source>
+        <translation>Lösa konflikter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+        <translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+        <source>Save my changes and replace other users&apos; versions.</source>
+        <translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+        <source>Undo my changes and keep other users&apos; versions.</source>
+        <translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=%1 href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+        <translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+        <source>Show item(s)</source>
+        <translation>Visa objekt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+        <source>VALIDATE</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+        <translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::FolderItemWidget</name>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
-<source>More actions</source>
-<translation>Fler åtgärder</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
-<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
-<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
-<translation>Synkroniserad till &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
-<source>Activate Lite Sync</source>
-<translation>Aktivera Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
-<source>Activate Lite Sync (Beta)</source>
-<translation>Aktivera Lite Sync (Beta)</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
-<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-<translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
-<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-<translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
-<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-<translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
-<source>Cancel</source>
-<translation>Avbryt</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
-<source>VALIDATE</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
-<source>Pause synchronization</source>
-<translation>Pausa synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
-<source>Deactivate Lite Sync</source>
-<translation>Inaktivera Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
-<source>Resume synchronization</source>
-<translation>Fortsätt synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
-<source>Remove synchronization</source>
-<translation>Avaktivera synkronisering</translation>
-</message>
+    <name>KDC::FolderItemWidget</name>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+        <source>More actions</source>
+        <translation>Fler åtgärder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+        <location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Synkroniserad till &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+        <source>Activate Lite Sync</source>
+        <translation>Aktivera Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+        <source>Activate Lite Sync (Beta)</source>
+        <translation>Aktivera Lite Sync (Beta)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+        <translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+        <translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+        <translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+        <source>Cancel</source>
+        <translation>Avbryt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+        <source>VALIDATE</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+        <source>Pause synchronization</source>
+        <translation>Pausa synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+        <source>Deactivate Lite Sync</source>
+        <translation>Inaktivera Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsätt synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+        <source>Remove synchronization</source>
+        <translation>Avaktivera synkronisering</translation>
+    </message>
 </context>
 <context>
-<name>KDC::GenericErrorItemWidget</name>
-<message>
-<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
-<source>Unable to open folder path %1.</source>
-<translation>Det går inte att öppna mappsökvägen %1.</translation>
-</message>
+    <name>KDC::GenericErrorItemWidget</name>
+    <message>
+        <location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncAppDialog</name>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
-<source>Application Id</source>
-<translation>Applikations-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
-<source>Application Name</source>
-<translation>Programnamn</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
-<source>VALIDATE</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::LiteSyncAppDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+        <source>Application Id</source>
+        <translation>Applikations-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+        <source>Application Name</source>
+        <translation>Programnamn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+        <source>VALIDATE</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LiteSyncDialog</name>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
-<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
-<translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
-<source>Add</source>
-<translation>Lägg till</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
-<source>APPLICATION ID</source>
-<translation>APPLIKATIONS-ID</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
-<source>NAME</source>
-<translation>NAMN</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
-<source>SAVE</source>
-<translation>SPARA</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vill du spara dina ändringar?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
-<source>Do you really want to delete?</source>
-<translation>Vill du verkligen ta bort det?</translation>
-</message>
-<message>
-<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
-<source>Cannot save changes!</source>
-<translation>Det går inte att spara ändringarna!</translation>
-</message>
+    <name>KDC::LiteSyncDialog</name>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
+        <translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+        <source>Add</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+        <source>APPLICATION ID</source>
+        <translation>APPLIKATIONS-ID</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+        <source>NAME</source>
+        <translation>NAMN</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+        <source>SAVE</source>
+        <translation>SPARA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vill du spara dina ändringar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+        <source>Do you really want to delete?</source>
+        <translation>Vill du verkligen ta bort det?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+        <source>Cannot save changes!</source>
+        <translation>Det går inte att spara ändringarna!</translation>
+    </message>
 </context>
 <context>
-<name>KDC::LocalFolderDialog</name>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
-<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-<translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
-<source>The content of this folder will be synchronized on the kDrive</source>
-<translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
-<source>Select a folder</source>
-<translation>Välj en mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
-<source>Edit folder</source>
-<translation>Ändra mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
-<source>CONTINUE</source>
-<translation>FORTSÄTT</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
-<source>This folder is not compatible with Lite Sync.&lt;br&gt;
+    <name>KDC::LocalFolderDialog</name>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+        <translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+        <source>The content of this folder will be synchronized on the kDrive</source>
+        <translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+        <source>Select a folder</source>
+        <translation>Välj en mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+        <source>Edit folder</source>
+        <translation>Ändra mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÄTT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
 Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
 
-&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
-<source>Select folder</source>
-<translation>Välj mapp</translation>
-</message>
-<message>
-<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
+&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+        <source>Select folder</source>
+        <translation>Välj mapp</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::Logger</name>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>Error</source>
-<translation>Fel</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/logger.cpp" line="201"/>
-<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-<translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
-</message>
+    <name>KDC::Logger</name>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>Error</source>
+        <translation>Fel</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/logger.cpp" line="201"/>
+        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+        <translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+    </message>
 </context>
 <context>
-<name>KDC::MainMenuBarWidget</name>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
-<source>Preferences</source>
-<translation>Inställningar</translation>
-</message>
-<message>
-<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
-<source>Help</source>
-<translation>Hjälp</translation>
-</message>
+    <name>KDC::MainMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+        <source>Preferences</source>
+        <translation>Inställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+        <source>Help</source>
+        <translation>Hjälp</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ParametersDialog</name>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-<source>Unable to open folder path %1.</source>
-<translation>Det går inte att öppna mappsökvägen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-<translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-<source>No kDrive configured!</source>
-<translation>kDrive är inte konfigurerat!</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-<source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
-<translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="337"/>
-<location filename="../src/gui/parametersdialog.cpp" line="440"/>
-<location filename="../src/gui/parametersdialog.cpp" line="506"/>
-<location filename="../src/gui/parametersdialog.cpp" line="546"/>
-<location filename="../src/gui/parametersdialog.cpp" line="560"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="342"/>
-<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-<translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="347"/>
-<location filename="../src/gui/parametersdialog.cpp" line="516"/>
-<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-<translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="352"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-<translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="356"/>
-<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-<translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="360"/>
-<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-<translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="385"/>
-<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-<translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="532"/>
-<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-<translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="397"/>
-<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="320"/>
-<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-<translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="330"/>
-<location filename="../src/gui/parametersdialog.cpp" line="487"/>
-<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="401"/>
-<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
-<translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="406"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-<translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="419"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="424"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="429"/>
-<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-<translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="435"/>
-<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="449"/>
-<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="455"/>
-<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="460"/>
-<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-<translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="466"/>
-<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-<translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="475"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="479"/>
-<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
-<translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="483"/>
-<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-<translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="493"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="512"/>
-<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="522"/>
-<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-<translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="526"/>
-<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-<translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="539"/>
-<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="550"/>
-<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-<translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="564"/>
-<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-<translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="569"/>
-<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-<translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="573"/>
-<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-<translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="580"/>
-<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-<translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="703"/>
-<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-<translation>Du har antingen inte behörighet att skapa ett objekt, eller så finns det redan ett annat objekt med samma namn. Objektet har ignorerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="722"/>
-<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
-<translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="814"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-<translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="818"/>
-<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Det går inte att skapa filen ”%1” eftersom den inte stöds i ditt filsystem.&lt;br&gt;Den har uteslutits från synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="609"/>
-<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="618"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-<translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="614"/>
-<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-<translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="393"/>
-<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-<translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="622"/>
-<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-<translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="626"/>
-<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-<translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="692"/>
-<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="708"/>
-<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-<translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="716"/>
-<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-<translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="727"/>
-<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-<translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="732"/>
-<source>Failed to move this item to trash, it has been blacklisted.</source>
-<translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="748"/>
-<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-<translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="765"/>
-<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="771"/>
-<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-<translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="776"/>
-<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-<translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="782"/>
-<source>Impossible to download the file.</source>
-<translation>Det går inte att ladda ner filen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="779"/>
-<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-<translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="389"/>
-<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-<translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="413"/>
-<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-<translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="649"/>
-<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="656"/>
-<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="662"/>
-<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="668"/>
-<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="674"/>
-<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="680"/>
-<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-<translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="686"/>
-<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-<translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="735"/>
-<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-<translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="740"/>
-<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-<translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="745"/>
-<source>This item has been excluded from sync because it is a hard link.</source>
-<translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="785"/>
-<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-<translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="790"/>
-<location filename="../src/gui/parametersdialog.cpp" line="837"/>
-<source>Synchronization error.</source>
-<translation>Synkroniseringsfel.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="810"/>
-<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
-<translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="821"/>
-<source>System error.</source>
-<translation>Systemfel.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="828"/>
-<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-<translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-</message>
-<message>
-<location filename="../src/gui/parametersdialog.cpp" line="843"/>
-<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-<translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-</message>
+    <name>KDC::ParametersDialog</name>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+        <source>Unable to open folder path %1.</source>
+        <translation>Det går inte att öppna mappsökvägen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+        <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive är inte konfigurerat!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+        <source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
+        <translation>Överföringen misslyckades!
+Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
+        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+        <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
+        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+        <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
+        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+        <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
+        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+        <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
+        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+        <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
+        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+        <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
+        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
+        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+        <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
+        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
+        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
+        <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
+        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+        <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
+        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
+        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
+        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+        <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
+        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
+        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
+        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
+        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+        <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
+        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
+        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+        <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
+        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+        <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
+        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
+        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+        <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
+        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
+        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+        <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
+        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+        <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
+        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+        <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
+        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+        <translation>Du har antingen inte behörighet att skapa ett objekt, eller så finns det redan ett annat objekt med samma namn. Objektet har ignorerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
+        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
+        <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
+        <source>Impossible to create file &quot;%1&quot; because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Det går inte att skapa filen ”%1” eftersom den inte stöds i ditt filsystem.&lt;br&gt;Den har uteslutits från synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
+        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
+        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
+        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
+        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+        <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
+        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+        <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
+        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
+        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+        <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
+        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+        <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
+        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+        <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
+        <source>Failed to move this item to trash, it has been blacklisted.</source>
+        <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
+        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+        <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
+        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
+        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+        <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
+        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+        <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
+        <source>Impossible to download the file.</source>
+        <translation>Det går inte att ladda ner filen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
+        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+        <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
+        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+        <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
+        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
+        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
+        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
+        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
+        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
+        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
+        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+        <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
+        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+        <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
+        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+        <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
+        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+        <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
+        <source>This item has been excluded from sync because it is a hard link.</source>
+        <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
+        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+        <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
+        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
+        <source>Synchronization error.</source>
+        <translation>Synkroniseringsfel.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
+        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
+        <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
+        <source>System error.</source>
+        <translation>Systemfel.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
+        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+        <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
+        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesBlocWidget</name>
-<message>
-<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
-<source>This synchronization is being deleted.</source>
-<translation>Denna synkronisering raderas.</translation>
-</message>
+    <name>KDC::PreferencesBlocWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+        <source>This synchronization is being deleted.</source>
+        <translation>Denna synkronisering raderas.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesMenuBarWidget</name>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
-<source>Back to drive list</source>
-<translation>Tillbaka till listan över körningar</translation>
-</message>
-<message>
-<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
-<source>Preferences</source>
-<translation>Inställningar</translation>
-</message>
+    <name>KDC::PreferencesMenuBarWidget</name>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+        <source>Back to drive list</source>
+        <translation>Tillbaka till listan över körningar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+        <source>Preferences</source>
+        <translation>Inställningar</translation>
+    </message>
 </context>
 <context>
-<name>KDC::PreferencesWidget</name>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
-<source>General</source>
-<translation>Allmänt</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
-<source>Activate dark theme</source>
-<translation>Aktivera mörkt tema</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
-<source>Activate monochrome icons</source>
-<translation>Aktivera monokroma ikoner</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
-<source>Launch kDrive at startup</source>
-<translation>Starta kDrive vid uppstart</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
-<source>Finnish</source>
-<translation>Finska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
-<source>Danish</source>
-<translation>Danska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
-<source>Greek</source>
-<translation>Grekiska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
-<source>Dutch</source>
-<translation>Nederländska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
-<source>Advanced</source>
-<translation>Avancerat</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
-<source>Debugging information</source>
-<translation>Felsökningsinformation</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
-<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
-<source>Files to exclude</source>
-<translation>Filer att exkludera</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
-<source>Swedish</source>
-<translation>Svenska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
-<source>Portuguese</source>
-<translation>Portugisiska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
-<source>Polish</source>
-<translation>Polska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
-<source>Norwegian</source>
-<translation>Norska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
-<source>Unable to open folder %1.</source>
-<translation>Det går inte att öppna mappen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
-<source>Invalid link %1.</source>
-<translation>Ogiltig länk %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
-<source>Lite Sync</source>
-<translation>Lite Sync</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
-<source>Language</source>
-<translation>Språk</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
-<source>Some process failed to run.</source>
-<translation>Någon process kunde inte köras.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
-<source>Move deleted files to my computer's trash</source>
-<translation>Flytta borttagna filer till datorns papperskorg</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
-<source>Some files or folders may not be moved to the computer's trash.</source>
-<translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
-<source>You can always retrieve already synced files from the kDrive web application trash.</source>
-<translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
-<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
-<source>English</source>
-<translation>Engelska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
-<source>French</source>
-<translation>Franska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
-<source>German</source>
-<translation>Tyska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
-<source>Spanish</source>
-<translation>Spanska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
-<source>Italian</source>
-<translation>Italienska</translation>
-</message>
-<message>
-<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
-<source>Default</source>
-<translation>Standard</translation>
-</message>
+    <name>KDC::PreferencesWidget</name>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+        <source>General</source>
+        <translation>Allmänt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+        <source>Activate dark theme</source>
+        <translation>Aktivera mörkt tema</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+        <source>Activate monochrome icons</source>
+        <translation>Aktivera monokroma ikoner</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+        <source>Launch kDrive at startup</source>
+        <translation>Starta kDrive vid uppstart</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+        <source>Finnish</source>
+        <translation>Finska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+        <source>Danish</source>
+        <translation>Danska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+        <source>Greek</source>
+        <translation>Grekiska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+        <source>Dutch</source>
+        <translation>Nederländska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+        <source>Advanced</source>
+        <translation>Avancerat</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+        <source>Debugging information</source>
+        <translation>Felsökningsinformation</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+        <source>Files to exclude</source>
+        <translation>Filer att exkludera</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+        <source>Swedish</source>
+        <translation>Svenska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+        <source>Portuguese</source>
+        <translation>Portugisiska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+        <source>Polish</source>
+        <translation>Polska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+        <source>Norwegian</source>
+        <translation>Norska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+        <source>Unable to open folder %1.</source>
+        <translation>Det går inte att öppna mappen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+        <source>Invalid link %1.</source>
+        <translation>Ogiltig länk %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+        <source>Lite Sync</source>
+        <translation>Lite Sync</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+        <source>Language</source>
+        <translation>Språk</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+        <source>Some process failed to run.</source>
+        <translation>Någon process kunde inte köras.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+        <source>Move deleted files to my computer&apos;s trash</source>
+        <translation>Flytta borttagna filer till datorns papperskorg</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
+        <translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
+        <translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+        <source>English</source>
+        <translation>Engelska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+        <source>French</source>
+        <translation>Franska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+        <source>German</source>
+        <translation>Tyska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+        <source>Spanish</source>
+        <translation>Spanska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+        <source>Italian</source>
+        <translation>Italienska</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+        <source>Default</source>
+        <translation>Standard</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProgressBarWidget</name>
-<message>
-<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
-<source>%1 in use</source>
-<translation>%1 används</translation>
-</message>
+    <name>KDC::ProgressBarWidget</name>
+    <message>
+        <location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+        <source>%1 in use</source>
+        <translation>%1 används</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ProxyServerDialog</name>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
-<source>HTTP(S) Proxy</source>
-<translation>HTTP(S)-proxy</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
-<source>Proxy server</source>
-<translation>Proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
-<source>No proxy server</source>
-<translation>Ingen proxyserver</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
-<source>Use system parameters</source>
-<translation>Använd systemparametrar</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
-<source>Indicate a proxy manually</source>
-<translation>Ange en fullmaktsinnehavare manuellt</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
-<source>Port</source>
-<translation>Hamn</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
-<source>Address of the proxy server</source>
-<translation>Proxyserverns adress</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
-<source>Authentication needed</source>
-<translation>Inloggning krävs</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
-<source>User</source>
-<translation>Användare</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
-<source>Password</source>
-<translation>Lösenord</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
-<source>SAVE</source>
-<translation>SPARA</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vill du spara dina ändringar?</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
-<source>Unable to save, all mandatory fields are not completed!</source>
-<translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
-</message>
-<message>
-<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
-<source>Proxy not found, save anyway?</source>
-<translation>Proxy hittades inte, vill du spara ändå?</translation>
-</message>
+    <name>KDC::ProxyServerDialog</name>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+        <source>HTTP(S) Proxy</source>
+        <translation>HTTP(S)-proxy</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+        <source>Proxy server</source>
+        <translation>Proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+        <source>No proxy server</source>
+        <translation>Ingen proxyserver</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+        <source>Use system parameters</source>
+        <translation>Använd systemparametrar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+        <source>Indicate a proxy manually</source>
+        <translation>Ange en fullmaktsinnehavare manuellt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+        <source>Port</source>
+        <translation>Hamn</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+        <source>Address of the proxy server</source>
+        <translation>Proxyserverns adress</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+        <source>Authentication needed</source>
+        <translation>Inloggning krävs</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+        <source>User</source>
+        <translation>Användare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+        <source>Password</source>
+        <translation>Lösenord</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+        <source>SAVE</source>
+        <translation>SPARA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vill du spara dina ändringar?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+        <source>Unable to save, all mandatory fields are not completed!</source>
+        <translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+        <source>Proxy not found, save anyway?</source>
+        <translation>Proxy hittades inte, vill du spara ändå?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ResourcesManagerDialog</name>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
-<source>Resources Manager</source>
-<translation>Resursansvarig</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
-<source>Maximum CPU usage allowed</source>
-<translation>Högsta tillåtna CPU-användning</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
-<source>SAVE</source>
-<translation>SPARA</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
-<message>
-<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
-<source>Do you want to save your modifications?</source>
-<translation>Vill du spara dina ändringar?</translation>
-</message>
+    <name>KDC::ResourcesManagerDialog</name>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+        <source>Resources Manager</source>
+        <translation>Resursansvarig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+        <source>Maximum CPU usage allowed</source>
+        <translation>Högsta tillåtna CPU-användning</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+        <source>SAVE</source>
+        <translation>SPARA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+        <source>Do you want to save your modifications?</source>
+        <translation>Vill du spara dina ändringar?</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerBaseFolderDialog</name>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
-<source>Select a folder on your kDrive</source>
-<translation>Välj en mapp på din kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
-<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-<translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
-<source>CONTINUE</source>
-<translation>FORTSÄTT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
-<source>Space available on your computer for the current folder : %1</source>
-<translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
-<source>This folder is already being synced.</source>
-<translation>Den här mappen synkroniseras redan.</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
-<source>CONFIRM</source>
-<translation>BEKRÄFTA</translation>
-</message>
-<message>
-<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
-<source>CANCEL</source>
-<translation>AVBRYT</translation>
-</message>
+    <name>KDC::ServerBaseFolderDialog</name>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+        <source>Select a folder on your kDrive</source>
+        <translation>Välj en mapp på din kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+        <translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÄTT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+        <source>Space available on your computer for the current folder : %1</source>
+        <translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+        <source>This folder is already being synced.</source>
+        <translation>Den här mappen synkroniseras redan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+        <source>CONFIRM</source>
+        <translation>BEKRÄFTA</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+        <source>CANCEL</source>
+        <translation>AVBRYT</translation>
+    </message>
 </context>
 <context>
-<name>KDC::ServerFoldersDialog</name>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
-<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
-<source>CONTINUE</source>
-<translation>FORTSÄTT</translation>
-</message>
-<message>
-<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
-<source>No subfolders currently on the server.</source>
-<translation>Det finns för närvarande inga undermappar på servern.</translation>
-</message>
+    <name>KDC::ServerFoldersDialog</name>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+        <source>CONTINUE</source>
+        <translation>FORTSÄTT</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+        <source>No subfolders currently on the server.</source>
+        <translation>Det finns för närvarande inga undermappar på servern.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::StatusBarWidget</name>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
-<source>Resume kDrive "%1" synchronization</source>
-<translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
-<source>Resume all kDrives synchronization</source>
-<translation>Återuppta all synkronisering av kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
-<source>Pause kDrive "%1" synchronization</source>
-<translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
-<source>Pause synchronization</source>
-<translation>Pausa synkroniseringen</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
-<source>Pause all kDrives synchronization</source>
-<translation>Pausa all synkronisering av kDrives</translation>
-</message>
-<message>
-<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
-<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
-<source>Resume synchronization</source>
-<translation>Fortsätt synkroniseringen</translation>
-</message>
+    <name>KDC::StatusBarWidget</name>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+        <source>Resume kDrive &quot;%1&quot; synchronization</source>
+        <translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+        <source>Resume all kDrives synchronization</source>
+        <translation>Återuppta all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+        <source>Pause kDrive &quot;%1&quot; synchronization</source>
+        <translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+        <source>Pause synchronization</source>
+        <translation>Pausa synkroniseringen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+        <source>Pause all kDrives synchronization</source>
+        <translation>Pausa all synkronisering av kDrives</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+        <location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+        <source>Resume synchronization</source>
+        <translation>Fortsätt synkroniseringen</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynchronizedItemWidget</name>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
-<source>Copy share link</source>
-<translation>Kopiera delningslänken</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
-<source>Display on kdrive.infomaniak.com</source>
-<translation>Visas på kdrive.infomaniak.com</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
-<source>Show in folder</source>
-<translation>Visa i mappen</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
-<source>More actions</source>
-<translation>Fler åtgärder</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
-<source>Open</source>
-<translation>Öppna</translation>
-</message>
-<message>
-<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
-<source>Add to favorites</source>
-<translation>Lägg till i favoriter</translation>
-</message>
+    <name>KDC::SynchronizedItemWidget</name>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+        <source>Copy share link</source>
+        <translation>Kopiera delningslänken</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+        <source>Display on kdrive.infomaniak.com</source>
+        <translation>Visas på kdrive.infomaniak.com</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+        <source>Show in folder</source>
+        <translation>Visa i mappen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+        <source>More actions</source>
+        <translation>Fler åtgärder</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+        <source>Open</source>
+        <translation>Öppna</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+        <source>Add to favorites</source>
+        <translation>Lägg till i favoriter</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisBar</name>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="495"/>
-<location filename="../src/gui/synthesisbar.cpp" line="502"/>
-<source>Never</source>
-<translation>Aldrig</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="496"/>
-<source>During 1 hour</source>
-<translation>Under 1 timme</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="497"/>
-<location filename="../src/gui/synthesisbar.cpp" line="504"/>
-<source>Until tomorrow 8:00AM</source>
-<translation>Fram till imorgon kl. 08.00</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="498"/>
-<source>During 3 days</source>
-<translation>Under tre dagar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="499"/>
-<source>During 1 week</source>
-<translation>Under en vecka</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="500"/>
-<location filename="../src/gui/synthesisbar.cpp" line="507"/>
-<source>Always</source>
-<translation>Alltid</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="503"/>
-<source>For 1 more hour</source>
-<translation>I ytterligare 1 timme</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="505"/>
-<source>For 3 more days</source>
-<translation>I ytterligare 3 dagar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="506"/>
-<source>For 1 more week</source>
-<translation>Ytterligare en vecka</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="149"/>
-<source>Unable to open folder url %1.</source>
-<translation>Det går inte att öppna mappen med adressen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="219"/>
-<source>Open in folder</source>
-<translation>Öppna i mappen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="257"/>
-<source>Open %1 web version</source>
-<translation>Öppna webbversionen av %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="267"/>
-<source>Drive parameters</source>
-<translation>Drivparametrar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="280"/>
-<source>Notifications disabled until %1</source>
-<translation>Meddelanden är inaktiverade fram till %1</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="281"/>
-<source>Disable Notifications</source>
-<translation>Inaktivera aviseringar</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="314"/>
-<source>Application preferences</source>
-<translation>Inställningar för applikationen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="322"/>
-<source>Need help</source>
-<translation>Behöver du hjälp?</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="330"/>
-<source>Send feedbacks</source>
-<translation>Skicka synpunkter</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="338"/>
-<source>Quit kDrive</source>
-<translation>Avsluta kDrive</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="401"/>
-<source>Unable to access web site %1.</source>
-<translation>Det går inte att komma åt webbplatsen %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="492"/>
-<source>Show errors and informations</source>
-<translation>Visa fel och information</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="493"/>
-<source>Show informations</source>
-<translation>Visa information</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesisbar.cpp" line="494"/>
-<source>More actions</source>
-<translation>Fler åtgärder</translation>
-</message>
+    <name>KDC::SynthesisBar</name>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="495"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="502"/>
+        <source>Never</source>
+        <translation>Aldrig</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="496"/>
+        <source>During 1 hour</source>
+        <translation>Under 1 timme</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="497"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="504"/>
+        <source>Until tomorrow 8:00AM</source>
+        <translation>Fram till imorgon kl. 08.00</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="498"/>
+        <source>During 3 days</source>
+        <translation>Under tre dagar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="499"/>
+        <source>During 1 week</source>
+        <translation>Under en vecka</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="500"/>
+        <location filename="../src/gui/synthesisbar.cpp" line="507"/>
+        <source>Always</source>
+        <translation>Alltid</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="503"/>
+        <source>For 1 more hour</source>
+        <translation>I ytterligare 1 timme</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="505"/>
+        <source>For 3 more days</source>
+        <translation>I ytterligare 3 dagar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="506"/>
+        <source>For 1 more week</source>
+        <translation>Ytterligare en vecka</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="149"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går inte att öppna mappen med adressen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="219"/>
+        <source>Open in folder</source>
+        <translation>Öppna i mappen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="257"/>
+        <source>Open %1 web version</source>
+        <translation>Öppna webbversionen av %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="267"/>
+        <source>Drive parameters</source>
+        <translation>Drivparametrar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="280"/>
+        <source>Notifications disabled until %1</source>
+        <translation>Meddelanden är inaktiverade fram till %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="281"/>
+        <source>Disable Notifications</source>
+        <translation>Inaktivera aviseringar</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="314"/>
+        <source>Application preferences</source>
+        <translation>Inställningar för applikationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="322"/>
+        <source>Need help</source>
+        <translation>Behöver du hjälp?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="330"/>
+        <source>Send feedbacks</source>
+        <translation>Skicka synpunkter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="338"/>
+        <source>Quit kDrive</source>
+        <translation>Avsluta kDrive</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="401"/>
+        <source>Unable to access web site %1.</source>
+        <translation>Det går inte att komma åt webbplatsen %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="492"/>
+        <source>Show errors and informations</source>
+        <translation>Visa fel och information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="493"/>
+        <source>Show informations</source>
+        <translation>Visa information</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesisbar.cpp" line="494"/>
+        <source>More actions</source>
+        <translation>Fler åtgärder</translation>
+    </message>
 </context>
 <context>
-<name>KDC::SynthesisPopover</name>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
-<source>Update kDrive App</source>
-<translation>Uppdatera kDrive-appen</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
-<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-<translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="980"/>
-<source>Update</source>
-<translation>Uppdatering</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
-<source>Please download the latest version on the website.</source>
-<translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="983"/>
-<source>Update download in progress</source>
-<translation>Uppdateringen hämtas just nu</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="986"/>
-<source>Looking for update...</source>
-<translation>Väntar på uppdatering...</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="989"/>
-<source>Manual update</source>
-<translation>Manuell uppdatering</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="992"/>
-<source>Unavailable</source>
-<translation>Ej tillgängligt</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
-<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-<translation>Du kan synkronisera filer &lt;a style="%1" href="%2"&gt;från din dator&lt;/a&gt; eller från &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="448"/>
-<source>Synchronized</source>
-<translation>Synkroniserad</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="452"/>
-<source>Favorites</source>
-<translation>Favoriter</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="456"/>
-<source>Activity</source>
-<translation>Aktivitet</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
-<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
-<source>Not implemented!</source>
-<translation>Har inte implementerats!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
-<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
-<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
-<source>No synchronized folder for this Drive!</source>
-<translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
-<source>No kDrive configured!</source>
-<translation>kDrive är inte konfigurerat!</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
-<source>Unable to open link %1.</source>
-<translation>Det går inte att öppna länken %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
-<source>Invalid link %1.</source>
-<translation>Ogiltig länk %1.</translation>
-</message>
-<message>
-<location filename="../src/gui/synthesispopover.cpp" line="588"/>
-<source>Unable to open folder url %1.</source>
-<translation>Det går inte att öppna mappen med adressen %1.</translation>
-</message>
+    <name>KDC::SynthesisPopover</name>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+        <source>Update kDrive App</source>
+        <translation>Uppdatera kDrive-appen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+        <translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="980"/>
+        <source>Update</source>
+        <translation>Uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+        <source>Please download the latest version on the website.</source>
+        <translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="983"/>
+        <source>Update download in progress</source>
+        <translation>Uppdateringen hämtas just nu</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="986"/>
+        <source>Looking for update...</source>
+        <translation>Väntar på uppdatering...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="989"/>
+        <source>Manual update</source>
+        <translation>Manuell uppdatering</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="992"/>
+        <source>Unavailable</source>
+        <translation>Ej tillgängligt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+        <translation>Du kan synkronisera filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;från din dator&lt;/a&gt; eller från &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="448"/>
+        <source>Synchronized</source>
+        <translation>Synkroniserad</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="452"/>
+        <source>Favorites</source>
+        <translation>Favoriter</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="456"/>
+        <source>Activity</source>
+        <translation>Aktivitet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+        <location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+        <source>Not implemented!</source>
+        <translation>Har inte implementerats!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
+        <translation>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+        <source>No synchronized folder for this Drive!</source>
+        <translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+        <source>No kDrive configured!</source>
+        <translation>kDrive är inte konfigurerat!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+        <source>Unable to open link %1.</source>
+        <translation>Det går inte att öppna länken %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+        <source>Invalid link %1.</source>
+        <translation>Ogiltig länk %1.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/synthesispopover.cpp" line="588"/>
+        <source>Unable to open folder url %1.</source>
+        <translation>Det går inte att öppna mappen med adressen %1.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateDialog</name>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
-<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-<translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
-<source>Skip this version</source>
-<translation>Hoppa över den här versionen</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
-<source>Remind me later</source>
-<translation>Påminn mig senare</translation>
-</message>
-<message>
-<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
-<source>Install update</source>
-<translation>Installera uppdatering</translation>
-</message>
+    <name>KDC::UpdateDialog</name>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+        <source>Skip this version</source>
+        <translation>Hoppa över den här versionen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+        <source>Remind me later</source>
+        <translation>Påminn mig senare</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+        <source>Install update</source>
+        <translation>Installera uppdatering</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UpdateManager</name>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
-<source>New update available.</source>
-<translation>En ny uppdatering finns tillgänglig.</translation>
-</message>
-<message>
-<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
-<source>Version %1 is available for download.</source>
-<translation>Version %1 finns tillgänglig för nedladdning.</translation>
-</message>
+    <name>KDC::UpdateManager</name>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+        <source>New update available.</source>
+        <translation>En ny uppdatering finns tillgänglig.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+        <source>Version %1 is available for download.</source>
+        <translation>Version %1 finns tillgänglig för nedladdning.</translation>
+    </message>
 </context>
 <context>
-<name>KDC::UserSelectionWidget</name>
-<message>
-<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
-<source>Add an account</source>
-<translation>Lägg till ett konto</translation>
-</message>
+    <name>KDC::UserSelectionWidget</name>
+    <message>
+        <location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+        <source>Add an account</source>
+        <translation>Lägg till ett konto</translation>
+    </message>
 </context>
 <context>
-<name>KDC::VersionWidget</name>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="314"/>
-<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="170"/>
-<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
-<translation>&lt;a style="%1" href="%2"&gt;Visa informationsnot&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="173"/>
-<source>Version</source>
-<translation>Version</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="174"/>
-<source>UPDATE</source>
-<translation>UPPDATERING</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="198"/>
-<source>%1 is up to date!</source>
-<translation>%1 är uppdaterad!</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="202"/>
-<source>Checking update on server...</source>
-<translation>Kontrollerar uppdateringar på servern...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="206"/>
-<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
-<translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style="%2" href="%3"&gt;här&lt;/a&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="213"/>
-<source>An update is available: %1</source>
-<translation>En uppdatering finns tillgänglig: %1</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="219"/>
-<source>Downloading %1. Please wait...</source>
-<translation>Hämtar %1. Vänta...</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="224"/>
-<source>Could not check for new updates.</source>
-<translation>Det gick inte att söka efter nya uppdateringar.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="228"/>
-<source>An error occurred during update.</source>
-<translation>Ett fel uppstod under uppdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="232"/>
-<source>Could not download update.</source>
-<translation>Det gick inte att ladda ner uppdateringen.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="236"/>
-<source>Update disabled.</source>
-<translation>Uppdateringen är inaktiverad.</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="252"/>
-<source>Beta program</source>
-<translation>Betaprogram</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="253"/>
-<source>Get early access to new versions of the application</source>
-<translation>Få tidig tillgång till nya versioner av applikationen</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="257"/>
-<source>Join</source>
-<translation>Gå med</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Modify</source>
-<translation>Ändra</translation>
-</message>
-<message>
-<location filename="../src/gui/versionwidget.cpp" line="260"/>
-<source>Quit</source>
-<translation>Avsluta</translation>
-</message>
+    <name>KDC::VersionWidget</name>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="314"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="170"/>
+        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
+        <translation>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Visa informationsnot&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="173"/>
+        <source>Version</source>
+        <translation>Version</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="174"/>
+        <source>UPDATE</source>
+        <translation>UPPDATERING</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="198"/>
+        <source>%1 is up to date!</source>
+        <translation>%1 är uppdaterad!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="202"/>
+        <source>Checking update on server...</source>
+        <translation>Kontrollerar uppdateringar på servern...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="206"/>
+        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
+        <translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;här&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="213"/>
+        <source>An update is available: %1</source>
+        <translation>En uppdatering finns tillgänglig: %1</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="219"/>
+        <source>Downloading %1. Please wait...</source>
+        <translation>Hämtar %1. Vänta...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="224"/>
+        <source>Could not check for new updates.</source>
+        <translation>Det gick inte att söka efter nya uppdateringar.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="228"/>
+        <source>An error occurred during update.</source>
+        <translation>Ett fel uppstod under uppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="232"/>
+        <source>Could not download update.</source>
+        <translation>Det gick inte att ladda ner uppdateringen.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="236"/>
+        <source>Update disabled.</source>
+        <translation>Uppdateringen är inaktiverad.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="252"/>
+        <source>Beta program</source>
+        <translation>Betaprogram</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="253"/>
+        <source>Get early access to new versions of the application</source>
+        <translation>Få tidig tillgång till nya versioner av applikationen</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="257"/>
+        <source>Join</source>
+        <translation>Gå med</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Modify</source>
+        <translation>Ändra</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/versionwidget.cpp" line="260"/>
+        <source>Quit</source>
+        <translation>Avsluta</translation>
+    </message>
 </context>
 <context>
-<name>QObject</name>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="59"/>
-<source>Unable to save parameters, please retry later.</source>
-<translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
-</message>
-<message>
-<location filename="../src/gui/parameterscache.cpp" line="60"/>
-<source>Unable to save parameters!</source>
-<translation>Det går inte att spara parametrarna!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
-<source>The parent folder is a sync folder or contained in one</source>
-<translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
-<source>Can't find a valid path</source>
-<translation>Det går inte att hitta en giltig sökväg</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
-<source>No valid folder selected!</source>
-<translation>Ingen giltig mapp har valts!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
-<source>The selected path does not exist!</source>
-<translation>Den valda sökvägen finns inte!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
-<source>The selected path is not a folder!</source>
-<translation>Den valda sökvägen är ingen mapp!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
-<source>You have no permission to write to the selected folder!</source>
-<translation>Du har inte behörighet att skriva till den valda mappen!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
-<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-<translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
-<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-<translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
-</message>
-<message>
-<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
-<source>The local folder %1 is already synced. Please pick another one!</source>
-<translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
-<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
-<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
-<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
-<translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
-</message>
-<message>
-<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
-<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-<translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
-<source>Make available locally</source>
-<translation>Gör tillgängligt lokalt</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
-<source>Free up local space</source>
-<translation>Frigör lokalt lagringsutrymme</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
-<source>Cancel free up local space</source>
-<translation>Avbryt för att frigöra lokalt utrymme</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
-<source>Cancel make available locally</source>
-<translation>Avbryt lokal tillgängliggöring</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
-<source>Resharing this file is not allowed</source>
-<translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
-<source>Resharing this folder is not allowed</source>
-<translation>Det är inte tillåtet att dela den här mappen vidare</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
-<source>Copy public share link</source>
-<translation>Kopiera länken till den offentliga delningen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
-<source>Copy private share link</source>
-<translation>Kopiera länken till den privata delningen</translation>
-</message>
-<message>
-<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
-<source>Open in browser</source>
-<translation>Öppna i webbläsaren</translation>
-</message>
+    <name>QObject</name>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="59"/>
+        <source>Unable to save parameters, please retry later.</source>
+        <translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/parameterscache.cpp" line="60"/>
+        <source>Unable to save parameters!</source>
+        <translation>Det går inte att spara parametrarna!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+        <source>The parent folder is a sync folder or contained in one</source>
+        <translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+        <source>Can&apos;t find a valid path</source>
+        <translation>Det går inte att hitta en giltig sökväg</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+        <source>No valid folder selected!</source>
+        <translation>Ingen giltig mapp har valts!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+        <source>The selected path does not exist!</source>
+        <translation>Den valda sökvägen finns inte!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+        <source>The selected path is not a folder!</source>
+        <translation>Den valda sökvägen är ingen mapp!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+        <source>You have no permission to write to the selected folder!</source>
+        <translation>Du har inte behörighet att skriva till den valda mappen!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+        <translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+        <translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
+    </message>
+    <message>
+        <location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+        <source>The local folder %1 is already synced. Please pick another one!</source>
+        <translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
+        <translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+        <translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+        <source>Make available locally</source>
+        <translation>Gör tillgängligt lokalt</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+        <source>Free up local space</source>
+        <translation>Frigör lokalt lagringsutrymme</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+        <source>Cancel free up local space</source>
+        <translation>Avbryt för att frigöra lokalt utrymme</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+        <source>Cancel make available locally</source>
+        <translation>Avbryt lokal tillgängliggöring</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+        <source>Resharing this file is not allowed</source>
+        <translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+        <source>Resharing this folder is not allowed</source>
+        <translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+        <source>Copy public share link</source>
+        <translation>Kopiera länken till den offentliga delningen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+        <source>Copy private share link</source>
+        <translation>Kopiera länken till den privata delningen</translation>
+    </message>
+    <message>
+        <location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+        <source>Open in browser</source>
+        <translation>Öppna i webbläsaren</translation>
+    </message>
 </context>
 <context>
-<name>SharedTools::QtSingleApplication</name>
-<message>
-<location filename="../src/server/appserver.cpp" line="134"/>
-<source>kDrive application will close due to a fatal error.</source>
-<translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
-</message>
+    <name>SharedTools::QtSingleApplication</name>
+    <message>
+        <location filename="../src/server/appserver.cpp" line="134"/>
+        <source>kDrive application will close due to a fatal error.</source>
+        <translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+    </message>
 </context>
 <context>
-<name>Utility</name>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
-<source>%L1 GB</source>
-<translation>%L1 GB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
-<source>%L1 MB</source>
-<translation>%L1 MB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
-<source>%L1 KB</source>
-<translation>%L1 KB</translation>
-</message>
-<message>
-<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
-<source>%L1 B</source>
-<translation>%L1 B</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
-<source>%n year(s)</source>
-<translation>
-<numerusform>%n år</numerusform>
-<numerusform>%n år</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
-<source>%n month(s)</source>
-<translation>
-<numerusform>%n månad</numerusform>
-<numerusform>%n månader</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
-<source>%n day(s)</source>
-<translation>
-<numerusform>%n dag</numerusform>
-<numerusform>%n dagar</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
-<source>%n hour(s)</source>
-<translation>
-<numerusform>%n timme</numerusform>
-<numerusform>%n timmar</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
-<source>%n minute(s)</source>
-<translation>
-<numerusform>%n minut</numerusform>
-<numerusform>%n minuter</numerusform>
-</translation>
-</message>
-<message numerus="yes">
-<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
-<source>%n second(s)</source>
-<translation>
-<numerusform>%n sekund</numerusform>
-<numerusform>%n sekunder</numerusform>
-</translation>
-</message>
+    <name>Utility</name>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+        <source>%L1 GB</source>
+        <translation>%L1 GB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+        <source>%L1 MB</source>
+        <translation>%L1 MB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+        <source>%L1 KB</source>
+        <translation>%L1 KB</translation>
+    </message>
+    <message>
+        <location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+        <source>%L1 B</source>
+        <translation>%L1 B</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+        <source>%n year(s)</source>
+        <translation>
+            <numerusform>%n år</numerusform>
+            <numerusform>%n år</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+        <source>%n month(s)</source>
+        <translation>
+            <numerusform>%n månad</numerusform>
+            <numerusform>%n månader</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+        <source>%n day(s)</source>
+        <translation>
+            <numerusform>%n dag</numerusform>
+            <numerusform>%n dagar</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+        <source>%n hour(s)</source>
+        <translation>
+            <numerusform>%n timme</numerusform>
+            <numerusform>%n timmar</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+        <source>%n minute(s)</source>
+        <translation>
+            <numerusform>%n minut</numerusform>
+            <numerusform>%n minuter</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+        <source>%n second(s)</source>
+        <translation>
+            <numerusform>%n sekund</numerusform>
+            <numerusform>%n sekunder</numerusform>
+        </translation>
+    </message>
 </context>
 <context>
-<name>main.cpp</name>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="49"/>
-<source>System Tray not available</source>
-<translation>Systemfältet är inte tillgängligt</translation>
-</message>
-<message>
-<location filename="../src/gui/mainclient.cpp" line="50"/>
-<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
-<translation>%1 kräver ett fungerande systemfält. Om du kör XFCE, följ &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;dessa instruktioner&lt;/a&gt;. Annars installerar du ett systemfältsprogram som 'trayer' och försöker igen.</translation>
-</message>
+    <name>main.cpp</name>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="49"/>
+        <source>System Tray not available</source>
+        <translation>Systemfältet är inte tillgängligt</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/mainclient.cpp" line="50"/>
+        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
+        <translation>%1 kräver ett fungerande systemfält. Om du kör XFCE, följ &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;dessa instruktioner&lt;/a&gt;. Annars installerar du ett systemfältsprogram som &apos;trayer&apos; och försöker igen.</translation>
+    </message>
 </context>
 <context>
-<name>utility</name>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="84"/>
-<source>Could not open browser</source>
-<translation>Det gick inte att öppna webbläsaren</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="85"/>
-<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-<translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="104"/>
-<source>Could not open email client</source>
-<translation>Det gick inte att öppna e-postprogrammet</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="105"/>
-<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-<translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="324"/>
-<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
-<translation>Du är inte inloggad längre. &lt;a style="%1" href="%2"&gt;Logga in&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="347"/>
-<source>Sync in progress (Step %1/%2).</source>
-<translation>Synkronisering pågår (Steg %1/%2).</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="353"/>
-<source>Sync in progress.</source>
-<translation>Synkronisering pågår.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="364"/>
-<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
-<translation>Vissa filer kunde inte synkroniseras. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="370"/>
-<source>Synchronization pausing ...</source>
-<translation>Synkroniseringen pausas ...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="570"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="576"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="584"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="595"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="599"/>
-<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="657"/>
-<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-<translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="666"/>
-<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-<translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="351"/>
-<source>Synchronization starting</source>
-<translation>Synkroniseringen påbörjas</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="374"/>
-<source>Synchronization paused.</source>
-<translation>Synkroniseringen har pausats.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="336"/>
-<source>Sync in progress (%1 of %2)</source>
-<translation>Synkronisering pågår (%1 av %2)</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="340"/>
-<source>Sync in progress (%1 of %2)
+    <name>utility</name>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="84"/>
+        <source>Could not open browser</source>
+        <translation>Det gick inte att öppna webbläsaren</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="85"/>
+        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+        <translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="104"/>
+        <source>Could not open email client</source>
+        <translation>Det gick inte att öppna e-postprogrammet</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="105"/>
+        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+        <translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="324"/>
+        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
+        <translation>Du är inte inloggad längre. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logga in&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="347"/>
+        <source>Sync in progress (Step %1/%2).</source>
+        <translation>Synkronisering pågår (Steg %1/%2).</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="353"/>
+        <source>Sync in progress.</source>
+        <translation>Synkronisering pågår.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="364"/>
+        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
+        <translation>Vissa filer kunde inte synkroniseras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="370"/>
+        <source>Synchronization pausing ...</source>
+        <translation>Synkroniseringen pausas ...</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="570"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="576"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="584"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="595"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="599"/>
+        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+        <translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="657"/>
+        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+        <translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="666"/>
+        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+        <translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="351"/>
+        <source>Synchronization starting</source>
+        <translation>Synkroniseringen påbörjas</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="374"/>
+        <source>Synchronization paused.</source>
+        <translation>Synkroniseringen har pausats.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="336"/>
+        <source>Sync in progress (%1 of %2)</source>
+        <translation>Synkronisering pågår (%1 av %2)</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="340"/>
+        <source>Sync in progress (%1 of %2)
 %3 left...</source>
-<translation>Synkronisering pågår (%1 av %2)
+        <translation>Synkronisering pågår (%1 av %2)
 %3 kvar...</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="358"/>
-<source>You are up to date, unresolved conflicts.</source>
-<translation>Du har aktuella, olösta konflikter.</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="360"/>
-<source>You are up to date!</source>
-<translation>Nu är du uppdaterad!</translation>
-</message>
-<message>
-<location filename="../src/gui/guiutility.cpp" line="329"/>
-<source>No folder to synchronize
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="358"/>
+        <source>You are up to date, unresolved conflicts.</source>
+        <translation>Du har aktuella, olösta konflikter.</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="360"/>
+        <source>You are up to date!</source>
+        <translation>Nu är du uppdaterad!</translation>
+    </message>
+    <message>
+        <location filename="../src/gui/guiutility.cpp" line="329"/>
+        <source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-<translation>Ingen mapp att synkronisera
+        <translation>Ingen mapp att synkronisera
 Du kan lägga till en i kDrive-inställningarna.</translation>
-</message>
+    </message>
 </context>
 </TS>

--- a/translations/client_sv.ts
+++ b/translations/client_sv.ts
@@ -1,2582 +1,3097 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="sv_SE">
+<TS language="sv_SE" version="2.1">
 <context>
-    <name>KDC::AboutDialog</name>
-    <message>
-        <source>About</source>
-        <translation type="vanished">Om</translation>
-    </message>
-    <message>
-        <source>CLOSE</source>
-        <translation type="vanished">STÄNG</translation>
-    </message>
-    <message>
-        <source>Version %1. For more information visit &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Version %1. För mer information, besök &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Distributed by %1 and licensed under the &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
-        <translation type="vanished">Distribueras av %1 och licensieras enligt &lt;a style=&quot;%3&quot; href=&quot;%4&quot;&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <source>&lt;p&gt;&lt;small&gt;Built from &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
-    </message>
+<name>KDC::AboutDialog</name>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="73"/>
+<source>About</source>
+<translation>Om</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="112"/>
+<source>CLOSE</source>
+<translation>STÄNG</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="123"/>
+<source>Version %1. For more information visit &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</source>
+<translation>Version %1. För mer information, besök &lt;a style="%2" href="%3"&gt;%4&lt;/a&gt;&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="126"/>
+<source>Copyright 2019-%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</source>
+<translation>Copyright 2019–%1 Infomaniak Network SA&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="127"/>
+<source>Distributed by %1 and licensed under the &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 and the %2 logo are registered trademarks of %1.&lt;br&gt;&lt;br&gt;</source>
+<translation>Distribueras av %1 och licensieras enligt &lt;a style="%3" href="%4"&gt;%5&lt;/a&gt;.&lt;br&gt;&lt;br&gt;%2 och %2-logotypen är registrerade varumärken som tillhör %1.&lt;br&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="151"/>
+<location filename="../src/gui/aboutdialog.cpp" line="162"/>
+<location filename="../src/gui/aboutdialog.cpp" line="171"/>
+<source>Unable to open folder %1.</source>
+<translation>Det går inte att öppna mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/aboutdialog.cpp" line="132"/>
+<source>&lt;p&gt;&lt;small&gt;Built from &lt;a style="color: #489EF3" href="%1"&gt;Git sources&lt;/a&gt; on %2, %3 using Qt %4, %5&lt;/small&gt;&lt;/p&gt;</source>
+<translation>&lt;p&gt;&lt;small&gt;Kompilerad från &lt;a style="color: #489EF3" href="%1"&gt;Git-källkod&lt;/a&gt; den %2, %3 med Qt %4, %5&lt;/small&gt;&lt;/p&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AbstractFileItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
+<name>KDC::AbstractFileItemWidget</name>
+<message>
+<location filename="../src/gui/abstractfileitemwidget.cpp" line="177"/>
+<source>Unable to open folder path %1.</source>
+<translation>Det går inte att öppna mappsökvägen %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveConfirmationWidget</name>
-    <message>
-        <source>Synchronization will start and you will be able to add files to your %1 folder.</source>
-        <translation type="vanished">Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
-    </message>
-    <message>
-        <source>Your kDrive is ready!</source>
-        <translation type="vanished">Din kDrive är klar!</translation>
-    </message>
-    <message>
-        <source>OPEN FOLDER</source>
-        <translation type="vanished">ÖPPNA MAPP</translation>
-    </message>
-    <message>
-        <source>PARAMETERS</source>
-        <translation type="vanished">INSTÄLLNINGAR</translation>
-    </message>
-    <message>
-        <source>Synchronize another drive</source>
-        <translation type="vanished">Synkronisera en annan enhet</translation>
-    </message>
+<name>KDC::AddDriveConfirmationWidget</name>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="55"/>
+<source>Synchronization will start and you will be able to add files to your %1 folder.</source>
+<translation>Synkroniseringen startar och du kan lägga till filer i mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="99"/>
+<source>Your kDrive is ready!</source>
+<translation>Din kDrive är klar!</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="123"/>
+<source>OPEN FOLDER</source>
+<translation>ÖPPNA MAPP</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="130"/>
+<source>PARAMETERS</source>
+<translation>INSTÄLLNINGAR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveconfirmationwidget.cpp" line="138"/>
+<source>Synchronize another drive</source>
+<translation>Synkronisera en annan enhet</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveListWidget</name>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>NEXT</source>
-        <translation type="vanished">NÄSTA</translation>
-    </message>
-    <message>
-        <source>Select the kDrive you want to synchronize</source>
-        <translation type="vanished">Välj den kDrive du vill synkronisera</translation>
-    </message>
-    <message>
-        <source>Get kDrive for free</source>
-        <translation type="vanished">Skaffa kDrive gratis</translation>
-    </message>
-    <message>
-        <source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
-        <translation type="vanished">Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
-    </message>
-    <message>
-        <source>Test for free</source>
-        <translation type="vanished">Testa gratis</translation>
-    </message>
+<name>KDC::AddDriveListWidget</name>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="170"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="177"/>
+<source>NEXT</source>
+<translation>NÄSTA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="196"/>
+<source>Select the kDrive you want to synchronize</source>
+<translation>Välj den kDrive du vill synkronisera</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="234"/>
+<source>Get kDrive for free</source>
+<translation>Skaffa kDrive gratis</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="244"/>
+<source>Store your pictures, documents and e-mails in Switzerland from an independent company that respects privacy. Learn more</source>
+<translation>Spara dina bilder, dokument och e-postmeddelanden i Schweiz hos ett oberoende företag som respekterar din integritet. Läs mer</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelistwidget.cpp" line="263"/>
+<source>Test for free</source>
+<translation>Testa gratis</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLiteSyncWidget</name>
-    <message>
-        <source>Conserve your computer space</source>
-        <translation type="vanished">Spara utrymme på datorn</translation>
-    </message>
-    <message>
-        <source>Decide which files should be available online or locally</source>
-        <translation type="vanished">Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
-    </message>
-    <message>
-        <source>LATER</source>
-        <translation type="vanished">SENARE</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync (Beta) ?</source>
-        <translation type="vanished">Vill du aktivera Lite Sync (Beta)?</translation>
-    </message>
-    <message>
-        <source>Would you like to activate Lite Sync ?</source>
-        <translation type="vanished">Vill du aktivera Lite Sync?</translation>
-    </message>
+<name>KDC::AddDriveLiteSyncWidget</name>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="147"/>
+<source>Conserve your computer space</source>
+<translation>Spara utrymme på datorn</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="167"/>
+<source>Decide which files should be available online or locally</source>
+<translation>Bestäm vilka filer som ska vara tillgängliga online eller lokalt</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="187"/>
+<source>LATER</source>
+<translation>SENARE</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="193"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="125"/>
+<source>Lite Sync syncs all your files without using your computer space. You can browse the files in your kDrive and download them locally whenever you want. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Lite Sync synkroniserar alla dina filer utan att ta upp utrymme på din dator. Du kan bläddra bland filerna i ditt kDrive och ladda ner dem lokalt när du vill. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="207"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="112"/>
+<source>Would you like to activate Lite Sync (Beta) ?</source>
+<translation>Vill du aktivera Lite Sync (Beta)?</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveslitesyncwidget.cpp" line="114"/>
+<source>Would you like to activate Lite Sync ?</source>
+<translation>Vill du aktivera Lite Sync?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLocalFolderWidget</name>
-    <message>
-        <source>Location of your %1 kDrive</source>
-        <translation type="vanished">Plats för din %1 kDrive</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Ändra mapp</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">SLUTFÖR</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Välj mapp</translation>
-    </message>
-    <message>
-        <source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
-        <translation type="vanished">Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
-    </message>
-    <message>
-        <source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
-        <translation type="vanished">När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt; 
+<name>KDC::AddDriveLocalFolderWidget</name>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="65"/>
+<source>Location of your %1 kDrive</source>
+<translation>Plats för din %1 kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="155"/>
+<source>Edit folder</source>
+<translation>Ändra mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>END</source>
+<translation>SLUTFÖR</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="297"/>
+<source>Select folder</source>
+<translation>Välj mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="264"/>
+<source>The contents of the &lt;b&gt;%1&lt;/b&gt; folder will be synchronized in your kDrive</source>
+<translation>Innehållet i mappen &lt;b&gt;%1&lt;/b&gt; kommer att synkroniseras i din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="212"/>
+<source>You will find all your files in this folder when the configuration is complete. You can drop new files there to sync them to your kDrive.</source>
+<translation>När konfigurationen är klar hittar du alla dina filer i den här mappen. Du kan lägga in nya filer där för att synkronisera dem till din kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="284"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt; 
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt; 
 Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt; 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÄTT</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="377"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivelocalfolderwidget.cpp" line="246"/>
+<source>CONTINUE</source>
+<translation>FORTSÄTT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveLoginWidget</name>
-    <message>
-        <source>Log in from your browser</source>
-        <translation type="vanished">Logga in från din webbläsare</translation>
-    </message>
-    <message>
-        <source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
-        <translation type="vanished">Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
-    </message>
-    <message>
-        <source>Open the login page</source>
-        <translation type="vanished">Öppna inloggningssidan</translation>
-    </message>
-    <message>
-        <source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
-        <translation type="vanished">Ett fel uppstod under autentiseringen. Stäng inloggningsfönstret och försök igen.&lt;br&gt;Om felet kvarstår, kontakta vårt supportteam.</translation>
-    </message>
-    <message>
-        <source>Login failed: %1 - %2</source>
-        <translation type="vanished">Inloggningen misslyckades: %1 - %2</translation>
-    </message>
-    <message>
-        <source>Failed to open the login page in your web browser</source>
-        <translation type="vanished">Det gick inte att öppna inloggningssidan i din webbläsare</translation>
-    </message>
+<name>KDC::AddDriveLoginWidget</name>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="69"/>
+<source>Log in from your browser</source>
+<translation>Logga in från din webbläsare</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="75"/>
+<source>Your browser should open automatically to complete the connection. Once connected, you will automatically return to kDrive.</source>
+<translation>Din webbläsare bör öppnas automatiskt för att slutföra anslutningen. När anslutningen är upprättad återgår du automatiskt till kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="85"/>
+<source>Open the login page</source>
+<translation>Öppna inloggningssidan</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="121"/>
+<source>An error occurred during authentication. Please close the login window and try again.&lt;br&gt;If the error persists, contact our support team.</source>
+<translation>Ett fel uppstod under autentiseringen. Stäng inloggningsfönstret och försök igen.&lt;br&gt;Om felet kvarstår, kontakta vårt supportteam.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="137"/>
+<source>Login failed: %1 - %2</source>
+<translation>Inloggningen misslyckades: %1 - %2</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveloginwidget.cpp" line="145"/>
+<source>Failed to open the login page in your web browser</source>
+<translation>Det gick inte att öppna inloggningssidan i din webbläsare</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveServerFoldersWidget</name>
-    <message>
-        <source>Select kDrive folders to synchronize on your desktop</source>
-        <translation type="vanished">Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÄTT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer : %1</source>
-        <translation type="vanished">Ledigt utrymme på din dator: %1</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-    </message>
-    <message>
-        <source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation type="vanished">Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
-    </message>
+<name>KDC::AddDriveServerFoldersWidget</name>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="129"/>
+<source>Select kDrive folders to synchronize on your desktop</source>
+<translation>Välj vilka kDrive-mappar som ska synkroniseras på din dator</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="174"/>
+<source>CONTINUE</source>
+<translation>FORTSÄTT</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="187"/>
+<source>Space available on your computer : %1</source>
+<translation>Ledigt utrymme på din dator: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="206"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+</message>
+<message>
+<location filename="../src/gui/adddriveserverfolderswidget.cpp" line="210"/>
+<source>Impossible to load the list of subfolders. Your kDrive might be in maintenance.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>Det går inte att ladda listan över undermappar&lt;br&gt;. Din kDrive kan vara under underhåll. Logga in på &lt;a style="%1" href="%2"&gt;webbversionen&lt;/a&gt; för att kontrollera statusen för din kDrive, eller kontakta din administratör.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AddDriveWizard</name>
-    <message>
-        <source>Failed to create local folder %1</source>
-        <translation type="vanished">Det gick inte att skapa den lokala mappen %1</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Det gick inte att skapa en ny synkronisering</translation>
-    </message>
-    <message>
-        <source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
-        <translation type="vanished">kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
-    </message>
+<name>KDC::AddDriveWizard</name>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="226"/>
+<source>Failed to create local folder %1</source>
+<translation>Det gick inte att skapa den lokala mappen %1</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="237"/>
+<source>Failed to create new synchronization</source>
+<translation>Det gick inte att skapa en ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/adddrivewizard.cpp" line="270"/>
+<source>The kDrive %1 is already synchronized on this computer. Continue anyway?</source>
+<translation>kDrive %1 är redan synkroniserat på den här datorn. Vill du fortsätta ändå?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppClient</name>
-    <message>
-        <source>kDrive client is run with bad parameters!</source>
-        <translation type="vanished">kDrive-klienten körs med felaktiga parametrar!</translation>
-    </message>
-    <message>
-        <source>kDrive client is already running!</source>
-        <translation type="vanished">kDrive-klienten är redan igång!</translation>
-    </message>
-    <message>
-        <source>The user %1 is not connected. Please log in again.</source>
-        <translation type="vanished">Användaren %1 är inte inloggad. Logga in igen.</translation>
-    </message>
+<name>KDC::AppClient</name>
+<message>
+<location filename="../src/gui/appclient.cpp" line="100"/>
+<source>kDrive client is run with bad parameters!</source>
+<translation>kDrive-klienten körs med felaktiga parametrar!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="109"/>
+<source>kDrive client is already running!</source>
+<translation>kDrive-klienten är redan igång!</translation>
+</message>
+<message>
+<location filename="../src/gui/appclient.cpp" line="724"/>
+<source>The user %1 is not connected. Please log in again.</source>
+<translation>Användaren %1 är inte inloggad. Logga in igen.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::AppServer</name>
-    <message>
-        <source>Share link copied to clipboard</source>
-        <translation type="vanished">Delningslänken har kopierats till urklipp</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been removed.</source>
-        <translation type="vanished">
-            <numerusform>%1 och %n annan fil har tagits bort.</numerusform>
-            <numerusform>%1 och %n andra filer har tagits bort.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been removed.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 har tagits bort.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been added.</source>
-        <translation type="vanished">
-            <numerusform>%1 och %n annan fil har lagts till.</numerusform>
-            <numerusform>%1 och %n andra filer har lagts till.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been added.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 har lagts till.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 and %n other file(s) have been updated.</source>
-        <translation type="vanished">
-            <numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
-            <numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been updated.</source>
-        <comment>%1 names a file.</comment>
-        <translation type="vanished">%1 har uppdaterats.</translation>
-    </message>
-    <message numerus="yes">
-        <source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
-        <translation type="vanished">
-            <numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
-            <numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
-        </translation>
-    </message>
-    <message>
-        <source>%1 has been moved to %2.</source>
-        <translation type="vanished">%1 har flyttats till %2.</translation>
-    </message>
-    <message>
-        <source>Sync Activity</source>
-        <translation type="vanished">Synkroniseringsaktivitet</translation>
-    </message>
+<name>KDC::AppServer</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="1691"/>
+<source>Share link copied to clipboard</source>
+<translation>Delningslänken har kopierats till urklipp</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3848"/>
+<source>%1 and %n other file(s) have been removed.</source>
+<translation>
+<numerusform>%1 och %n annan fil har tagits bort.</numerusform>
+<numerusform>%1 och %n andra filer har tagits bort.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3850"/>
+<source>%1 has been removed.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 har tagits bort.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3855"/>
+<source>%1 and %n other file(s) have been added.</source>
+<translation>
+<numerusform>%1 och %n annan fil har lagts till.</numerusform>
+<numerusform>%1 och %n andra filer har lagts till.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3857"/>
+<source>%1 has been added.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 har lagts till.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3862"/>
+<source>%1 and %n other file(s) have been updated.</source>
+<translation>
+<numerusform>%1 och %n annan fil har uppdaterats.</numerusform>
+<numerusform>%1 och %n andra filer har uppdaterats.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3864"/>
+<source>%1 has been updated.</source>
+<comment>%1 names a file.</comment>
+<translation>%1 har uppdaterats.</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/server/appserver.cpp" line="3869"/>
+<source>%1 has been moved to %2 and %n other file(s) have been moved.</source>
+<translation>
+<numerusform>%1 har flyttats till %2 och %n annan fil har flyttats.</numerusform>
+<numerusform>%1 har flyttats till %2 och %n andra filer har flyttats.</numerusform>
+</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3872"/>
+<source>%1 has been moved to %2.</source>
+<translation>%1 har flyttats till %2.</translation>
+</message>
+<message>
+<location filename="../src/server/appserver.cpp" line="3880"/>
+<source>Sync Activity</source>
+<translation>Synkroniseringsaktivitet</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BaseFolderTreeItemWidget</name>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Det finns för närvarande inga undermappar på servern.</translation>
-    </message>
+<name>KDC::BaseFolderTreeItemWidget</name>
+<message>
+<location filename="../src/gui/basefoldertreeitemwidget.cpp" line="102"/>
+<source>No subfolders currently on the server.</source>
+<translation>Det finns för närvarande inga undermappar på servern.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::BetaProgramDialog</name>
-    <message>
-        <source>Quit the beta program</source>
-        <translation type="vanished">Avsluta betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Join the beta program</source>
-        <translation type="vanished">Anmäl dig till betaprogrammet</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
-        <translation type="vanished">Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
-    </message>
-    <message>
-        <source>Benefit from application beta updates</source>
-        <translation type="vanished">Dra nytta av uppdateringar av betaversionen av appen</translation>
-    </message>
-    <message>
-        <source>No</source>
-        <translation type="vanished">Nej</translation>
-    </message>
-    <message>
-        <source>Public beta version</source>
-        <translation type="vanished">Offentlig betaversion</translation>
-    </message>
-    <message>
-        <source>Internal beta version</source>
-        <translation type="vanished">Intern betaversion</translation>
-    </message>
-    <message>
-        <source>Test version</source>
-        <translation type="vanished">Testversion</translation>
-    </message>
-    <message>
-        <source>I understand</source>
-        <translation type="vanished">Jag förstår</translation>
-    </message>
-    <message>
-        <source>Are you sure you want to leave the beta program?</source>
-        <translation type="vanished">Är du säker på att du vill lämna betaprogrammet?</translation>
-    </message>
-    <message>
-        <source>Save</source>
-        <translation type="vanished">Spara</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
-        <translation type="vanished">Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
-    </message>
-    <message>
-        <source>Beta versions may leave unexpectedly or cause instabilities.</source>
-        <translation type="vanished">Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
-    </message>
+<name>KDC::BetaProgramDialog</name>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Quit the beta program</source>
+<translation>Avsluta betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="70"/>
+<source>Join the beta program</source>
+<translation>Anmäl dig till betaprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="78"/>
+<source>Get early access to new versions of the application before they are released to the general public, and take part in improving the application by sending us your comments.</source>
+<translation>Få tillgång till nya versioner av applikationen innan de släpps till allmänheten och bidra till att förbättra applikationen genom att skicka oss dina synpunkter.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="88"/>
+<source>Benefit from application beta updates</source>
+<translation>Dra nytta av uppdateringar av betaversionen av appen</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="92"/>
+<source>No</source>
+<translation>Nej</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="93"/>
+<source>Public beta version</source>
+<translation>Offentlig betaversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="94"/>
+<source>Internal beta version</source>
+<translation>Intern betaversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="95"/>
+<source>Test version</source>
+<translation>Testversion</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="146"/>
+<source>I understand</source>
+<translation>Jag förstår</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="152"/>
+<source>Are you sure you want to leave the beta program?</source>
+<translation>Är du säker på att du vill lämna betaprogrammet?</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="166"/>
+<source>Save</source>
+<translation>Spara</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="172"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="235"/>
+<source>Your current version of the application may be too recent, your choice will be effective when the next update is available.</source>
+<translation>Din nuvarande version av appen kan vara för ny; ditt val träder i kraft när nästa uppdatering blir tillgänglig.</translation>
+</message>
+<message>
+<location filename="../src/gui/betaprogramdialog.cpp" line="240"/>
+<source>Beta versions may leave unexpectedly or cause instabilities.</source>
+<translation>Betaversioner kan stängas ner utan förvarning eller orsaka instabilitet.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ClientGui</name>
-    <message>
-        <source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
-        <translation type="vanished">Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
-    </message>
-    <message>
-        <source>Please sign in</source>
-        <translation type="vanished">Logga in</translation>
-    </message>
-    <message>
-        <source>Folder %1: %2</source>
-        <translation type="vanished">Mappen %1: %2</translation>
-    </message>
-    <message>
-        <source>There are no sync folders configured.</source>
-        <translation type="vanished">Det finns inga synkroniseringsmappar konfigurerade.</translation>
-    </message>
-    <message>
-        <source>Synthesis</source>
-        <translation type="vanished">Sammanfattning</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translatorcomment>Préférences</translatorcomment>
-        <translation type="vanished">Inställningar</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Avsluta</translation>
-    </message>
-    <message>
-        <source>Undefined State.</source>
-        <translation type="vanished">Odefinierat tillstånd.</translation>
-    </message>
-    <message>
-        <source>Waiting to start syncing.</source>
-        <translation type="vanished">Väntar på att synkroniseringen ska starta.</translation>
-    </message>
-    <message>
-        <source>Sync is running.</source>
-        <translation type="vanished">Synkroniseringen pågår.</translation>
-    </message>
-    <message>
-        <source>Sync was successful, unresolved conflicts.</source>
-        <translation type="vanished">Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
-    </message>
-    <message>
-        <source>Last Sync was successful.</source>
-        <translation type="vanished">Den senaste synkroniseringen genomfördes utan problem.</translation>
-    </message>
-    <message>
-        <source>User Abort.</source>
-        <translation type="vanished">Användaren avbryter.</translation>
-    </message>
-    <message>
-        <source>Sync is paused.</source>
-        <translation type="vanished">Synkroniseringen är pausad.</translation>
-    </message>
-    <message>
-        <source>%1 (Sync is paused)</source>
-        <translation type="vanished">%1 (Synkroniseringen är pausad)</translation>
-    </message>
-    <message>
-        <source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
-    </message>
-    <message>
-        <source>REMOVE ALL SYNCHRONIZATIONS</source>
-        <translation type="vanished">TA BORT ALLA SYNKRONISERINGAR</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>%1 items have been deleted from your from your local sync folder &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
-        <translation type="vanished">%1 objekt har tagits bort från din lokala synkmapp &lt;a style=&quot;%2&quot; href=&quot;file:///%3&quot;&gt;%3&lt;/a&gt;. För att undvika oavsiktliga borttagningar har synkroniseringen pausats.&lt;br&gt;Vill du sprida dessa borttagningar till ditt kDrive?</translation>
-    </message>
-    <message>
-        <source>Several files have been deleted from your local sync folder &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive&apos;s &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;trash&lt;/a&gt;.</source>
-        <translation type="vanished">Flera filer har tagits bort från din lokala synkmapp &lt;a style=&quot;%1&quot; href=&quot;file:///%2&quot;&gt;%2&lt;/a&gt;. Borttagna filer finns i kDrives &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;papperskorg&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Don&apos;t show again</source>
-        <translation type="vanished">Visa inte igen</translation>
-    </message>
-    <message>
-        <source>Failed to start synchronizations!</source>
-        <translation type="vanished">Det gick inte att starta synkroniseringarna!</translation>
-    </message>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
-    <message>
-        <source>Unable to initialize kDrive client</source>
-        <translation type="vanished">Det går inte att starta kDrive-klienten</translation>
-    </message>
-    <message>
-        <source>Synchronization is paused</source>
-        <translation type="vanished">Synkroniseringen är pausad</translation>
-    </message>
+<name>KDC::ClientGui</name>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="190"/>
+<source>Failed to fix conflict(s) on %1 item(s) in sync folder: %2</source>
+<translation>Det gick inte att lösa konflikterna för %1 objekt i synkroniseringsmappen: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="243"/>
+<source>Please sign in</source>
+<translation>Logga in</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="293"/>
+<source>Folder %1: %2</source>
+<translation>Mappen %1: %2</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="299"/>
+<source>There are no sync folders configured.</source>
+<translation>Det finns inga synkroniseringsmappar konfigurerade.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1508"/>
+<source>Synthesis</source>
+<translation>Sammanfattning</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1509"/>
+<source>Preferences</source>
+<translatorcomment>Préférences</translatorcomment>
+<translation>Inställningar</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1510"/>
+<source>Quit</source>
+<translation>Avsluta</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="674"/>
+<source>Undefined State.</source>
+<translation>Odefinierat tillstånd.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="677"/>
+<source>Waiting to start syncing.</source>
+<translation>Väntar på att synkroniseringen ska starta.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="680"/>
+<source>Sync is running.</source>
+<translation>Synkroniseringen pågår.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="684"/>
+<source>Sync was successful, unresolved conflicts.</source>
+<translation>Synkroniseringen lyckades, men det finns olösta konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="686"/>
+<source>Last Sync was successful.</source>
+<translation>Den senaste synkroniseringen genomfördes utan problem.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="693"/>
+<source>User Abort.</source>
+<translation>Användaren avbryter.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="697"/>
+<source>Sync is paused.</source>
+<translation>Synkroniseringen är pausad.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="706"/>
+<source>%1 (Sync is paused)</source>
+<translation>%1 (Synkroniseringen är pausad)</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1250"/>
+<source>Do you really want to remove the synchronizations of the account &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vill du verkligen ta bort synkroniseringarna för kontot &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta raderar inga filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1254"/>
+<source>REMOVE ALL SYNCHRONIZATIONS</source>
+<translation>TA BORT ALLA SYNKRONISERINGAR</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1255"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1382"/>
+<source>%1 items have been deleted from your from your local sync folder &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. To avoid unintended deletions the synchronization have been paused.&lt;br&gt;Do you want to propagate those deletion to your kDrive?</source>
+<translation>%1 objekt har tagits bort från din lokala synkmapp &lt;a style="%2" href="file:///%3"&gt;%3&lt;/a&gt;. För att undvika oavsiktliga borttagningar har synkroniseringen pausats.&lt;br&gt;Vill du sprida dessa borttagningar till ditt kDrive?</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1420"/>
+<source>Several files have been deleted from your local sync folder &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Deleted files can be found in kDrive's &lt;a style="%1" href="%3"&gt;trash&lt;/a&gt;.</source>
+<translation>Flera filer har tagits bort från din lokala synkmapp &lt;a style="%1" href="file:///%2"&gt;%2&lt;/a&gt;. Borttagna filer finns i kDrives &lt;a style="%1" href="%3"&gt;papperskorg&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1426"/>
+<source>Don't show again</source>
+<translation>Visa inte igen</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="1676"/>
+<source>Failed to start synchronizations!</source>
+<translation>Det gick inte att starta synkroniseringarna!</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="850"/>
+<source>Unable to open folder path %1.</source>
+<translation>Det går inte att öppna mappsökvägen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="117"/>
+<source>Unable to initialize kDrive client</source>
+<translation>Det går inte att starta kDrive-klienten</translation>
+</message>
+<message>
+<location filename="../src/gui/clientgui.cpp" line="256"/>
+<source>Synchronization is paused</source>
+<translation>Synkroniseringen är pausad</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ConfirmSynchronizationDialog</name>
-    <message>
-        <source>Summary of your local folder synchronization</source>
-        <translation type="vanished">Sammanfattning av synkroniseringen av din lokala mapp</translation>
-    </message>
-    <message>
-        <source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
-        <translation type="vanished">Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>SYNCHRONIZE</source>
-        <translation type="vanished">SYNKRONISERA</translation>
-    </message>
+<name>KDC::ConfirmSynchronizationDialog</name>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="86"/>
+<source>Summary of your local folder synchronization</source>
+<translation>Sammanfattning av synkroniseringen av din lokala mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="95"/>
+<source>The contents of the folder on your computer will be synchronized to the folder of the selected kDrive and vice versa.</source>
+<translation>Innehållet i mappen på din dator kommer att synkroniseras med mappen på den valda kDrive-enheten och vice versa.</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="184"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/confirmsynchronizationdialog.cpp" line="191"/>
+<source>SYNCHRONIZE</source>
+<translation>SYNKRONISERA</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomExtensionSetupWidget</name>
-    <message>
-        <source>Before finishing</source>
-        <translation type="vanished">Innan du avslutar</translation>
-    </message>
-    <message>
-        <source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
-        <translation type="vanished">Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Open your Mac&apos;s &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Login Items &amp; Extensions&quot;&lt;/b&gt; section and then to &lt;b&gt;&quot;Endpoint Security Extensions&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application</source>
-        <translation type="vanished">Godkänn appen kDrive</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Security&quot;&lt;/b&gt; section</source>
-        <translation type="vanished">Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
-        <translation type="vanished">Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
-    </message>
-    <message>
-        <source>Unlock the padlock &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; and authorize the kDrive application</source>
-        <translation type="vanished">Lås upp hänglåset &lt;img src=&quot;:/client/resources/icons/actions/lock.png&quot;&gt; och godkänn kDrive-appen</translation>
-    </message>
-    <message>
-        <source>Go to &lt;b&gt;&quot;Privacy &amp; Security&quot;&lt;/b&gt; section and click on &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt; or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;&quot;Privacy&quot;&lt;/b&gt; tab or &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;click here&lt;/a&gt;</source>
-        <translation type="vanished">Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;klicka här&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box then the &quot;kDrive.app&quot; box (if not already checked)</source>
-        <translation type="vanished">Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
-    </message>
-    <message>
-        <source>A restart of the app might be proposed, in this case accept it</source>
-        <translation type="vanished">Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
-    </message>
-    <message>
-        <source>Check the &quot;kDrive LiteSync Extension&quot; box (and &quot;kDrive.app&quot; if it exists) in &lt;b&gt;&quot;Full Disk Access&quot;&lt;/b&gt;</source>
-        <translation type="vanished">Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>STEP 1</source>
-        <translation type="vanished">STEG 1</translation>
-    </message>
-    <message>
-        <source>(Done)</source>
-        <translation type="vanished">(Klart)</translation>
-    </message>
-    <message>
-        <source>STEP 2</source>
-        <translation type="vanished">STEG 2</translation>
-    </message>
-    <message>
-        <source>STEPS PERFORMED</source>
-        <translation type="vanished">UTFÖRDA STEG</translation>
-    </message>
-    <message>
-        <source>END</source>
-        <translation type="vanished">SLUTFÖR</translation>
-    </message>
+<name>KDC::CustomExtensionSetupWidget</name>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="97"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="121"/>
+<source>Before finishing</source>
+<translation>Innan du avslutar</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="108"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="132"/>
+<source>Perform the following steps to ensure that Lite Sync works correctly on your computer and to complete the configuration of the kDrive.</source>
+<translation>Följ dessa steg för att säkerställa att Lite Sync fungerar korrekt på din dator och för att slutföra konfigurationen av kDrive.</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="209"/>
+<source>Open your Mac's &lt;b&gt;General settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öppna &lt;b&gt;inställningarna under ”Allmänt”&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="213"/>
+<source>Open your Mac's &lt;b&gt;Privacy &amp; Security settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öppna &lt;b&gt;inställningarna för sekretess och säkerhet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="217"/>
+<source>Open your Mac's &lt;b&gt;Security &amp; Privacy settings&lt;/b&gt; or  &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öppna &lt;b&gt;inställningarna&lt;/b&gt; för &lt;b&gt;Säkerhet och integritet&lt;/b&gt; på din Mac eller  &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="247"/>
+<source>Go to &lt;b&gt;"Login Items &amp; Extensions"&lt;/b&gt; section and then to &lt;b&gt;"Endpoint Security Extensions"&lt;/b&gt;</source>
+<translation>Gå till avsnittet &lt;b&gt;”Inloggningsobjekt och tillägg”&lt;/b&gt; och sedan till &lt;b&gt;”Endpoint Security-tillägg”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="264"/>
+<source>Authorize the kDrive application</source>
+<translation>Godkänn appen kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="273"/>
+<source>Go to &lt;b&gt;"Security"&lt;/b&gt; section</source>
+<translation>Gå till avsnittet &lt;b&gt;”Säkerhet”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="290"/>
+<source>Authorize the kDrive application in the box indicating that kDrive has been blocked</source>
+<translation>Godkänn kDrive-appen i rutan där det står att kDrive har blockerats</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="300"/>
+<source>Unlock the padlock &lt;img src=":/client/resources/icons/actions/lock.png"&gt; and authorize the kDrive application</source>
+<translation>Lås upp hänglåset &lt;img src=":/client/resources/icons/actions/lock.png"&gt; och godkänn kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="345"/>
+<source>Go to &lt;b&gt;"Privacy &amp; Security"&lt;/b&gt; section and click on &lt;b&gt;"Full Disk Access"&lt;/b&gt; or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Gå till avsnittet &lt;b&gt;”Sekretess och säkerhet”&lt;/b&gt; och klicka på &lt;b&gt;”Fullständig disktillgång”&lt;/b&gt; eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="349"/>
+<source>Still in the Security &amp; Privacy settings, open the &lt;b&gt;"Privacy"&lt;/b&gt; tab or &lt;a style="%1" href="%2"&gt;click here&lt;/a&gt;</source>
+<translation>Öppna fliken &lt;b&gt;”Sekretess”&lt;/b&gt; i inställningarna för säkerhet och sekretess, eller &lt;a style="%1" href="%2"&gt;klicka här&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="377"/>
+<source>Check the "kDrive LiteSync Extension" box then the "kDrive.app" box (if not already checked)</source>
+<translation>Markera rutan ”kDrive LiteSync Extension” och sedan rutan ”kDrive.app” (om den inte redan är markerad)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="394"/>
+<source>A restart of the app might be proposed, in this case accept it</source>
+<translation>Det kan hända att appen föreslår en omstart; i så fall godkänner du den</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="400"/>
+<source>Check the "kDrive LiteSync Extension" box (and "kDrive.app" if it exists) in &lt;b&gt;"Full Disk Access"&lt;/b&gt;</source>
+<translation>Markera rutan ”kDrive LiteSync Extension” (och ”kDrive.app” om den finns) under &lt;b&gt;”Fullständig diskåtkomst”&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<source>STEP 1</source>
+<translation>STEG 1</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="491"/>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>(Done)</source>
+<translation>(Klart)</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="492"/>
+<source>STEP 2</source>
+<translation>STEG 2</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="495"/>
+<source>STEPS PERFORMED</source>
+<translation>UTFÖRDA STEG</translation>
+</message>
+<message>
+<location filename="../src/gui/customextensionsetupwidget.cpp" line="497"/>
+<source>END</source>
+<translation>SLUTFÖR</translation>
+</message>
 </context>
 <context>
-    <name>KDC::CustomMessageBox</name>
-    <message>
-        <source>OK</source>
-        <translation type="vanished">OKEJ</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>YES</source>
-        <translation type="vanished">JA</translation>
-    </message>
-    <message>
-        <source>NO</source>
-        <translation type="vanished">NEJ</translation>
-    </message>
+<name>KDC::CustomMessageBox</name>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="105"/>
+<source>OK</source>
+<translation>OKEJ</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="115"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="125"/>
+<source>YES</source>
+<translation>JA</translation>
+</message>
+<message>
+<location filename="../src/gui/custommessagebox.cpp" line="135"/>
+<source>NO</source>
+<translation>NEJ</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebugReporter</name>
-    <message>
-        <source>Sending of debugging information</source>
-        <translation type="vanished">Översändning av felsökningsinformation</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
+<name>KDC::DebugReporter</name>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Sending of debugging information</source>
+<translation>Översändning av felsökningsinformation</translation>
+</message>
+<message>
+<location filename="../src/gui/debugreporter.cpp" line="37"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DebuggingDialog</name>
-    <message>
-        <source>Info</source>
-        <translation type="vanished">Info</translation>
-    </message>
-    <message>
-        <source>Debug</source>
-        <translation type="vanished">Felsökning</translation>
-    </message>
-    <message>
-        <source>Warning</source>
-        <translation type="vanished">Varning</translation>
-    </message>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fel</translation>
-    </message>
-    <message>
-        <source>Fatal</source>
-        <translation type="vanished">Dödlig</translation>
-    </message>
-    <message>
-        <source>Debugging settings</source>
-        <translation type="vanished">Felsökningsinställningar</translation>
-    </message>
-    <message>
-        <source>Save debugging information in a folder on my computer (Recommended)</source>
-        <translation type="vanished">Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
-    </message>
-    <message>
-        <source>This information enables IT support to determine the origin of an incident.</source>
-        <translation type="vanished">Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Debug level</source>
-        <translation type="vanished">Felsökningsnivå</translation>
-    </message>
-    <message>
-        <source>The trace level lets you choose the extent of the debugging information recorded</source>
-        <translation type="vanished">Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
-    </message>
-    <message>
-        <source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
-        <translation type="vanished">Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
-    </message>
-    <message>
-        <source>Extended Full Log</source>
-        <translation type="vanished">Utökad fullständig logg</translation>
-    </message>
-    <message>
-        <source>Delete logs older than %1 days</source>
-        <translation type="vanished">Ta bort loggar som är äldre än %1 dagar</translation>
-    </message>
-    <message>
-        <source>Share the debug folder with Infomaniak support.</source>
-        <translation type="vanished">Skicka debug-mappen till Infomaniaks support.</translation>
-    </message>
-    <message>
-        <source>The last session is the periode since the last kDrive start.</source>
-        <translation type="vanished">Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
-    </message>
-    <message>
-        <source>Share only the last kDrive session</source>
-        <translation type="vanished">Dela endast den senaste kDrive-sessionen</translation>
-    </message>
-    <message>
-        <source>  Loading</source>
-        <translation type="vanished">  Laddar</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPARA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Failed to share</source>
-        <translation type="vanished">Det gick inte att dela</translation>
-    </message>
-    <message>
-        <source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
-        <translation type="vanished">1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
-    </message>
-    <message>
-        <source> (Connexion interrupted)</source>
-        <translation type="vanished"> (Anslutningen avbröts)</translation>
-    </message>
-    <message>
-        <source>Share the folder with SwissTransfer &lt;br&gt;</source>
-        <translation type="vanished">Dela mappen med SwissTransfer &lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 1. We automatically compressed your log &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;here&lt;/a&gt;.&lt;br&gt;</source>
-        <translation type="vanished"> 1. Vi har automatiskt komprimerat din logg &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 2. Transfer the archive with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 2. Skicka arkivet via &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source> 3. Share the link with &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
-        <translation type="vanished"> 3. Dela länken med &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>Last upload the %1</source>
-        <translation type="vanished">Senaste uppladdning: %1</translation>
-    </message>
-    <message>
-        <source>Sharing has been cancelled</source>
-        <translation type="vanished">Delningen har avbrutits</translation>
-    </message>
-    <message>
-        <source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
-        <translation type="vanished">Den utökade fullständiga loggen aktiveras via miljövariabeln KDRIVE_FORCE_EXTENDED_LOG. Sätt den till 0 för att inaktivera den.</translation>
-    </message>
-    <message>
-        <source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
-        <translation type="vanished">Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
-    </message>
-    <message>
-        <source>%1/%2/%3 at %4h%5m and %6s</source>
-        <extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
-        <translation type="vanished">%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vill du spara dina ändringar?</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <source>  Share</source>
-        <translation type="vanished">  Dela</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 1/2 %1%</source>
-        <translation type="vanished">  Dela | steg 1/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Sharing | step 2/2 %1%</source>
-        <translation type="vanished">  Dela | steg 2/2 %1%</translation>
-    </message>
-    <message>
-        <source>  Canceling...</source>
-        <translation type="vanished">  Avbryter...</translation>
-    </message>
+<name>KDC::DebuggingDialog</name>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="46"/>
+<source>Info</source>
+<translation>Info</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="45"/>
+<source>Debug</source>
+<translation>Felsökning</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="47"/>
+<source>Warning</source>
+<translation>Varning</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="48"/>
+<source>Error</source>
+<translation>Fel</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="49"/>
+<source>Fatal</source>
+<translation>Dödlig</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="74"/>
+<source>Debugging settings</source>
+<translation>Felsökningsinställningar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="90"/>
+<source>Save debugging information in a folder on my computer (Recommended)</source>
+<translation>Spara felsökningsinformation i en mapp på min dator (rekommenderas)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="104"/>
+<source>This information enables IT support to determine the origin of an incident.</source>
+<translation>Med hjälp av denna information kan IT-supporten fastställa var ett fel har sitt ursprung.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="114"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="143"/>
+<source>Debug level</source>
+<translation>Felsökningsnivå</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="152"/>
+<source>The trace level lets you choose the extent of the debugging information recorded</source>
+<translation>Med spårningsnivån kan du välja hur mycket felsökningsinformation som ska registreras</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="179"/>
+<source>The extended full log collects a detailed history that can be used for debugging. Enabling it can slow down the kDrive application.</source>
+<translation>Den utökade fullständiga loggen samlar in en detaljerad historik som kan användas för felsökning. Om du aktiverar den kan det göra att kDrive-programmet går långsammare.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="183"/>
+<source>Extended Full Log</source>
+<translation>Utökad fullständig logg</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="207"/>
+<source>Delete logs older than %1 days</source>
+<translation>Ta bort loggar som är äldre än %1 dagar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="226"/>
+<source>Share the debug folder with Infomaniak support.</source>
+<translation>Skicka debug-mappen till Infomaniaks support.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="250"/>
+<source>The last session is the periode since the last kDrive start.</source>
+<translation>Den sista sessionen är tidsperioden sedan kDrive senast startades.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="254"/>
+<source>Share only the last kDrive session</source>
+<translation>Dela endast den senaste kDrive-sessionen</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="285"/>
+<source>  Loading</source>
+<translation>  Laddar</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="294"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="320"/>
+<source>SAVE</source>
+<translation>SPARA</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="327"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="471"/>
+<source>Failed to share</source>
+<translation>Det gick inte att dela</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="481"/>
+<source>1. Check that you are logged in &lt;br&gt;2. Check that you have configured at least one kDrive</source>
+<translation>1. Kontrollera att du är inloggad &lt;br&gt;2. Kontrollera att du har konfigurerat minst en kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="486"/>
+<source> (Connexion interrupted)</source>
+<translation> (Anslutningen avbröts)</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="493"/>
+<source>Share the folder with SwissTransfer &lt;br&gt;</source>
+<translation>Dela mappen med SwissTransfer &lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="494"/>
+<source> 1. We automatically compressed your log &lt;a style="%1" href="%2"&gt;here&lt;/a&gt;.&lt;br&gt;</source>
+<translation> 1. Vi har automatiskt komprimerat din logg &lt;a style="%1" href="%2"&gt;här&lt;/a&gt;.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="496"/>
+<source> 2. Transfer the archive with &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</source>
+<translation> 2. Skicka arkivet via &lt;a style="%1" href="%2"&gt;swisstransfer.com&lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="498"/>
+<source> 3. Share the link with &lt;a style="%1" href="%2"&gt; support@infomaniak.com &lt;/a&gt;&lt;br&gt;</source>
+<translation> 3. Dela länken med &lt;a style="%1" href="%2"&gt;support@infomaniak.com &lt;/a&gt;&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="528"/>
+<source>Last upload the %1</source>
+<translation>Senaste uppladdning: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="556"/>
+<source>Sharing has been cancelled</source>
+<translation>Delningen har avbrutits</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="598"/>
+<source>The extended full log is activated through the KDRIVE_FORCE_EXTENDED_LOG environment variable. Set it to 0 to disable it.</source>
+<translation>Den utökade fullständiga loggen aktiveras via miljövariabeln KDRIVE_FORCE_EXTENDED_LOG. Sätt den till 0 för att inaktivera den.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.h" line="70"/>
+<source>The entire folder is large (&gt; 100 MB) and may take some time to share. To reduce the sharing time, we recommend, that you share only the last kDrive session.</source>
+<translation>Hela mappen är stor (&gt; 100 MB) och det kan ta en stund att dela den. För att minska delningstiden rekommenderar vi att du endast delar den senaste kDrive-sessionen.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="612"/>
+<source>%1/%2/%3 at %4h%5m and %6s</source>
+<extracomment>Date format for the last successful log upload. %1: month, %2: day, %3: year, %4: hour, %5: minute, %6: second</extracomment>
+<translation>%1/%2/%3 kl. %4:%5 och %6 sekunder</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="655"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vill du spara dina ändringar?</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="710"/>
+<location filename="../src/gui/debuggingdialog.cpp" line="716"/>
+<source>Unable to open folder %1.</source>
+<translation>Det går inte att öppna mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="723"/>
+<source>  Share</source>
+<translation>  Dela</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="733"/>
+<source>  Sharing | step 1/2 %1%</source>
+<translation>  Dela | steg 1/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="742"/>
+<source>  Sharing | step 2/2 %1%</source>
+<translation>  Dela | steg 2/2 %1%</translation>
+</message>
+<message>
+<location filename="../src/gui/debuggingdialog.cpp" line="752"/>
+<source>  Canceling...</source>
+<translation>  Avbryter...</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DrivePreferencesWidget</name>
-    <message>
-        <source>Folders</source>
-        <translation type="vanished">Mappar</translation>
-    </message>
-    <message>
-        <source>Notifications</source>
-        <translation type="vanished">Meddelanden</translation>
-    </message>
-    <message>
-        <source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
-        <translation type="vanished">Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
-    </message>
-    <message>
-        <source>Connected with</source>
-        <translation type="vanished">I samband med</translation>
-    </message>
-    <message>
-        <source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
-        <translation type="vanished">Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
-    </message>
-    <message>
-        <source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
-        <translation type="vanished">Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>New local folder synchronization failed!</source>
-        <translation type="vanished">Synkroniseringen av den nya lokala mappen misslyckades!</translation>
-    </message>
-    <message>
-        <source>Lite Sync activation failed.</source>
-        <translation type="vanished">Aktiveringen av Lite Sync misslyckades.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivation failed.</source>
-        <translation type="vanished">Det gick inte att inaktivera Lite Sync.</translation>
-    </message>
-    <message>
-        <source>REMOVE FOLDER SYNC CONNECTION</source>
-        <translation type="vanished">TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
-    </message>
-    <message>
-        <source>An error occurred while loading the list of subfolders.</source>
-        <translation type="vanished">Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
-    </message>
-    <message>
-        <source>Enable the notifications for this kDrive</source>
-        <translation type="vanished">Aktivera aviseringar för denna kDrive</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>Synchronization errors and information.</source>
-        <translation type="vanished">Synkroniseringsfel och information.</translation>
-    </message>
-    <message>
-        <source>Synchronize a local folder</source>
-        <translation type="vanished">Synkronisera en lokal mapp</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn on Lite Sync?</source>
-        <translation type="vanished">Vill du verkligen aktivera Lite Sync?</translation>
-    </message>
-    <message>
-        <source>Do you really want to turn off Lite Sync?</source>
-        <translation type="vanished">Vill du verkligen stänga av Lite Sync?</translation>
-    </message>
-    <message>
-        <source>You don&apos;t have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
-        <translation type="vanished">Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
-    </message>
-    <message>
-        <source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
-        <translation type="vanished">Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
-    </message>
-    <message>
-        <source>Failed to create new synchronization</source>
-        <translation type="vanished">Det gick inte att skapa en ny synkronisering</translation>
-    </message>
-    <message>
-        <source>Lite Sync activated.</source>
-        <translation type="vanished">Lite Sync är aktiverat.</translation>
-    </message>
-    <message>
-        <source>Lite Sync deactivated.</source>
-        <translation type="vanished">Lite Sync är inaktiverat.</translation>
-    </message>
-    <message>
-        <source>This drive is being deleted.</source>
-        <translation type="vanished">Den här enheten raderas.</translation>
-    </message>
-    <message>
-        <source>Impossible to open item %1</source>
-        <translation type="vanished">Det går inte att öppna objekt %1</translation>
-    </message>
-    <message>
-        <source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
-        <translation type="vanished">Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
-    </message>
-    <message>
-        <source>Remove all synchronizations</source>
-        <translation type="vanished">Ta bort alla synkroniseringar</translation>
-    </message>
-    <message>
-        <source>Search in your kDrive</source>
-        <translation type="vanished">Sök i din kDrive</translation>
-    </message>
-    <message>
-        <source>Search</source>
-        <translation type="vanished">Sök</translation>
-    </message>
+<name>KDC::DrivePreferencesWidget</name>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1118"/>
+<source>Folders</source>
+<translation>Mappar</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1120"/>
+<source>Notifications</source>
+<translation>Meddelanden</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1123"/>
+<source>A notification will be displayed as soon as a new folder has been synchronized or modified</source>
+<translation>Ett meddelande visas så snart en ny mapp har synkroniserats eller ändrats</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1124"/>
+<source>Connected with</source>
+<translation>I samband med</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="981"/>
+<source>Do you really want to stop syncing the folder &lt;i&gt;%1&lt;/i&gt; ?&lt;br&gt;&lt;b&gt;Note:&lt;/b&gt; This will &lt;b&gt;not&lt;/b&gt; delete any files.</source>
+<translation>Vill du verkligen sluta synkronisera mappen &lt;i&gt;%1&lt;/i&gt;?&lt;br&gt;&lt;b&gt;Obs!&lt;/b&gt; Detta kommer &lt;b&gt;inte&lt;/b&gt; att radera några filer.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="356"/>
+<source>This operation may take from a few seconds to a few minutes depending on the size of the folder.</source>
+<translation>Denna åtgärd kan ta allt från några sekunder till några minuter, beroende på mappens storlek.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="360"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="391"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="986"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="645"/>
+<source>New local folder synchronization failed!</source>
+<translation>Synkroniseringen av den nya lokala mappen misslyckades!</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="823"/>
+<source>Lite Sync activation failed.</source>
+<translation>Aktiveringen av Lite Sync misslyckades.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="841"/>
+<source>Lite Sync deactivation failed.</source>
+<translation>Det gick inte att inaktivera Lite Sync.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="985"/>
+<source>REMOVE FOLDER SYNC CONNECTION</source>
+<translation>TA BORT SYNKRONISERINGSFÖRBINDELSEN FÖR MAPPEN</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1048"/>
+<source>An error occurred while loading the list of subfolders.</source>
+<translation>Ett fel uppstod vid inläsningen av listan över undermappar.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1121"/>
+<source>Enable the notifications for this kDrive</source>
+<translation>Aktivera aviseringar för denna kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="359"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="390"/>
+<source>CONFIRM</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="120"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1117"/>
+<source>Synchronization errors and information.</source>
+<translation>Synkroniseringsfel och information.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="144"/>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1119"/>
+<source>Synchronize a local folder</source>
+<translation>Synkronisera en lokal mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="355"/>
+<source>Do you really want to turn on Lite Sync?</source>
+<translation>Vill du verkligen aktivera Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="382"/>
+<source>Do you really want to turn off Lite Sync?</source>
+<translation>Vill du verkligen stänga av Lite Sync?</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="384"/>
+<source>You don't have enough space to sync all the files on your kDrive (%1 missing). If you turn off Lite Sync, you need to select which folders to sync on your computer. In the meantime, the synchronization of your kDrive will be paused.</source>
+<translation>Du har inte tillräckligt med utrymme för att synkronisera alla filer på din kDrive (%1 saknas). Om du inaktiverar Lite Sync måste du välja vilka mappar som ska synkroniseras på din dator. Under tiden kommer synkroniseringen av din kDrive att pausas.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="388"/>
+<source>If you turn off Lite Sync, all files will be downloaded to your computer.</source>
+<translation>Om du stänger av Lite Sync kommer alla filer att laddas ner till din dator.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="627"/>
+<source>Failed to create new synchronization</source>
+<translation>Det gick inte att skapa en ny synkronisering</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="819"/>
+<source>Lite Sync activated.</source>
+<translation>Lite Sync är aktiverat.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="837"/>
+<source>Lite Sync deactivated.</source>
+<translation>Lite Sync är inaktiverat.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="899"/>
+<source>This drive is being deleted.</source>
+<translation>Den här enheten raderas.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="962"/>
+<source>Impossible to open item %1</source>
+<translation>Det går inte att öppna objekt %1</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1007"/>
+<source>Failed to stop syncing the folder &lt;i&gt;%1&lt;/i&gt;.</source>
+<translation>Det gick inte att avbryta synkroniseringen av mappen &lt;i&gt;%1&lt;/i&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1125"/>
+<source>Remove all synchronizations</source>
+<translation>Ta bort alla synkroniseringar</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1126"/>
+<source>Search in your kDrive</source>
+<translation>Sök i din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/drivepreferenceswidget.cpp" line="1127"/>
+<source>Search</source>
+<translation>Sök</translation>
+</message>
 </context>
 <context>
-    <name>KDC::DriveSelectionWidget</name>
-    <message>
-        <source>Synchronize a kDrive</source>
-        <translation type="vanished">Synkronisera en kDrive</translation>
-    </message>
-    <message>
-        <source>Add a kDrive</source>
-        <translation type="vanished">Lägg till en kDrive</translation>
-    </message>
+<name>KDC::DriveSelectionWidget</name>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="216"/>
+<source>Synchronize a kDrive</source>
+<translation>Synkronisera en kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/driveselectionwidget.cpp" line="150"/>
+<source>Add a kDrive</source>
+<translation>Lägg till en kDrive</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorTabWidget</name>
-    <message>
-        <source>Resolve</source>
-        <translation type="vanished">Lösa</translation>
-    </message>
-    <message>
-        <source>Conflicted item(s)</source>
-        <translation type="vanished">Konflikterande objekt</translation>
-    </message>
-    <message>
-        <source>Item(s) with unsupported characters</source>
-        <translation type="vanished">Objekt med tecken som inte stöds</translation>
-    </message>
-    <message>
-        <source>Clear history</source>
-        <translation type="vanished">Rensa historiken</translation>
-    </message>
-    <message>
-        <source>To Resolve</source>
-        <translation type="vanished">Att lösa</translation>
-    </message>
-    <message>
-        <source>Automatically resolved</source>
-        <translation type="vanished">Löst automatiskt</translation>
-    </message>
-    <message>
-        <source>problem(s) solved</source>
-        <translation type="vanished">problem löst</translation>
-    </message>
-    <message>
-        <source>problem(s) detected</source>
-        <translation type="vanished">problem har upptäckts</translation>
-    </message>
+<name>KDC::ErrorTabWidget</name>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="179"/>
+<source>Resolve</source>
+<translation>Lösa</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="180"/>
+<source>Conflicted item(s)</source>
+<translation>Konflikterande objekt</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="181"/>
+<source>Item(s) with unsupported characters</source>
+<translation>Objekt med tecken som inte stöds</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="92"/>
+<location filename="../src/gui/errortabwidget.cpp" line="135"/>
+<location filename="../src/gui/errortabwidget.cpp" line="178"/>
+<location filename="../src/gui/errortabwidget.cpp" line="186"/>
+<source>Clear history</source>
+<translation>Rensa historiken</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="176"/>
+<source>To Resolve</source>
+<translation>Att lösa</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="184"/>
+<source>Automatically resolved</source>
+<translation>Löst automatiskt</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="185"/>
+<source>problem(s) solved</source>
+<translation>problem löst</translation>
+</message>
+<message>
+<location filename="../src/gui/errortabwidget.cpp" line="177"/>
+<source>problem(s) detected</source>
+<translation>problem har upptäckts</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsMenuBarWidget</name>
-    <message>
-        <source>Synchronization conflicts or errors</source>
-        <translation type="vanished">Synkroniseringskonflikter eller fel</translation>
-    </message>
-    <message>
-        <source>Errors</source>
-        <translation type="vanished">Fel</translation>
-    </message>
-    <message>
-        <source>Back to preferences</source>
-        <translation type="vanished">Tillbaka till inställningar</translation>
-    </message>
+<name>KDC::ErrorsMenuBarWidget</name>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="84"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="103"/>
+<source>Synchronization conflicts or errors</source>
+<translation>Synkroniseringskonflikter eller fel</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="86"/>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="105"/>
+<source>Errors</source>
+<translation>Fel</translation>
+</message>
+<message>
+<location filename="../src/gui/errorsmenubarwidget.cpp" line="101"/>
+<source>Back to preferences</source>
+<translation>Tillbaka till inställningar</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ErrorsPopup</name>
-    <message>
-        <source>Some files couldn&apos;t be synchronized on the following kDrive(s) :</source>
-        <translation type="vanished">Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
-    </message>
-    <message>
-        <source> (%1 error(s))</source>
-        <translation type="vanished"> (%1 fel)</translation>
-    </message>
-    <message>
-        <source> (%1 information(s))</source>
-        <translation type="vanished"> (%1 uppgift(er))</translation>
-    </message>
-    <message>
-        <source> (%1 error(s) and %2 information(s))</source>
-        <translation type="vanished"> (%1 fel och %2 uppgifter)</translation>
-    </message>
-    <message numerus="yes">
-        <source>Generic errors (%n warning(s) or error(s))</source>
-        <comment>Number of warnings or errors</comment>
-        <translation type="vanished">
-            <numerusform>Allmänna fel (%n varning eller fel)</numerusform>
-            <numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
-        </translation>
-    </message>
+<name>KDC::ErrorsPopup</name>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="73"/>
+<source>Some files couldn't be synchronized on the following kDrive(s) :</source>
+<translation>Vissa filer kunde inte synkroniseras på följande kDrive-enheter:</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="95"/>
+<source> (%1 error(s))</source>
+<translation> (%1 fel)</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="101"/>
+<source> (%1 information(s))</source>
+<translation> (%1 uppgift(er))</translation>
+</message>
+<message>
+<location filename="../src/gui/errorspopup.cpp" line="107"/>
+<source> (%1 error(s) and %2 information(s))</source>
+<translation> (%1 fel och %2 uppgifter)</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/gui/errorspopup.cpp" line="147"/>
+<source>Generic errors (%n warning(s) or error(s))</source>
+<comment>Number of warnings or errors</comment>
+<translation>
+<numerusform>Allmänna fel (%n varning eller fel)</numerusform>
+<numerusform>Allmänna fel (%n varningar eller fel)</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionDialog</name>
-    <message>
-        <source>Excluded files</source>
-        <translation type="vanished">Undantagna filer</translation>
-    </message>
-    <message>
-        <source>Add files or folders that will not be synchronized on your computer.</source>
-        <translation type="vanished">Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Lägg till</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAMN</translation>
-    </message>
-    <message>
-        <source>WARNING</source>
-        <translation type="vanished">VARNING</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPARA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vill du spara dina ändringar?</translation>
-    </message>
-    <message>
-        <source>Exclusion template already exists!</source>
-        <translation type="vanished">Mallen för uteslutning finns redan!</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vill du verkligen ta bort det?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Det går inte att spara ändringarna!</translation>
-    </message>
+<name>KDC::FileExclusionDialog</name>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="78"/>
+<source>Excluded files</source>
+<translation>Undantagna filer</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="86"/>
+<source>Add files or folders that will not be synchronized on your computer.</source>
+<translation>Lägg till filer eller mappar som inte ska synkroniseras på din dator.</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="97"/>
+<source>Add</source>
+<translation>Lägg till</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="109"/>
+<source>NAME</source>
+<translation>NAMN</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="114"/>
+<source>WARNING</source>
+<translation>VARNING</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="149"/>
+<source>SAVE</source>
+<translation>SPARA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="156"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="304"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vill du spara dina ändringar?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="353"/>
+<source>Exclusion template already exists!</source>
+<translation>Mallen för uteslutning finns redan!</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="374"/>
+<source>Do you really want to delete?</source>
+<translation>Vill du verkligen ta bort det?</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusiondialog.cpp" line="434"/>
+<source>Cannot save changes!</source>
+<translation>Det går inte att spara ändringarna!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FileExclusionNameDialog</name>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::FileExclusionNameDialog</name>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="58"/>
+<source>VALIDATE</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fileexclusionnamedialog.cpp" line="65"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FixConflictingFilesDialog</name>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <source>Solve conflict(s)</source>
-        <translation type="vanished">Lösa konflikter</translation>
-    </message>
-    <message>
-        <source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
-        <translation type="vanished">&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>Save my changes and replace other users&apos; versions.</source>
-        <translation type="vanished">Spara mina ändringar och ersätt andra användares versioner.</translation>
-    </message>
-    <message>
-        <source>Undo my changes and keep other users&apos; versions.</source>
-        <translation type="vanished">Ångra mina ändringar och behåll andra användares versioner.</translation>
-    </message>
-    <message>
-        <source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=%1 href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=%1 href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
-        <translation type="vanished">Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
-    </message>
-    <message>
-        <source>Show item(s)</source>
-        <translation type="vanished">Visa objekt</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
-        <translation type="vanished">Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
-    </message>
-    <message>
-        <source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style=&quot;color: #489EF3&quot; href=&quot;%1&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
+<name>KDC::FixConflictingFilesDialog</name>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="67"/>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="73"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="122"/>
+<source>Solve conflict(s)</source>
+<translation>Lösa konflikter</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="140"/>
+<source>&lt;b&gt;What do you want to do with the %1 conflicted item(s)?&lt;/b&gt;</source>
+<translation>&lt;b&gt;Vad vill du göra med den/de %1 objektet/objekten som är i konflikt?&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="143"/>
+<source>Save my changes and replace other users' versions.</source>
+<translation>Spara mina ändringar och ersätt andra användares versioner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="147"/>
+<source>Undo my changes and keep other users' versions.</source>
+<translation>Ångra mina ändringar och behåll andra användares versioner.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="169"/>
+<source>Your changes may be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Dina ändringar kan raderas permanent. De går inte att återställa via kDrive-webbappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="171"/>
+<source>&lt;a style=%1 href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style=%1 href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="175"/>
+<source>Your changes will be permanently deleted. They cannot be restored from the kDrive web application.</source>
+<translation>Dina ändringar kommer att raderas permanent. De kan inte återställas via kDrive-webbappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="191"/>
+<source>Show item(s)</source>
+<translation>Visa objekt</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="228"/>
+<source>VALIDATE</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="234"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="251"/>
+<source>Modifications have been made to these files by several users in several places (online on kDrive, a computer or a mobile). Folders containing these files may also have been deleted.&lt;br&gt;</source>
+<translation>Flera användare har gjort ändringar i dessa filer på olika ställen (online på kDrive, på en dator eller i en mobil). Mappar som innehåller dessa filer kan också ha raderats.&lt;br&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/fixconflictingfilesdialog.cpp" line="253"/>
+<source>The local version of your item &lt;b&gt;is not synced&lt;/b&gt; with kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Learn more&lt;/a&gt;</source>
+<translation>Den lokala versionen av din artikel &lt;b&gt;är inte synkroniserad&lt;/b&gt; med kDrive. &lt;a style="color: #489EF3" href="%1"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::FolderItemWidget</name>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Fler åtgärder</translation>
-    </message>
-    <message>
-        <source>Synchronized into &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</source>
-        <translation type="vanished">Synkroniserad till &lt;a style=&quot;%1&quot; href=&quot;ref&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync</source>
-        <translation type="vanished">Aktivera Lite Sync</translation>
-    </message>
-    <message>
-        <source>Activate Lite Sync (Beta)</source>
-        <translation type="vanished">Aktivera Lite Sync (Beta)</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
-    </message>
-    <message>
-        <source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
-        <translation type="vanished">Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
-    </message>
-    <message>
-        <source>Cancel</source>
-        <translation type="vanished">Avbryt</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausa synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Deactivate Lite Sync</source>
-        <translation type="vanished">Inaktivera Lite Sync</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Fortsätt synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Remove synchronization</source>
-        <translation type="vanished">Avaktivera synkronisering</translation>
-    </message>
+<name>KDC::FolderItemWidget</name>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="458"/>
+<source>More actions</source>
+<translation>Fler åtgärder</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="188"/>
+<location filename="../src/gui/folderitemwidget.cpp" line="476"/>
+<source>Synchronized into &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</source>
+<translation>Synkroniserad till &lt;a style="%1" href="ref"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="343"/>
+<source>Activate Lite Sync</source>
+<translation>Aktivera Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="345"/>
+<source>Activate Lite Sync (Beta)</source>
+<translation>Aktivera Lite Sync (Beta)</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="481"/>
+<source>Unselected folders will be moved to trash provided they contain offline items. Folders synced to kDrive will remain available online.</source>
+<translation>Mappar som inte är markerade flyttas till papperskorgen om de innehåller objekt som är offline. Mappar som synkroniserats till kDrive förblir tillgängliga online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="485"/>
+<source>Unselected folders will be moved to trash. Folders synced to kDrive will remain available online.</source>
+<translation>Mappar som inte är markerade kommer att flyttas till papperskorgen. Mappar som synkroniserats till kDrive kommer att förbli tillgängliga online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="488"/>
+<source>Unselected folders will be &lt;b&gt;permanently&lt;/b&gt; deleted from the computer. Folders synced to kDrive will remain available online.</source>
+<translation>Mappar som inte är markerade kommer att raderas &lt;b&gt;permanent&lt;/b&gt; från datorn. Mappar som synkroniserats till kDrive kommer att finnas kvar online.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="493"/>
+<source>Cancel</source>
+<translation>Avbryt</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="494"/>
+<source>VALIDATE</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="365"/>
+<source>Pause synchronization</source>
+<translation>Pausa synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="354"/>
+<source>Deactivate Lite Sync</source>
+<translation>Inaktivera Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="375"/>
+<source>Resume synchronization</source>
+<translation>Fortsätt synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="386"/>
+<source>Remove synchronization</source>
+<translation>Avaktivera synkronisering</translation>
+</message>
 </context>
 <context>
-    <name>KDC::GenericErrorItemWidget</name>
-    <message>
-        <source>Unable to open folder path %1.</source>
-        <translation type="vanished">Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
+<name>KDC::GenericErrorItemWidget</name>
+<message>
+<location filename="../src/gui/genericerroritemwidget.cpp" line="85"/>
+<source>Unable to open folder path %1.</source>
+<translation>Det går inte att öppna mappsökvägen %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncAppDialog</name>
-    <message>
-        <source>Application Id</source>
-        <translation type="vanished">Applikations-ID</translation>
-    </message>
-    <message>
-        <source>Application Name</source>
-        <translation type="vanished">Programnamn</translation>
-    </message>
-    <message>
-        <source>VALIDATE</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::LiteSyncAppDialog</name>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="48"/>
+<source>Application Id</source>
+<translation>Applikations-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="98"/>
+<source>Application Name</source>
+<translation>Programnamn</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="121"/>
+<source>VALIDATE</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncappdialog.cpp" line="128"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LiteSyncDialog</name>
-    <message>
-        <source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are &quot;online&quot;. Add them in the list below to avoid this behaviour.</source>
-        <translation type="vanished">Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
-    </message>
-    <message>
-        <source>Add</source>
-        <translation type="vanished">Lägg till</translation>
-    </message>
-    <message>
-        <source>APPLICATION ID</source>
-        <translation type="vanished">APPLIKATIONS-ID</translation>
-    </message>
-    <message>
-        <source>NAME</source>
-        <translation type="vanished">NAMN</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPARA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vill du spara dina ändringar?</translation>
-    </message>
-    <message>
-        <source>Do you really want to delete?</source>
-        <translation type="vanished">Vill du verkligen ta bort det?</translation>
-    </message>
-    <message>
-        <source>Cannot save changes!</source>
-        <translation type="vanished">Det går inte att spara ändringarna!</translation>
-    </message>
+<name>KDC::LiteSyncDialog</name>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="91"/>
+<source>Some apps (backup, anti-virus...) access your files, which leads to their download when they are "online". Add them in the list below to avoid this behaviour.</source>
+<translation>Vissa appar (säkerhetskopieringsappar, antivirusprogram...) får åtkomst till dina filer, vilket gör att de laddas ner när de är ”uppkopplade”. Lägg till dem i listan nedan för att undvika detta.</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="103"/>
+<source>Add</source>
+<translation>Lägg till</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="115"/>
+<source>APPLICATION ID</source>
+<translation>APPLIKATIONS-ID</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="120"/>
+<source>NAME</source>
+<translation>NAMN</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="154"/>
+<source>SAVE</source>
+<translation>SPARA</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="161"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="295"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vill du spara dina ändringar?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="337"/>
+<source>Do you really want to delete?</source>
+<translation>Vill du verkligen ta bort det?</translation>
+</message>
+<message>
+<location filename="../src/gui/litesyncdialog.cpp" line="374"/>
+<source>Cannot save changes!</source>
+<translation>Det går inte att spara ändringarna!</translation>
+</message>
 </context>
 <context>
-    <name>KDC::LocalFolderDialog</name>
-    <message>
-        <source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
-        <translation type="vanished">Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
-    </message>
-    <message>
-        <source>The content of this folder will be synchronized on the kDrive</source>
-        <translation type="vanished">Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
-    </message>
-    <message>
-        <source>Select a folder</source>
-        <translation type="vanished">Välj en mapp</translation>
-    </message>
-    <message>
-        <source>Edit folder</source>
-        <translation type="vanished">Ändra mapp</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÄTT</translation>
-    </message>
-    <message>
-        <source>This folder is not compatible with Lite Sync.&lt;br&gt;
+<name>KDC::LocalFolderDialog</name>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="63"/>
+<source>Which folder on your computer would you like to&lt;br&gt;synchronize ?</source>
+<translation>Vilken mapp på din dator vill du&lt;br&gt;synkronisera?</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="72"/>
+<source>The content of this folder will be synchronized on the kDrive</source>
+<translation>Innehållet i den här mappen kommer att synkroniseras på kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="91"/>
+<source>Select a folder</source>
+<translation>Välj en mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="131"/>
+<source>Edit folder</source>
+<translation>Ändra mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="166"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="173"/>
+<source>CONTINUE</source>
+<translation>FORTSÄTT</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="210"/>
+<source>This folder is not compatible with Lite Sync.&lt;br&gt;
 Please select another folder. If you continue Lite Sync will be disabled.&lt;br&gt;
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
+&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Den här mappen är inte kompatibel med Lite Sync.&lt;br&gt;
 Välj en annan mapp. Om du fortsätter kommer Lite Sync att inaktiveras.&lt;br&gt;
 
-&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Select folder</source>
-        <translation type="vanished">Välj mapp</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
+&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="233"/>
+<source>Select folder</source>
+<translation>Välj mapp</translation>
+</message>
+<message>
+<location filename="../src/gui/localfolderdialog.cpp" line="292"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::Logger</name>
-    <message>
-        <source>Error</source>
-        <translation type="vanished">Fel</translation>
-    </message>
-    <message>
-        <source>&lt;nobr&gt;File &apos;%1&apos;&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
-        <translation type="vanished">&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
-    </message>
+<name>KDC::Logger</name>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>Error</source>
+<translation>Fel</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/logger.cpp" line="201"/>
+<source>&lt;nobr&gt;File '%1'&lt;br/&gt;cannot be opened for writing.&lt;br/&gt;&lt;br/&gt;The log output can &lt;b&gt;not&lt;/b&gt; be saved!&lt;/nobr&gt;</source>
+<translation>&lt;nobr&gt;Filen &amp;#x27;%1&amp;#x27;&lt;br/&gt;kan inte öppnas för skrivning.&lt;br/&gt;&lt;br/&gt;Logginformationen kan &lt;b&gt;inte&lt;/b&gt; sparas!&lt;/nobr&gt;</translation>
+</message>
 </context>
 <context>
-    <name>KDC::MainMenuBarWidget</name>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Inställningar</translation>
-    </message>
-    <message>
-        <source>Help</source>
-        <translation type="vanished">Hjälp</translation>
-    </message>
+<name>KDC::MainMenuBarWidget</name>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="115"/>
+<source>Preferences</source>
+<translation>Inställningar</translation>
+</message>
+<message>
+<location filename="../src/gui/mainmenubarwidget.cpp" line="116"/>
+<source>Help</source>
+<translation>Hjälp</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ParametersDialog</name>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1085"/>
-        <source>Unable to open folder path %1.</source>
-        <translation>Det går inte att öppna mappsökvägen %1.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1099"/>
-        <source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
-        <translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1121"/>
-        <source>No kDrive configured!</source>
-        <translation>kDrive är inte konfigurerat!</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="1100"/>
-        <source>Transmission failed!
-Please, use the following link to send the logs to the support: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</source>
-        <translation>Överföringen misslyckades!
-Använd följande länk för att skicka loggfilerna till supporten: &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%2&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="337"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="440"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="506"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="546"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="560"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="342"/>
-        <source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
-        <translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="347"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="516"/>
-        <source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
-        <translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="352"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="356"/>
-        <source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
-        <translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="360"/>
-        <source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
-        <translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="385"/>
-        <source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
-        <translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="532"/>
-        <source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
-        <translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="397"/>
-        <source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="320"/>
-        <source>kDrive needs to have write access to your computer&apos;s temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
-        <translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="330"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="487"/>
-        <source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="401"/>
-        <source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing &apos;/etc/sysctl.conf&apos;.</source>
-        <translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="406"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="419"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="424"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="429"/>
-        <source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
-        <translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="435"/>
-        <source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="449"/>
-        <source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="455"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="460"/>
-        <source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
-        <translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="466"/>
-        <source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="475"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web version&lt;/a&gt; to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="479"/>
-        <source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive&apos;s status, or contact your administrator.</source>
-        <translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="483"/>
-        <source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
-        <translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="493"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="512"/>
-        <source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="522"/>
-        <source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="526"/>
-        <source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
-        <translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="539"/>
-        <source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="550"/>
-        <source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
-        <translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="564"/>
-        <source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
-        <translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="569"/>
-        <source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
-        <translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="573"/>
-        <source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
-        <translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="580"/>
-        <source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
-        <translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="703"/>
-        <source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
-        <translation>Du har antingen inte behörighet att skapa ett objekt, eller så finns det redan ett annat objekt med samma namn. Objektet har ignorerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="722"/>
-        <source>You are not allowed to move item to &quot;%1&quot;.&lt;br&gt;It will be restored into its original parent folder.</source>
-        <translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="814"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="609"/>
-        <source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="618"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="614"/>
-        <source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="393"/>
-        <source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
-        <translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="622"/>
-        <source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
-        <translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="626"/>
-        <source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
-        <translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="692"/>
-        <source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="708"/>
-        <source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
-        <translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="716"/>
-        <source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
-        <translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="727"/>
-        <source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
-        <translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="732"/>
-        <source>Failed to move this item to trash, it has been blacklisted.</source>
-        <translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="748"/>
-        <source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
-        <translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="765"/>
-        <source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="771"/>
-        <source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
-        <translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="776"/>
-        <source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
-        <translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="782"/>
-        <source>Impossible to download the file.</source>
-        <translation>Det går inte att ladda ner filen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="779"/>
-        <source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
-        <translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="389"/>
-        <source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
-        <translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="413"/>
-        <source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
-        <translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="649"/>
-        <source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="656"/>
-        <source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="662"/>
-        <source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="668"/>
-        <source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="674"/>
-        <source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="680"/>
-        <source>The item path is too long.&lt;br&gt;It has been ignored.</source>
-        <translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="686"/>
-        <source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
-        <translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="735"/>
-        <source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
-        <translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="740"/>
-        <source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
-        <translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="745"/>
-        <source>This item has been excluded from sync because it is a hard link.</source>
-        <translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="785"/>
-        <source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
-        <translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="790"/>
-        <location filename="../src/gui/parametersdialog.cpp" line="837"/>
-        <source>Synchronization error.</source>
-        <translation>Synkroniseringsfel.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="810"/>
-        <source>Can&apos;t access item.&lt;br&gt;Please fix the read and write permissions.</source>
-        <translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="818"/>
-        <source>Impossible to create file %1 because it is not supported on your filesystem.&lt;br&gt;&quot;It has been excluded from synchronization.</source>
-        <translation>Det går inte att skapa filen %1 eftersom den inte stöds av ditt filsystem.&lt;br&gt;Den har uteslutits från synkroniseringen.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="821"/>
-        <source>System error.</source>
-        <translation>Systemfel.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="828"/>
-        <source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
-        <translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
-    </message>
-    <message>
-        <location filename="../src/gui/parametersdialog.cpp" line="843"/>
-        <source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
-        <translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
-    </message>
+<name>KDC::ParametersDialog</name>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1085"/>
+<source>Unable to open folder path %1.</source>
+<translation>Det går inte att öppna mappsökvägen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1099"/>
+<source>Transmission done!&lt;br&gt;Please refer to identifier &lt;b&gt;%1&lt;/b&gt; in bug reports.</source>
+<translation>Överföringen är klar!&lt;br&gt;Ange referensnummer &lt;b&gt;%1&lt;/b&gt; i felrapporter.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1121"/>
+<source>No kDrive configured!</source>
+<translation>kDrive är inte konfigurerat!</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="1100"/>
+<source>Transmission failed!
+Please, use the following link to send the logs to the support: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</source>
+<translation>Överföringen misslyckades!
+Använd följande länk för att skicka loggfilerna till supporten: &lt;a style="%1" href="%2"&gt;%2&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="337"/>
+<location filename="../src/gui/parametersdialog.cpp" line="440"/>
+<location filename="../src/gui/parametersdialog.cpp" line="506"/>
+<location filename="../src/gui/parametersdialog.cpp" line="546"/>
+<location filename="../src/gui/parametersdialog.cpp" line="560"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="342"/>
+<source>It seems that your network connection is configured with too low a timeout for the application to work correctly (error %1).&lt;br&gt;Please check your network configuration.</source>
+<translation>Det verkar som om tidsgränsen för din nätverksanslutning är inställd på ett för lågt värde för att programmet ska fungera korrekt (fel %1).&lt;br&gt;Kontrollera din nätverkskonfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="347"/>
+<location filename="../src/gui/parametersdialog.cpp" line="516"/>
+<source>Cannot connect to kDrive server (error %1).&lt;br&gt;Attempting reconnection. Please check your Internet connection and your firewall.</source>
+<translation>Det går inte att ansluta till kDrive-servern (fel %1).&lt;br&gt;Försöker ansluta igen. Kontrollera din internetanslutning och din brandvägg.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="352"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Please log in again and if the error persists, contact our support team.</source>
+<translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Logga in igen. Om felet kvarstår, kontakta vår support.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="356"/>
+<source>A new version of the application is available.&lt;br&gt;Please update the application to continue using it.</source>
+<translation>En ny version av appen finns tillgänglig. Uppdatera&lt;br&gt;appen för att kunna fortsätta använda den.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="360"/>
+<source>The log upload failed (error %1).&lt;br&gt;Please try again later.</source>
+<translation>Uppladdningen av loggen misslyckades (fel %1).&lt;br&gt;Försök igen senare.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="385"/>
+<source>The synchronization folder is no longer accessible (error %1).&lt;br&gt;Synchronization will resume as soon as the folder is accessible.</source>
+<translation>Synkroniseringsmappen är inte längre tillgänglig (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart mappen blir tillgänglig.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="532"/>
+<source>The synchronization folder has been replaced or moved in a way that prevents syncing (error %1).&lt;br&gt;This can happen after copying, moving, or restoring the folder.&lt;br&gt;To fix this, please create a new synchronization with a new folder.&lt;br&gt;Note: if you have unsynced changes in the old folder, you will need to copy them manually into the new one.</source>
+<translation>Synkroniseringsmappen har ersatts eller flyttats på ett sätt som förhindrar synkronisering (fel %1).&lt;br&gt;Detta kan inträffa efter att mappen har kopierats, flyttats eller återställts.&lt;br&gt;För att åtgärda detta, skapa en ny synkronisering med en ny mapp.&lt;br&gt;Obs! Om det finns osynkroniserade ändringar i den gamla mappen måste du kopiera dem manuellt till den nya.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="397"/>
+<source>There is not enough memory left on your machine.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Det finns inte tillräckligt med minne kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="320"/>
+<source>kDrive needs to have write access to your computer's temporary directory.&lt;br&gt;Please restart the kDrive app to resolve this issue.</source>
+<translation>kDrive måste ha skrivbehörighet till datorns temporära katalog.&lt;br&gt;Starta om kDrive-appen för att lösa problemet.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="330"/>
+<location filename="../src/gui/parametersdialog.cpp" line="487"/>
+<source>A technical error has occurred.&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Ett tekniskt fel har uppstått.&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="401"/>
+<source>The number of inotify watches is insufficient (error %1).&lt;br&gt;You can raise this number by editing '/etc/sysctl.conf'.</source>
+<translation>Antalet inotify-övervakningar är otillräckligt (fel %1).&lt;br&gt;Du kan öka detta antal genom att redigera filen &amp;#x27;/etc/sysctl.conf&amp;#x27;.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="406"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;You must allow:&lt;br&gt;- kDrive in System Settings &gt;&gt; General &gt;&gt; Login Items &amp; Extensions &gt;&gt; Endpoint Security Extensions&lt;br&gt;- kDrive LiteSync Extension in System Settings &gt;&gt; Privacy &amp; Security &gt;&gt; Full Disk Access.</source>
+<translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Du måste ge behörighet till:&lt;br&gt;– kDrive i Systeminställningar &gt;&gt; Allmänt &gt;&gt; Inloggningsobjekt och tillägg &gt;&gt; Tillägg för&lt;br&gt;Endpoint Security– kDrive LiteSync-tillägget i Systeminställningar &gt;&gt; Sekretess och säkerhet &gt;&gt; Fullständig disktillgång.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="419"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension is installed and Windows Search service is enabled.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync är installerat och att tjänsten Windows Search är aktiverad.&lt;br&gt;Rensa historiken, starta om datorn och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="424"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Check that the Lite Sync extension has the correct permissions and is running.&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går inte att starta tillägget Lite Sync (fel %1).&lt;br&gt;Kontrollera att tillägget Lite Sync har rätt behörigheter och är igång.&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="429"/>
+<source>Unable to start Lite Sync plugin (error %1).&lt;br&gt;Please empty the history, restart and if the error persists, contact our support team.</source>
+<translation>Det går inte att starta Lite Sync-tillägget (fel %1).&lt;br&gt;Rensa historiken, starta om och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="435"/>
+<source>A file or folder inside your synchronisation folder appears to be corrupted.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="449"/>
+<source>The kDrive is in maintenance mode.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive är i underhållsläge.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="455"/>
+<source>The kDrive is blocked.&lt;br&gt;Please renew kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive är blockerat.&lt;br&gt;Förnya kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="460"/>
+<source>The kDrive is blocked.&lt;br&gt;Please contact an administrator to renew the kDrive. If no action is taken, the data will be permanently deleted and it will be impossible to recover them.</source>
+<translation>kDrive är spärrat.&lt;br&gt;Kontakta en administratör för att återställa kDrive. Om inga åtgärder vidtas kommer uppgifterna att raderas permanent och det går inte att återställa dem.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="466"/>
+<source>The kDrive is waking up.&lt;br&gt;Synchronization will begin again as soon as possible. Please contact our support team if the error persists.</source>
+<translation>kDrive startar upp.&lt;br&gt;Synkroniseringen kommer att återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="475"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the &lt;a style="%1" href="%2"&gt;web version&lt;/a&gt; to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive är inaktivt.&lt;br&gt;Logga in på &lt;a style="%1" href="%2"&gt;web&lt;/a&gt;versionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="479"/>
+<source>The kDrive is asleep.&lt;br&gt;Please, login to the web version to check your kDrive's status, or contact your administrator.</source>
+<translation>kDrive är inaktivt.&lt;br&gt;Logga in på webbversionen för att kontrollera statusen för ditt kDrive, eller kontakta din administratör.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="483"/>
+<source>You are not authorised to access this kDrive.&lt;br&gt;Synchronization has been paused. Please contact an administrator.</source>
+<translation>Du har inte behörighet att komma åt denna kDrive.&lt;br&gt;Synkroniseringen har pausats. Kontakta en administratör.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="493"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization will resume as soon as possible. Please contact our support team if the error persists.</source>
+<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen återupptas så snart som möjligt. Kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="512"/>
+<source>The network connections have been dropped by the kernel (error %1).&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Nätverksanslutningarna har avbrutits av kärnan (fel %1).&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="522"/>
+<source>Unfortunately your old configuration could not be migrated.&lt;br&gt;The application will use a blank configuration.</source>
+<translation>Tyvärr gick det inte att överföra din gamla konfiguration.&lt;br&gt;Programmet kommer att använda en tom konfiguration.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="526"/>
+<source>Unfortunately your old proxy configuration could not be migrated, SOCKS5 proxies are not supported at this time.&lt;br&gt;The application will use system proxy settings instead.</source>
+<translation>Tyvärr gick det inte att överföra din gamla proxykonfiguration, eftersom SOCKS5-proxyservrar inte stöds för närvarande.&lt;br&gt;Programmet kommer istället att använda systemets proxyinställningar.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="539"/>
+<source>A technical error has occurred (error %1).&lt;br&gt;Synchronization has been restarted. Please empty the history and if the error persists, please contact our support team.</source>
+<translation>Ett tekniskt fel har uppstått (fel %1).&lt;br&gt;Synkroniseringen har startats om. Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="550"/>
+<source>An error accessing the synchronization database has happened (error %1).&lt;br&gt;Synchronization has been stopped.</source>
+<translation>Ett fel har uppstått vid åtkomst till synkroniseringsdatabasen (fel %1).&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="564"/>
+<source>A login problem has occurred (error %1).&lt;br&gt;Token invalid or revoked.</source>
+<translation>Ett inloggningsproblem har uppstått (fel %1).&lt;br&gt;Tokenet är ogiltigt eller har återkallats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="569"/>
+<source>Nested synchronizations are prohibited (error %1).&lt;br&gt;You should only keep synchronizations whose folders are not nested.</source>
+<translation>Nästlade synkroniseringar är inte tillåtna (fel %1).&lt;br&gt;Du bör endast behålla synkroniseringar där mapparna inte är nästlade.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="573"/>
+<source>The sync folder on the remote kDrive no longer exists or is no longer accessible (error %1).&lt;br&gt;You need to restore it or give it back access rights or delete/recreate the synchronization.</source>
+<translation>Synkroniseringsmappen på den fjärranslutna kDrive-enheten finns inte längre eller är inte längre tillgänglig (fel %1).&lt;br&gt;Du måste återställa den, återställa åtkomsträttigheterna eller ta bort och skapa synkroniseringen på nytt.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="580"/>
+<source>File name parsing error (error %1).&lt;br&gt;Special characters such as double quotes, backslashes or line returns can cause parsing failures.</source>
+<translation>Fel vid tolkning av filnamn (fel %1).&lt;br&gt;Specialtecken som dubbla citattecken, bakstreck eller radbrytningar kan orsaka fel vid tolkningen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="703"/>
+<source>Either you are not allowed to create an item, or another item already exists with the same name. The item has been ignored.</source>
+<translation>Du har antingen inte behörighet att skapa ett objekt, eller så finns det redan ett annat objekt med samma namn. Objektet har ignorerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="722"/>
+<source>You are not allowed to move item to "%1".&lt;br&gt;It will be restored into its original parent folder.</source>
+<translation>Du får inte flytta objektet till &amp;quot;%1&amp;quot;.&lt;br&gt;Det kommer att återställas till sin ursprungliga överordnade mapp.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="814"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The download has been canceled.</source>
+<translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Nedladdningen har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="818"/>
+<source>Impossible to create file "%1" because it is not supported on your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Det går inte att skapa filen ”%1” eftersom den inte stöds i ditt filsystem.&lt;br&gt;Den har uteslutits från synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="609"/>
+<source>This element has been moved somewhere else.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Denna komponent har flyttats till en annan plats.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="618"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local element has been renamed.</source>
+<translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Det lokala elementet har bytt namn.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="614"/>
+<source>An element with the same name already exists in this location.&lt;br&gt;The local operation has been canceled.</source>
+<translation>Det finns redan ett element med samma namn på den här platsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="393"/>
+<source>There is not enough space left on your computer.&lt;br&gt;The synchronization has been stopped.</source>
+<translation>Det finns inte tillräckligt med utrymme kvar på din dator.&lt;br&gt;Synkroniseringen har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="622"/>
+<source>The file was modified at the same time by another user.&lt;br&gt;Your modifications have been saved in a copy.</source>
+<translation>Filen redigerades samtidigt av en annan användare.&lt;br&gt;Dina ändringar har sparats i en kopia.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="626"/>
+<source>Another user has moved a parent folder of the destination.&lt;br&gt;The local operation has been canceled.</source>
+<translation>En annan användare har flyttat en överordnad mapp till målplatsen.&lt;br&gt;Den lokala åtgärden har avbrutits.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="692"/>
+<source>The item name contains only spaces.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Artikelnamnet innehåller endast mellanslag.&lt;br&gt;Det har tillfälligt lagts till på svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="708"/>
+<source>You are not allowed to edit item.&lt;br&gt;The file containing your modifications has been renamed and excluded from synchronization.</source>
+<translation>Du har inte behörighet att redigera objektet.&lt;br&gt;Filen med dina ändringar har bytt namn och har undantagits från synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="716"/>
+<source>You are not allowed to rename item.&lt;br&gt;It will be restored with its original name.</source>
+<translation>Du får inte byta namn på objektet.&lt;br&gt;Det återställs till sitt ursprungliga namn.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="727"/>
+<source>You are not allowed to delete item.&lt;br&gt;It will be restored to its original location.</source>
+<translation>Du får inte ta bort objektet.&lt;br&gt;Det återställs till sin ursprungliga plats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="732"/>
+<source>Failed to move this item to trash, it has been blacklisted.</source>
+<translation>Det gick inte att flytta objektet till papperskorgen; det har lagts till i svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="748"/>
+<source>The file has been modified locally while it has been deleted on the remote kDrive.&lt;br&gt;Local copy has been saved in the rescue folder.</source>
+<translation>Filen har ändrats lokalt samtidigt som den har raderats på den fjärranslutna kDrive-enheten. En&lt;br&gt;lokal kopia har sparats i räddningsmappen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="765"/>
+<source>The operation performed on item is forbidden.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Den åtgärd som utförts på objektet är inte tillåten.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="771"/>
+<source>The operation performed on this item failed.&lt;br&gt;The item has been temporarily blacklisted.</source>
+<translation>Åtgärden som utfördes på detta objekt misslyckades.&lt;br&gt;Objektet har tillfälligt lagts till i svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="776"/>
+<source>The file is too large to be uploaded. It has been temporarily blacklisted.</source>
+<translation>Filen är för stor för att laddas upp. Den har tillfälligt blockerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="782"/>
+<source>Impossible to download the file.</source>
+<translation>Det går inte att ladda ner filen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="779"/>
+<source>You have exceeded your quota. Increase your space quota to re-enable file upload.</source>
+<translation>Du har överskridit din kvot. Öka din lagringskvot för att återaktivera filuppladdning.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="389"/>
+<source>The drive containing your synchronization folder is no longer connected (error %1).&lt;br&gt;Please reconnect it to resume synchronization.</source>
+<translation>Enheten som innehåller din synkroniseringsmapp är inte längre ansluten (fel %1).&lt;br&gt;Anslut den igen för att återuppta synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="413"/>
+<source>Unable to start synchronization (error %1).&lt;br&gt;The LiteSyncExt process is not currently running. Synchronization will resume as soon as it is started.</source>
+<translation>Det går inte att starta synkroniseringen (fel %1).&lt;br&gt;Processen LiteSyncExt körs inte just nu. Synkroniseringen återupptas så snart processen har startats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="649"/>
+<source>An existing item has an identical name with the same case options (same upper and lower case letters).&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Ett befintligt objekt har ett identiskt namn med samma versaler och gemener.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="656"/>
+<source>The item name contains an unsupported character.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Produktnamnet innehåller ett tecken som inte stöds.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="662"/>
+<source>The item name ends with a space, which is forbidden on your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Objektnamnet slutar med ett mellanslag, vilket inte är tillåtet i ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="668"/>
+<source>This item name is reserved by your operating system.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Det här objektnamnet är reserverat av ditt operativsystem.&lt;br&gt;Det har tillfälligt lagts till i svartlistan.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="674"/>
+<source>The item name is too long.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Artikelnamnet är för långt.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="680"/>
+<source>The item path is too long.&lt;br&gt;It has been ignored.</source>
+<translation>Sökvägen är för lång.&lt;br&gt;Den har ignorerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="686"/>
+<source>The item name contains a recent UNICODE character not yet supported by your filesystem.&lt;br&gt;It has been excluded from synchronization.</source>
+<translation>Objektnamnet innehåller ett nytt Unicode-tecken som ännu inte stöds av ditt filsystem.&lt;br&gt;Det har uteslutits från synkroniseringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="735"/>
+<source>Failed to synchronize this item. It has been temporarily blacklisted.&lt;br&gt;Another attempt to sync it will be done in one hour or on next application startup.</source>
+<translation>Det gick inte att synkronisera det här objektet. Det har tillfälligt lagts till i svartlistan.&lt;br&gt;Ett nytt försök att synkronisera det kommer att göras om en timme eller nästa gång programmet startas.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="740"/>
+<source>This item has been excluded from sync by a custom template.&lt;br&gt;You can disable this type of notification from the Preferences</source>
+<translation>Denna post har undantagits från synkroniseringen genom en anpassad mall.&lt;br&gt;Du kan inaktivera denna typ av avisering under Inställningar</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="745"/>
+<source>This item has been excluded from sync because it is a hard link.</source>
+<translation>Den här posten har uteslutits från synkroniseringen eftersom det är en hård länk.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="785"/>
+<source>This item is currently locked by another user online.&lt;br&gt;We will retry uploading your changes later.</source>
+<translation>Den här artikeln är för närvarande upptagen av en annan användare som är inloggad.&lt;br&gt;Vi försöker ladda upp dina ändringar igen senare.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="790"/>
+<location filename="../src/gui/parametersdialog.cpp" line="837"/>
+<source>Synchronization error.</source>
+<translation>Synkroniseringsfel.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="810"/>
+<source>Can't access item.&lt;br&gt;Please fix the read and write permissions.</source>
+<translation>Det går inte att komma åt objektet.&lt;br&gt;Kontrollera läs- och skrivbehörigheterna.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="821"/>
+<source>System error.</source>
+<translation>Systemfel.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="828"/>
+<source>Item already exists on other side.&lt;br&gt;It has been temporarily blacklisted.</source>
+<translation>Objektet finns redan på den andra sidan.&lt;br&gt;Det har tillfälligt blockerats.</translation>
+</message>
+<message>
+<location filename="../src/gui/parametersdialog.cpp" line="843"/>
+<source>A technical error has occurred.&lt;br&gt;Please empty the history and if the error persists, contact our support team.</source>
+<translation>Ett tekniskt fel har uppstått.&lt;br&gt;Rensa historiken och kontakta vår support om felet kvarstår.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesBlocWidget</name>
-    <message>
-        <source>This synchronization is being deleted.</source>
-        <translation type="vanished">Denna synkronisering raderas.</translation>
-    </message>
+<name>KDC::PreferencesBlocWidget</name>
+<message>
+<location filename="../src/gui/preferencesblocwidget.cpp" line="187"/>
+<source>This synchronization is being deleted.</source>
+<translation>Denna synkronisering raderas.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesMenuBarWidget</name>
-    <message>
-        <source>Back to drive list</source>
-        <translation type="vanished">Tillbaka till listan över körningar</translation>
-    </message>
-    <message>
-        <source>Preferences</source>
-        <translation type="vanished">Inställningar</translation>
-    </message>
+<name>KDC::PreferencesMenuBarWidget</name>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="63"/>
+<source>Back to drive list</source>
+<translation>Tillbaka till listan över körningar</translation>
+</message>
+<message>
+<location filename="../src/gui/preferencesmenubarwidget.cpp" line="64"/>
+<source>Preferences</source>
+<translation>Inställningar</translation>
+</message>
 </context>
 <context>
-    <name>KDC::PreferencesWidget</name>
-    <message>
-        <source>General</source>
-        <translation type="vanished">Allmänt</translation>
-    </message>
-    <message>
-        <source>Activate dark theme</source>
-        <translation type="vanished">Aktivera mörkt tema</translation>
-    </message>
-    <message>
-        <source>Activate monochrome icons</source>
-        <translation type="vanished">Aktivera monokroma ikoner</translation>
-    </message>
-    <message>
-        <source>Launch kDrive at startup</source>
-        <translation type="vanished">Starta kDrive vid uppstart</translation>
-    </message>
-    <message>
-        <source>Finnish</source>
-        <translation type="vanished">Finska</translation>
-    </message>
-    <message>
-        <source>Danish</source>
-        <translation type="vanished">Danska</translation>
-    </message>
-    <message>
-        <source>Greek</source>
-        <translation type="vanished">Grekiska</translation>
-    </message>
-    <message>
-        <source>Dutch</source>
-        <translation type="vanished">Nederländska</translation>
-    </message>
-    <message>
-        <source>Advanced</source>
-        <translation type="vanished">Avancerat</translation>
-    </message>
-    <message>
-        <source>Debugging information</source>
-        <translation type="vanished">Felsökningsinformation</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Open debugging folder&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Files to exclude</source>
-        <translation type="vanished">Filer att exkludera</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>Swedish</source>
-        <translation type="vanished">Svenska</translation>
-    </message>
-    <message>
-        <source>Portuguese</source>
-        <translation type="vanished">Portugisiska</translation>
-    </message>
-    <message>
-        <source>Polish</source>
-        <translation type="vanished">Polska</translation>
-    </message>
-    <message>
-        <source>Norwegian</source>
-        <translation type="vanished">Norska</translation>
-    </message>
-    <message>
-        <source>Unable to open folder %1.</source>
-        <translation type="vanished">Det går inte att öppna mappen %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ogiltig länk %1.</translation>
-    </message>
-    <message>
-        <source>Lite Sync</source>
-        <translation type="vanished">Lite Sync</translation>
-    </message>
-    <message>
-        <source>Language</source>
-        <translation type="vanished">Språk</translation>
-    </message>
-    <message>
-        <source>Some process failed to run.</source>
-        <translation type="vanished">Någon process kunde inte köras.</translation>
-    </message>
-    <message>
-        <source>Move deleted files to my computer&apos;s trash</source>
-        <translation type="vanished">Flytta borttagna filer till datorns papperskorg</translation>
-    </message>
-    <message>
-        <source>Some files or folders may not be moved to the computer&apos;s trash.</source>
-        <translation type="vanished">Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
-    </message>
-    <message>
-        <source>You can always retrieve already synced files from the kDrive web application trash.</source>
-        <translation type="vanished">Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>English</source>
-        <translation type="vanished">Engelska</translation>
-    </message>
-    <message>
-        <source>French</source>
-        <translation type="vanished">Franska</translation>
-    </message>
-    <message>
-        <source>German</source>
-        <translation type="vanished">Tyska</translation>
-    </message>
-    <message>
-        <source>Spanish</source>
-        <translation type="vanished">Spanska</translation>
-    </message>
-    <message>
-        <source>Italian</source>
-        <translation type="vanished">Italienska</translation>
-    </message>
-    <message>
-        <source>Default</source>
-        <translation type="vanished">Standard</translation>
-    </message>
+<name>KDC::PreferencesWidget</name>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="485"/>
+<source>General</source>
+<translation>Allmänt</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="487"/>
+<source>Activate dark theme</source>
+<translation>Aktivera mörkt tema</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="489"/>
+<source>Activate monochrome icons</source>
+<translation>Aktivera monokroma ikoner</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="490"/>
+<source>Launch kDrive at startup</source>
+<translation>Starta kDrive vid uppstart</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="509"/>
+<source>Finnish</source>
+<translation>Finska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="510"/>
+<source>Danish</source>
+<translation>Danska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="511"/>
+<source>Greek</source>
+<translation>Grekiska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="512"/>
+<source>Dutch</source>
+<translation>Nederländska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="518"/>
+<source>Advanced</source>
+<translation>Avancerat</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="519"/>
+<source>Debugging information</source>
+<translation>Felsökningsinformation</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="521"/>
+<source>&lt;a style="%1" href="%2"&gt;Open debugging folder&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Öppna felsökningsmappen&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="522"/>
+<source>Files to exclude</source>
+<translation>Filer att exkludera</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="523"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="505"/>
+<source>Swedish</source>
+<translation>Svenska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="506"/>
+<source>Portuguese</source>
+<translation>Portugisiska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="507"/>
+<source>Polish</source>
+<translation>Polska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="508"/>
+<source>Norwegian</source>
+<translation>Norska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="460"/>
+<source>Unable to open folder %1.</source>
+<translation>Det går inte att öppna mappen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="472"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="477"/>
+<source>Invalid link %1.</source>
+<translation>Ogiltig länk %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="525"/>
+<source>Lite Sync</source>
+<translation>Lite Sync</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="491"/>
+<source>Language</source>
+<translation>Språk</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="484"/>
+<source>Some process failed to run.</source>
+<translation>Någon process kunde inte köras.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="492"/>
+<source>Move deleted files to my computer's trash</source>
+<translation>Flytta borttagna filer till datorns papperskorg</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="493"/>
+<source>Some files or folders may not be moved to the computer's trash.</source>
+<translation>Vissa filer eller mappar kanske inte kan flyttas till datorns papperskorg.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="494"/>
+<source>You can always retrieve already synced files from the kDrive web application trash.</source>
+<translation>Du kan alltid återställa redan synkroniserade filer från papperskorgen i kDrives webbapp.</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="496"/>
+<source>&lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="500"/>
+<source>English</source>
+<translation>Engelska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="501"/>
+<source>French</source>
+<translation>Franska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="502"/>
+<source>German</source>
+<translation>Tyska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="503"/>
+<source>Spanish</source>
+<translation>Spanska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="504"/>
+<source>Italian</source>
+<translation>Italienska</translation>
+</message>
+<message>
+<location filename="../src/gui/preferenceswidget.cpp" line="499"/>
+<source>Default</source>
+<translation>Standard</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProgressBarWidget</name>
-    <message>
-        <source>%1 in use</source>
-        <translation type="vanished">%1 används</translation>
-    </message>
+<name>KDC::ProgressBarWidget</name>
+<message>
+<location filename="../src/gui/progressbarwidget.cpp" line="70"/>
+<source>%1 in use</source>
+<translation>%1 används</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ProxyServerDialog</name>
-    <message>
-        <source>HTTP(S) Proxy</source>
-        <translation type="vanished">HTTP(S)-proxy</translation>
-    </message>
-    <message>
-        <source>Proxy server</source>
-        <translation type="vanished">Proxyserver</translation>
-    </message>
-    <message>
-        <source>No proxy server</source>
-        <translation type="vanished">Ingen proxyserver</translation>
-    </message>
-    <message>
-        <source>Use system parameters</source>
-        <translation type="vanished">Använd systemparametrar</translation>
-    </message>
-    <message>
-        <source>Indicate a proxy manually</source>
-        <translation type="vanished">Ange en fullmaktsinnehavare manuellt</translation>
-    </message>
-    <message>
-        <source>Port</source>
-        <translation type="vanished">Hamn</translation>
-    </message>
-    <message>
-        <source>Address of the proxy server</source>
-        <translation type="vanished">Proxyserverns adress</translation>
-    </message>
-    <message>
-        <source>Authentication needed</source>
-        <translation type="vanished">Inloggning krävs</translation>
-    </message>
-    <message>
-        <source>User</source>
-        <translation type="vanished">Användare</translation>
-    </message>
-    <message>
-        <source>Password</source>
-        <translation type="vanished">Lösenord</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPARA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vill du spara dina ändringar?</translation>
-    </message>
-    <message>
-        <source>Unable to save, all mandatory fields are not completed!</source>
-        <translation type="vanished">Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
-    </message>
-    <message>
-        <source>Proxy not found, save anyway?</source>
-        <translation type="vanished">Proxy hittades inte, vill du spara ändå?</translation>
-    </message>
+<name>KDC::ProxyServerDialog</name>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="50"/>
+<source>HTTP(S) Proxy</source>
+<translation>HTTP(S)-proxy</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="73"/>
+<source>Proxy server</source>
+<translation>Proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="85"/>
+<source>No proxy server</source>
+<translation>Ingen proxyserver</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="90"/>
+<source>Use system parameters</source>
+<translation>Använd systemparametrar</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="95"/>
+<source>Indicate a proxy manually</source>
+<translation>Ange en fullmaktsinnehavare manuellt</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="131"/>
+<source>Port</source>
+<translation>Hamn</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="144"/>
+<source>Address of the proxy server</source>
+<translation>Proxyserverns adress</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="150"/>
+<source>Authentication needed</source>
+<translation>Inloggning krävs</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="165"/>
+<source>User</source>
+<translation>Användare</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="171"/>
+<source>Password</source>
+<translation>Lösenord</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="185"/>
+<source>SAVE</source>
+<translation>SPARA</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="192"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="286"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vill du spara dina ändringar?</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="295"/>
+<source>Unable to save, all mandatory fields are not completed!</source>
+<translation>Det går inte att spara, eftersom alla obligatoriska fält inte är ifyllda!</translation>
+</message>
+<message>
+<location filename="../src/gui/proxyserverdialog.cpp" line="316"/>
+<source>Proxy not found, save anyway?</source>
+<translation>Proxy hittades inte, vill du spara ändå?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ResourcesManagerDialog</name>
-    <message>
-        <source>Resources Manager</source>
-        <translation type="vanished">Resursansvarig</translation>
-    </message>
-    <message>
-        <source>Maximum CPU usage allowed</source>
-        <translation type="vanished">Högsta tillåtna CPU-användning</translation>
-    </message>
-    <message>
-        <source>SAVE</source>
-        <translation type="vanished">SPARA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
-    <message>
-        <source>Do you want to save your modifications?</source>
-        <translation type="vanished">Vill du spara dina ändringar?</translation>
-    </message>
+<name>KDC::ResourcesManagerDialog</name>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="55"/>
+<source>Resources Manager</source>
+<translation>Resursansvarig</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="65"/>
+<source>Maximum CPU usage allowed</source>
+<translation>Högsta tillåtna CPU-användning</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="96"/>
+<source>SAVE</source>
+<translation>SPARA</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="103"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
+<message>
+<location filename="../src/gui/resourcesmanagerdialog.cpp" line="122"/>
+<source>Do you want to save your modifications?</source>
+<translation>Vill du spara dina ändringar?</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerBaseFolderDialog</name>
-    <message>
-        <source>Select a folder on your kDrive</source>
-        <translation type="vanished">Välj en mapp på din kDrive</translation>
-    </message>
-    <message>
-        <source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
-        <translation type="vanished">Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÄTT</translation>
-    </message>
-    <message>
-        <source>Space available on your computer for the current folder : %1</source>
-        <translation type="vanished">Ledig utrymme på din dator för den aktuella mappen: %1</translation>
-    </message>
-    <message>
-        <source>This folder is already being synced.</source>
-        <translation type="vanished">Den här mappen synkroniseras redan.</translation>
-    </message>
-    <message>
-        <source>CONFIRM</source>
-        <translation type="vanished">BEKRÄFTA</translation>
-    </message>
-    <message>
-        <source>CANCEL</source>
-        <translation type="vanished">AVBRYT</translation>
-    </message>
+<name>KDC::ServerBaseFolderDialog</name>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="81"/>
+<source>Select a folder on your kDrive</source>
+<translation>Välj en mapp på din kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="90"/>
+<source>The content of the selected folder will be synchronized into the &lt;b&gt;%1&lt;/b&gt; folder.</source>
+<translation>Innehållet i den valda mappen kommer att synkroniseras till mappen &lt;b&gt;%1&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="134"/>
+<source>CONTINUE</source>
+<translation>FORTSÄTT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="150"/>
+<source>Space available on your computer for the current folder : %1</source>
+<translation>Ledig utrymme på din dator för den aktuella mappen: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="190"/>
+<source>This folder is already being synced.</source>
+<translation>Den här mappen synkroniseras redan.</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="204"/>
+<source>CONFIRM</source>
+<translation>BEKRÄFTA</translation>
+</message>
+<message>
+<location filename="../src/gui/serverbasefolderdialog.cpp" line="205"/>
+<source>CANCEL</source>
+<translation>AVBRYT</translation>
+</message>
 </context>
 <context>
-    <name>KDC::ServerFoldersDialog</name>
-    <message>
-        <source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
-    </message>
-    <message>
-        <source>CONTINUE</source>
-        <translation type="vanished">FORTSÄTT</translation>
-    </message>
-    <message>
-        <source>No subfolders currently on the server.</source>
-        <translation type="vanished">Det finns för närvarande inga undermappar på servern.</translation>
-    </message>
+<name>KDC::ServerFoldersDialog</name>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="80"/>
+<source>The &lt;b&gt;%1&lt;/b&gt; folder contains subfolders,&lt;br&gt; select the ones you want to synchronize</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; innehåller undermappar.&lt;br&gt; Välj de som du vill synkronisera</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="110"/>
+<source>CONTINUE</source>
+<translation>FORTSÄTT</translation>
+</message>
+<message>
+<location filename="../src/gui/serverfoldersdialog.cpp" line="146"/>
+<source>No subfolders currently on the server.</source>
+<translation>Det finns för närvarande inga undermappar på servern.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::StatusBarWidget</name>
-    <message>
-        <source>Resume kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <source>Resume all kDrives synchronization</source>
-        <translation type="vanished">Återuppta all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <source>Pause kDrive &quot;%1&quot; synchronization</source>
-        <translation type="vanished">Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
-    </message>
-    <message>
-        <source>Pause synchronization</source>
-        <translation type="vanished">Pausa synkroniseringen</translation>
-    </message>
-    <message>
-        <source>Pause all kDrives synchronization</source>
-        <translation type="vanished">Pausa all synkronisering av kDrives</translation>
-    </message>
-    <message>
-        <source>Resume synchronization</source>
-        <translation type="vanished">Fortsätt synkroniseringen</translation>
-    </message>
+<name>KDC::StatusBarWidget</name>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="178"/>
+<source>Resume kDrive "%1" synchronization</source>
+<translation>Återuppta synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="180"/>
+<source>Resume all kDrives synchronization</source>
+<translation>Återuppta all synkronisering av kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="183"/>
+<source>Pause kDrive "%1" synchronization</source>
+<translation>Avbryt synkroniseringen av kDrive &amp;quot;%1&amp;quot;</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="184"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="321"/>
+<source>Pause synchronization</source>
+<translation>Pausa synkroniseringen</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="185"/>
+<source>Pause all kDrives synchronization</source>
+<translation>Pausa all synkronisering av kDrives</translation>
+</message>
+<message>
+<location filename="../src/gui/statusbarwidget.cpp" line="179"/>
+<location filename="../src/gui/statusbarwidget.cpp" line="322"/>
+<source>Resume synchronization</source>
+<translation>Fortsätt synkroniseringen</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynchronizedItemWidget</name>
-    <message>
-        <source>Copy share link</source>
-        <translation type="vanished">Kopiera delningslänken</translation>
-    </message>
-    <message>
-        <source>Display on kdrive.infomaniak.com</source>
-        <translation type="vanished">Visas på kdrive.infomaniak.com</translation>
-    </message>
-    <message>
-        <source>Show in folder</source>
-        <translation type="vanished">Visa i mappen</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Fler åtgärder</translation>
-    </message>
-    <message>
-        <source>Open</source>
-        <translation type="vanished">Öppna</translation>
-    </message>
-    <message>
-        <source>Add to favorites</source>
-        <translation type="vanished">Lägg till i favoriter</translation>
-    </message>
+<name>KDC::SynchronizedItemWidget</name>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="333"/>
+<source>Copy share link</source>
+<translation>Kopiera delningslänken</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="342"/>
+<source>Display on kdrive.infomaniak.com</source>
+<translation>Visas på kdrive.infomaniak.com</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="387"/>
+<source>Show in folder</source>
+<translation>Visa i mappen</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="388"/>
+<source>More actions</source>
+<translation>Fler åtgärder</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="317"/>
+<source>Open</source>
+<translation>Öppna</translation>
+</message>
+<message>
+<location filename="../src/gui/synchronizeditemwidget.cpp" line="325"/>
+<source>Add to favorites</source>
+<translation>Lägg till i favoriter</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisBar</name>
-    <message>
-        <source>Never</source>
-        <translation type="vanished">Aldrig</translation>
-    </message>
-    <message>
-        <source>During 1 hour</source>
-        <translation type="vanished">Under 1 timme</translation>
-    </message>
-    <message>
-        <source>Until tomorrow 8:00AM</source>
-        <translation type="vanished">Fram till imorgon kl. 08.00</translation>
-    </message>
-    <message>
-        <source>During 3 days</source>
-        <translation type="vanished">Under tre dagar</translation>
-    </message>
-    <message>
-        <source>During 1 week</source>
-        <translation type="vanished">Under en vecka</translation>
-    </message>
-    <message>
-        <source>Always</source>
-        <translation type="vanished">Alltid</translation>
-    </message>
-    <message>
-        <source>For 1 more hour</source>
-        <translation type="vanished">I ytterligare 1 timme</translation>
-    </message>
-    <message>
-        <source>For 3 more days</source>
-        <translation type="vanished">I ytterligare 3 dagar</translation>
-    </message>
-    <message>
-        <source>For 1 more week</source>
-        <translation type="vanished">Ytterligare en vecka</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Det går inte att öppna mappen med adressen %1.</translation>
-    </message>
-    <message>
-        <source>Open in folder</source>
-        <translation type="vanished">Öppna i mappen</translation>
-    </message>
-    <message>
-        <source>Open %1 web version</source>
-        <translation type="vanished">Öppna webbversionen av %1</translation>
-    </message>
-    <message>
-        <source>Drive parameters</source>
-        <translation type="vanished">Drivparametrar</translation>
-    </message>
-    <message>
-        <source>Notifications disabled until %1</source>
-        <translation type="vanished">Meddelanden är inaktiverade fram till %1</translation>
-    </message>
-    <message>
-        <source>Disable Notifications</source>
-        <translation type="vanished">Inaktivera aviseringar</translation>
-    </message>
-    <message>
-        <source>Application preferences</source>
-        <translation type="vanished">Inställningar för applikationen</translation>
-    </message>
-    <message>
-        <source>Need help</source>
-        <translation type="vanished">Behöver du hjälp?</translation>
-    </message>
-    <message>
-        <source>Send feedbacks</source>
-        <translation type="vanished">Skicka synpunkter</translation>
-    </message>
-    <message>
-        <source>Quit kDrive</source>
-        <translation type="vanished">Avsluta kDrive</translation>
-    </message>
-    <message>
-        <source>Unable to access web site %1.</source>
-        <translation type="vanished">Det går inte att komma åt webbplatsen %1.</translation>
-    </message>
-    <message>
-        <source>Show errors and informations</source>
-        <translation type="vanished">Visa fel och information</translation>
-    </message>
-    <message>
-        <source>Show informations</source>
-        <translation type="vanished">Visa information</translation>
-    </message>
-    <message>
-        <source>More actions</source>
-        <translation type="vanished">Fler åtgärder</translation>
-    </message>
+<name>KDC::SynthesisBar</name>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="495"/>
+<location filename="../src/gui/synthesisbar.cpp" line="502"/>
+<source>Never</source>
+<translation>Aldrig</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="496"/>
+<source>During 1 hour</source>
+<translation>Under 1 timme</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="497"/>
+<location filename="../src/gui/synthesisbar.cpp" line="504"/>
+<source>Until tomorrow 8:00AM</source>
+<translation>Fram till imorgon kl. 08.00</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="498"/>
+<source>During 3 days</source>
+<translation>Under tre dagar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="499"/>
+<source>During 1 week</source>
+<translation>Under en vecka</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="500"/>
+<location filename="../src/gui/synthesisbar.cpp" line="507"/>
+<source>Always</source>
+<translation>Alltid</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="503"/>
+<source>For 1 more hour</source>
+<translation>I ytterligare 1 timme</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="505"/>
+<source>For 3 more days</source>
+<translation>I ytterligare 3 dagar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="506"/>
+<source>For 1 more week</source>
+<translation>Ytterligare en vecka</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="149"/>
+<source>Unable to open folder url %1.</source>
+<translation>Det går inte att öppna mappen med adressen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="219"/>
+<source>Open in folder</source>
+<translation>Öppna i mappen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="257"/>
+<source>Open %1 web version</source>
+<translation>Öppna webbversionen av %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="267"/>
+<source>Drive parameters</source>
+<translation>Drivparametrar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="280"/>
+<source>Notifications disabled until %1</source>
+<translation>Meddelanden är inaktiverade fram till %1</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="281"/>
+<source>Disable Notifications</source>
+<translation>Inaktivera aviseringar</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="314"/>
+<source>Application preferences</source>
+<translation>Inställningar för applikationen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="322"/>
+<source>Need help</source>
+<translation>Behöver du hjälp?</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="330"/>
+<source>Send feedbacks</source>
+<translation>Skicka synpunkter</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="338"/>
+<source>Quit kDrive</source>
+<translation>Avsluta kDrive</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="401"/>
+<source>Unable to access web site %1.</source>
+<translation>Det går inte att komma åt webbplatsen %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="492"/>
+<source>Show errors and informations</source>
+<translation>Visa fel och information</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="493"/>
+<source>Show informations</source>
+<translation>Visa information</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesisbar.cpp" line="494"/>
+<source>More actions</source>
+<translation>Fler åtgärder</translation>
+</message>
 </context>
 <context>
-    <name>KDC::SynthesisPopover</name>
-    <message>
-        <source>Update kDrive App</source>
-        <translation type="vanished">Uppdatera kDrive-appen</translation>
-    </message>
-    <message>
-        <source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
-        <translation type="vanished">Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
-    </message>
-    <message>
-        <source>Update</source>
-        <translation type="vanished">Uppdatering</translation>
-    </message>
-    <message>
-        <source>Please download the latest version on the website.</source>
-        <translation type="vanished">Ladda gärna ner den senaste versionen från webbplatsen.</translation>
-    </message>
-    <message>
-        <source>Update download in progress</source>
-        <translation type="vanished">Uppdateringen hämtas just nu</translation>
-    </message>
-    <message>
-        <source>Looking for update...</source>
-        <translation type="vanished">Väntar på uppdatering...</translation>
-    </message>
-    <message>
-        <source>Manual update</source>
-        <translation type="vanished">Manuell uppdatering</translation>
-    </message>
-    <message>
-        <source>Unavailable</source>
-        <translation type="vanished">Ej tillgängligt</translation>
-    </message>
-    <message>
-        <source>You can synchronize files &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;from your computer&lt;/a&gt; or on &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
-        <translation type="vanished">Du kan synkronisera filer &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;från din dator&lt;/a&gt; eller från &lt;a style=&quot;%1&quot; href=&quot;%3&quot;&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>Synchronized</source>
-        <translation type="vanished">Synkroniserad</translation>
-    </message>
-    <message>
-        <source>Favorites</source>
-        <translation type="vanished">Favoriter</translation>
-    </message>
-    <message>
-        <source>Activity</source>
-        <translation type="vanished">Aktivitet</translation>
-    </message>
-    <message>
-        <source>Not implemented!</source>
-        <translation type="vanished">Har inte implementerats!</translation>
-    </message>
-    <message>
-        <source>&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Click here to download manually&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style= text-decoration:none; href=&quot;https://www.infomaniak.com/en/apps/download-kdrive&quot;&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>No synchronized folder for this Drive!</source>
-        <translation type="vanished">Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
-    </message>
-    <message>
-        <source>No kDrive configured!</source>
-        <translation type="vanished">kDrive är inte konfigurerat!</translation>
-    </message>
-    <message>
-        <source>Unable to open link %1.</source>
-        <translation type="vanished">Det går inte att öppna länken %1.</translation>
-    </message>
-    <message>
-        <source>Invalid link %1.</source>
-        <translation type="vanished">Ogiltig länk %1.</translation>
-    </message>
-    <message>
-        <source>Unable to open folder url %1.</source>
-        <translation type="vanished">Det går inte att öppna mappen med adressen %1.</translation>
-    </message>
+<name>KDC::SynthesisPopover</name>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1183"/>
+<source>Update kDrive App</source>
+<translation>Uppdatera kDrive-appen</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1184"/>
+<source>This kDrive app version is not supported anymore. To access the latest features and enhancements, please update.</source>
+<translation>Denna version av kDrive-appen stöds inte längre. Uppdatera appen för att få tillgång till de senaste funktionerna och förbättringarna.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="980"/>
+<source>Update</source>
+<translation>Uppdatering</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1190"/>
+<source>Please download the latest version on the website.</source>
+<translation>Ladda gärna ner den senaste versionen från webbplatsen.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="983"/>
+<source>Update download in progress</source>
+<translation>Uppdateringen hämtas just nu</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="986"/>
+<source>Looking for update...</source>
+<translation>Väntar på uppdatering...</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="989"/>
+<source>Manual update</source>
+<translation>Manuell uppdatering</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="992"/>
+<source>Unavailable</source>
+<translation>Ej tillgängligt</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1203"/>
+<source>You can synchronize files &lt;a style="%1" href="%2"&gt;from your computer&lt;/a&gt; or on &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</source>
+<translation>Du kan synkronisera filer &lt;a style="%1" href="%2"&gt;från din dator&lt;/a&gt; eller från &lt;a style="%1" href="%3"&gt;kdrive.infomaniak.com&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="448"/>
+<source>Synchronized</source>
+<translation>Synkroniserad</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="452"/>
+<source>Favorites</source>
+<translation>Favoriter</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="456"/>
+<source>Activity</source>
+<translation>Aktivitet</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1135"/>
+<location filename="../src/gui/synthesispopover.cpp" line="1182"/>
+<source>Not implemented!</source>
+<translation>Har inte implementerats!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1187"/>
+<source>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Click here to download manually&lt;/a&gt;</source>
+<translation>&lt;a style= text-decoration:none; href="https://www.infomaniak.com/en/apps/download-kdrive"&gt;Klicka här för att ladda ner manuellt&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1196"/>
+<source>No synchronized folder for this Drive!</source>
+<translation>Det finns ingen synkroniserad mapp för den här Drive-kontot!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1199"/>
+<source>No kDrive configured!</source>
+<translation>kDrive är inte konfigurerat!</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1163"/>
+<source>Unable to open link %1.</source>
+<translation>Det går inte att öppna länken %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="1175"/>
+<source>Invalid link %1.</source>
+<translation>Ogiltig länk %1.</translation>
+</message>
+<message>
+<location filename="../src/gui/synthesispopover.cpp" line="588"/>
+<source>Unable to open folder url %1.</source>
+<translation>Det går inte att öppna mappen med adressen %1.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateDialog</name>
-    <message>
-        <source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
-        <translation type="vanished">&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
-    </message>
-    <message>
-        <source>Skip this version</source>
-        <translation type="vanished">Hoppa över den här versionen</translation>
-    </message>
-    <message>
-        <source>Remind me later</source>
-        <translation type="vanished">Påminn mig senare</translation>
-    </message>
-    <message>
-        <source>Install update</source>
-        <translation type="vanished">Installera uppdatering</translation>
-    </message>
+<name>KDC::UpdateDialog</name>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="61"/>
+<source>&lt;p&gt;The new version &lt;b&gt;%1&lt;/b&gt; of the %2 Client is available and has been downloaded.&lt;/p&gt;&lt;p&gt;The installed version is %3.&lt;/p&gt;</source>
+<translation>&lt;p&gt;Den nya versionen &lt;b&gt;%1&lt;/b&gt; av %2-klienten är tillgänglig och har hämtats.&lt;/p&gt;&lt;p&gt;Den installerade versionen är %3.&lt;/p&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="95"/>
+<source>Skip this version</source>
+<translation>Hoppa över den här versionen</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="103"/>
+<source>Remind me later</source>
+<translation>Påminn mig senare</translation>
+</message>
+<message>
+<location filename="../src/gui/updater/updatedialog.cpp" line="109"/>
+<source>Install update</source>
+<translation>Installera uppdatering</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UpdateManager</name>
-    <message>
-        <source>New update available.</source>
-        <translation type="vanished">En ny uppdatering finns tillgänglig.</translation>
-    </message>
-    <message>
-        <source>Version %1 is available for download.</source>
-        <translation type="vanished">Version %1 finns tillgänglig för nedladdning.</translation>
-    </message>
+<name>KDC::UpdateManager</name>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="88"/>
+<source>New update available.</source>
+<translation>En ny uppdatering finns tillgänglig.</translation>
+</message>
+<message>
+<location filename="../src/server/updater/updatemanager.cpp" line="89"/>
+<source>Version %1 is available for download.</source>
+<translation>Version %1 finns tillgänglig för nedladdning.</translation>
+</message>
 </context>
 <context>
-    <name>KDC::UserSelectionWidget</name>
-    <message>
-        <source>Add an account</source>
-        <translation type="vanished">Lägg till ett konto</translation>
-    </message>
+<name>KDC::UserSelectionWidget</name>
+<message>
+<location filename="../src/gui/userselectionwidget.cpp" line="131"/>
+<source>Add an account</source>
+<translation>Lägg till ett konto</translation>
+</message>
 </context>
 <context>
-    <name>KDC::VersionWidget</name>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;%3&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Show release note&lt;/a&gt;</source>
-        <translation type="vanished">&lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Visa informationsnot&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Version</source>
-        <translation type="vanished">Version</translation>
-    </message>
-    <message>
-        <source>UPDATE</source>
-        <translation type="vanished">UPPDATERING</translation>
-    </message>
-    <message>
-        <source>%1 is up to date!</source>
-        <translation type="vanished">%1 är uppdaterad!</translation>
-    </message>
-    <message>
-        <source>Checking update on server...</source>
-        <translation type="vanished">Kontrollerar uppdateringar på servern...</translation>
-    </message>
-    <message>
-        <source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;here&lt;/a&gt;.</source>
-        <translation type="vanished">En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style=&quot;%2&quot; href=&quot;%3&quot;&gt;här&lt;/a&gt;.</translation>
-    </message>
-    <message>
-        <source>An update is available: %1</source>
-        <translation type="vanished">En uppdatering finns tillgänglig: %1</translation>
-    </message>
-    <message>
-        <source>Downloading %1. Please wait...</source>
-        <translation type="vanished">Hämtar %1. Vänta...</translation>
-    </message>
-    <message>
-        <source>Could not check for new updates.</source>
-        <translation type="vanished">Det gick inte att söka efter nya uppdateringar.</translation>
-    </message>
-    <message>
-        <source>An error occurred during update.</source>
-        <translation type="vanished">Ett fel uppstod under uppdateringen.</translation>
-    </message>
-    <message>
-        <source>Could not download update.</source>
-        <translation type="vanished">Det gick inte att ladda ner uppdateringen.</translation>
-    </message>
-    <message>
-        <source>Update disabled.</source>
-        <translation type="vanished">Uppdateringen är inaktiverad.</translation>
-    </message>
-    <message>
-        <source>Beta program</source>
-        <translation type="vanished">Betaprogram</translation>
-    </message>
-    <message>
-        <source>Get early access to new versions of the application</source>
-        <translation type="vanished">Få tidig tillgång till nya versioner av applikationen</translation>
-    </message>
-    <message>
-        <source>Join</source>
-        <translation type="vanished">Gå med</translation>
-    </message>
-    <message>
-        <source>Modify</source>
-        <translation type="vanished">Ändra</translation>
-    </message>
-    <message>
-        <source>Quit</source>
-        <translation type="vanished">Avsluta</translation>
-    </message>
+<name>KDC::VersionWidget</name>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="314"/>
+<source>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;%3&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="170"/>
+<source>&lt;a style="%1" href="%2"&gt;Show release note&lt;/a&gt;</source>
+<translation>&lt;a style="%1" href="%2"&gt;Visa informationsnot&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="173"/>
+<source>Version</source>
+<translation>Version</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="174"/>
+<source>UPDATE</source>
+<translation>UPPDATERING</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="198"/>
+<source>%1 is up to date!</source>
+<translation>%1 är uppdaterad!</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="202"/>
+<source>Checking update on server...</source>
+<translation>Kontrollerar uppdateringar på servern...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="206"/>
+<source>An update is available: %1.&lt;br&gt;Please download it from &lt;a style="%2" href="%3"&gt;here&lt;/a&gt;.</source>
+<translation>En uppdatering finns tillgänglig: %1.&lt;br&gt;Ladda ner den &lt;a style="%2" href="%3"&gt;här&lt;/a&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="213"/>
+<source>An update is available: %1</source>
+<translation>En uppdatering finns tillgänglig: %1</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="219"/>
+<source>Downloading %1. Please wait...</source>
+<translation>Hämtar %1. Vänta...</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="224"/>
+<source>Could not check for new updates.</source>
+<translation>Det gick inte att söka efter nya uppdateringar.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="228"/>
+<source>An error occurred during update.</source>
+<translation>Ett fel uppstod under uppdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="232"/>
+<source>Could not download update.</source>
+<translation>Det gick inte att ladda ner uppdateringen.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="236"/>
+<source>Update disabled.</source>
+<translation>Uppdateringen är inaktiverad.</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="252"/>
+<source>Beta program</source>
+<translation>Betaprogram</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="253"/>
+<source>Get early access to new versions of the application</source>
+<translation>Få tidig tillgång till nya versioner av applikationen</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="257"/>
+<source>Join</source>
+<translation>Gå med</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Modify</source>
+<translation>Ändra</translation>
+</message>
+<message>
+<location filename="../src/gui/versionwidget.cpp" line="260"/>
+<source>Quit</source>
+<translation>Avsluta</translation>
+</message>
 </context>
 <context>
-    <name>QObject</name>
-    <message>
-        <source>Unable to save parameters, please retry later.</source>
-        <translation type="vanished">Det gick inte att spara parametrarna. Försök igen senare.</translation>
-    </message>
-    <message>
-        <source>Unable to save parameters!</source>
-        <translation type="vanished">Det går inte att spara parametrarna!</translation>
-    </message>
-    <message>
-        <source>The parent folder is a sync folder or contained in one</source>
-        <translation type="vanished">Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
-    </message>
-    <message>
-        <source>Can&apos;t find a valid path</source>
-        <translation type="vanished">Det går inte att hitta en giltig sökväg</translation>
-    </message>
-    <message>
-        <source>No valid folder selected!</source>
-        <translation type="vanished">Ingen giltig mapp har valts!</translation>
-    </message>
-    <message>
-        <source>The selected path does not exist!</source>
-        <translation type="vanished">Den valda sökvägen finns inte!</translation>
-    </message>
-    <message>
-        <source>The selected path is not a folder!</source>
-        <translation type="vanished">Den valda sökvägen är ingen mapp!</translation>
-    </message>
-    <message>
-        <source>You have no permission to write to the selected folder!</source>
-        <translation type="vanished">Du har inte behörighet att skriva till den valda mappen!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 contains a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
-    </message>
-    <message>
-        <source>The local folder %1 is already synced. Please pick another one!</source>
-        <translation type="vanished">Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
-    </message>
-    <message>
-        <source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
-    </message>
-    <message>
-        <source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer&apos;s storage space.</source>
-        <translation type="vanished">Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
-    </message>
-    <message>
-        <source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
-        <translation type="vanished">Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
-    </message>
-    <message>
-        <source>Make available locally</source>
-        <translation type="vanished">Gör tillgängligt lokalt</translation>
-    </message>
-    <message>
-        <source>Free up local space</source>
-        <translation type="vanished">Frigör lokalt lagringsutrymme</translation>
-    </message>
-    <message>
-        <source>Cancel free up local space</source>
-        <translation type="vanished">Avbryt för att frigöra lokalt utrymme</translation>
-    </message>
-    <message>
-        <source>Cancel make available locally</source>
-        <translation type="vanished">Avbryt lokal tillgängliggöring</translation>
-    </message>
-    <message>
-        <source>Resharing this file is not allowed</source>
-        <translation type="vanished">Det är inte tillåtet att vidarebefordra den här filen</translation>
-    </message>
-    <message>
-        <source>Resharing this folder is not allowed</source>
-        <translation type="vanished">Det är inte tillåtet att dela den här mappen vidare</translation>
-    </message>
-    <message>
-        <source>Copy public share link</source>
-        <translation type="vanished">Kopiera länken till den offentliga delningen</translation>
-    </message>
-    <message>
-        <source>Copy private share link</source>
-        <translation type="vanished">Kopiera länken till den privata delningen</translation>
-    </message>
-    <message>
-        <source>Open in browser</source>
-        <translation type="vanished">Öppna i webbläsaren</translation>
-    </message>
+<name>QObject</name>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="59"/>
+<source>Unable to save parameters, please retry later.</source>
+<translation>Det gick inte att spara parametrarna. Försök igen senare.</translation>
+</message>
+<message>
+<location filename="../src/gui/parameterscache.cpp" line="60"/>
+<source>Unable to save parameters!</source>
+<translation>Det går inte att spara parametrarna!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="490"/>
+<source>The parent folder is a sync folder or contained in one</source>
+<translation>Överordnad mapp är en synkroniseringsmapp eller ingår i en sådan</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="524"/>
+<source>Can't find a valid path</source>
+<translation>Det går inte att hitta en giltig sökväg</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2133"/>
+<source>No valid folder selected!</source>
+<translation>Ingen giltig mapp har valts!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2144"/>
+<source>The selected path does not exist!</source>
+<translation>Den valda sökvägen finns inte!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2149"/>
+<source>The selected path is not a folder!</source>
+<translation>Den valda sökvägen är ingen mapp!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2154"/>
+<source>You have no permission to write to the selected folder!</source>
+<translation>Du har inte behörighet att skriva till den valda mappen!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2184"/>
+<source>The local folder %1 contains a folder already synced. Please pick another one!</source>
+<translation>Den lokala mappen %1 innehåller en mapp som redan är synkroniserad. Välj en annan!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2192"/>
+<source>The local folder %1 is contained in a folder already synced. Please pick another one!</source>
+<translation>Den lokala mappen %1 finns i en mapp som redan är synkroniserad. Välj en annan mapp!</translation>
+</message>
+<message>
+<location filename="../src/server/requests/serverrequests.cpp" line="2200"/>
+<source>The local folder %1 is already synced. Please pick another one!</source>
+<translation>Den lokala mappen %1 är redan synkroniserad. Välj en annan!</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="42"/>
+<source>Lite sync (Beta) is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite sync (Beta) är aktiverat. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="45"/>
+<source>Lite sync (Beta) is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync (Beta) är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="48"/>
+<source>Lite sync is enabled. Files from kDrive remain in the Cloud and do not use your computer's storage space.</source>
+<translation>Lite-synkronisering är aktiverad. Filerna från kDrive sparas i molnet och tar inte upp lagringsutrymme på din dator.</translation>
+</message>
+<message>
+<location filename="../src/gui/folderitemwidget.cpp" line="50"/>
+<source>Lite sync is disabled. The kDrive files use the storage space of your computer.</source>
+<translation>Lite sync är inaktiverat. kDrive-filerna använder lagringsutrymmet på din dator.</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1242"/>
+<source>Make available locally</source>
+<translation>Gör tillgängligt lokalt</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1246"/>
+<source>Free up local space</source>
+<translation>Frigör lokalt lagringsutrymme</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1250"/>
+<source>Cancel free up local space</source>
+<translation>Avbryt för att frigöra lokalt utrymme</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1254"/>
+<source>Cancel make available locally</source>
+<translation>Avbryt lokal tillgängliggöring</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1258"/>
+<source>Resharing this file is not allowed</source>
+<translation>Det är inte tillåtet att vidarebefordra den här filen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1259"/>
+<source>Resharing this folder is not allowed</source>
+<translation>Det är inte tillåtet att dela den här mappen vidare</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1263"/>
+<source>Copy public share link</source>
+<translation>Kopiera länken till den offentliga delningen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1267"/>
+<source>Copy private share link</source>
+<translation>Kopiera länken till den privata delningen</translation>
+</message>
+<message>
+<location filename="../src/server/comm/extensionjob.cpp" line="1271"/>
+<source>Open in browser</source>
+<translation>Öppna i webbläsaren</translation>
+</message>
 </context>
 <context>
-    <name>SharedTools::QtSingleApplication</name>
-    <message>
-        <source>kDrive application will close due to a fatal error.</source>
-        <translation type="vanished">kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
-    </message>
+<name>SharedTools::QtSingleApplication</name>
+<message>
+<location filename="../src/server/appserver.cpp" line="134"/>
+<source>kDrive application will close due to a fatal error.</source>
+<translation>kDrive-programmet kommer att stängas på grund av ett allvarligt fel.</translation>
+</message>
 </context>
 <context>
-    <name>Utility</name>
-    <message>
-        <source>%L1 GB</source>
-        <translation type="vanished">%L1 GB</translation>
-    </message>
-    <message>
-        <source>%L1 MB</source>
-        <translation type="vanished">%L1 MB</translation>
-    </message>
-    <message>
-        <source>%L1 KB</source>
-        <translation type="vanished">%L1 KB</translation>
-    </message>
-    <message>
-        <source>%L1 B</source>
-        <translation type="vanished">%L1 B</translation>
-    </message>
-    <message numerus="yes">
-        <source>%n year(s)</source>
-        <translation type="vanished">
-            <numerusform>%n år</numerusform>
-            <numerusform>%n år</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n month(s)</source>
-        <translation type="vanished">
-            <numerusform>%n månad</numerusform>
-            <numerusform>%n månader</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n day(s)</source>
-        <translation type="vanished">
-            <numerusform>%n dag</numerusform>
-            <numerusform>%n dagar</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n hour(s)</source>
-        <translation type="vanished">
-            <numerusform>%n timme</numerusform>
-            <numerusform>%n timmar</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n minute(s)</source>
-        <translation type="vanished">
-            <numerusform>%n minut</numerusform>
-            <numerusform>%n minuter</numerusform>
-        </translation>
-    </message>
-    <message numerus="yes">
-        <source>%n second(s)</source>
-        <translation type="vanished">
-            <numerusform>%n sekund</numerusform>
-            <numerusform>%n sekunder</numerusform>
-        </translation>
-    </message>
+<name>Utility</name>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="97"/>
+<source>%L1 GB</source>
+<translation>%L1 GB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="101"/>
+<source>%L1 MB</source>
+<translation>%L1 MB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="105"/>
+<source>%L1 KB</source>
+<translation>%L1 KB</translation>
+</message>
+<message>
+<location filename="../src/libcommongui/utility/utility.cpp" line="108"/>
+<source>%L1 B</source>
+<translation>%L1 B</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="41"/>
+<source>%n year(s)</source>
+<translation>
+<numerusform>%n år</numerusform>
+<numerusform>%n år</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="42"/>
+<source>%n month(s)</source>
+<translation>
+<numerusform>%n månad</numerusform>
+<numerusform>%n månader</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="43"/>
+<source>%n day(s)</source>
+<translation>
+<numerusform>%n dag</numerusform>
+<numerusform>%n dagar</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="44"/>
+<source>%n hour(s)</source>
+<translation>
+<numerusform>%n timme</numerusform>
+<numerusform>%n timmar</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="45"/>
+<source>%n minute(s)</source>
+<translation>
+<numerusform>%n minut</numerusform>
+<numerusform>%n minuter</numerusform>
+</translation>
+</message>
+<message numerus="yes">
+<location filename="../src/libcommongui/utility/utility.cpp" line="46"/>
+<source>%n second(s)</source>
+<translation>
+<numerusform>%n sekund</numerusform>
+<numerusform>%n sekunder</numerusform>
+</translation>
+</message>
 </context>
 <context>
-    <name>main.cpp</name>
-    <message>
-        <source>System Tray not available</source>
-        <translation type="vanished">Systemfältet är inte tillgängligt</translation>
-    </message>
-    <message>
-        <source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as &apos;trayer&apos; and try again.</source>
-        <translation type="vanished">%1 kräver ett fungerande systemfält. Om du kör XFCE, följ &lt;a href=&quot;http://docs.xfce.org/xfce/xfce4-panel/systray&quot;&gt;dessa instruktioner&lt;/a&gt;. Annars installerar du ett systemfältsprogram som &apos;trayer&apos; och försöker igen.</translation>
-    </message>
+<name>main.cpp</name>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="49"/>
+<source>System Tray not available</source>
+<translation>Systemfältet är inte tillgängligt</translation>
+</message>
+<message>
+<location filename="../src/gui/mainclient.cpp" line="50"/>
+<source>%1 requires a working system tray. If you are running XFCE, please follow &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;these instructions&lt;/a&gt;. Otherwise, please install a system tray application such as 'trayer' and try again.</source>
+<translation>%1 kräver ett fungerande systemfält. Om du kör XFCE, följ &lt;a href="http://docs.xfce.org/xfce/xfce4-panel/systray"&gt;dessa instruktioner&lt;/a&gt;. Annars installerar du ett systemfältsprogram som 'trayer' och försöker igen.</translation>
+</message>
 </context>
 <context>
-    <name>utility</name>
-    <message>
-        <source>Could not open browser</source>
-        <translation type="vanished">Det gick inte att öppna webbläsaren</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
-        <translation type="vanished">Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
-    </message>
-    <message>
-        <source>Could not open email client</source>
-        <translation type="vanished">Det gick inte att öppna e-postprogrammet</translation>
-    </message>
-    <message>
-        <source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
-        <translation type="vanished">Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
-    </message>
-    <message>
-        <source>You are not connected anymore. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Log in&lt;/a&gt;</source>
-        <translation type="vanished">Du är inte inloggad längre. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Logga in&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Sync in progress (Step %1/%2).</source>
-        <translation type="vanished">Synkronisering pågår (Steg %1/%2).</translation>
-    </message>
-    <message>
-        <source>Sync in progress.</source>
-        <translation type="vanished">Synkronisering pågår.</translation>
-    </message>
-    <message>
-        <source>Some files couldn&apos;t be synchronized. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Learn more&lt;/a&gt;</source>
-        <translation type="vanished">Vissa filer kunde inte synkroniseras. &lt;a style=&quot;%1&quot; href=&quot;%2&quot;&gt;Läs mer&lt;/a&gt;</translation>
-    </message>
-    <message>
-        <source>Synchronization pausing ...</source>
-        <translation type="vanished">Synkroniseringen pausas ...</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
-    </message>
-    <message>
-        <source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
-        <translation type="vanished">Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
-    </message>
-    <message>
-        <source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
-        <translation type="vanished">Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
-    </message>
-    <message>
-        <source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
-        <translation type="vanished">Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
-    </message>
-    <message>
-        <source>Synchronization starting</source>
-        <translation type="vanished">Synkroniseringen påbörjas</translation>
-    </message>
-    <message>
-        <source>Synchronization paused.</source>
-        <translation type="vanished">Synkroniseringen har pausats.</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)</source>
-        <translation type="vanished">Synkronisering pågår (%1 av %2)</translation>
-    </message>
-    <message>
-        <source>Sync in progress (%1 of %2)
+<name>utility</name>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="84"/>
+<source>Could not open browser</source>
+<translation>Det gick inte att öppna webbläsaren</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="85"/>
+<source>There was an error when launching the browser to go to URL %1. Maybe no default browser is configured?</source>
+<translation>Det uppstod ett fel när webbläsaren startades för att öppna webbadressen %1. Kanske har ingen standardwebbläsare angetts?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="104"/>
+<source>Could not open email client</source>
+<translation>Det gick inte att öppna e-postprogrammet</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="105"/>
+<source>There was an error when launching the email client to create a new message. Maybe no default email client is configured?</source>
+<translation>Det uppstod ett fel när e-postprogrammet startades för att skapa ett nytt meddelande. Kanske har inget standardprogram för e-post konfigurerats?</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="324"/>
+<source>You are not connected anymore. &lt;a style="%1" href="%2"&gt;Log in&lt;/a&gt;</source>
+<translation>Du är inte inloggad längre. &lt;a style="%1" href="%2"&gt;Logga in&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="347"/>
+<source>Sync in progress (Step %1/%2).</source>
+<translation>Synkronisering pågår (Steg %1/%2).</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="353"/>
+<source>Sync in progress.</source>
+<translation>Synkronisering pågår.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="364"/>
+<source>Some files couldn't be synchronized. &lt;a style="%1" href="%2"&gt;Learn more&lt;/a&gt;</source>
+<translation>Vissa filer kunde inte synkroniseras. &lt;a style="%1" href="%2"&gt;Läs mer&lt;/a&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="370"/>
+<source>Synchronization pausing ...</source>
+<translation>Synkroniseringen pausas ...</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="570"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because another sync is using the same folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom en annan synkronisering använder samma mapp.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="576"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it contains the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den innehåller den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="584"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected because it is contained in the synchronized folder &lt;b&gt;%2&lt;/b&gt;.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas eftersom den ingår i den synkroniserade mappen &lt;b&gt;%2&lt;/b&gt;.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="595"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder.</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="599"/>
+<source>Folder &lt;b&gt;%1&lt;/b&gt; cannot be selected as sync folder. Please, select another folder. Suggested folder: &lt;b&gt;%2&lt;/b&gt;</source>
+<translation>Mappen &lt;b&gt;%1&lt;/b&gt; kan inte väljas som synkroniseringsmapp. Välj en annan mapp. Föreslagen mapp: &lt;b&gt;%2&lt;/b&gt;</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="657"/>
+<source>You have excluded more than %1 folders, please note that this will affect synchronization performance.</source>
+<translation>Du har uteslutit mer än %1 mappar. Observera att detta kommer att påverka synkroniseringsprestandan.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="666"/>
+<source>You cannot exclude more than %1 folders. Please uncheck higher-level folders.</source>
+<translation>Du kan inte utesluta fler än %1 mappar. Avmarkera mapparna på högre nivå.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="351"/>
+<source>Synchronization starting</source>
+<translation>Synkroniseringen påbörjas</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="374"/>
+<source>Synchronization paused.</source>
+<translation>Synkroniseringen har pausats.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="336"/>
+<source>Sync in progress (%1 of %2)</source>
+<translation>Synkronisering pågår (%1 av %2)</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="340"/>
+<source>Sync in progress (%1 of %2)
 %3 left...</source>
-        <translation type="vanished">Synkronisering pågår (%1 av %2)
+<translation>Synkronisering pågår (%1 av %2)
 %3 kvar...</translation>
-    </message>
-    <message>
-        <source>You are up to date, unresolved conflicts.</source>
-        <translation type="vanished">Du har aktuella, olösta konflikter.</translation>
-    </message>
-    <message>
-        <source>You are up to date!</source>
-        <translation type="vanished">Nu är du uppdaterad!</translation>
-    </message>
-    <message>
-        <source>No folder to synchronize
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="358"/>
+<source>You are up to date, unresolved conflicts.</source>
+<translation>Du har aktuella, olösta konflikter.</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="360"/>
+<source>You are up to date!</source>
+<translation>Nu är du uppdaterad!</translation>
+</message>
+<message>
+<location filename="../src/gui/guiutility.cpp" line="329"/>
+<source>No folder to synchronize
 You can add one from the kDrive settings.</source>
-        <translation type="vanished">Ingen mapp att synkronisera
+<translation>Ingen mapp att synkronisera
 Du kan lägga till en i kDrive-inställningarna.</translation>
-    </message>
+</message>
 </context>
 </TS>

--- a/translations/update_ui_translations.py
+++ b/translations/update_ui_translations.py
@@ -54,6 +54,7 @@ DEEPL_LANGUAGE_CODES = {
     "pl": "PL",
     "sv": "SV",
     "pt": "PT-PT",
+    "nl": "NL",
 }
 
 def fill_missing_translations(git_dir_path, language):
@@ -86,7 +87,7 @@ def fill_missing_translations(git_dir_path, language):
     
     
 
-languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb", "fi", "da", "el"]
+languages = ["de", "es", "fr", "it", "sv", "pt", "pl", "nb", "fi", "da", "el", "nl"]
 
 for language in languages:
     fill_missing_translations(args.git_dir_path, language)


### PR DESCRIPTION
## Changes

- Fix all translation files where every entry was marked with `type="vanished"` 
- Added missing translations in all languages for new error string in parametersdialog.cpp
- Fixed `update_ui_translations.py` script to include Dutch (nl) language support

## Verification

- [x] No vanished tags remain across all 12 .ts files
- [x] All languages have proper translations
- [x] 0 unfinished entries remain
