### PR TITLE
fix(Download): remove hidden flag before copying tmp file

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -518,7 +518,7 @@ class HiddenStatusHolder {
             }
         }
 
-        bool operator==(const HiddenStatusHolder &other) const = delete;
+        HiddenStatusHolder &operator=(const HiddenStatusHolder &other) = delete;
 
     private:
         SyncPath _path;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -499,12 +499,14 @@ bool DownloadJob::removeTmpFile() {
 namespace {
 class HiddenStatusHolder {
     public:
-        HiddenStatusHolder(const SyncPath &path) :
+        HiddenStatusHolder(const HiddenStatusHolder &) = delete;
+        explicit HiddenStatusHolder(const SyncPath &path) :
             _path(path) {
             bool isHidden = false;
-            auto ioError = IoError::Unknown;
-            if (!IoHelper::checkIfIsHiddenFile(_path, false, isHidden, ioError) || ioError != IoError::Success)
+            if (auto ioError = IoError::Unknown;
+                !IoHelper::checkIfIsHiddenFile(_path, false, isHidden, ioError) || ioError != IoError::Success) {
                 return; // This is best effort
+            }
             if (isHidden) {
                 IoHelper::setFileHidden(_path, false);
                 _isActive = true;
@@ -515,6 +517,8 @@ class HiddenStatusHolder {
                 IoHelper::setFileHidden(_path, true);
             }
         }
+
+        bool operator==(const HiddenStatusHolder &other) const = delete;
 
     private:
         SyncPath _path;

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -495,6 +495,8 @@ bool DownloadJob::removeTmpFile() {
     return true;
 }
 
+#if defined(KD_WINDOWS)
+namespace {
 class HiddenStatusHolder {
     public:
         HiddenStatusHolder(const SyncPath &path) :
@@ -518,6 +520,8 @@ class HiddenStatusHolder {
         SyncPath _path;
         bool _isActive{false};
 };
+} // namespace
+#endif
 
 ExitInfo DownloadJob::moveTmpFile() {
     // Move downloaded file from tmp directory to sync directory

--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -384,8 +384,8 @@ ExitInfo DownloadJob::createLink(const std::string &mimeType, const std::string 
 
         if (!CommonUtility::isNTFS(_fileDownloadInfo.localpath)) {
             // Junctions are supported only on NTFS systems
-            LOGW_WARN(_logger,
-                      L"Filesystem is not NTFS, junctions are not supported: " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
+            LOGW_WARN(_logger, L"Filesystem is not NTFS, junctions are not supported: "
+                                       << Utility::formatSyncPath(_fileDownloadInfo.localpath));
             return {ExitCode::SystemError, ExitCause::FileSystemNotSupported};
         }
 
@@ -495,9 +495,34 @@ bool DownloadJob::removeTmpFile() {
     return true;
 }
 
+class HiddenStatusHolder {
+    public:
+        HiddenStatusHolder(const SyncPath &path) :
+            _path(path) {
+            bool isHidden = false;
+            auto ioError = IoError::Unknown;
+            if (!IoHelper::checkIfIsHiddenFile(_path, false, isHidden, ioError) || ioError != IoError::Success)
+                return; // This is best effort
+            if (isHidden) {
+                IoHelper::setFileHidden(_path, false);
+                _isActive = true;
+            }
+        }
+        ~HiddenStatusHolder() {
+            if (_isActive) {
+                IoHelper::setFileHidden(_path, true);
+            }
+        }
+
+    private:
+        SyncPath _path;
+        bool _isActive{false};
+};
+
 ExitInfo DownloadJob::moveTmpFile() {
     // Move downloaded file from tmp directory to sync directory
 #if defined(KD_WINDOWS)
+    HiddenStatusHolder hiddenStatusHolder(_fileDownloadInfo.localpath);
     bool retry = true;
     int counter = 50;
     while (retry) {

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -483,6 +483,24 @@ void TestNetworkJobs::testDownload() {
                             DownloadJob::DateTimePolicy::ApplyDateTime);
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.runSynchronously().code());
         }
+
+        // Download again but local file is now hidden
+        IoHelper::setFileHidden(localDestFilePath, true);
+        {
+            modificationTimeIn += std::chrono::minutes(1);
+            DownloadJob job(nullptr, _cacheDirectory,
+                            DownloadJob::FileDownloadInfo{_driveDbId, testFileRemoteId, localDestFilePath, 0,
+                                                          creationTimeIn.count(), modificationTimeIn.count(), false},
+                            DownloadJob::DateTimePolicy::ApplyDateTime);
+            CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.runSynchronously().code());
+
+            // Check that the file is still hidden
+            bool isHidden = false;
+            IoError ioError = IoError::Unknown;
+            CPPUNIT_ASSERT(IoHelper::checkIfIsHiddenFile(localDestFilePath, isHidden, ioError));
+            CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+            CPPUNIT_ASSERT(isHidden);
+        }
     }
 
     // Cross Device Link
@@ -791,7 +809,7 @@ void TestNetworkJobs::testDownload() {
 void TestNetworkJobs::testDownloadHasEnoughSpace() {
     if (!testhelpers::isRunningOnCI() || !testhelpers::isExtendedTest(false)) return;
 
-    // Only run on CI because it requires a small partition to be set up)
+    // Only run on CI because it requires a small partition to be set up
     const SyncPath smallPartitionPath = testhelpers::TestVariables().local8MoPartitionPath;
     if (smallPartitionPath.empty()) return;
 

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -484,6 +484,7 @@ void TestNetworkJobs::testDownload() {
             CPPUNIT_ASSERT_EQUAL(ExitCode::Ok, job.runSynchronously().code());
         }
 
+#if defined(KD_WINDOWS)
         // Download again but local file is now hidden
         IoHelper::setFileHidden(localDestFilePath, true);
         {
@@ -501,6 +502,7 @@ void TestNetworkJobs::testDownload() {
             CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
             CPPUNIT_ASSERT(isHidden);
         }
+#endif
     }
 
     // Cross Device Link


### PR DESCRIPTION
## Problem

On Windows, editing a hidden file could fail because the temporary downloaded file retained the hidden attribute. When copying the temp file to its destination, the hidden flag was preserved, causing issues with subsequent operations on the file.

## Solution

Remove the hidden attribute from the temporary file before copying it to the final location in DownloadJob.\n\n## Changes

- **src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp**
  - Remove the hidden flag from the temp file before copying
  - Keep the original file's hidden attribute on the destination
- **test/libsyncengine/jobs/network/testnetworkjobs.cpp**
  - Add unit test to verify hidden file handling during download