### PR TITLE
feat: client should not send the desired path

### DIFF
--- a/src/gui/adddrivelocalfolderwidget.cpp
+++ b/src/gui/adddrivelocalfolderwidget.cpp
@@ -254,7 +254,7 @@ void AddDriveLocalFolderWidget::initUI() {
 }
 
 void AddDriveLocalFolderWidget::updateUI() {
-    if (const bool ok = !_localFolderPath.isEmpty(); !ok) return;
+    if (_localFolderPath.isEmpty()) return;
 
     const QDir dir(_localFolderPath);
     _folderNameLabel->setText(dir.dirName());
@@ -357,6 +357,12 @@ void AddDriveLocalFolderWidget::onBackButtonTriggered(bool checked) {
 void AddDriveLocalFolderWidget::onContinueButtonTriggered(bool checked) {
     Q_UNUSED(checked)
     MatomoClient::sendEvent("addDriveLocalFolder", MatomoEventAction::Click, "continueButton");
+
+    if (_localFolderPath.isEmpty()) {
+        CustomMessageBox msgBox(QMessageBox::Warning, tr("Please select a folder to continue."), QMessageBox::Ok, this);
+        msgBox.exec();
+        return;
+    }
 
     emit terminated();
 }

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -187,7 +187,8 @@ void AddDriveWizard::startNextStep(bool backward) {
         _addDriveLocalFolderWidget->setLiteSync(_liteSync);
         QString goodLocalFolderPath;
         QString error;
-        if (const auto exitCode = GuiRequests::findGoodPathForNewSync(goodLocalFolderPath, error); exitCode != ExitCode::Ok) {
+        if (const auto exitCode = GuiRequests::findGoodPathForNewSync(_driveInfo.name(), goodLocalFolderPath, error);
+            exitCode != ExitCode::Ok) {
             qCWarning(lcAddDriveWizard()) << "Error in Requests::findGoodPathForNewSyncFolder : " << error;
         }
 

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -185,16 +185,10 @@ void AddDriveWizard::startNextStep(bool backward) {
     } else if (_currentStep == LocalFolder) {
         _addDriveLocalFolderWidget->setDrive(QString::fromStdString(_driveInfo.name()));
         _addDriveLocalFolderWidget->setLiteSync(_liteSync);
-        QString localFolderPath = QString::fromStdString(Theme::instance()->appName());
-        if (!QDir(localFolderPath).isAbsolute()) {
-            localFolderPath = QDir::homePath() + dirSeparator + localFolderPath;
-        }
         QString goodLocalFolderPath;
         QString error;
-        ExitCode exitCode = GuiRequests::findGoodPathForNewSync(localFolderPath, goodLocalFolderPath, error);
-        if (exitCode != ExitCode::Ok) {
+        if (const auto exitCode = GuiRequests::findGoodPathForNewSync(goodLocalFolderPath, error); exitCode != ExitCode::Ok) {
             qCWarning(lcAddDriveWizard()) << "Error in Requests::findGoodPathForNewSyncFolder : " << error;
-            goodLocalFolderPath = localFolderPath;
         }
 
         _addDriveLocalFolderWidget->setLocalFolderPath(goodLocalFolderPath);

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -190,6 +190,10 @@ void AddDriveWizard::startNextStep(bool backward) {
         if (const auto exitCode = GuiRequests::findGoodPathForNewSync(_driveInfo.name(), goodLocalFolderPath, error);
             exitCode != ExitCode::Ok) {
             qCWarning(lcAddDriveWizard()) << "Error in Requests::findGoodPathForNewSyncFolder : " << error;
+            CustomMessageBox msgBox(
+                    QMessageBox::Warning,
+                    tr("Failed to find a a valid local folder to create your synchronisation. Please, select a folder manually."),
+                    QMessageBox::Ok, this);
         }
 
         _addDriveLocalFolderWidget->setLocalFolderPath(goodLocalFolderPath);

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -187,7 +187,8 @@ void AddDriveWizard::startNextStep(bool backward) {
         _addDriveLocalFolderWidget->setLiteSync(_liteSync);
         QString goodLocalFolderPath;
         QString error;
-        if (const auto exitCode = GuiRequests::findGoodPathForNewSync(_driveInfo.name(), goodLocalFolderPath, error);
+        if (const auto exitCode =
+                    GuiRequests::findGoodPathForNewSync(QString::fromStdString(_driveInfo.name()), goodLocalFolderPath, error);
             exitCode != ExitCode::Ok) {
             qCWarning(lcAddDriveWizard()) << "Error in Requests::findGoodPathForNewSyncFolder : " << error;
             CustomMessageBox msgBox(

--- a/src/gui/adddrivewizard.cpp
+++ b/src/gui/adddrivewizard.cpp
@@ -193,7 +193,7 @@ void AddDriveWizard::startNextStep(bool backward) {
             qCWarning(lcAddDriveWizard()) << "Error in Requests::findGoodPathForNewSyncFolder : " << error;
             CustomMessageBox msgBox(
                     QMessageBox::Warning,
-                    tr("Failed to find a a valid local folder to create your synchronisation. Please, select a folder manually."),
+                    tr("Failed to find a valid local folder to create your synchronisation. Please, select a folder manually."),
                     QMessageBox::Ok, this);
         }
 

--- a/src/gui/guirequests.cpp
+++ b/src/gui/guirequests.cpp
@@ -451,9 +451,13 @@ ExitCode GuiRequests::getNodePath(const SyncDbId syncDbId, const QString &nodeId
     return exitCode;
 }
 
-ExitCode GuiRequests::findGoodPathForNewSync(QString &path, QString &error) {
+ExitCode GuiRequests::findGoodPathForNewSync(const QString &driveName, QString &path, QString &error) {
+    QByteArray params;
+    QDataStream paramsStream(&params, QIODevice::WriteOnly);
+    paramsStream << driveName;
+
     QByteArray results;
-    if (!CommClient::instance()->execute(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC, {}, results)) {
+    if (!CommClient::instance()->execute(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC, params, results)) {
         return ExitCode::SystemError;
     }
 

--- a/src/gui/guirequests.cpp
+++ b/src/gui/guirequests.cpp
@@ -451,13 +451,9 @@ ExitCode GuiRequests::getNodePath(const SyncDbId syncDbId, const QString &nodeId
     return exitCode;
 }
 
-ExitCode GuiRequests::findGoodPathForNewSync(const QString &basePath, QString &path, QString &error) {
-    QByteArray params;
-    QDataStream paramsStream(&params, QIODevice::WriteOnly);
-    paramsStream << basePath;
-
+ExitCode GuiRequests::findGoodPathForNewSync(QString &path, QString &error) {
     QByteArray results;
-    if (!CommClient::instance()->execute(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC, params, results)) {
+    if (!CommClient::instance()->execute(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC, {}, results)) {
         return ExitCode::SystemError;
     }
 

--- a/src/gui/guirequests.h
+++ b/src/gui/guirequests.h
@@ -56,7 +56,7 @@ struct GuiRequests {
         static ExitCode getParameters(ParametersInfo &parametersInfo);
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
         static ExitCode getNodePath(SyncDbId syncDbId, const QString &nodeId, QString &path);
-        static ExitCode findGoodPathForNewSync(QString &path, QString &error);
+        static ExitCode findGoodPathForNewSync(const QString &driveName, QString &path, QString &error);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const QString &fileId, QString &linkUrl);
         static ExitCode getNameExcluded(const QString &name, bool excluded);
         static ExitCode getExclusionTemplateList(bool def, QList<ExclusionTemplateInfo> &templateList);

--- a/src/gui/guirequests.h
+++ b/src/gui/guirequests.h
@@ -56,7 +56,7 @@ struct GuiRequests {
         static ExitCode getParameters(ParametersInfo &parametersInfo);
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
         static ExitCode getNodePath(SyncDbId syncDbId, const QString &nodeId, QString &path);
-        static ExitCode findGoodPathForNewSync(const QString &basePath, QString &path, QString &error);
+        static ExitCode findGoodPathForNewSync(QString &path, QString &error);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const QString &fileId, QString &linkUrl);
         static ExitCode getNameExcluded(const QString &name, bool excluded);
         static ExitCode getExclusionTemplateList(bool def, QList<ExclusionTemplateInfo> &templateList);

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Onboarding/DriveSelectionPage.xaml.cs
@@ -95,10 +95,7 @@ namespace Infomaniak.kDrive.Pages.Onboarding
                 _analyticsService.TrackClick(Analytics.Keys.Category.OnboardingSyncConfigurationPage, Analytics.Keys.EventName.SelectDrive);
                 cb.IsEnabled = false;
                 var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-                string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-                string desiredFolderName = drive.Name.StartsWith("kDrive") ? drive.Name : $"kDrive {drive.Name}";
-                string desiredPath = Path.Combine(userProfile, desiredFolderName);
-                string? result = await commServices.GetGoodPathForNewSync(drive, desiredPath, CancellationToken.None);
+                string? result = await commServices.GetGoodPathForNewSync(drive, CancellationToken.None);
                 if (result is null)
                 {
                     Logger.Log(Logger.Level.Error, $"Failed to get a valid sync path for drive '{drive.Name}'");

--- a/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/Pages/Settings/DriveManagementPage.xaml.cs
@@ -281,10 +281,7 @@ namespace Infomaniak.kDrive.Pages.Settings
                 control.IsEnabled = false;
 
             var commServices = App.ServiceProvider.GetRequiredService<IServerCommService>();
-            string userProfile = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-            string desiredFolderName = BaseDrive.Name.StartsWith("kDrive") ? BaseDrive.Name : $"kDrive {BaseDrive.Name}";
-            string desiredPath = Path.Combine(userProfile, desiredFolderName);
-            string? result = await commServices.GetGoodPathForNewSync(BaseDrive, desiredPath, CancellationToken.None);
+            string? result = await commServices.GetGoodPathForNewSync(BaseDrive, CancellationToken.None);
             if (result is null)
             {
                 Logger.Log(Logger.Level.Error, $"Failed to get a valid sync path for drive '{BaseDrive.Name}'");

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Interfaces/IServerCommService.cs
@@ -82,7 +82,7 @@ namespace Infomaniak.kDrive.ServerCommunication.Interfaces
         Task<bool?> CanPathSupportLiteSync(string absoluteLocalPath, CancellationToken cancellationToken);
 
         // Returns a valid path for a new sync as close as possible to the desiredPath, if not known, the driveDbId can be set to -1
-        Task<string?> GetGoodPathForNewSync(IDrive? drive, string desiredPath, CancellationToken cancellationToken);
+        Task<string?> GetGoodPathForNewSync(IDrive? drive, CancellationToken cancellationToken);
         Task<bool?> IsPathValidForNewSync(string path, SyncConfiguration syncConfiguration, CancellationToken cancellationToken);
         Task<List<SearchItem>?> SearchItem(Sync? sync, string searchString, CancellationToken cancellationToken);
         Task<UInt64?> GetSyncOfflineFilesSize(DbId syncDbId, CancellationToken cancellationToken);

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/CommSharedJsonKeys.cs
@@ -86,7 +86,7 @@ namespace Infomaniak.kDrive.ServerCommunication.CommStruct
         static public string IsValid = "isValid";
         static public string Path = "path";
         static public string SyncConfiguration = "syncConfiguration";
-        static public string BasePath = "basePath";
+        static public string DriveName = "driveName";
         static public string GoodPath = "goodPath";
         static public string BestMode = "bestMode";
         static public string Value = "value";

--- a/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
+++ b/src/gui4/windows/kDrive client/kDrive client/ServerCommunication/Services/ServerCommService.cs
@@ -713,11 +713,11 @@ namespace Infomaniak.kDrive.ServerCommunication.Services
             return bestMode == VirtualFileMode.Win;
         }
 
-        public async Task<string?> GetGoodPathForNewSync(IDrive? drive, string desiredPath, CancellationToken cancellationToken)
+        public async Task<string?> GetGoodPathForNewSync(IDrive? drive, CancellationToken cancellationToken)
         {
             var parms = new JsonObject
             {
-                [JsonKeys.BasePath] = Utility.ToBase64String(desiredPath)
+                [JsonKeys.DriveName] = Utility.ToBase64String(drive?.Name)
             };
 
             CommData data = await _commClient.SendRequestAsync(RequestNum.UTILITY_FINDGOODPATHFORNEWSYNC, parms, cancellationToken).ConfigureAwait(false);

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -563,6 +563,13 @@ struct COMMON_EXPORT CommonUtility {
          */
         static ExitInfo logDirectoryPath(SyncPath &directoryPath) noexcept;
 
+        //! Returns the user's home directory path.
+        /*!
+         \param directoryPath is set with the path to the user's home directory. Empty if there is an error.
+         \return An ExitInfo representing the return value of the underlying OS API call.
+         */
+        static ExitInfo homeDirectoryPath(SyncPath &directoryPath) noexcept;
+
         static ExitInfo stdErrorToExitInfo(int64_t error) noexcept;
         static ExitInfo stdErrorToExitInfo(const std::error_code &ec) noexcept;
 

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -33,29 +33,11 @@
 
 namespace KDC {
 
-static std::string homeDirectoryStr() {
-    if (auto homeDir = CommonUtility::envVarValue("HOME"); !homeDir.empty()) return homeDir;
-
-    // The "HOME" environment variable might not be set. In this case, fallback on a more robust method by using getpwuid_r. The
-    // "passwd" struct retrieved contains information such as username, user id, encrypted password or  home directory.
-    struct passwd pwd;
-    struct passwd *result = nullptr;
-    auto bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
-    if (bufsize == -1) bufsize = 16384;
-    if (std::vector<char> buf(static_cast<size_t>(bufsize));
-        getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 && result != nullptr) {
-        return std::string(result->pw_dir);
-    }
-    return {};
-}
-
 SyncPath CommonUtility::getGenericAppSupportDir() {
-    const auto homeDir = homeDirectoryStr();
-    if (homeDir.empty()) return {};
+    SyncPath homeDir;
+    if (const auto exitInfo = homeDirectoryPath(homeDir); !exitInfo) return {};
 
-    SyncPath homePath(homeDir);
-    std::string appSupportName(".config");
-    SyncPath appSupportPath(homePath / appSupportName);
+    SyncPath appSupportPath(homeDir / ".config");
 
     std::error_code ec;
     if (!std::filesystem::exists(appSupportPath, ec)) {
@@ -205,9 +187,8 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     if (!xdgStateHome.empty() && xdgStateHomePath.is_absolute()) {
         directoryPath = xdgStateHomePath;
     } else {
-        const auto homeDir = homeDirectoryStr();
-        if (homeDir.empty()) return {ExitCode::SystemError, ExitCause::NotFound};
-        directoryPath = SyncPath(homeDir) / ".local" / "state";
+        if (const auto exitInfo = homeDirectoryPath(directoryPath); !exitInfo) return exitInfo;
+        directoryPath /= ".local" / "state";
     }
 
     directoryPath /= Str2SyncName(APPLICATION_NAME);
@@ -231,6 +212,27 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     }
 
     return ExitCode::Ok;
+}
+
+ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
+    if (auto homeDir = CommonUtility::envVarValue("HOME"); !homeDir.empty()) {
+        directoryPath = SyncPath(homeDir);
+        return ExitCode::Ok;
+    }
+
+    // The "HOME" environment variable might not be set. In this case, fallback on a more robust method by using getpwuid_r. The
+    // "passwd" struct retrieved contains information such as username, user id, encrypted password or  home directory.
+    struct passwd pwd;
+    struct passwd *result = nullptr;
+    auto bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+    if (bufsize == -1) bufsize = 16384;
+    if (std::vector<char> buf(static_cast<size_t>(bufsize));
+        getpwuid_r(getuid(), &pwd, buf.data(), buf.size(), &result) == 0 && result != nullptr) {
+        directoryPath = SyncPath(std::string(result->pw_dir));
+        return ExitCode::Ok;
+    }
+
+    return {ExitCode::SystemError, ExitCause::NotFound};
 }
 
 } // namespace KDC

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -188,7 +188,7 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
         directoryPath = xdgStateHomePath;
     } else {
         if (const auto exitInfo = homeDirectoryPath(directoryPath); !exitInfo) return exitInfo;
-        directoryPath /= ".local" / "state";
+        directoryPath /= ".local/state";
     }
 
     directoryPath /= Str2SyncName(APPLICATION_NAME);

--- a/src/libcommon/utility/utility_linux.cpp
+++ b/src/libcommon/utility/utility_linux.cpp
@@ -215,7 +215,7 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
 }
 
 ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
-    if (auto homeDir = CommonUtility::envVarValue("HOME"); !homeDir.empty()) {
+    if (const auto homeDir = CommonUtility::envVarValue("HOME"); !homeDir.empty()) {
         directoryPath = SyncPath(homeDir);
         return ExitCode::Ok;
     }

--- a/src/libcommon/utility/utility_mac.mm
+++ b/src/libcommon/utility/utility_mac.mm
@@ -170,4 +170,14 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     return ExitCode::Ok;
 }
 
+ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
+    NSString *homeDir = NSHomeDirectory();
+    if (!homeDir) {
+        return {ExitCode::SystemError, ExitCause::Unknown};
+    }
+
+    directoryPath = SyncPath([homeDir UTF8String]);
+    return ExitCode::Ok;
+}
+
 } // namespace KDC

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -204,13 +204,18 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
 }
 
 ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
-    if (PWSTR path = nullptr; SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_NO_ALIAS, nullptr, &path))) {
+    PWSTR path = nullptr;
+    const HRESULT hr = SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_NO_ALIAS, nullptr, &path);
+    if (SUCCEEDED(hr) && path) {
         directoryPath = path;
         CoTaskMemFree(path);
         return ExitCode::Ok;
     }
+    if (path) {
+        CoTaskMemFree(path);
+    }
 
-    return stdErrorToExitInfo(static_cast<int64_t>(GetLastError()));
+    return {ExitCode::SystemError, ExitCause::Unknown};
 }
 
 } // namespace KDC

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -203,4 +203,14 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
     return ExitCode::Ok;
 }
 
+ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
+    if (PWSTR path = nullptr; SUCCEEDED(SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_NO_ALIAS, nullptr, &path))) {
+        directoryPath = path;
+        CoTaskMemFree(path);
+        return ExitCode::Ok;
+    }
+
+    return stdErrorToExitInfo(static_cast<int64_t>(GetLastError()));
+}
+
 } // namespace KDC

--- a/src/libcommon/utility/utility_win.cpp
+++ b/src/libcommon/utility/utility_win.cpp
@@ -1,18 +1,20 @@
-// Infomaniak kDrive - Desktop
-// Copyright (C) 2023-2026 Infomaniak Network SA
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
 
 #include "utility.h"
 #include "utility_base.h"
@@ -205,8 +207,7 @@ ExitInfo CommonUtility::logDirectoryPath(SyncPath &directoryPath) noexcept {
 
 ExitInfo CommonUtility::homeDirectoryPath(SyncPath &directoryPath) noexcept {
     PWSTR path = nullptr;
-    const HRESULT hr = SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_NO_ALIAS, nullptr, &path);
-    if (SUCCEEDED(hr) && path) {
+    if (const HRESULT hr = SHGetKnownFolderPath(FOLDERID_Profile, KF_FLAG_NO_ALIAS, nullptr, &path); SUCCEEDED(hr) && path) {
         directoryPath = path;
         CoTaskMemFree(path);
         return ExitCode::Ok;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2282,9 +2282,13 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             break;
         }
         case RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC: {
+            QString driveName;
+            QDataStream paramsStream(params);
+            paramsStream >> driveName;
+
             SyncPath path;
             std::string error;
-            const auto exitInfo = ServerRequests::findGoodPathForNewSync(path, error);
+            const auto exitInfo = ServerRequests::findGoodPathForNewSync(driveName.toStdString(), path, error);
             if (!exitInfo) {
                 LOG_WARN(_logger, "Error in Requests::findGoodPathForNewSyncFolder");
                 addError(Error(ERR_ID, exitInfo));

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2282,13 +2282,9 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             break;
         }
         case RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC: {
-            QString basePath;
-            QDataStream paramsStream(params);
-            paramsStream >> basePath;
-
             QString path;
             QString error;
-            const auto exitInfo = ServerRequests::findGoodPathForNewSync(basePath, path, error);
+            const auto exitInfo = ServerRequests::findGoodPathForNewSync(path, error);
             if (!exitInfo) {
                 LOG_WARN(_logger, "Error in Requests::findGoodPathForNewSyncFolder");
                 addError(Error(ERR_ID, exitInfo));

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2288,7 +2288,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
 
             SyncPath path;
             std::string error;
-            const auto exitInfo = ServerRequests::findGoodPathForNewSync(driveName.toStdString(), path, error);
+            const auto exitInfo = ServerRequests::findGoodPathForNewSync(QStr2SyncName(driveName), path, error);
             if (!exitInfo) {
                 LOG_WARN(_logger, "Error in Requests::findGoodPathForNewSyncFolder");
                 addError(Error(ERR_ID, exitInfo));

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2282,8 +2282,8 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             break;
         }
         case RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC: {
-            QString path;
-            QString error;
+            SyncPath path;
+            std::string error;
             const auto exitInfo = ServerRequests::findGoodPathForNewSync(path, error);
             if (!exitInfo) {
                 LOG_WARN(_logger, "Error in Requests::findGoodPathForNewSyncFolder");
@@ -2291,8 +2291,8 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             }
 
             resultStream << toInt(exitInfo.code());
-            resultStream << path;
-            resultStream << error;
+            resultStream << Path2QStr(path);
+            resultStream << QString::fromStdString(error);
             break;
         }
         case RequestNum::UTILITY_BESTVFSAVAILABLEMODE_LEGACY: {

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
@@ -21,7 +21,7 @@
 #include "libcommonserver/log/log.h"
 #include "requests/serverrequests.h"
 
-// Imput parameters key
+// Input parameters key
 static const auto inputParamsDriveName = "driveName";
 
 // Output parameters keys

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
@@ -21,6 +21,9 @@
 #include "libcommonserver/log/log.h"
 #include "requests/serverrequests.h"
 
+// Imput parameters key
+static const auto inputParamsDriveName = "driveName";
+
 // Output parameters keys
 static const auto outParamsGoodPath = "goodPath";
 static const auto outParamsErrorMessage = "errorMessage";
@@ -34,6 +37,11 @@ UtilityFindGoodPathForNewSyncJob::UtilityFindGoodPathForNewSyncJob(std::shared_p
     _requestNum = RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC;
 }
 
+ExitInfo UtilityFindGoodPathForNewSyncJob::deserializeInputParms() {
+    readParamValue(inputParamsDriveName, _driveName);
+    return ExitCode::Ok;
+}
+
 ExitInfo UtilityFindGoodPathForNewSyncJob::serializeOutputParms() {
     writeParamValue(outParamsGoodPath, CommonUtility::syncPath2CommString(_goodPath));
     writeParamValue(outParamsErrorMessage, CommonUtility::str2CommString(_errorMessage));
@@ -41,7 +49,7 @@ ExitInfo UtilityFindGoodPathForNewSyncJob::serializeOutputParms() {
 }
 
 ExitInfo UtilityFindGoodPathForNewSyncJob::process() {
-    if (const auto exitInfo = ServerRequests::findGoodPathForNewSync(_goodPath, _errorMessage); !exitInfo) {
+    if (const auto exitInfo = ServerRequests::findGoodPathForNewSync(_driveName, _goodPath, _errorMessage); !exitInfo) {
         LOGW_WARN(_logger, L"findGoodPathForNewSync failed: " << L", errorMessage=" << CommonUtility::s2ws(_errorMessage));
         return exitInfo;
     }

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
@@ -38,7 +38,13 @@ UtilityFindGoodPathForNewSyncJob::UtilityFindGoodPathForNewSyncJob(std::shared_p
 }
 
 ExitInfo UtilityFindGoodPathForNewSyncJob::deserializeInputParms() {
-    readParamValue(inputParamsDriveName, _driveName);
+    try {
+        readParamValue(inputParamsDriveName, _driveName);
+    } catch (const std::exception &e) {
+        LOG_WARN(_logger, "Exception in NodeInfoJob::readParamValue: error=" << e.what());
+        return ExitCode::LogicError;
+    }
+
     return ExitCode::Ok;
 }
 

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.cpp
@@ -21,9 +21,6 @@
 #include "libcommonserver/log/log.h"
 #include "requests/serverrequests.h"
 
-// Input parameters keys
-static const auto inParamsBasePath = "basePath";
-
 // Output parameters keys
 static const auto outParamsGoodPath = "goodPath";
 static const auto outParamsErrorMessage = "errorMessage";
@@ -37,20 +34,6 @@ UtilityFindGoodPathForNewSyncJob::UtilityFindGoodPathForNewSyncJob(std::shared_p
     _requestNum = RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC;
 }
 
-ExitInfo UtilityFindGoodPathForNewSyncJob::deserializeInputParms() {
-    constexpr auto logMessage = "Exception in UtilityFindGoodPathForNewSyncJob::readParamValue: error=";
-    CommString pathStr;
-    try {
-        readParamValue(inParamsBasePath, pathStr);
-    } catch (const Poco::Exception &pocoException) {
-        LOG_WARN(_logger, logMessage << pocoException.message());
-        return ExitCode::LogicError;
-    }
-    _basePath = SyncPath(pathStr);
-
-    return ExitCode::Ok;
-}
-
 ExitInfo UtilityFindGoodPathForNewSyncJob::serializeOutputParms() {
     writeParamValue(outParamsGoodPath, CommonUtility::syncPath2CommString(_goodPath));
     writeParamValue(outParamsErrorMessage, CommonUtility::str2CommString(_errorMessage));
@@ -58,9 +41,8 @@ ExitInfo UtilityFindGoodPathForNewSyncJob::serializeOutputParms() {
 }
 
 ExitInfo UtilityFindGoodPathForNewSyncJob::process() {
-    if (const auto exitInfo = ServerRequests::findGoodPathForNewSync(_basePath, _goodPath, _errorMessage); !exitInfo) {
-        LOGW_WARN(_logger, L"findGoodPathForNewSync failed: " << L", basePath=" << Path2WStr(_basePath) << L", errorMessage="
-                                                              << CommonUtility::s2ws(_errorMessage));
+    if (const auto exitInfo = ServerRequests::findGoodPathForNewSync(_goodPath, _errorMessage); !exitInfo) {
+        LOGW_WARN(_logger, L"findGoodPathForNewSync failed: " << L", errorMessage=" << CommonUtility::s2ws(_errorMessage));
         return exitInfo;
     }
     return ExitCode::Ok;

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.h
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.h
@@ -28,14 +28,11 @@ class UtilityFindGoodPathForNewSyncJob : public AbstractGuiJob {
                                          const Poco::DynamicStruct &inParams, std::shared_ptr<AbstractCommChannel> channel);
 
     private:
-        // Input parameters
-        SyncPath _basePath;
-
         // Output parameters
         SyncPath _goodPath;
         std::string _errorMessage;
 
-        ExitInfo deserializeInputParms() override;
+        ExitInfo deserializeInputParms() override { return ExitCode::Ok; }
         ExitInfo serializeOutputParms() override;
         ExitInfo process() override;
 

--- a/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.h
+++ b/src/server/comm/guijobs/utilityfindgoodpathfornewsyncjob.h
@@ -28,11 +28,14 @@ class UtilityFindGoodPathForNewSyncJob : public AbstractGuiJob {
                                          const Poco::DynamicStruct &inParams, std::shared_ptr<AbstractCommChannel> channel);
 
     private:
+        // Input parameters
+        SyncName _driveName;
+
         // Output parameters
         SyncPath _goodPath;
         std::string _errorMessage;
 
-        ExitInfo deserializeInputParms() override { return ExitCode::Ok; }
+        ExitInfo deserializeInputParms() override;
         ExitInfo serializeOutputParms() override;
         ExitInfo process() override;
 

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -421,7 +421,8 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const SyncName &driveName, SyncP
     if (const auto exitCode = CommonUtility::homeDirectoryPath(homeFolder); !exitCode) {
         return exitCode;
     }
-    SyncPath initialPath = homeFolder / (Str2SyncName(Theme::instance()->appName()) + Str(" ") + driveName);
+    const SyncName initialFolderName = Str2SyncName(Theme::instance()->appName()) + Str(" ") + driveName;
+    SyncPath initialPath = homeFolder / initialFolderName;
 
     // If the parent folder is a sync folder or contained in one, we can't possibly find a valid sync folder inside it.
     SyncDbId syncDbId = 0;
@@ -462,7 +463,7 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const SyncName &driveName, SyncP
         }
         attempt++;
 
-        finalPath = homeFolder / Theme::instance()->appName() / (SyncName2Str(driveName) + " " + std::to_string(attempt));
+        finalPath = homeFolder / (initialFolderName + Str2SyncName(std::to_string(attempt)));
     }
 
     path = finalPath;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -409,24 +409,23 @@ ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, boo
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::findGoodPathForNewSync(const SyncPath &basePath, SyncPath &path, std::string &error) {
-    const QString qBasePath = Path2QStr(basePath);
+ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &error) {
     QString qPath;
     QString qError;
-    const ExitInfo exitInfo = findGoodPathForNewSync(qBasePath, qPath, qError);
+    const ExitInfo exitInfo = findGoodPathForNewSync(qPath, qError);
     path = QStr2Path(qPath);
     error = QStr2Str(qError);
     return exitInfo;
 }
 
-ExitInfo ServerRequests::findGoodPathForNewSync(const QString &basePath, QString &path, QString &error) {
+ExitInfo ServerRequests::findGoodPathForNewSync(QString &path, QString &error) {
     std::vector<Sync> syncList;
     if (!ParmsDb::instance()->selectAllSyncs(syncList)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllSyncs");
         return ExitCode::DbError;
     }
 
-    QString folder = basePath;
+    QString defaultFolder = CommonUtility::deviceTempDirectoryPath();
 
     // If the parent folder is a sync folder or contained in one, we can't possibly find a valid sync folder inside it.
     QString parentFolder = QFileInfo(folder).dir().canonicalPath();

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -410,7 +410,7 @@ ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, boo
     return ExitCode::Ok;
 }
 
-ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &error) {
+ExitInfo ServerRequests::findGoodPathForNewSync(const SyncName &driveName, SyncPath &path, std::string &error) {
     std::vector<Sync> syncList;
     if (!ParmsDb::instance()->selectAllSyncs(syncList)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllSyncs");
@@ -421,7 +421,7 @@ ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &err
     if (const auto exitCode = CommonUtility::homeDirectoryPath(homeFolder); !exitCode) {
         return exitCode;
     }
-    SyncPath initialPath = homeFolder / Theme::instance()->appName();
+    SyncPath initialPath = homeFolder / Theme::instance()->appName() / driveName;
 
     // If the parent folder is a sync folder or contained in one, we can't possibly find a valid sync folder inside it.
     SyncDbId syncDbId = 0;
@@ -462,7 +462,7 @@ ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &err
         }
         attempt++;
 
-        finalPath = homeFolder / (Theme::instance()->appName() + " " + std::to_string(attempt));
+        finalPath = homeFolder / Theme::instance()->appName() / (SyncName2Str(driveName) + " " + std::to_string(attempt));
     }
 
     path = finalPath;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -47,6 +47,7 @@
 #include "libsyncengine/requests/parameterscache.h"
 #include "libsyncengine/requests/exclusiontemplatecache.h"
 #include "server/comm/guijobs/signalerrorremovedjob.h"
+#include "theme/theme.h"
 
 #include <QDir>
 #include <QUuid>
@@ -410,42 +411,37 @@ ExitInfo ServerRequests::folderContainsNonExcludedItem(const SyncPath &path, boo
 }
 
 ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &error) {
-    QString qPath;
-    QString qError;
-    const ExitInfo exitInfo = findGoodPathForNewSync(qPath, qError);
-    path = QStr2Path(qPath);
-    error = QStr2Str(qError);
-    return exitInfo;
-}
-
-ExitInfo ServerRequests::findGoodPathForNewSync(QString &path, QString &error) {
     std::vector<Sync> syncList;
     if (!ParmsDb::instance()->selectAllSyncs(syncList)) {
         LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllSyncs");
         return ExitCode::DbError;
     }
 
-    QString defaultFolder = CommonUtility::deviceTempDirectoryPath();
+    SyncPath homeFolder;
+    if (const auto exitCode = CommonUtility::homeDirectoryPath(homeFolder); !exitCode) {
+        return exitCode;
+    }
+    SyncPath initialPath = homeFolder / Theme::instance()->appName();
 
     // If the parent folder is a sync folder or contained in one, we can't possibly find a valid sync folder inside it.
-    QString parentFolder = QFileInfo(folder).dir().canonicalPath();
     SyncDbId syncDbId = 0;
-    ExitCode exitCode = syncForPath(syncList, parentFolder, syncDbId);
-    if (exitCode != ExitCode::Ok) {
+    if (const auto exitCode = syncForPath(syncList, Path2QStr(homeFolder), syncDbId); exitCode != ExitCode::Ok) {
         LOG_WARN(Log::instance()->getLogger(), "Error in syncForPath: code=" << exitCode);
         return exitCode;
     }
 
     if (syncDbId) {
         LOGW_WARN(Log::instance()->getLogger(),
-                  L"The parent folder is a sync folder or contained in one : " << Path2WStr(QStr2Path(parentFolder)));
-        error = QObject::tr("The parent folder is a sync folder or contained in one");
+                  L"The parent folder is a sync folder or contained in one : " << Utility::formatSyncPath(homeFolder));
+        error = "The parent folder is a sync folder or contained in one";
         return ExitCode::SystemError;
     }
 
     int attempt = 1;
+    SyncPath finalPath = initialPath;
     forever {
-        const ExitInfo exitInfo = checkSyncNesting(syncList, folder, error);
+        QString dummyErrorStr;
+        const ExitInfo exitInfo = checkSyncNesting(syncList, Path2QStr(finalPath), dummyErrorStr);
         if (!exitInfo && (exitInfo.code() != ExitCode::InvalidSync ||
                           attempt >= 100)) { // If the error is a sync nesting error, we can try another
                                              // as the folder can just be already used by another sync
@@ -457,11 +453,11 @@ ExitInfo ServerRequests::findGoodPathForNewSync(QString &path, QString &error) {
             // Check if the local directory already exists
             auto ioError = IoError::Success;
             bool alreadyExists = false;
-            const bool success = IoHelper::checkIfPathExists(QStr2Path(folder), alreadyExists, ioError,
-                                                             IoHelper::PathCheckOption::Insensitive);
+            const bool success =
+                    IoHelper::checkIfPathExists(finalPath, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
             if (!success) {
                 LOGW_WARN(Log::instance()->getLogger(),
-                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(folder, ioError));
+                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(finalPath, ioError));
                 return ExitCode::SystemError;
             }
 
@@ -473,15 +469,15 @@ ExitInfo ServerRequests::findGoodPathForNewSync(QString &path, QString &error) {
         // Count attempts and give up eventually
         if (attempt >= 100) {
             LOG_WARN(Log::instance()->getLogger(), "Can't find a valid path");
-            error = QObject::tr("Can't find a valid path");
+            error = "Can't find a valid path";
             return ExitCode::SystemError;
         }
         attempt++;
 
-        folder = basePath + " " + QString::number(attempt);
+        finalPath = homeFolder / (Theme::instance()->appName() + " " + std::to_string(attempt));
     }
 
-    path = folder;
+    path = finalPath;
     error = "";
     return ExitCode::Ok;
 }

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -438,15 +438,20 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const SyncName &driveName, SyncP
         return ExitCode::SystemError;
     }
 
-    int attempt = 1;
+    QString errorMessage;
+    const ExitInfo exitInfo = checkSyncNesting(syncList, Path2QStr(initialPath), errorMessage);
+    if (!exitInfo) {
+        LOGW_WARN(Log::instance()->getLogger(), QStr2WStr(errorMessage));
+        return exitInfo;
+    }
+
+    auto attempt = 1;
     SyncPath finalPath = initialPath;
     forever {
         // Check if the local directory already exists
         auto ioError = IoError::Success;
         bool alreadyExists = false;
-        const bool success =
-                IoHelper::checkIfPathExists(finalPath, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
-        if (!success) {
+        if (!IoHelper::checkIfPathExists(finalPath, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive)) {
             LOGW_WARN(Log::instance()->getLogger(),
                       L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(finalPath, ioError));
             return ExitCode::SystemError;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -421,7 +421,7 @@ ExitInfo ServerRequests::findGoodPathForNewSync(const SyncName &driveName, SyncP
     if (const auto exitCode = CommonUtility::homeDirectoryPath(homeFolder); !exitCode) {
         return exitCode;
     }
-    SyncPath initialPath = homeFolder / Theme::instance()->appName() / driveName;
+    SyncPath initialPath = homeFolder / (Str2SyncName(Theme::instance()->appName()) + Str(" ") + driveName);
 
     // If the parent folder is a sync folder or contained in one, we can't possibly find a valid sync folder inside it.
     SyncDbId syncDbId = 0;

--- a/src/server/requests/serverrequests.cpp
+++ b/src/server/requests/serverrequests.cpp
@@ -440,30 +440,18 @@ ExitInfo ServerRequests::findGoodPathForNewSync(SyncPath &path, std::string &err
     int attempt = 1;
     SyncPath finalPath = initialPath;
     forever {
-        QString dummyErrorStr;
-        const ExitInfo exitInfo = checkSyncNesting(syncList, Path2QStr(finalPath), dummyErrorStr);
-        if (!exitInfo && (exitInfo.code() != ExitCode::InvalidSync ||
-                          attempt >= 100)) { // If the error is a sync nesting error, we can try another
-                                             // as the folder can just be already used by another sync
-            LOG_WARN(Log::instance()->getLogger(), "Error in checkSyncNesting:" << exitInfo);
-            return exitInfo;
+        // Check if the local directory already exists
+        auto ioError = IoError::Success;
+        bool alreadyExists = false;
+        const bool success =
+                IoHelper::checkIfPathExists(finalPath, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
+        if (!success) {
+            LOGW_WARN(Log::instance()->getLogger(),
+                      L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(finalPath, ioError));
+            return ExitCode::SystemError;
         }
-
-        if (exitInfo) {
-            // Check if the local directory already exists
-            auto ioError = IoError::Success;
-            bool alreadyExists = false;
-            const bool success =
-                    IoHelper::checkIfPathExists(finalPath, alreadyExists, ioError, IoHelper::PathCheckOption::Insensitive);
-            if (!success) {
-                LOGW_WARN(Log::instance()->getLogger(),
-                          L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(finalPath, ioError));
-                return ExitCode::SystemError;
-            }
-
-            if (!alreadyExists) {
-                break;
-            }
+        if (!alreadyExists) {
+            break;
         }
 
         // Count attempts and give up eventually

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -64,8 +64,8 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
         static ExitInfo isPathValidForNewSync(const SyncPath &path, SyncConfiguration syncConfig, bool &valid);
         static ExitInfo folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile);
-        static ExitInfo findGoodPathForNewSync(const SyncPath &basePath, SyncPath &path, std::string &error);
-        static ExitInfo findGoodPathForNewSync(const QString &basePath, QString &path, QString &error);
+        static ExitInfo findGoodPathForNewSync(SyncPath &path, std::string &error);
+        static ExitInfo findGoodPathForNewSync(QString &path, QString &error);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const std::string &fileId, std::string &linkUrl);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const QString &fileId, QString &linkUrl);
         static ExitCode getExclusionTemplateList(bool def, std::vector<ExclusionTemplateInfo> &list);

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -64,7 +64,7 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitCode updateParameters(const ParametersInfo &parametersInfo);
         static ExitInfo isPathValidForNewSync(const SyncPath &path, SyncConfiguration syncConfig, bool &valid);
         static ExitInfo folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile);
-        static ExitInfo findGoodPathForNewSync(SyncPath &path, std::string &error);
+        static ExitInfo findGoodPathForNewSync(const SyncName &driveName, SyncPath &path, std::string &error);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const std::string &fileId, std::string &linkUrl);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const QString &fileId, QString &linkUrl);
         static ExitCode getExclusionTemplateList(bool def, std::vector<ExclusionTemplateInfo> &list);

--- a/src/server/requests/serverrequests.h
+++ b/src/server/requests/serverrequests.h
@@ -65,7 +65,6 @@ struct SYNCENGINE_EXPORT ServerRequests {
         static ExitInfo isPathValidForNewSync(const SyncPath &path, SyncConfiguration syncConfig, bool &valid);
         static ExitInfo folderContainsNonExcludedItem(const SyncPath &path, bool &containsNonExcludedFile);
         static ExitInfo findGoodPathForNewSync(SyncPath &path, std::string &error);
-        static ExitInfo findGoodPathForNewSync(QString &path, QString &error);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const std::string &fileId, std::string &linkUrl);
         static ExitCode getPrivateLinkUrl(DriveDbId driveDbId, const QString &fileId, QString &linkUrl);
         static ExitCode getExclusionTemplateList(bool def, std::vector<ExclusionTemplateInfo> &list);

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -1475,7 +1475,7 @@ void TestUtility::testHomeDirectoryPath() {
     const std::string homeStr = homePath.string();
     // Must contain a drive letter root such as "C:\"
     CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr.size() >= 3);
-    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::isalpha(static_cast<unsigned char>(homeStr[0])));
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::isalpha(homeStr[0], std::locale{}));
     CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[1] == ':');
     CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[2] == '\\');
     // Must contain the "Users" segment

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -1460,6 +1460,44 @@ void TestUtility::testPathDepth() {
         path /= "dir";
         CPPUNIT_ASSERT_EQUAL(i, CommonUtility::pathDepth(path));
     }
+void TestUtility::testHomeDirectoryPath() {
+    SyncPath homePath;
+    const auto exitInfo = CommonUtility::homeDirectoryPath(homePath);
+    const std::string failureMessage = "homeDirectoryPath failed: path=" + homePath.string();
+
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), exitInfo);
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), !homePath.empty());
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homePath.is_absolute());
+
+#if defined(KD_WINDOWS)
+    // On Windows the home directory follows the pattern: <drive letter>:\Users\<username>
+    // e.g. C:\Users\John
+    const std::string homeStr = homePath.string();
+    // Must contain a drive letter root such as "C:\"
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr.size() >= 3);
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::isalpha(static_cast<unsigned char>(homeStr[0])));
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[1] == ':');
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[2] == '\\');
+    // Must contain the "Users" segment
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr.find("Users") != std::string::npos);
+    // Must match the pattern <letter>:\Users\<non-empty username>
+    const std::regex windowsHomePattern(R"([A-Za-z]:\\Users\\[^\\]+.*)");
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::regex_match(homeStr, windowsHomePattern));
+#elif defined(KD_MACOS)
+    // On macOS the home directory follows the pattern: /Users/<username>
+    // e.g. /Users/john
+    const std::string homeStr = homePath.string();
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[0] == '/');
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr.find("Users") != std::string::npos);
+    const std::regex macOsHomePattern(R"(/Users/[^/]+.*)");
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::regex_match(homeStr, macOsHomePattern));
+#else
+    // On Linux the home directory is typically /home/<username> or /root for the root user
+    const std::string homeStr = homePath.string();
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), homeStr[0] == '/');
+    const std::regex linuxHomePattern(R"((/home/[^/]+.*|/root))");
+    CPPUNIT_ASSERT_MESSAGE(failureMessage.c_str(), std::regex_match(homeStr, linuxHomePattern));
+#endif
 }
 
 void TestUtility::testGetSyncTime() {

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -1460,6 +1460,8 @@ void TestUtility::testPathDepth() {
         path /= "dir";
         CPPUNIT_ASSERT_EQUAL(i, CommonUtility::pathDepth(path));
     }
+}
+
 void TestUtility::testHomeDirectoryPath() {
     SyncPath homePath;
     const auto exitInfo = CommonUtility::homeDirectoryPath(homePath);

--- a/test/libcommon/utility/testutility.h
+++ b/test/libcommon/utility/testutility.h
@@ -73,6 +73,7 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testTempDirectoryPath);
         CPPUNIT_TEST(testLogDirectoryPath);
         CPPUNIT_TEST(testPathDepth);
+        CPPUNIT_TEST(testHomeDirectoryPath);
         CPPUNIT_TEST(testGetSyncTime);
         CPPUNIT_TEST_SUITE_END();
 
@@ -128,6 +129,7 @@ class TestUtility : public CppUnit::TestFixture, public TestBase {
         void testTempDirectoryPath();
         void testLogDirectoryPath();
         void testPathDepth();
+        void testHomeDirectoryPath();
         void testGetSyncTime();
 
     private:

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -112,6 +112,7 @@ void TestGuiCommChannel::testUtilityFindGoodPathForNewSyncJob() {
     (void) queryObj.set("num", toInt(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC));
 
     Poco::JSON::Object queryParamsObj;
+    (void) queryParamsObj.set("driveName", "dummyDriveName");
     (void) queryParamsObj.set("driveDbId", 0);
 
     (void) queryObj.set("params", queryParamsObj);

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -112,7 +112,6 @@ void TestGuiCommChannel::testUtilityFindGoodPathForNewSyncJob() {
     (void) queryObj.set("num", toInt(RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC));
 
     Poco::JSON::Object queryParamsObj;
-    (void) queryParamsObj.set("basePath", "");
     (void) queryParamsObj.set("driveDbId", 0);
 
     (void) queryObj.set("params", queryParamsObj);

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -101,8 +101,8 @@ void TestServerRequests::testGetPublicLink() {
 void TestServerRequests::testFindGoodPathForNewSync() {
     SyncPath homePath;
     (void) CommonUtility::homeDirectoryPath(homePath);
-    const SyncPath defaultPath = homePath / APPLICATION_NAME;
     const SyncName driveName(Str("dummyDriveName"));
+    const SyncPath defaultPath = homePath / APPLICATION_NAME / driveName;
 
     SyncPath returnedPath;
     std::string error;
@@ -113,7 +113,7 @@ void TestServerRequests::testFindGoodPathForNewSync() {
 
     // Check again but returnedPath already exists
     const auto previousPath = returnedPath;
-    LocalTemporaryDirectoryFromAbsolutePath localTempDir(previousPath);
+    LocalTemporaryDirectoryFromAbsolutePath localTempDir(defaultPath);
 
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
                          ServerRequests::findGoodPathForNewSync(driveName, returnedPath, error));

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -99,74 +99,87 @@ void TestServerRequests::testGetPublicLink() {
 }
 
 void TestServerRequests::testFindGoodPathForNewSync() {
-    SyncPath localTempDirPath;
-    {
-        LocalTemporaryDirectory localTempDir("testFindGoodPathForNewSync");
-        localTempDirPath = localTempDir.path();
-        const SyncPath defaultPath = localTempDirPath / APPLICATION_NAME;
+    SyncPath homePath;
+    (void) CommonUtility::homeDirectoryPath(homePath);
+    const SyncPath defaultPath = homePath / APPLICATION_NAME;
 
-        // Check with a valid path
-        SyncPath returnedPath;
-        std::string error;
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                             ServerRequests::findGoodPathForNewSync(defaultPath, returnedPath, error));
-        CPPUNIT_ASSERT_EQUAL(defaultPath, returnedPath);
-        CPPUNIT_ASSERT(error.empty());
-
-        // Check with an existing path
-        IoError ioError = IoError::Success;
-        CPPUNIT_ASSERT(IoHelper::createDirectory(defaultPath, false, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                             ServerRequests::findGoodPathForNewSync(defaultPath, returnedPath, error));
-        CPPUNIT_ASSERT(!returnedPath.empty());
-        CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-        CPPUNIT_ASSERT(error.empty());
-
-        // check an already synced & existing path
-        const Sync sync(1, _driveDbId, defaultPath, NodeId(), SyncPath(), NodeId());
-        (void) ParmsDb::instance()->insertSync(sync);
-
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                             ServerRequests::findGoodPathForNewSync(defaultPath, returnedPath, error));
-        CPPUNIT_ASSERT(!returnedPath.empty());
-        CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-        CPPUNIT_ASSERT(error.empty());
-
-        // Check an already synced but non-existing path
-        CPPUNIT_ASSERT(IoHelper::deleteItem(defaultPath, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                             ServerRequests::findGoodPathForNewSync(defaultPath, returnedPath, error));
-        CPPUNIT_ASSERT(!returnedPath.empty());
-        CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-        CPPUNIT_ASSERT(error.empty());
-
-        // check with an already synced parent path
-        const SyncPath childPath = defaultPath / "childFolder";
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::InvalidSync, ExitCause::SyncDirNestingError),
-                             ServerRequests::findGoodPathForNewSync(childPath, returnedPath, error));
-        CPPUNIT_ASSERT(returnedPath.empty());
-        CPPUNIT_ASSERT(!error.empty());
-
-        // Check with an existing path containing an already synced child
-        CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                             ServerRequests::findGoodPathForNewSync(localTempDirPath, returnedPath, error));
-        CPPUNIT_ASSERT(!returnedPath.empty());
-        CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-        CPPUNIT_ASSERT(error.empty());
-    }
-
-    // Check with a non-existing path containing an already synced child
     SyncPath returnedPath;
     std::string error;
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-                         ServerRequests::findGoodPathForNewSync(localTempDirPath, returnedPath, error));
-    CPPUNIT_ASSERT(!returnedPath.empty());
-    CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    CPPUNIT_ASSERT(CommonUtility::startsWith(returnedPath, defaultPath));
     CPPUNIT_ASSERT(error.empty());
+
+    // Check again but returnedPath no already exists
+    const auto previousPath = returnedPath;
+    auto dummyIoError = IoError::Unknown;
+    (void) IoHelper::createDirectory(previousPath, false, dummyIoError);
+
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    CPPUNIT_ASSERT(CommonUtility::startsWith(returnedPath, defaultPath));
+    CPPUNIT_ASSERT(error.empty());
+    CPPUNIT_ASSERT(previousPath != returnedPath);
+
+    (void) IoHelper::deleteItem(previousPath);
+}
+
+void TestServerRequests::testIsPathValidForNewSync() {
+    // SyncPath localTempDirPath;
+    // {
+    //     LocalTemporaryDirectory localTempDir("testIsPathValidForNewSync");
+    //     localTempDirPath = localTempDir.path();
+    //     const SyncPath defaultPath = localTempDirPath / APPLICATION_NAME;
+    //
+    //     IoError ioError = IoError::Success;
+    //     CPPUNIT_ASSERT(IoHelper::createDirectory(defaultPath, false, ioError));
+    //     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    //
+    //     // Check with default path for normal sync
+    //     bool isValid = false;
+    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+    //                          ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
+    //     CPPUNIT_ASSERT(isValid);
+    //
+    //     // check an already synced & existing path
+    //     const Sync sync(1, _driveDbId, defaultPath, NodeId(), SyncPath(), NodeId());
+    //     (void) ParmsDb::instance()->insertSync(sync);
+    //
+    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    //     CPPUNIT_ASSERT(!returnedPath.empty());
+    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
+    //     CPPUNIT_ASSERT(error.empty());
+    //
+    //     // Check an already synced but non-existing path
+    //     CPPUNIT_ASSERT(IoHelper::deleteItem(defaultPath, ioError));
+    //     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    //
+    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    //     CPPUNIT_ASSERT(!returnedPath.empty());
+    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
+    //     CPPUNIT_ASSERT(error.empty());
+    //
+    //     // check with an already synced parent path
+    //     const SyncPath childPath = defaultPath / "childFolder";
+    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::InvalidSync, ExitCause::SyncDirNestingError),
+    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    //     CPPUNIT_ASSERT(returnedPath.empty());
+    //     CPPUNIT_ASSERT(!error.empty());
+    //
+    //     // Check with an existing path containing an already synced child
+    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    //     CPPUNIT_ASSERT(!returnedPath.empty());
+    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
+    //     CPPUNIT_ASSERT(error.empty());
+    // }
+    //
+    // // Check with a non-existing path containing an already synced child
+    // SyncPath returnedPath;
+    // std::string error;
+    // CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath,
+    // error)); CPPUNIT_ASSERT(!returnedPath.empty()); CPPUNIT_ASSERT(returnedPath.filename().string().find('2') !=
+    // std::string::npos); CPPUNIT_ASSERT(error.empty());
 }
 
 void TestServerRequests::testDeleteUser() {

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -102,18 +102,21 @@ void TestServerRequests::testFindGoodPathForNewSync() {
     SyncPath homePath;
     (void) CommonUtility::homeDirectoryPath(homePath);
     const SyncPath defaultPath = homePath / APPLICATION_NAME;
+    const SyncName driveName("dummyDriveName");
 
     SyncPath returnedPath;
     std::string error;
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::findGoodPathForNewSync(driveName, returnedPath, error));
     CPPUNIT_ASSERT(CommonUtility::startsWith(returnedPath, defaultPath));
     CPPUNIT_ASSERT(error.empty());
 
-    // Check again but returnedPath no already exists
+    // Check again but returnedPath already exists
     const auto previousPath = returnedPath;
     LocalTemporaryDirectoryFromAbsolutePath localTempDir(previousPath);
 
-    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath, error));
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::findGoodPathForNewSync(driveName, returnedPath, error));
     CPPUNIT_ASSERT(CommonUtility::startsWith(returnedPath, defaultPath));
     CPPUNIT_ASSERT(error.empty());
     CPPUNIT_ASSERT(previousPath != returnedPath);

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -123,63 +123,57 @@ void TestServerRequests::testFindGoodPathForNewSync() {
 }
 
 void TestServerRequests::testIsPathValidForNewSync() {
-    // SyncPath localTempDirPath;
-    // {
-    //     LocalTemporaryDirectory localTempDir("testIsPathValidForNewSync");
-    //     localTempDirPath = localTempDir.path();
-    //     const SyncPath defaultPath = localTempDirPath / APPLICATION_NAME;
-    //
-    //     IoError ioError = IoError::Success;
-    //     CPPUNIT_ASSERT(IoHelper::createDirectory(defaultPath, false, ioError));
-    //     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    //
-    //     // Check with default path for normal sync
-    //     bool isValid = false;
-    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-    //                          ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
-    //     CPPUNIT_ASSERT(isValid);
-    //
-    //     // check an already synced & existing path
-    //     const Sync sync(1, _driveDbId, defaultPath, NodeId(), SyncPath(), NodeId());
-    //     (void) ParmsDb::instance()->insertSync(sync);
-    //
-    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
-    //     CPPUNIT_ASSERT(!returnedPath.empty());
-    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-    //     CPPUNIT_ASSERT(error.empty());
-    //
-    //     // Check an already synced but non-existing path
-    //     CPPUNIT_ASSERT(IoHelper::deleteItem(defaultPath, ioError));
-    //     CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-    //
-    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
-    //     CPPUNIT_ASSERT(!returnedPath.empty());
-    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-    //     CPPUNIT_ASSERT(error.empty());
-    //
-    //     // check with an already synced parent path
-    //     const SyncPath childPath = defaultPath / "childFolder";
-    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::InvalidSync, ExitCause::SyncDirNestingError),
-    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
-    //     CPPUNIT_ASSERT(returnedPath.empty());
-    //     CPPUNIT_ASSERT(!error.empty());
-    //
-    //     // Check with an existing path containing an already synced child
-    //     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
-    //                          ServerRequests::findGoodPathForNewSync(returnedPath, error));
-    //     CPPUNIT_ASSERT(!returnedPath.empty());
-    //     CPPUNIT_ASSERT(returnedPath.filename().string().find('2') != std::string::npos);
-    //     CPPUNIT_ASSERT(error.empty());
-    // }
-    //
-    // // Check with a non-existing path containing an already synced child
-    // SyncPath returnedPath;
-    // std::string error;
-    // CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath,
-    // error)); CPPUNIT_ASSERT(!returnedPath.empty()); CPPUNIT_ASSERT(returnedPath.filename().string().find('2') !=
-    // std::string::npos); CPPUNIT_ASSERT(error.empty());
+    LocalTemporaryDirectory localTempDir("testIsPathValidForNewSync");
+    const SyncPath basePath = localTempDir.path();
+    const SyncPath defaultPath = basePath / APPLICATION_NAME;
+
+    auto ioError = IoError::Unknown;
+    CPPUNIT_ASSERT(IoHelper::createDirectory(defaultPath, false, ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+
+    // Existing and empty folder is valid in classic mode.
+    bool isValid = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(isValid);
+
+    // Existing and non-empty folder with a regular file is invalid in classic mode.
+    testhelpers::generateTestFile(defaultPath / "regular_file.txt");
+    isValid = true;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(!isValid);
+
+    // Folder containing only excluded files remains valid.
+    CPPUNIT_ASSERT(IoHelper::deleteItem(defaultPath / "regular_file.txt", ioError));
+    CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+    testhelpers::generateTestFile(defaultPath / "excluded_file~");
+    isValid = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(isValid);
+
+    // In advanced mode, non-empty folders are accepted.
+    testhelpers::generateTestFile(defaultPath / "advanced_regular_file.txt");
+    isValid = false;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Advanced, isValid));
+    CPPUNIT_ASSERT(isValid);
+
+    // A path already used by an existing sync is rejected.
+    const Sync sync(1, _driveDbId, defaultPath, NodeId(), SyncPath(), NodeId());
+    (void) ParmsDb::instance()->insertSync(sync);
+    isValid = true;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(defaultPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(!isValid);
+
+    // A child folder of an existing sync is also rejected.
+    const SyncPath childPath = defaultPath / "childFolder";
+    isValid = true;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(childPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(!isValid);
 }
 
 void TestServerRequests::testDeleteUser() {

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -102,7 +102,7 @@ void TestServerRequests::testFindGoodPathForNewSync() {
     SyncPath homePath;
     (void) CommonUtility::homeDirectoryPath(homePath);
     const SyncPath defaultPath = homePath / APPLICATION_NAME;
-    const SyncName driveName("dummyDriveName");
+    const SyncName driveName(Str("dummyDriveName"));
 
     SyncPath returnedPath;
     std::string error;

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -33,6 +33,7 @@
 
 #include "test_utility/remotetemporarydirectory.h"
 #include "test_utility/testhelpers.h"
+#include "theme/theme.h"
 
 namespace KDC {
 
@@ -102,7 +103,7 @@ void TestServerRequests::testFindGoodPathForNewSync() {
     SyncPath homePath;
     (void) CommonUtility::homeDirectoryPath(homePath);
     const SyncName driveName(Str("dummyDriveName"));
-    const SyncPath defaultPath = homePath / (SyncName(APPLICATION_NAME) + Str(" ") + driveName);
+    const SyncPath defaultPath = homePath / (Str2SyncName(Theme::instance()->appName()) + Str(" ") + driveName);
 
     SyncPath returnedPath;
     std::string error;

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -102,7 +102,7 @@ void TestServerRequests::testFindGoodPathForNewSync() {
     SyncPath homePath;
     (void) CommonUtility::homeDirectoryPath(homePath);
     const SyncName driveName(Str("dummyDriveName"));
-    const SyncPath defaultPath = homePath / APPLICATION_NAME / driveName;
+    const SyncPath defaultPath = homePath / (SyncName(APPLICATION_NAME) + Str(" ") + driveName);
 
     SyncPath returnedPath;
     std::string error;
@@ -113,7 +113,7 @@ void TestServerRequests::testFindGoodPathForNewSync() {
 
     // Check again but returnedPath already exists
     const auto previousPath = returnedPath;
-    LocalTemporaryDirectoryFromAbsolutePath localTempDir(defaultPath,
+    LocalTemporaryDirectoryFromAbsolutePath localTempDir(previousPath,
                                                          LocalTemporaryDirectoryFromAbsolutePath::RecursiveMode::Recursive);
 
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -174,6 +174,13 @@ void TestServerRequests::testIsPathValidForNewSync() {
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
                          ServerRequests::isPathValidForNewSync(childPath, SyncConfiguration::Classic, isValid));
     CPPUNIT_ASSERT(!isValid);
+
+    // A parent folder of an existing sync is also rejected.
+    const SyncPath parentPath = defaultPath.parent_path();
+    isValid = true;
+    CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
+                         ServerRequests::isPathValidForNewSync(parentPath, SyncConfiguration::Classic, isValid));
+    CPPUNIT_ASSERT(!isValid);
 }
 
 void TestServerRequests::testDeleteUser() {

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -111,15 +111,12 @@ void TestServerRequests::testFindGoodPathForNewSync() {
 
     // Check again but returnedPath no already exists
     const auto previousPath = returnedPath;
-    auto dummyIoError = IoError::Unknown;
-    (void) IoHelper::createDirectory(previousPath, false, dummyIoError);
+    LocalTemporaryDirectoryFromAbsolutePath localTempDir(previousPath);
 
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown), ServerRequests::findGoodPathForNewSync(returnedPath, error));
     CPPUNIT_ASSERT(CommonUtility::startsWith(returnedPath, defaultPath));
     CPPUNIT_ASSERT(error.empty());
     CPPUNIT_ASSERT(previousPath != returnedPath);
-
-    (void) IoHelper::deleteItem(previousPath);
 }
 
 void TestServerRequests::testIsPathValidForNewSync() {

--- a/test/server/requests/testserverrequests.cpp
+++ b/test/server/requests/testserverrequests.cpp
@@ -113,7 +113,8 @@ void TestServerRequests::testFindGoodPathForNewSync() {
 
     // Check again but returnedPath already exists
     const auto previousPath = returnedPath;
-    LocalTemporaryDirectoryFromAbsolutePath localTempDir(defaultPath);
+    LocalTemporaryDirectoryFromAbsolutePath localTempDir(defaultPath,
+                                                         LocalTemporaryDirectoryFromAbsolutePath::RecursiveMode::Recursive);
 
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::Ok, ExitCause::Unknown),
                          ServerRequests::findGoodPathForNewSync(driveName, returnedPath, error));

--- a/test/server/requests/testserverrequests.h
+++ b/test/server/requests/testserverrequests.h
@@ -26,6 +26,7 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testFixProxyConfig);
         CPPUNIT_TEST(testGetPublicLink);
         CPPUNIT_TEST(testFindGoodPathForNewSync);
+        CPPUNIT_TEST(testIsPathValidForNewSync);
         CPPUNIT_TEST(testDeleteUser);
         CPPUNIT_TEST(testDeleteUserNotFound);
         CPPUNIT_TEST(testDeleteAccount);
@@ -44,6 +45,7 @@ class TestServerRequests : public CppUnit::TestFixture, public TestBase {
         void testFixProxyConfig();
         void testGetPublicLink();
         void testFindGoodPathForNewSync();
+        void testIsPathValidForNewSync();
         void testDeleteUser();
         void testDeleteUserNotFound();
         void testDeleteAccount();

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -29,33 +29,10 @@
 
 namespace KDC {
 
-LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType, const SyncPath &destinationPath /*= {}*/) {
-    const std::time_t now = std::time(nullptr);
-    const std::tm tm = *std::localtime(&now);
-    std::ostringstream woss;
-    woss << std::put_time(&tm, "%Y%m%d_%H%M%S");
+AbstractLocalTemporaryDirectory::AbstractLocalTemporaryDirectory(const SyncPath &inputPath) :
+    _inputPath(inputPath) {}
 
-    const auto basePath = destinationPath.empty() ? std::filesystem::temp_directory_path() : destinationPath;
-    _path = basePath / ("kdrive_" + testType + "_unit_tests_" + woss.str());
-    int retryCount = 0;
-    const int maxRetry = 100;
-    while (!std::filesystem::create_directory(_path) && retryCount < maxRetry) {
-        retryCount++;
-        _path = basePath / ("kdrive_" + testType + "_unit_tests_" + woss.str() + "_" + std::to_string(retryCount));
-    }
-
-    if (retryCount == maxRetry) {
-        throw std::runtime_error("Failed to create local temporary directory");
-    }
-
-    _path = std::filesystem::canonical(_path); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
-    FileStat fileStat;
-    IoError ioError = IoError::Success;
-    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
-    _id = std::to_string(fileStat.inode);
-}
-
-LocalTemporaryDirectory::~LocalTemporaryDirectory() {
+AbstractLocalTemporaryDirectory::~AbstractLocalTemporaryDirectory() {
     auto ioError = IoError::Success;
 
     // Set full access to temp directory.
@@ -78,6 +55,55 @@ LocalTemporaryDirectory::~LocalTemporaryDirectory() {
         std::cout << CommonUtility::ws2s(Utility::formatIoError(_path, ioError)) << std::endl;
         assert(false);
     }
+}
+
+LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType, const SyncPath &destinationPath /*= {}*/) :
+    AbstractLocalTemporaryDirectory(destinationPath),
+    _testType(testType) {
+    createDirectory();
+}
+
+void LocalTemporaryDirectory::createDirectory() {
+    const std::time_t now = std::time(nullptr);
+    const std::tm tm = *std::localtime(&now);
+    std::ostringstream woss;
+    woss << std::put_time(&tm, "%Y%m%d_%H%M%S");
+
+    const auto basePath = _inputPath.empty() ? std::filesystem::temp_directory_path() : _inputPath;
+    _path = basePath / ("kdrive_" + _testType + "_unit_tests_" + woss.str());
+    int retryCount = 0;
+    const int maxRetry = 100;
+    while (!std::filesystem::create_directory(_path) && retryCount < maxRetry) {
+        retryCount++;
+        _path = basePath / ("kdrive_" + _testType + "_unit_tests_" + woss.str() + "_" + std::to_string(retryCount));
+    }
+
+    if (retryCount == maxRetry) {
+        throw std::runtime_error("Failed to create local temporary directory");
+    }
+
+    _path = std::filesystem::canonical(_path); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
+    FileStat fileStat;
+    IoError ioError = IoError::Success;
+    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    _id = std::to_string(fileStat.inode);
+}
+
+LocalTemporaryDirectoryFromAbsolutePath::LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath) :
+    AbstractLocalTemporaryDirectory(absolutePath) {
+    createDirectory();
+}
+
+void LocalTemporaryDirectoryFromAbsolutePath::createDirectory() {
+    if (!std::filesystem::create_directory(_inputPath)) {
+        throw std::runtime_error("Failed to create local temporary directory");
+    }
+
+    _path = std::filesystem::canonical(_inputPath); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
+    FileStat fileStat;
+    IoError ioError = IoError::Success;
+    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    _id = std::to_string(fileStat.inode);
 }
 
 

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -89,13 +89,17 @@ void LocalTemporaryDirectory::createDirectory() {
     _id = std::to_string(fileStat.inode);
 }
 
-LocalTemporaryDirectoryFromAbsolutePath::LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath) :
-    AbstractLocalTemporaryDirectory(absolutePath) {
+LocalTemporaryDirectoryFromAbsolutePath::LocalTemporaryDirectoryFromAbsolutePath(
+        const SyncPath &absolutePath, RecursiveMode recursiveMode /*= RecursiveMode::NonRecursive*/) :
+    AbstractLocalTemporaryDirectory(absolutePath),
+    _recursiveMode(recursiveMode) {
     LocalTemporaryDirectoryFromAbsolutePath::createDirectory();
 }
 
 void LocalTemporaryDirectoryFromAbsolutePath::createDirectory() {
-    if (!std::filesystem::create_directory(_inputPath)) {
+    bool ok = _recursiveMode == RecursiveMode::Recursive ? std::filesystem::create_directories(_inputPath)
+                                                         : std::filesystem::create_directory(_inputPath);
+    if (!ok) {
         throw std::runtime_error("Failed to create local temporary directory");
     }
 

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -60,7 +60,7 @@ AbstractLocalTemporaryDirectory::~AbstractLocalTemporaryDirectory() {
 LocalTemporaryDirectory::LocalTemporaryDirectory(const std::string &testType, const SyncPath &destinationPath /*= {}*/) :
     AbstractLocalTemporaryDirectory(destinationPath),
     _testType(testType) {
-    createDirectory();
+    LocalTemporaryDirectory::createDirectory();
 }
 
 void LocalTemporaryDirectory::createDirectory() {
@@ -85,13 +85,13 @@ void LocalTemporaryDirectory::createDirectory() {
     _path = std::filesystem::canonical(_path); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
     FileStat fileStat;
     IoError ioError = IoError::Success;
-    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
     _id = std::to_string(fileStat.inode);
 }
 
 LocalTemporaryDirectoryFromAbsolutePath::LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath) :
     AbstractLocalTemporaryDirectory(absolutePath) {
-    createDirectory();
+    LocalTemporaryDirectoryFromAbsolutePath::createDirectory();
 }
 
 void LocalTemporaryDirectoryFromAbsolutePath::createDirectory() {
@@ -102,7 +102,7 @@ void LocalTemporaryDirectoryFromAbsolutePath::createDirectory() {
     _path = std::filesystem::canonical(_inputPath); // Follows symlinks to work around the symlink /var -> private/var on MacOSX.
     FileStat fileStat;
     IoError ioError = IoError::Success;
-    IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
+    (void) IoHelper::getFileStat(_path, &fileStat, ioError, IoHelper::PathCheckOption::Insensitive);
     _id = std::to_string(fileStat.inode);
 }
 

--- a/test/test_utility/localtemporarydirectory.cpp
+++ b/test/test_utility/localtemporarydirectory.cpp
@@ -90,16 +90,16 @@ void LocalTemporaryDirectory::createDirectory() {
 }
 
 LocalTemporaryDirectoryFromAbsolutePath::LocalTemporaryDirectoryFromAbsolutePath(
-        const SyncPath &absolutePath, RecursiveMode recursiveMode /*= RecursiveMode::NonRecursive*/) :
+        const SyncPath &absolutePath, const RecursiveMode recursiveMode /*= RecursiveMode::NonRecursive*/) :
     AbstractLocalTemporaryDirectory(absolutePath),
     _recursiveMode(recursiveMode) {
     LocalTemporaryDirectoryFromAbsolutePath::createDirectory();
 }
 
 void LocalTemporaryDirectoryFromAbsolutePath::createDirectory() {
-    bool ok = _recursiveMode == RecursiveMode::Recursive ? std::filesystem::create_directories(_inputPath)
-                                                         : std::filesystem::create_directory(_inputPath);
-    if (!ok) {
+    if (const auto ok = _recursiveMode == RecursiveMode::Recursive ? std::filesystem::create_directories(_inputPath)
+                                                                   : std::filesystem::create_directory(_inputPath);
+        !ok) {
         throw std::runtime_error("Failed to create local temporary directory");
     }
 

--- a/test/test_utility/localtemporarydirectory.h
+++ b/test/test_utility/localtemporarydirectory.h
@@ -23,17 +23,40 @@
 
 namespace KDC {
 
-class LocalTemporaryDirectory {
+class AbstractLocalTemporaryDirectory {
     public:
-        explicit LocalTemporaryDirectory(const std::string &testType = "undef", const SyncPath &destinationPath = {});
-        ~LocalTemporaryDirectory();
+        explicit AbstractLocalTemporaryDirectory(const SyncPath &inputPath = {});
+        ~AbstractLocalTemporaryDirectory();
 
         [[nodiscard]] const std::filesystem::path &path() const { return _path; }
         [[nodiscard]] const NodeId &id() const { return _id; }
 
-    private:
+    protected:
+        SyncPath _inputPath;
+
         std::filesystem::path _path;
         NodeId _id;
+
+    private:
+        virtual void createDirectory() = 0;
+};
+
+class LocalTemporaryDirectory : public AbstractLocalTemporaryDirectory {
+    public:
+        explicit LocalTemporaryDirectory(const std::string &testType = "undef", const SyncPath &destinationPath = {});
+
+    private:
+        virtual void createDirectory();
+
+        std::string _testType;
+};
+
+class LocalTemporaryDirectoryFromAbsolutePath : public AbstractLocalTemporaryDirectory {
+    public:
+        explicit LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath);
+
+    private:
+        void createDirectory() override;
 };
 
 } // namespace KDC

--- a/test/test_utility/localtemporarydirectory.h
+++ b/test/test_utility/localtemporarydirectory.h
@@ -46,7 +46,7 @@ class LocalTemporaryDirectory : public AbstractLocalTemporaryDirectory {
         explicit LocalTemporaryDirectory(const std::string &testType = "undef", const SyncPath &destinationPath = {});
 
     private:
-        virtual void createDirectory();
+        void createDirectory() override;
 
         std::string _testType;
 };

--- a/test/test_utility/localtemporarydirectory.h
+++ b/test/test_utility/localtemporarydirectory.h
@@ -53,10 +53,17 @@ class LocalTemporaryDirectory : public AbstractLocalTemporaryDirectory {
 
 class LocalTemporaryDirectoryFromAbsolutePath : public AbstractLocalTemporaryDirectory {
     public:
-        explicit LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath);
+        enum class RecursiveMode {
+            NonRecursive,
+            Recursive
+        };
+        explicit LocalTemporaryDirectoryFromAbsolutePath(const SyncPath &absolutePath,
+                                                         RecursiveMode recursiveMode = RecursiveMode::NonRecursive);
 
     private:
         void createDirectory() override;
+
+        RecursiveMode _recursiveMode{RecursiveMode::NonRecursive};
 };
 
 } // namespace KDC


### PR DESCRIPTION
This PR adapts the sync setup flow so that the client no longer sends the desired path to the server.

Commits:
- feat: client does not send desired path anymore
- feat: implement utility function to get home directory
- feat: adapt call in serverRequests
- test: update tests for findGoodPathForNewSync
- test: generate unit tests for isPathValidForNewSync with IA