### PR TITLE
chore(logging): Surrounds paths with quotes in logging messages

### DIFF
--- a/src/gui/parametersdialog.cpp
+++ b/src/gui/parametersdialog.cpp
@@ -368,6 +368,7 @@ QString ParametersDialog::getAppErrorText(const QString &fctCode, const ExitCode
         case ExitCode::OperationCanceled:
         case ExitCode::InvalidOperation:
         case ExitCode::UpdateFailed:
+        case ExitCode::TooManyDeleteOperations:
             break;
         case ExitCode::EnumEnd: {
             assert(false && "Invalid enum value in switch statement.");
@@ -590,6 +591,7 @@ QString ParametersDialog::getSyncPalErrorText(const QString &fctCode, const Exit
         case ExitCode::UpdateRequired:
         case ExitCode::LogUploadFailed:
         case ExitCode::UpdateFailed:
+        case ExitCode::TooManyDeleteOperations:
             break;
         case ExitCode::EnumEnd: {
             assert(false && "Invalid enum value in switch statement.");

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -313,7 +313,8 @@ SyncDb::SyncDb(const std::string &dbPath, const std::string &targetNodeId) :
         throw std::runtime_error("Cannot open DB!");
     }
 
-    LOG_INFO(_logger, "SyncDb initialization done: dbPath=" << dbPath << " targetNodeId=" << targetNodeId);
+    LOGW_INFO(_logger, L"SyncDb initialization done DB " << Utility::formatSyncPath(dbPath) << L" targetNodeId="
+                                                         << CommonUtility::s2ws(targetNodeId));
 }
 
 bool SyncDb::create(bool &retry) {

--- a/src/libsyncengine/db/syncdb.cpp
+++ b/src/libsyncengine/db/syncdb.cpp
@@ -313,8 +313,8 @@ SyncDb::SyncDb(const std::string &dbPath, const std::string &targetNodeId) :
         throw std::runtime_error("Cannot open DB!");
     }
 
-    LOGW_INFO(_logger, L"SyncDb initialization done DB " << Utility::formatSyncPath(dbPath) << L" targetNodeId="
-                                                         << CommonUtility::s2ws(targetNodeId));
+    LOGW_INFO(_logger, L"SyncDb initialization done with DB " << Utility::formatSyncPath(dbPath) << L" targetNodeId="
+                                                              << CommonUtility::s2ws(targetNodeId));
 }
 
 bool SyncDb::create(bool &retry) {

--- a/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/folderwatcher_mac.cpp
@@ -67,8 +67,8 @@ static void callback([[maybe_unused]] ConstFSEventStreamRef streamRef, void *cli
         }
 
         if (ParametersCache::isExtendedLogEnabled()) {
-            LOGW_DEBUG(fw->logger(),
-                       L"Operation " << opType << L" detected on item " << CommonUtility::s2ws(pathPtr ? pathPtr : pathBuf));
+            const SyncPath itemPath = CommonUtility::s2ws(pathPtr ? pathPtr : pathBuf);
+            LOGW_DEBUG(fw->logger(), L"Operation " << opType << L" detected on item with " << Utility::formatSyncPath(itemPath));
         }
 
         // TODO : to be tested to get inode (https://github.com/fsevents/fsevents/pull/360/files)


### PR DESCRIPTION
These changes also comprise the fix of a compilation warning about a missing `ExitCode` enum used in two long `switch` statements.