### PR TITLE
fix(linux): make OAuth callback reliable when single-application detection fails

### DIFF
--- a/src/libcommonserver/utility/utility_linux.cpp
+++ b/src/libcommonserver/utility/utility_linux.cpp
@@ -345,6 +345,9 @@ bool Utility::registerLoginRedirection() {
     } else {
         execPath = CommonUtility::applicationFilePath();
     }
+
+    LOGW_INFO(logger(), L"Registering login URL scheme in " << Utility::formatSyncPath(urlSchemeFilePath) << L" with executable "
+                                                            << Utility::formatSyncPath(execPath));
     urlSchemeFile << "[Desktop Entry]" << '\n';
     urlSchemeFile << "Name=" << APPLICATION_EXECUTABLE << '\n';
     urlSchemeFile << "Icon=" << applicationIconName << '\n';
@@ -370,6 +373,8 @@ bool Utility::registerLoginRedirection() {
                     std::vector<std::string>{"default", (std::string(APPLICATION_EXECUTABLE) + ".desktop"), mimeType})) {
         LOGW_WARN(logger(), L"Failed to register URL scheme with xdg-mime");
         res = false;
+    } else {
+        LOG_INFO(logger(), "Registered URL scheme " << mimeType << " with xdg-mime");
     }
 
     return res;

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -249,6 +249,9 @@ void AppServer::init() {
     connect(this, &QtSingleApplication::messageReceived, this, &AppServer::onMessageReceivedFromAnotherProcess);
 
 #if defined(KD_LINUX)
+    // This adds a bit of Qt to the server, which is deliberate: it temporarily makes the OAuth callback reliable, and the
+    // planned removal of QtSingleApplication will de facto remove this small Qt addition along with it.
+    // The removal of QtSingleApplication will be done before Qt is fully removed from the server.
     _fallbackLocalPeer = std::make_unique<SharedTools::QtLocalPeer>(
             this, applicationId() + QLatin1Char('-') + QString::number(QCoreApplication::applicationPid()));
     (void) connect(_fallbackLocalPeer.get(), &SharedTools::QtLocalPeer::messageReceived, this,

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -17,6 +17,9 @@
  */
 
 #include "appserver.h"
+#if defined(KD_LINUX)
+#include "qtlocalpeer.h"
+#endif
 #include "version.h"
 #include "migration/migrationparams.h"
 #include "keychainmanager/keychainmanager.h"
@@ -83,8 +86,13 @@
 #include <iostream>
 #include <fstream>
 #include <filesystem>
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <optional>
 #ifdef Q_OS_UNIX
 #include <sys/resource.h>
+#include <unistd.h>
 #endif
 
 #if defined(KD_WINDOWS)
@@ -123,13 +131,43 @@ static const char optionsC[] =
         "  -v --version         : show the application version.\n"
         "  --settings           : show the Settings window (if the application is running).\n"
         "  --synthesis          : show the Synthesis window (if the application is running).\n";
+
+#if defined(KD_LINUX)
+std::optional<qint64> runningProcessPid(const std::string &processName) {
+    const auto currentPid = static_cast<qint64>(getpid());
+    try {
+        for (const auto &entry: std::filesystem::directory_iterator("/proc")) {
+            if (!entry.is_directory()) continue;
+
+            const std::string pidStr = entry.path().filename().string();
+            if (!std::all_of(pidStr.begin(), pidStr.end(),
+                             [](const unsigned char character) { return std::isdigit(character) != 0; })) {
+                continue;
+            }
+
+            const auto pid = static_cast<qint64>(std::stoll(pidStr));
+            if (pid == currentPid) continue;
+
+            std::ifstream commFile(entry.path() / "comm");
+            std::string currentProcessName;
+            if (commFile >> currentProcessName && currentProcessName == processName) {
+                return pid;
+            }
+        }
+    } catch (const std::exception &e) {
+        LOG_WARN(Log::instance()->getLogger(), "Error while looking for running kDrive process: " << e.what());
+    }
+    return std::nullopt;
 }
+#endif
+} // namespace
 
 static const QString showSynthesisMsg("showSynthesis");
 static const QString showSettingsMsg("showSettings");
 static const QString restartClientMsg("restartClient");
 static const QString authorizationCodeMsg("redirectLogin");
 static const QString separatorMsg("$$$");
+static constexpr std::int32_t singleApplicationMessageTimeoutMs = 5000;
 
 static const QString crashMsg = SharedTools::QtSingleApplication::tr("kDrive application will close due to a fatal error.");
 
@@ -196,12 +234,37 @@ void AppServer::init() {
         LOG_INFO(_logger, "AppServer already running");
         return;
     }
+#if defined(KD_LINUX)
+    if (const auto processPid = runningProcessPid(APPLICATION_EXECUTABLE); processPid.has_value()) {
+        _runningServerPid = *processPid;
+        LOG_INFO(_logger, "AppServer already running with PID " << _runningServerPid);
+        return;
+    }
+#endif
 
     // Cleanup at quit
     connect(this, &QCoreApplication::aboutToQuit, this, &AppServer::onCleanup);
 
     // Setup single application: show the Settings or Synthesis window if the application is running.
     connect(this, &QtSingleApplication::messageReceived, this, &AppServer::onMessageReceivedFromAnotherProcess);
+
+#if defined(KD_LINUX)
+    _fallbackLocalPeer = std::make_unique<SharedTools::QtLocalPeer>(
+            this, applicationId() + QLatin1Char('-') + QString::number(QCoreApplication::applicationPid()));
+    (void) connect(_fallbackLocalPeer.get(), &SharedTools::QtLocalPeer::messageReceived, this,
+                   &AppServer::onMessageReceivedFromAnotherProcess);
+    if (_fallbackLocalPeer->isClient()) {
+        _fallbackLocalPeer.reset();
+    } else {
+        LOG_INFO(_logger, "Started Linux fallback single-application peer");
+    }
+#endif
+
+    if (!Utility::registerLoginRedirection()) {
+        std::string errorMsg = "Failed to register login redirection";
+        LOG_ERROR(_logger, errorMsg);
+        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "Login redirection registration error", errorMsg);
+    }
 
     // Remove the files that keep a record of former crash or kill events
     SignalType signalType = SignalType::None;
@@ -502,12 +565,6 @@ void AppServer::init() {
 
     // Process possible interrupted logs upload
     processInterruptedLogsUpload();
-
-    if (!Utility::registerLoginRedirection()) {
-        std::string errorMsg = "Failed to register login redirection";
-        LOG_ERROR(_logger, errorMsg);
-        KDC::sentry::Handler::captureMessage(KDC::sentry::Level::Error, "Login redirection registration error", errorMsg);
-    }
 
     // Start client
     if (!startClient()) {
@@ -3756,20 +3813,29 @@ void AppServer::clearSyncNodes() {
     }
 }
 
-void AppServer::sendShowSettingsMsg() {
-    sendMessage(showSettingsMsg);
+void AppServer::sendShowSettingsMsg(qint64 pid) {
+    if (!sendMessage(showSettingsMsg, singleApplicationMessageTimeoutMs, pid)) {
+        LOG_WARN(_logger, "Failed to forward show-settings request to the running server");
+    }
 }
 
-void AppServer::sendShowSynthesisMsg() {
-    sendMessage(showSynthesisMsg);
+void AppServer::sendShowSynthesisMsg(qint64 pid) {
+    if (!sendMessage(showSynthesisMsg, singleApplicationMessageTimeoutMs, pid)) {
+        LOG_WARN(_logger, "Failed to forward show-synthesis request to the running server");
+    }
 }
 
-void AppServer::sendRestartClientMsg() {
-    sendMessage(restartClientMsg);
+void AppServer::sendRestartClientMsg(qint64 pid) {
+    if (!sendMessage(restartClientMsg, singleApplicationMessageTimeoutMs, pid)) {
+        LOG_WARN(_logger, "Failed to forward restart-client request to the running server");
+    }
 }
 
-void AppServer::sendAuthorizationCode() {
-    sendMessage(authorizationCodeMsg + separatorMsg + _authorizationCodeStr);
+void AppServer::sendAuthorizationCode(qint64 pid) {
+    LOG_INFO(_logger, "Forwarding login authorization callback to the running server");
+    if (!sendMessage(authorizationCodeMsg + separatorMsg + _authorizationCodeStr, singleApplicationMessageTimeoutMs, pid)) {
+        LOG_WARN(_logger, "Failed to forward login authorization callback to the running server");
+    }
 }
 
 void AppServer::showSettings() {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -256,8 +256,8 @@ void AppServer::init() {
             this, applicationId() + QLatin1Char('-') + QString::number(QCoreApplication::applicationPid()));
     (void) connect(_fallbackLocalPeer.get(), &SharedTools::QtLocalPeer::messageReceived, this,
                    &AppServer::onMessageReceivedFromAnotherProcess);
-    if (_fallbackLocalPeer->isClient()) { // Despite its name, isClient() tries to become the local server; true means another
-                                          // peer already owns it.
+    // isClient() starts the fallback server when possible; true means this process is only a client.
+    if (_fallbackLocalPeer->isClient()) {
         _fallbackLocalPeer.reset();
     } else {
         LOG_INFO(_logger, "Started Linux fallback single-application peer");

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -256,7 +256,8 @@ void AppServer::init() {
             this, applicationId() + QLatin1Char('-') + QString::number(QCoreApplication::applicationPid()));
     (void) connect(_fallbackLocalPeer.get(), &SharedTools::QtLocalPeer::messageReceived, this,
                    &AppServer::onMessageReceivedFromAnotherProcess);
-    if (_fallbackLocalPeer->isClient()) {
+    if (_fallbackLocalPeer->isClient()) { // Despite its name, isClient() tries to become the local server; true means another
+                                          // peer already owns it.
         _fallbackLocalPeer.reset();
     } else {
         LOG_INFO(_logger, "Started Linux fallback single-application peer");

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -42,6 +42,7 @@
 #include <QApplication>
 #include <QElapsedTimer>
 #include <QPointer>
+#include <memory>
 #include <QProcess>
 #include <QQueue>
 #include <QTimer>
@@ -128,14 +129,15 @@ class AppServer : public SharedTools::QtSingleApplication {
         inline bool synthesisAsked() { return _synthesisAsked; }
         inline bool authorizationCodeReceived() { return !_authorizationCodeStr.isEmpty(); }
         inline bool clearKeychainKeysAsked() { return _clearKeychainKeysAsked; }
+        inline qint64 runningServerPid() const { return _runningServerPid; }
 
         void showHelp();
         void showVersion();
         void clearSyncNodes();
-        void sendShowSettingsMsg();
-        void sendShowSynthesisMsg();
-        void sendRestartClientMsg();
-        void sendAuthorizationCode();
+        void sendShowSettingsMsg(qint64 pid = -1);
+        void sendShowSynthesisMsg(qint64 pid = -1);
+        void sendRestartClientMsg(qint64 pid = -1);
+        void sendAuthorizationCode(qint64 pid = -1);
         void handleClientDisconnection() { onClientDisconnectedReceived(); }
 
         void clearKeychainKeys();
@@ -271,6 +273,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         bool _settingsAsked{false};
         bool _synthesisAsked{false};
         QString _authorizationCodeStr;
+        qint64 _runningServerPid{-1};
         bool _clearKeychainKeysAsked{false};
         bool _vfsInstallationDone{false};
         bool _vfsActivationDone{false};
@@ -279,6 +282,9 @@ class AppServer : public SharedTools::QtSingleApplication {
         bool _noUpdate{false};
         bool _appStartPTraceStopped{false};
         bool _clientManuallyRestarted{false};
+#if defined(KD_LINUX)
+        std::unique_ptr<SharedTools::QtLocalPeer> _fallbackLocalPeer;
+#endif
         QElapsedTimer _startedAt;
         QTimer _loadSyncsProgressTimer;
         QTimer _sendFilesNotificationsTimer;

--- a/src/server/mainserver.cpp
+++ b/src/server/mainserver.cpp
@@ -39,7 +39,6 @@
 #include <sys/time.h>
 #include <sys/resource.h>
 #include <unistd.h>
-#include <algorithm>
 #endif
 
 #include <log4cplus/loggingmacros.h>
@@ -134,36 +133,6 @@ void increaseFileSystemCapacity() {
 }
 #endif
 
-#if defined(KD_LINUX)
-bool isProcessRunning(const std::string &processName) {
-    pid_t currentPid = getpid();
-    try {
-        for (const auto &entry: std::filesystem::directory_iterator("/proc")) {
-            if (!entry.is_directory()) continue;
-
-            std::string pidStr = entry.path().filename().string();
-            // Check that the folder is a numeric value
-            if (!std::all_of(pidStr.begin(), pidStr.end(), ::isdigit)) continue;
-
-            // Ignore current process
-            pid_t pid = std::stoi(pidStr);
-            if (pid == currentPid) continue;
-
-            // Read process name in /proc/[PID]/comm
-            std::ifstream commFile(entry.path() / "comm");
-            std::string currentProcessName;
-            if (commFile >> currentProcessName && currentProcessName == processName) {
-                std::cout << "Process " << processName << " is already running!" << std::endl;
-                return true;
-            }
-        }
-    } catch (const std::exception &e) {
-        std::cerr << "Error: " << e.what() << std::endl;
-    }
-    return false;
-}
-#endif
-
 std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
     if (appPtr->helpAsked()) {
         appPtr->showHelp();
@@ -205,13 +174,8 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
 #endif
 
     // If the application is already running, notify it.
-    if (appPtr->isRunning()
-#if defined(KD_LINUX)
-        // On Linux, we might fail to detect an already running kDrive process using only QSingleApplication. Therefor, check also
-        // with a Linux dedicated method.
-        || isProcessRunning(APPLICATION_EXECUTABLE)
-#endif
-    ) {
+    const qint64 runningServerPid = appPtr->runningServerPid();
+    if (appPtr->isRunning() || runningServerPid != -1) {
         std::cout << "Server already running" << std::endl;
 
         if (appPtr->isSessionRestored()) {
@@ -221,22 +185,22 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
         }
 
         if (appPtr->settingsAsked()) {
-            appPtr->sendShowSettingsMsg();
+            appPtr->sendShowSettingsMsg(runningServerPid);
             return 0;
         }
 
         if (appPtr->synthesisAsked()) {
-            appPtr->sendShowSynthesisMsg();
+            appPtr->sendShowSynthesisMsg(runningServerPid);
             return 0;
         }
 
         if (appPtr->authorizationCodeReceived()) {
-            appPtr->sendAuthorizationCode();
+            appPtr->sendAuthorizationCode(runningServerPid);
             return 0;
         }
 
         std::cout << "Asking the running server to start a newClient." << std::endl;
-        appPtr->sendRestartClientMsg();
+        appPtr->sendRestartClientMsg(runningServerPid);
         return 0;
     }
 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Sur Linux, le mécanisme `QtSingleApplication` peut échouer à détecter qu'une instance du serveur est déjà en cours d'exécution, ce qui empêche la transmission du callback OAuth à la bonne instance. Ce correctif introduit une double détection — via `/proc` et un pair `QtLocalPeer` de secours — et déplace l'enregistrement du schéma URL plus tôt dans le cycle de démarrage pour garantir sa disponibilité avant toute connexion OAuth.

## Changements
- Déplacement de la fonction `isProcessRunning` de `mainserver.cpp` vers `appserver.cpp` sous le nom `runningProcessPid`, retournant désormais un `std::optional<qint64>` avec le PID du processus trouvé plutôt qu'un booléen.
- Ajout d'un `QtLocalPeer` de secours (identifié par `applicationId() + '-' + PID`) sur Linux pour recevoir les messages inter-processus quand `QtSingleApplication` ne suffit pas ; le pair est libéré immédiatement s'il se comporte comme un client.
- Les méthodes `sendShowSettingsMsg`, `sendShowSynthesisMsg`, `sendRestartClientMsg` et `sendAuthorizationCode` acceptent maintenant un PID optionnel pour cibler explicitement l'instance serveur en cours d'exécution.
- Déplacement de l'appel à `Utility::registerLoginRedirection()` depuis la fin de `AppServer::init()` vers le début, juste après la mise en place des pairs de communication.
- Ajout d'une constante `singleApplicationMessageTimeoutMs` (5000 ms) appliquée uniformément à tous les appels `sendMessage`.
- Ajout de logs informatifs dans `utility_linux.cpp` pour confirmer le chemin du fichier de schéma URL, l'exécutable cible et le résultat de l'enregistrement `xdg-mime`.

## Détails techniques
Le pair `QtLocalPeer` de secours utilise un ID composé de `applicationId()` et du PID courant pour éviter toute collision avec le pair principal de `QtSingleApplication`. Cette dépendance Qt ajoutée au serveur est intentionnelle et temporaire : la suppression prévue de `QtSingleApplication` emportera ce pair de secours avec elle.

</details>

---

## Summary
On Linux, `QtSingleApplication` can fail to detect an already-running server instance, which causes the OAuth authorization callback to never reach the correct process. This fix adds a dual detection strategy - scanning `/proc` for the process PID and a `QtLocalPeer` fallback peer - and moves URL scheme registration earlier in startup so it is in place before any OAuth flow begins.

## Changes
- Moved `isProcessRunning` from `mainserver.cpp` into `appserver.cpp`, renamed to `runningProcessPid`, and changed return type to `std::optional<qint64>` to expose the actual PID.
- Added a Linux-only `QtLocalPeer` fallback (keyed by `applicationId() + '-' + PID`) that receives inter-process messages when `QtSingleApplication` alone is insufficient; the peer is discarded if it behaves as a client.
- Updated `sendShowSettingsMsg`, `sendShowSynthesisMsg`, `sendRestartClientMsg`, and `sendAuthorizationCode` to accept an optional `pid` argument so messages are directed to the known running server PID.
- Moved `Utility::registerLoginRedirection()` from the end of `AppServer::init()` to just after IPC peers are set up, ensuring the URL scheme is registered before the first OAuth callback can arrive.
- Added `singleApplicationMessageTimeoutMs` constant (5000 ms) applied consistently to all `sendMessage` calls, replacing previously unbounded blocking calls.
- Added informational log lines in `utility_linux.cpp` to confirm the URL scheme file path, target executable, and `xdg-mime` registration result.

## Technical Details
The fallback `QtLocalPeer` uses an ID of `applicationId() + '-' + PID` to avoid colliding with the main `QtSingleApplication` peer. If a peer with that ID already exists (`isClient()` returns true), the fallback is immediately released. The Qt dependency added to the server is intentional and temporary: the planned removal of `QtSingleApplication` will remove this fallback peer along with it.

----
Depends on #1984