### PR TITLE
chore: add Qt 6.11.1 support and bump client version

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -148,8 +148,13 @@ class KDriveDesktop(ConanFile):
         """
         self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True, options={"shared": True})
         # From local recipe, using the qt online installer.
-        # Qt 6.8.3 for Linux ARM, Qt 6.5.3 for other platforms
-        qt_version = "6.8.3" if self.settings.os == "Linux" and str(self.settings.arch).startswith("arm") else "6.11.1"
+        # Qt 6.8.3 for Linux ARM, Qt 6.11.1 for Windows, Qt 6.2.3 for other platforms
+        if self.settings.os == "Linux" and str(self.settings.arch).startswith("arm"):
+            qt_version = "6.8.3"
+        elif self.settings.os == "Windows":
+            qt_version = "6.11.1"
+        else:
+            qt_version = "6.2.3"
         self.requires(f"qt/{qt_version}")
         self.requires("xxhash/0.8.2") # From local recipe
         self.requires("sqlite3/3.53.0", options={

--- a/conanfile.py
+++ b/conanfile.py
@@ -149,7 +149,7 @@ class KDriveDesktop(ConanFile):
         self.requires("zlib/[>=1.2.11 <2]", transitive_headers=True, options={"shared": True})
         # From local recipe, using the qt online installer.
         # Qt 6.8.3 for Linux ARM, Qt 6.5.3 for other platforms
-        qt_version = "6.8.3" if self.settings.os == "Linux" and str(self.settings.arch).startswith("arm") else "6.2.3"
+        qt_version = "6.8.3" if self.settings.os == "Linux" and str(self.settings.arch).startswith("arm") else "6.11.1"
         self.requires(f"qt/{qt_version}")
         self.requires("xxhash/0.8.2") # From local recipe
         self.requires("sqlite3/3.53.0", options={

--- a/infomaniak-build-tools/conan/recipes/qt/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/qt/all/conanfile.py
@@ -498,7 +498,8 @@ class QtConan(ConanFile):
             )
 
 
-        for folder in ("doc", "modules"):
+        # Save space by removing not needed folder (/!\ modules folder is needed by <os>deployqt from at least Qt 6.11.1)
+        for folder in ("doc"):
             rmdir(self, pjoin(self.package_folder, folder))
 
 

--- a/infomaniak-build-tools/conan/recipes/qt/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/qt/all/conanfile.py
@@ -163,7 +163,7 @@ class QtConan(ConanFile):
             return "win64_mingw" if compiler == "gcc" else "win64_msvc2019_64"
 
         # Qt 6.8.3+ and 6.10.1+ supports both MinGW and MSVC 2022 (2019 is no longer compatible)
-        elif self.version in ("6.8.3", "6.10.1"):
+        elif self.version in ("6.8.3", "6.10.1", "6.11.1"):
             return "win64_mingw" if compiler == "gcc" else "win64_msvc2022_64"
         else:
             return "win64_msvc2019_64"  # May fail, if an error occurs, verify with a manual run of the Qt Online Installer.
@@ -184,7 +184,7 @@ class QtConan(ConanFile):
             f"qt.qt{major}.{compact}.addons.qtpositioning"
         ]
 
-        if version in ("6.8.3", "6.10.1"):
+        if version in ("6.8.3", "6.10.1", "6.11.1"):
             modules.append(f"qt.qt{major}.{compact}.addons.qt5compat")
         else:
             modules.append(f"qt.qt{major}.{compact}.qt5compat")
@@ -458,7 +458,7 @@ class QtConan(ConanFile):
             # Determine Windows subfolder based on compiler and version
             if self.version == "6.2.3":
                 return "msvc2019_64"
-            elif self.version in ["6.8.3", "6.10.1"]:
+            elif self.version in ["6.8.3", "6.10.1", "6.11.1"]:
                 if str(self.settings.compiler) == "gcc":  # MinGW
                     return "mingw_64"
                 else:  # MSVC 2022

--- a/infomaniak-build-tools/conan/recipes/qt/config.yml
+++ b/infomaniak-build-tools/conan/recipes/qt/config.yml
@@ -11,3 +11,5 @@ versions:
     folder: all
   "6.10.1":
     folder: all
+  "6.11.1":
+    folder: all

--- a/infomaniak-build-tools/conan/recipes/sentry/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/sentry/all/conanfile.py
@@ -28,7 +28,7 @@ class SentryNativeConan(ConanFile):
 
     options = {
         "shared": [True, False],
-        "qt_version": ["6.2.3", "6.5.3", "6.8.3"],
+        "qt_version": ["6.2.3", "6.5.3", "6.8.3", "6.11.1"],
     }
     default_options = {"shared": True, "qt_version": "6.2.3"}
 


### PR DESCRIPTION
Add support for Qt 6.11.1 in Conan build scripts, configuration, and SentryNativeConan options. Update Windows platform and submodule logic for the new Qt version. Bump kDrive client .NET assembly version to 3.8.6.1.