### PR TITLE
fix: UpdateTreeWorker issue

### DIFF
--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1831,7 +1831,7 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
         std::shared_ptr<UpdateTree> updateTree = targetUpdateTree(syncOp);
         updateTree->insertNode(node);
 
-        if (!newCorrespondingParentNode->insertChildren(node)) {
+        if (!newCorrespondingParentNode->insertChild(node)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                << Utility::formatSyncName(node->name()) << L" parent node "
                                                << Utility::formatSyncName(newCorrespondingParentNode->name()));
@@ -2010,11 +2010,11 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
     // information in this structure.
     if (!syncOp->omit()) {
         auto prevParent = correspondingNode->parentNode();
-        prevParent->deleteChildren(correspondingNode);
+        prevParent->deleteChild(correspondingNode);
 
         correspondingNode->setName(syncOp->newName());
 
-        if (!parentNode->insertChildren(correspondingNode)) {
+        if (!parentNode->insertChild(correspondingNode)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                << Utility::formatSyncName(correspondingNode->name()) << L" parent node "
                                                << Utility::formatSyncName(parentNode->name()));

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -1832,7 +1832,7 @@ ExitInfo ExecutorWorker::propagateCreateToDbAndTree(SyncOpPtr syncOp, const Node
         updateTree->insertNode(node);
 
         if (!newCorrespondingParentNode->insertChild(node)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                                << Utility::formatSyncName(node->name()) << L" parent node "
                                                << Utility::formatSyncName(newCorrespondingParentNode->name()));
             return ExitCode::DataError;
@@ -2015,9 +2015,9 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
         correspondingNode->setName(syncOp->newName());
 
         if (!parentNode->insertChild(correspondingNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
-                                               << Utility::formatSyncName(correspondingNode->name()) << L" parent node "
-                                               << Utility::formatSyncName(parentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(correspondingNode->name())
+                                                                            << L" parent node "
+                                                                            << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
     }

--- a/src/libsyncengine/propagation/executor/executorworker.cpp
+++ b/src/libsyncengine/propagation/executor/executorworker.cpp
@@ -2010,7 +2010,7 @@ ExitInfo ExecutorWorker::propagateMoveToDbAndTree(SyncOpPtr syncOp) {
     // information in this structure.
     if (!syncOp->omit()) {
         auto prevParent = correspondingNode->parentNode();
-        prevParent->deleteChild(correspondingNode);
+        (void) prevParent->deleteChild(correspondingNode);
 
         correspondingNode->setName(syncOp->newName());
 

--- a/src/libsyncengine/update_detection/file_system_observer/fsoperationset.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/fsoperationset.cpp
@@ -34,17 +34,18 @@ bool FSOperationSet::getOp(UniqueId id, FSOpPtr &opPtr) const {
     return false;
 }
 
-std::unordered_map<UniqueId, FSOpPtr> FSOperationSet::getAllOps() const {
+OpMap FSOperationSet::getAllOps() const {
     const std::scoped_lock lock(_mutex);
     return _ops;
 }
 
-std::unordered_set<UniqueId> FSOperationSet::getOpsByType(const OperationType type) const {
+OpSet FSOperationSet::getOpsByType(const OperationType type) const {
     const std::scoped_lock lock(_mutex);
+    OpSet ret(CmpOp(const_cast<OpMap &>(_ops)));
     if (auto it = _opsByType.find(type); it != _opsByType.end()) {
-        return it->second;
+        ret.insert(it->second.begin(), it->second.end());
     }
-    return std::unordered_set<UniqueId>();
+    return ret;
 }
 
 std::unordered_set<UniqueId> FSOperationSet::getOpsByNodeId(const NodeId &nodeId) const {

--- a/src/libsyncengine/update_detection/file_system_observer/fsoperationset.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/fsoperationset.cpp
@@ -41,7 +41,7 @@ OpMap FSOperationSet::getAllOps() const {
 
 OpSet FSOperationSet::getOpsByType(const OperationType type) const {
     const std::scoped_lock lock(_mutex);
-    OpSet ret(CmpOp(const_cast<OpMap &>(_ops)));
+    OpSet ret((CmpOp(_ops)));
     if (auto it = _opsByType.find(type); it != _opsByType.end()) {
         ret.insert(it->second.begin(), it->second.end());
     }

--- a/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
+++ b/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
@@ -21,6 +21,7 @@
 #include "syncpal/sharedobject.h"
 #include "fsoperation.h"
 #include "libcommon/utility/types.h"
+#include "libcommonserver/utility/utility.h"
 
 #include <mutex>
 #include <unordered_set>
@@ -29,6 +30,39 @@
 namespace KDC {
 
 using FSOpPtr = std::shared_ptr<FSOperation>;
+using OpMap = std::unordered_map<UniqueId, FSOpPtr>;
+
+// Functor for ordering operations by path depth
+class CmpOp {
+    public:
+        explicit CmpOp(OpMap &ops) :
+            _ops(ops) {}
+
+        bool operator()(UniqueId id1, UniqueId id2) const {
+            const auto opIt1 = _ops.get().find(id1);
+            SyncPath path1;
+            if (opIt1 != _ops.get().end()) {
+                path1 = opIt1->second->path();
+            }
+
+            const auto opIt2 = _ops.get().find(id2);
+            SyncPath path2;
+            if (opIt2 != _ops.get().end()) {
+                path2 = opIt2->second->path();
+            }
+
+            const auto pathDepth1 = Utility::pathDepth(path1);
+            const auto pathDepth2 = Utility::pathDepth(path2);
+
+            return pathDepth1 == pathDepth2 ? id1 < id2 : pathDepth1 < pathDepth2;
+        }
+
+    private:
+        std::reference_wrapper<OpMap> _ops;
+};
+
+// Set of operations ordered by path depth
+using OpSet = std::set<UniqueId, CmpOp>;
 
 class FSOperationSet : public SharedObject {
     public:
@@ -44,8 +78,8 @@ class FSOperationSet : public SharedObject {
         FSOperationSet &operator=(FSOperationSet &other);
 
         bool getOp(UniqueId id, FSOpPtr &opPtr) const;
-        std::unordered_map<UniqueId, FSOpPtr> getAllOps() const;
-        std::unordered_set<UniqueId> getOpsByType(const OperationType type) const;
+        OpMap getAllOps() const;
+        OpSet getOpsByType(const OperationType type) const;
         std::unordered_set<UniqueId> getOpsByNodeId(const NodeId &nodeId) const;
 
         uint64_t nbOps() const;
@@ -60,7 +94,7 @@ class FSOperationSet : public SharedObject {
         ReplicaSide side() const;
 
     private:
-        std::unordered_map<UniqueId, FSOpPtr> _ops;
+        OpMap _ops;
         std::unordered_map<OperationType, std::unordered_set<UniqueId>> _opsByType;
         std::unordered_map<NodeId, std::unordered_set<UniqueId>> _opsByNodeId;
         ReplicaSide _side = ReplicaSide::Unknown;

--- a/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
+++ b/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
@@ -33,6 +33,7 @@ using FSOpPtr = std::shared_ptr<FSOperation>;
 using OpMap = std::unordered_map<UniqueId, FSOpPtr>;
 
 // Functor for ordering operations by path depth
+// NB: The ops map passed as a parameter must not be modified
 class CmpOp {
     public:
         explicit CmpOp(const OpMap &ops) :

--- a/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
+++ b/src/libsyncengine/update_detection/file_system_observer/fsoperationset.h
@@ -35,10 +35,10 @@ using OpMap = std::unordered_map<UniqueId, FSOpPtr>;
 // Functor for ordering operations by path depth
 class CmpOp {
     public:
-        explicit CmpOp(OpMap &ops) :
+        explicit CmpOp(const OpMap &ops) :
             _ops(ops) {}
 
-        bool operator()(UniqueId id1, UniqueId id2) const {
+        bool operator()(const UniqueId id1, const UniqueId id2) const {
             const auto opIt1 = _ops.get().find(id1);
             SyncPath path1;
             if (opIt1 != _ops.get().end()) {
@@ -58,7 +58,7 @@ class CmpOp {
         }
 
     private:
-        std::reference_wrapper<OpMap> _ops;
+        std::reference_wrapper<const OpMap> _ops;
 };
 
 // Set of operations ordered by path depth

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -163,7 +163,7 @@ std::shared_ptr<Node> Node::findChildById(const NodeId &nodeId) {
     return nullptr;
 }
 
-bool Node::insertChildren(std::shared_ptr<Node> child) {
+bool Node::insertChild(std::shared_ptr<Node> child) {
     if (!child->id().has_value()) {
         return false;
     }
@@ -196,14 +196,14 @@ bool Node::insertChildren(std::shared_ptr<Node> child) {
     return true;
 }
 
-size_t Node::deleteChildren(std::shared_ptr<Node> child) {
+size_t Node::deleteChild(std::shared_ptr<Node> child) {
     if (!child->id().has_value()) {
         return 0;
     }
-    return deleteChildren(*child->id());
+    return deleteChild(*child->id());
 }
 
-size_t Node::deleteChildren(const NodeId &childId) {
+size_t Node::deleteChild(const NodeId &childId) {
     return _childrenById.erase(childId);
 }
 

--- a/src/libsyncengine/update_detection/update_detector/node.cpp
+++ b/src/libsyncengine/update_detection/update_detector/node.cpp
@@ -173,7 +173,7 @@ bool Node::insertChild(std::shared_ptr<Node> child) {
         while (tmpNode->parentNode() != nullptr) {
             if (child == tmpNode) {
                 assert(false);
-                sentry::Handler::captureMessage(sentry::Level::Warning, "Node::insertChildren", "Child is an ancestor");
+                sentry::Handler::captureMessage(sentry::Level::Warning, "Node::insertChild", "Child is an ancestor");
                 return false;
             }
 

--- a/src/libsyncengine/update_detection/update_detector/node.h
+++ b/src/libsyncengine/update_detection/update_detector/node.h
@@ -134,9 +134,9 @@ class Node : public std::enable_shared_from_this<Node> {
         std::shared_ptr<Node> findChild(const SyncName &name, const NodeId &nodeId = "");
 
         std::shared_ptr<Node> findChildById(const NodeId &nodeId);
-        [[nodiscard]] bool insertChildren(std::shared_ptr<Node> child);
-        size_t deleteChildren(std::shared_ptr<Node> child);
-        size_t deleteChildren(const NodeId &childId);
+        [[nodiscard]] bool insertChild(std::shared_ptr<Node> child);
+        size_t deleteChild(std::shared_ptr<Node> child);
+        size_t deleteChild(const NodeId &childId);
 
         /**
          * @brief Retrieve the child node based on its name, which is assumed to be normalized. Filter out the nodes with change

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -73,7 +73,7 @@ bool UpdateTree::deleteNode(std::shared_ptr<Node> node, bool deleteNodeLater, in
         node->setStatus(NodeStatus::ToDelete);
     } else {
         // Remove node from tree
-        node->parentNode()->deleteChild(node);
+        (void) node->parentNode()->deleteChild(node);
         _validNodes.erase(*node->id());
     }
 
@@ -196,7 +196,7 @@ bool UpdateTree::updateNodeId(std::shared_ptr<Node> node, const NodeId &newId) {
         return false;
     }
 
-    node->parentNode()->deleteChild(node);
+    (void) node->parentNode()->deleteChild(node);
     node->setId(newId);
 
     if (!node->parentNode()->insertChild(node)) {

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -73,7 +73,7 @@ bool UpdateTree::deleteNode(std::shared_ptr<Node> node, bool deleteNodeLater, in
         node->setStatus(NodeStatus::ToDelete);
     } else {
         // Remove node from tree
-        node->parentNode()->deleteChildren(node);
+        node->parentNode()->deleteChild(node);
         _validNodes.erase(*node->id());
     }
 
@@ -196,10 +196,10 @@ bool UpdateTree::updateNodeId(std::shared_ptr<Node> node, const NodeId &newId) {
         return false;
     }
 
-    node->parentNode()->deleteChildren(node);
+    node->parentNode()->deleteChild(node);
     node->setId(newId);
 
-    if (!node->parentNode()->insertChildren(node)) {
+    if (!node->parentNode()->insertChild(node)) {
         LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::insertChildren: node "
                                                         << Utility::formatSyncName(node->name()) << L" parent node "
                                                         << Utility::formatSyncName(node->parentNode()->name()));

--- a/src/libsyncengine/update_detection/update_detector/updatetree.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetree.cpp
@@ -200,7 +200,7 @@ bool UpdateTree::updateNodeId(std::shared_ptr<Node> node, const NodeId &newId) {
     node->setId(newId);
 
     if (!node->parentNode()->insertChild(node)) {
-        LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::insertChildren: node "
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in Node::insertChild: node "
                                                         << Utility::formatSyncName(node->name()) << L" parent node "
                                                         << Utility::formatSyncName(node->parentNode()->name()));
         return false;

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1461,6 +1461,8 @@ ExitCode UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode
             break;
         }
     }
+
+    return ExitCode::Ok;
 }
 
 ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -175,7 +175,7 @@ ExitCode UpdateTreeWorker::searchForAncestorNode(const SyncPath &nodePath, std::
 ExitCode UpdateTreeWorker::step3DeleteDirectory() {
     auto perfMonitor = sentry::pTraces::scoped::Step3DeleteDirectory(syncDbId());
 
-    const std::unordered_set<UniqueId> deleteOpsIds = _operationSet->getOpsByType(OperationType::Delete);
+    const OpSet deleteOpsIds = _operationSet->getOpsByType(OperationType::Delete);
     for (const auto &deleteOpId: deleteOpsIds) {
         // worker stop or pause
         if (stopAsked()) {
@@ -263,7 +263,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                     return ExitCode::SystemError;
                 }
 
-                if (!parentNode->insertChildren(existingNode)) {
+                if (!parentNode->insertChild(existingNode)) {
                     LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                        << Utility::formatSyncName(existingNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(parentNode->name()));
@@ -290,7 +290,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
 ExitCode UpdateTreeWorker::handleCreateOperationsWithSamePath() {
     _createFileOperationSet.clear();
     FSOpPtrMap createDirectoryOperationSet;
-    std::unordered_set<UniqueId> createOpsIds = _operationSet->getOpsByType(OperationType::Create);
+    const OpSet createOpsIds = _operationSet->getOpsByType(OperationType::Create);
 
     bool isSnapshotRebuildRequired = false;
 
@@ -400,7 +400,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
     const ExitCode exitCode = handleCreateOperationsWithSamePath();
     if (exitCode != ExitCode::Ok) return exitCode; // Rebuild the snapshot.
 
-    std::unordered_set<UniqueId> deleteOpsIds = _operationSet->getOpsByType(OperationType::Delete);
+    const OpSet deleteOpsIds = _operationSet->getOpsByType(OperationType::Delete);
     for (const auto &deleteOpId: deleteOpsIds) {
         // worker stop or pause
         if (stopAsked()) {
@@ -504,7 +504,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
                     _updateTree->previousIdSet()[deleteOp->nodeId()] = op->nodeId();
                 }
 
-                if (!parentNode->insertChildren(newNode)) {
+                if (!parentNode->insertChild(newNode)) {
                     LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                        << Utility::formatSyncName(newNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(parentNode->name()));
@@ -523,7 +523,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
 ExitCode UpdateTreeWorker::step5CreateDirectory() {
     const auto perfMonitor = sentry::pTraces::scoped::Step5CreateDirectory(syncDbId());
 
-    const std::unordered_set<UniqueId> createOpsIds = _operationSet->getOpsByType(OperationType::Create);
+    const OpSet createOpsIds = _operationSet->getOpsByType(OperationType::Create);
     for (const auto &createOpId: createOpsIds) {
         // worker stop or pause
         if (stopAsked()) {
@@ -546,8 +546,8 @@ ExitCode UpdateTreeWorker::step5CreateDirectory() {
 
         // find node by path because it may have been created before
         std::shared_ptr<Node> currentNode;
-        if (const auto exitCode = getOrCreateNodeFromExistingPath(createOp->path(), currentNode); exitCode != ExitCode::Ok) {
-            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromExistingPath");
+        if (const auto exitCode = getOrCreateNodeFromPath(createOp->path(), currentNode); exitCode != ExitCode::Ok) {
+            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromPath");
             return exitCode;
         }
 
@@ -608,9 +608,9 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
 
         // find parentNode by path
         std::shared_ptr<Node> parentNode;
-        if (const auto exitCode = getOrCreateNodeFromExistingPath(operation->path().parent_path(), parentNode);
+        if (const auto exitCode = getOrCreateNodeFromPath(operation->path().parent_path(), parentNode);
             exitCode != ExitCode::Ok) {
-            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromExistingPath");
+            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromPath");
             return exitCode;
         }
 
@@ -652,7 +652,7 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
             return ExitCode::SystemError;
         }
 
-        if (!parentNode->insertChildren(newNode)) {
+        if (!parentNode->insertChild(newNode)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name())
                                                                                << L" parent node "
                                                                                << Utility::formatSyncName(parentNode->name()));
@@ -674,7 +674,7 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
 
 ExitCode UpdateTreeWorker::step7EditFile() {
     auto perfMonitor = sentry::pTraces::scoped::Step7EditFile(syncDbId());
-    std::unordered_set<UniqueId> editOpsIds = _operationSet->getOpsByType(OperationType::Edit);
+    const OpSet editOpsIds = _operationSet->getOpsByType(OperationType::Edit);
     for (const auto &editOpId: editOpsIds) {
         // worker stop or pause
         if (stopAsked()) {
@@ -688,9 +688,8 @@ ExitCode UpdateTreeWorker::step7EditFile() {
         }
         // find parentNode by path because should have been created
         std::shared_ptr<Node> parentNode;
-        if (const auto exitCode = getOrCreateNodeFromExistingPath(editOp->path().parent_path(), parentNode);
-            exitCode != ExitCode::Ok) {
-            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromExistingPath");
+        if (const auto exitCode = getOrCreateNodeFromPath(editOp->path().parent_path(), parentNode); exitCode != ExitCode::Ok) {
+            LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromPath");
             return exitCode;
         }
 
@@ -739,7 +738,7 @@ ExitCode UpdateTreeWorker::step7EditFile() {
             return ExitCode::SystemError;
         }
 
-        if (!parentNode->insertChildren(newNode)) {
+        if (!parentNode->insertChild(newNode)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name()).c_str()
                                                                                << L" parent node "
                                                                                << Utility::formatSyncName(parentNode->name()));
@@ -864,7 +863,7 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
                 return ExitCode::SystemError;
             }
 
-            if (!parentNode->insertChildren(newNode)) {
+            if (!parentNode->insertChild(newNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                    << Utility::formatSyncName(newNode->name()) << L" parent node "
                                                    << Utility::formatSyncName(parentNode->name()));
@@ -889,7 +888,7 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
 }
 
 ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
-    std::unordered_set<UniqueId> moveOpsIds = _operationSet->getOpsByType(OperationType::Move);
+    const OpSet moveOpsIds = _operationSet->getOpsByType(OperationType::Move);
     for (const auto &moveOpId: moveOpsIds) {
         if (stopAsked()) {
             return ExitCode::Ok;
@@ -940,14 +939,14 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
 
             // Create the parent node if it does not exist
             std::shared_ptr<Node> parentNode;
-            if (const auto exitCode = getOrCreateNodeFromExistingPath(moveOp->destinationPath().parent_path(), parentNode);
+            if (const auto exitCode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path(), parentNode);
                 exitCode != ExitCode::Ok) {
-                LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromExistingPath");
+                LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromPath");
                 return exitCode;
             }
 
             // delete the current Node from children list of old parent
-            if (!currentNode->parentNode()->deleteChildren(currentNode)) {
+            if (!currentNode->parentNode()->deleteChild(currentNode)) {
                 LOG_SYNCPAL_WARN(_logger, "children " << currentNodeIt->first << " was not affected to parent "
                                                       << (currentNodeIt->second->parentNode()->id().has_value()
                                                                   ? *currentNodeIt->second->parentNode()->id()
@@ -956,7 +955,7 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
             }
 
             // insert currentNode into children list of new parent
-            if (!parentNode->insertChildren(currentNode)) {
+            if (!parentNode->insertChild(currentNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                                    << Utility::formatSyncName(currentNode->name()) << L" parent node "
                                                    << Utility::formatSyncName(parentNode->name()));
@@ -976,9 +975,9 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
         } else {
             // get parentNode
             std::shared_ptr<Node> parentNode;
-            if (const auto exitCode = getOrCreateNodeFromExistingPath(moveOp->destinationPath().parent_path(), parentNode);
+            if (const auto exitCode = getOrCreateNodeFromPath(moveOp->destinationPath().parent_path(), parentNode);
                 exitCode != ExitCode::Ok) {
-                LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromExistingPath");
+                LOG_SYNCPAL_WARN(_logger, "Error in UpdateTreeWorker::getOrCreateNodeFromPath");
                 return exitCode;
             }
 
@@ -1026,8 +1025,7 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
     return ExitCode::Ok;
 }
 
-ExitCode UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &path, std::shared_ptr<Node> &node,
-                                                   const bool existingBranchOnly /*= true*/) {
+ExitCode UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &path, std::shared_ptr<Node> &node) {
     node = nullptr;
 
     if (path.empty()) {
@@ -1043,7 +1041,7 @@ ExitCode UpdateTreeWorker::getOrCreateNodeFromPath(const SyncPath &path, std::sh
         std::shared_ptr<Node> tmpChildNode = nullptr;
         for (const auto &[_, childNode]: tmpNode->children()) {
             if (childNode->type() == NodeType::Directory && name == childNode->name()) {
-                if (existingBranchOnly && childNode->hasChangeEvent(OperationType::Delete)) {
+                if (childNode->hasChangeEvent(OperationType::Delete)) {
                     continue;
                 }
                 tmpChildNode = childNode;
@@ -1074,7 +1072,7 @@ ExitCode UpdateTreeWorker::createTmpNode(std::shared_ptr<Node> &tmpNode, const S
         return ExitCode::SystemError;
     }
 
-    if (!parentNode->insertChildren(tmpNode)) {
+    if (!parentNode->insertChild(tmpNode)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(tmpNode->name())
                                                                            << L" parent node "
                                                                            << Utility::formatSyncName(parentNode->name()));
@@ -1196,7 +1194,7 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // merging tmpNode's children to realNode
     for (auto &child: tmpNode->children()) {
-        if (!realNode->insertChildren(child.second)) {
+        if (!realNode->insertChild(child.second)) {
             LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(child.second->name())
                                                                                << L" parent node "
                                                                                << Utility::formatSyncName(realNode->name()));
@@ -1206,10 +1204,10 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // temp node removed from children list
     std::shared_ptr<Node> parentTmpNode = tmpNode->parentNode();
-    parentTmpNode->deleteChildren(tmpNode);
+    parentTmpNode->deleteChild(tmpNode);
 
     // Real node added as child of parent node
-    if (!realNode->parentNode()->insertChildren(realNode)) {
+    if (!realNode->parentNode()->insertChild(realNode)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
                                            << Utility::formatSyncName(realNode->name()) << L" parent node "
                                            << Utility::formatSyncName(realNode->parentNode()->name()));
@@ -1235,6 +1233,7 @@ bool UpdateTreeWorker::checkTreeIntegrity() {
         if (!checkNodeIntegrity(node)) return false;
         // In some cases, the pointer to the parent node might not have been updated correctly and still pointing to a temporary
         // node.
+
         if (node->parentNode() && !checkNodeIntegrity(node->parentNode())) return false;
         if (!checkOperationTypes(node)) return false;
     }
@@ -1330,7 +1329,19 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
             return ExitCode::Ok;
         }
 
-        bool found = false;
+        for (auto &nodeChild: node->children()) {
+            nodeQueue.push(nodeChild.second);
+        }
+
+        if (node->isTmp()) {
+            // Merge the node with a permanent one if possible
+            bool merged = false;
+            tryToMergeTmpNode(node, merged);
+            if (merged) {
+                assert(node.use_count() == 1);
+                continue;
+            }
+        }
 
         // update myself
         // if it's a Create we don't have node's database data
@@ -1358,6 +1369,7 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
             }
 
             DbNode dbNode;
+            bool found = false;
             if (!_syncDbReadOnlyCache.node(_side, usableNodeId, dbNode, found)) {
                 LOG_SYNCPAL_WARN(_logger, "Error in SyncDb::node");
                 return ExitCode::DbError;
@@ -1383,10 +1395,6 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
                 node->setSize(dbNode.size());
             }
         }
-
-        for (auto &nodeChild: node->children()) {
-            nodeQueue.push(nodeChild.second);
-        }
     }
 
     return ExitCode::Ok;
@@ -1407,7 +1415,7 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
         }
     }
 
-    if (!parentNode->insertChildren(node)) {
+    if (!parentNode->insertChild(node)) {
         LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(node->name())
                                                                            << L" parent node "
                                                                            << Utility::formatSyncName(parentNode->name()));
@@ -1415,6 +1423,28 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
     }
 
     return ExitCode::Ok;
+}
+
+void UpdateTreeWorker::tryToMergeTmpNode(std::shared_ptr<Node> tmpNode, bool &merged) {
+    assert(tmpNode);
+    assert(tmpNode->parentNode());
+
+    merged = false;
+
+    for (auto [_, brotherNode]: tmpNode->parentNode()->children()) {
+        if (brotherNode == tmpNode || brotherNode->isTmp() || brotherNode->hasChangeEvent(OperationType::Delete)) continue;
+        if (brotherNode->name() == tmpNode->name()) {
+            // Move tmpNode children to its brother
+            for (auto [_, childNode]: tmpNode->children()) {
+                (void) brotherNode->insertChild(childNode);
+                childNode->setParentNode(brotherNode);
+            }
+            tmpNode->children().clear();
+            tmpNode->parentNode()->deleteChild(tmpNode);
+            merged = true;
+            break;
+        }
+    }
 }
 
 ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
@@ -1463,7 +1493,7 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
     if (prevNode) {
         // Update children list
         for (const auto &[_, childNode]: prevNode->children()) {
-            if (!tmpNode->insertChildren(childNode)) {
+            if (!tmpNode->insertChild(childNode)) {
                 LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << SyncName2WStr(childNode->name())
                                                                                    << L" parent node "
                                                                                    << SyncName2WStr(tmpNode->name()));

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1425,17 +1425,17 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
     return ExitCode::Ok;
 }
 
-void UpdateTreeWorker::tryToMergeTmpNode(std::shared_ptr<Node> tmpNode, bool &merged) {
+void UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged) {
     assert(tmpNode);
     assert(tmpNode->parentNode());
 
     merged = false;
 
-    for (auto [_, brotherNode]: tmpNode->parentNode()->children()) {
+    for (const auto &[_, brotherNode]: tmpNode->parentNode()->children()) {
         if (brotherNode == tmpNode || brotherNode->isTmp() || brotherNode->hasChangeEvent(OperationType::Delete)) continue;
         if (brotherNode->name() == tmpNode->name()) {
             // Move tmpNode children to its brother
-            for (auto [_2, childNode]: tmpNode->children()) {
+            for (const auto &[__, childNode]: tmpNode->children()) {
                 (void) brotherNode->insertChild(childNode);
                 (void) childNode->setParentNode(brotherNode);
             }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1447,7 +1447,7 @@ ExitCode UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode
                     LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                                        << Utility::formatSyncName(childNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(brotherNode->name()));
-                    // return ExitCode::DataError;
+                    return ExitCode::DataError;
                 }
             }
             tmpNode->children().clear();

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1204,7 +1204,7 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // temp node removed from children list
     std::shared_ptr<Node> parentTmpNode = tmpNode->parentNode();
-    parentTmpNode->deleteChild(tmpNode);
+    (void) parentTmpNode->deleteChild(tmpNode);
 
     // Real node added as child of parent node
     if (!realNode->parentNode()->insertChild(realNode)) {
@@ -1435,12 +1435,12 @@ void UpdateTreeWorker::tryToMergeTmpNode(std::shared_ptr<Node> tmpNode, bool &me
         if (brotherNode == tmpNode || brotherNode->isTmp() || brotherNode->hasChangeEvent(OperationType::Delete)) continue;
         if (brotherNode->name() == tmpNode->name()) {
             // Move tmpNode children to its brother
-            for (auto [_, childNode]: tmpNode->children()) {
+            for (auto [_2, childNode]: tmpNode->children()) {
                 (void) brotherNode->insertChild(childNode);
-                childNode->setParentNode(brotherNode);
+                (void) childNode->setParentNode(brotherNode);
             }
             tmpNode->children().clear();
-            tmpNode->parentNode()->deleteChild(tmpNode);
+            (void) tmpNode->parentNode()->deleteChild(tmpNode);
             merged = true;
             break;
         }

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -1447,7 +1447,7 @@ ExitCode UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode
                     LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                                        << Utility::formatSyncName(childNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(brotherNode->name()));
-                    return ExitCode::DataError;
+                    // return ExitCode::DataError;
                 }
             }
             tmpNode->children().clear();

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.cpp
@@ -264,7 +264,7 @@ ExitCode UpdateTreeWorker::step3DeleteDirectory() {
                 }
 
                 if (!parentNode->insertChild(existingNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                                        << Utility::formatSyncName(existingNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(parentNode->name()));
                     return ExitCode::DataError;
@@ -505,7 +505,7 @@ ExitCode UpdateTreeWorker::step4DeleteFile() {
                 }
 
                 if (!parentNode->insertChild(newNode)) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                                        << Utility::formatSyncName(newNode->name()) << L" parent node "
                                                        << Utility::formatSyncName(parentNode->name()));
                     return ExitCode::DataError;
@@ -653,9 +653,9 @@ ExitCode UpdateTreeWorker::step6CreateFile() {
         }
 
         if (!parentNode->insertChild(newNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name())
-                                                                               << L" parent node "
-                                                                               << Utility::formatSyncName(parentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(newNode->name())
+                                                                            << L" parent node "
+                                                                            << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
 
@@ -739,9 +739,9 @@ ExitCode UpdateTreeWorker::step7EditFile() {
         }
 
         if (!parentNode->insertChild(newNode)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(newNode->name()).c_str()
-                                                                               << L" parent node "
-                                                                               << Utility::formatSyncName(parentNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(newNode->name()).c_str()
+                                                                            << L" parent node "
+                                                                            << Utility::formatSyncName(parentNode->name()));
             return ExitCode::DataError;
         }
 
@@ -864,9 +864,9 @@ ExitCode UpdateTreeWorker::step8CompleteUpdateTree() {
             }
 
             if (!parentNode->insertChild(newNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
-                                                   << Utility::formatSyncName(newNode->name()) << L" parent node "
-                                                   << Utility::formatSyncName(parentNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(newNode->name())
+                                                                                << L" parent node "
+                                                                                << Utility::formatSyncName(parentNode->name()));
                 return ExitCode::DataError;
             }
 
@@ -956,9 +956,9 @@ ExitCode UpdateTreeWorker::createMoveNodes(const NodeType &nodeType) {
 
             // insert currentNode into children list of new parent
             if (!parentNode->insertChild(currentNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
-                                                   << Utility::formatSyncName(currentNode->name()) << L" parent node "
-                                                   << Utility::formatSyncName(parentNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(currentNode->name())
+                                                                                << L" parent node "
+                                                                                << Utility::formatSyncName(parentNode->name()));
                 return ExitCode::DataError;
             }
 
@@ -1073,9 +1073,9 @@ ExitCode UpdateTreeWorker::createTmpNode(std::shared_ptr<Node> &tmpNode, const S
     }
 
     if (!parentNode->insertChild(tmpNode)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(tmpNode->name())
-                                                                           << L" parent node "
-                                                                           << Utility::formatSyncName(parentNode->name()));
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(tmpNode->name())
+                                                                        << L" parent node "
+                                                                        << Utility::formatSyncName(parentNode->name()));
         return ExitCode::DataError;
     }
     return ExitCode::Ok;
@@ -1195,9 +1195,9 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
     // merging tmpNode's children to realNode
     for (auto &child: tmpNode->children()) {
         if (!realNode->insertChild(child.second)) {
-            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(child.second->name())
-                                                                               << L" parent node "
-                                                                               << Utility::formatSyncName(realNode->name()));
+            LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(child.second->name())
+                                                                            << L" parent node "
+                                                                            << Utility::formatSyncName(realNode->name()));
             return false;
         }
     }
@@ -1208,7 +1208,7 @@ bool UpdateTreeWorker::mergingTempNodeToRealNode(std::shared_ptr<Node> tmpNode, 
 
     // Real node added as child of parent node
     if (!realNode->parentNode()->insertChild(realNode)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node "
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
                                            << Utility::formatSyncName(realNode->name()) << L" parent node "
                                            << Utility::formatSyncName(realNode->parentNode()->name()));
         return false;
@@ -1336,7 +1336,11 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
         if (node->isTmp()) {
             // Merge the node with a permanent one if possible
             bool merged = false;
-            tryToMergeTmpNode(node, merged);
+            if (const auto exitCode = tryToMergeTmpNode(node, merged); exitCode != ExitCode::Ok) {
+                LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTreeWorker::tryToMergeTmpNode for node "
+                                                   << Utility::formatSyncName(node->name()));
+                return exitCode;
+            }
             if (merged) {
                 assert(node.use_count() == 1);
                 continue;
@@ -1348,21 +1352,24 @@ ExitCode UpdateTreeWorker::updateNodeWithDb(const std::shared_ptr<Node> parentNo
         if (!node->hasChangeEvent(OperationType::Create)) {
             // if node is temporary node
             if (node->isTmp()) {
-                if (const ExitCode exitCode = updateTmpNode(node); exitCode != ExitCode::Ok) {
+                if (const auto exitCode = updateTmpNode(node); exitCode != ExitCode::Ok) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in UpdateTreeWorker::updateTmpNode for node "
+                                                       << Utility::formatSyncName(node->name()));
                     return exitCode;
                 }
             }
 
             // use previous nodeId if it's an Edit from Delete-Create
             if (!node->id().has_value()) {
-                LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve ID for node= " << SyncName2WStr(node->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve ID for node " << Utility::formatSyncName(node->name()));
                 return ExitCode::DataError;
             }
 
             NodeId usableNodeId = node->id().value();
             if (node->isEditFromDeleteCreate()) {
                 if (!node->previousId().has_value()) {
-                    LOGW_SYNCPAL_WARN(_logger, L"Failed to retrieve previousId for node= " << SyncName2WStr(node->name()));
+                    LOGW_SYNCPAL_WARN(_logger,
+                                      L"Failed to retrieve previousId for node " << Utility::formatSyncName(node->name()));
                     return ExitCode::DataError;
                 }
                 usableNodeId = node->previousId().value();
@@ -1416,16 +1423,16 @@ ExitCode UpdateTreeWorker::mergeNodeToParentChildren(std::shared_ptr<Node> paren
     }
 
     if (!parentNode->insertChild(node)) {
-        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << Utility::formatSyncName(node->name())
-                                                                           << L" parent node "
-                                                                           << Utility::formatSyncName(parentNode->name()));
+        LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << Utility::formatSyncName(node->name())
+                                                                        << L" parent node "
+                                                                        << Utility::formatSyncName(parentNode->name()));
         return ExitCode::DataError;
     }
 
     return ExitCode::Ok;
 }
 
-void UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged) {
+ExitCode UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged) {
     assert(tmpNode);
     assert(tmpNode->parentNode());
 
@@ -1436,11 +1443,20 @@ void UpdateTreeWorker::tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bo
         if (brotherNode->name() == tmpNode->name()) {
             // Move tmpNode children to its brother
             for (const auto &[__, childNode]: tmpNode->children()) {
-                (void) brotherNode->insertChild(childNode);
-                (void) childNode->setParentNode(brotherNode);
+                if (!brotherNode->insertChild(childNode)) {
+                    LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node "
+                                                       << Utility::formatSyncName(childNode->name()) << L" parent node "
+                                                       << Utility::formatSyncName(brotherNode->name()));
+                    return ExitCode::DataError;
+                }
             }
             tmpNode->children().clear();
-            (void) tmpNode->parentNode()->deleteChild(tmpNode);
+            if (!tmpNode->parentNode()->deleteChild(tmpNode)) {
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::deleteChild: node "
+                                                   << Utility::formatSyncName(tmpNode->name()) << L" parent node "
+                                                   << Utility::formatSyncName(tmpNode->parentNode()->name()));
+                return ExitCode::DataError;
+            }
             merged = true;
             break;
         }
@@ -1494,9 +1510,9 @@ ExitCode UpdateTreeWorker::updateTmpNode(const std::shared_ptr<Node> tmpNode) {
         // Update children list
         for (const auto &[_, childNode]: prevNode->children()) {
             if (!tmpNode->insertChild(childNode)) {
-                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChildren: node " << SyncName2WStr(childNode->name())
-                                                                                   << L" parent node "
-                                                                                   << SyncName2WStr(tmpNode->name()));
+                LOGW_SYNCPAL_WARN(_logger, L"Error in Node::insertChild: node " << SyncName2WStr(childNode->name())
+                                                                                << L" parent node "
+                                                                                << SyncName2WStr(tmpNode->name()));
                 return ExitCode::DataError;
             }
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -114,7 +114,7 @@ class UpdateTreeWorker : public ISyncWorker {
         ExitCode getNewPathAfterMove(const SyncPath &path, SyncPath &newPath);
         ExitCode updateNodeWithDb(const std::shared_ptr<Node> parentNode);
         [[nodiscard]] ExitCode mergeNodeToParentChildren(std::shared_ptr<Node> parentNode, const std::shared_ptr<Node> node);
-        void tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged);
+        ExitCode tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged);
         ExitCode updateTmpNode(const std::shared_ptr<Node> tmpNode);
         ExitCode getOriginPath(const std::shared_ptr<Node> node, SyncPath &path);
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -114,7 +114,7 @@ class UpdateTreeWorker : public ISyncWorker {
         ExitCode getNewPathAfterMove(const SyncPath &path, SyncPath &newPath);
         ExitCode updateNodeWithDb(const std::shared_ptr<Node> parentNode);
         [[nodiscard]] ExitCode mergeNodeToParentChildren(std::shared_ptr<Node> parentNode, const std::shared_ptr<Node> node);
-        void tryToMergeTmpNode(std::shared_ptr<Node> tmpNode, bool &merged);
+        void tryToMergeTmpNode(const std::shared_ptr<Node> tmpNode, bool &merged);
         ExitCode updateTmpNode(const std::shared_ptr<Node> tmpNode);
         ExitCode getOriginPath(const std::shared_ptr<Node> node, SyncPath &path);
 

--- a/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
+++ b/src/libsyncengine/update_detection/update_detector/updatetreeworker.h
@@ -114,6 +114,7 @@ class UpdateTreeWorker : public ISyncWorker {
         ExitCode getNewPathAfterMove(const SyncPath &path, SyncPath &newPath);
         ExitCode updateNodeWithDb(const std::shared_ptr<Node> parentNode);
         [[nodiscard]] ExitCode mergeNodeToParentChildren(std::shared_ptr<Node> parentNode, const std::shared_ptr<Node> node);
+        void tryToMergeTmpNode(std::shared_ptr<Node> tmpNode, bool &merged);
         ExitCode updateTmpNode(const std::shared_ptr<Node> tmpNode);
         ExitCode getOriginPath(const std::shared_ptr<Node> node, SyncPath &path);
 
@@ -142,13 +143,9 @@ class UpdateTreeWorker : public ISyncWorker {
          */
         ExitCode handleCreateOperationsWithSamePath();
 
-        [[nodiscard]] ExitCode getOrCreateNodeFromPath(const SyncPath &path, std::shared_ptr<Node> &node,
-                                                       bool existingBranchOnly = true);
+        [[nodiscard]] ExitCode getOrCreateNodeFromPath(const SyncPath &path, std::shared_ptr<Node> &node);
         [[nodiscard]] ExitCode createTmpNode(std::shared_ptr<Node> &tmpNode, const SyncName &name,
                                              const std::shared_ptr<Node> parentNode);
-        [[nodiscard]] ExitCode getOrCreateNodeFromExistingPath(const SyncPath &path, std::shared_ptr<Node> &node) {
-            return getOrCreateNodeFromPath(path, node, true);
-        }
 
         /**
          * Create missing nodes in the update tree for a given 'path'.

--- a/test/libsyncengine/propagation/executor/testexecutorworker.cpp
+++ b/test/libsyncengine/propagation/executor/testexecutorworker.cpp
@@ -579,7 +579,7 @@ void TestExecutorWorker::testInitSyncFileItem() {
                                        _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
 
         CPPUNIT_ASSERT(remoteNode->setParentNode(remoteParentNode));
-        CPPUNIT_ASSERT(remoteParentNode->insertChildren(remoteNode));
+        CPPUNIT_ASSERT(remoteParentNode->insertChild(remoteNode));
 
         // Local move from parent_dir/test_file.txt to /test_file.txt
         localNode->setMoveOriginInfos({"parent_dir/test_file.txt", localParentNode->id().value()});

--- a/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
+++ b/test/libsyncengine/propagation/operation_sorter/testoperationsorterworker.cpp
@@ -439,21 +439,21 @@ void TestOperationSorterWorker::testFixCreateBeforeCreateSameIdOnBothSide() {
     const auto nodeA = std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("A"), NodeType::Directory,
                                               OperationType::Create, "a", testhelpers::defaultTime, testhelpers::defaultTime,
                                               testhelpers::defaultDirSize, _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
-    (void) _syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(nodeA);
+    (void) _syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChild(nodeA);
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeA);
     const auto opA = generateSyncOperation(OperationType::Create, nodeA);
 
     const auto nodeAA =
             std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("AA"), NodeType::Directory, OperationType::Create, "aa",
                                    testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
-    (void) nodeA->insertChildren(nodeAA);
+    (void) nodeA->insertChild(nodeAA);
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeAA);
     const auto opAA = generateSyncOperation(OperationType::Create, nodeAA);
 
     const auto nodeAAA =
             std::make_shared<Node>(std::nullopt, ReplicaSide::Remote, Str("AAA"), NodeType::File, OperationType::Create, "aaa",
                                    testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAA);
-    (void) nodeAA->insertChildren(nodeAAA);
+    (void) nodeAA->insertChild(nodeAAA);
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeAAA);
     const auto opAAA = generateSyncOperation(OperationType::Create, nodeAAA);
 
@@ -464,14 +464,14 @@ void TestOperationSorterWorker::testFixCreateBeforeCreateSameIdOnBothSide() {
     const auto nodeB = std::make_shared<Node>(std::nullopt, ReplicaSide::Local, Str("B"), NodeType::Directory,
                                               OperationType::Create, "b", testhelpers::defaultTime, testhelpers::defaultTime,
                                               testhelpers::defaultDirSize, _syncPal->updateTree(ReplicaSide::Local)->rootNode());
-    (void) _syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChildren(nodeB);
+    (void) _syncPal->updateTree(ReplicaSide::Local)->rootNode()->insertChild(nodeB);
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeB);
     const auto opB = generateSyncOperation(OperationType::Create, nodeB);
 
     const auto nodeBA =
             std::make_shared<Node>(std::nullopt, ReplicaSide::Local, Str("BA"), NodeType::File, OperationType::Create, "aa",
                                    testhelpers::defaultTime, testhelpers::defaultTime, testhelpers::defaultDirSize, nodeB);
-    (void) nodeB->insertChildren(nodeBA);
+    (void) nodeB->insertChild(nodeBA);
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(nodeBA);
     const auto opBA = generateSyncOperation(OperationType::Create, nodeBA);
 

--- a/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
+++ b/test/libsyncengine/reconciliation/platform_inconsistency_checker/testplatforminconsistencycheckerworker.cpp
@@ -208,8 +208,8 @@ void TestPlatformInconsistencyCheckerWorker::testNameClash() {
     const auto nodeUpper = std::make_shared<Node>(ReplicaSide::Remote, Str("A"), NodeType::File, OperationType::Create, "A", 0, 0,
                                                   12345, parentNode);
 
-    CPPUNIT_ASSERT(parentNode->insertChildren(nodeLower));
-    CPPUNIT_ASSERT(parentNode->insertChildren(nodeUpper));
+    CPPUNIT_ASSERT(parentNode->insertChild(nodeLower));
+    CPPUNIT_ASSERT(parentNode->insertChild(nodeUpper));
 
     _syncPal->_platformInconsistencyCheckerWorker->checkNameClashAgainstSiblings(parentNode);
 
@@ -250,8 +250,8 @@ void TestPlatformInconsistencyCheckerWorker::testNameClashAfterRename() {
             std::make_shared<Node>(dbNodeIdUpper, ReplicaSide::Remote, Str("A"), NodeType::File, OperationType::None, "rA", 0, 0,
                                    12345, _syncPal->updateTree(ReplicaSide::Remote)->rootNode());
 
-    CPPUNIT_ASSERT(remoteParentNode->insertChildren(remoteNodeLower));
-    CPPUNIT_ASSERT(remoteParentNode->insertChildren(remoteNodeUpper));
+    CPPUNIT_ASSERT(remoteParentNode->insertChild(remoteNodeLower));
+    CPPUNIT_ASSERT(remoteParentNode->insertChild(remoteNodeUpper));
 
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(remoteNodeLower);
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(remoteNodeUpper);
@@ -263,8 +263,8 @@ void TestPlatformInconsistencyCheckerWorker::testNameClashAfterRename() {
     const auto localNodeUpper = std::make_shared<Node>(dbNodeIdUpper, ReplicaSide::Local, Str("A"), NodeType::File,
                                                        OperationType::None, "lA", 0, 0, 12345, localParentNode);
 
-    CPPUNIT_ASSERT(localParentNode->insertChildren(localNodeLower));
-    CPPUNIT_ASSERT(localParentNode->insertChildren(localNodeUpper));
+    CPPUNIT_ASSERT(localParentNode->insertChild(localNodeLower));
+    CPPUNIT_ASSERT(localParentNode->insertChild(localNodeUpper));
 
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(localNodeLower);
     _syncPal->updateTree(ReplicaSide::Local)->insertNode(localNodeUpper);
@@ -289,9 +289,9 @@ void TestPlatformInconsistencyCheckerWorker::testExecute() {
     const auto nodeUpper = std::make_shared<Node>(ReplicaSide::Remote, Str("A"), NodeType::File, OperationType::Create, "A", 0, 0,
                                                   12345, parentNode);
 
-    CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChildren(parentNode));
-    CPPUNIT_ASSERT(parentNode->insertChildren(nodeLower));
-    CPPUNIT_ASSERT(parentNode->insertChildren(nodeUpper));
+    CPPUNIT_ASSERT(_syncPal->updateTree(ReplicaSide::Remote)->rootNode()->insertChild(parentNode));
+    CPPUNIT_ASSERT(parentNode->insertChild(nodeLower));
+    CPPUNIT_ASSERT(parentNode->insertChild(nodeUpper));
 
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(parentNode);
     _syncPal->updateTree(ReplicaSide::Remote)->insertNode(nodeLower);
@@ -393,13 +393,13 @@ void TestPlatformInconsistencyCheckerWorker::initUpdateTree(ReplicaSide side) {
                                               OperationType::None, "BNode", 0, 0, 12345, testNode2);
 
 
-    CPPUNIT_ASSERT(_syncPal->updateTree(side)->rootNode()->insertChildren(testNode));
-    CPPUNIT_ASSERT(testNode->insertChildren(aNode));
-    CPPUNIT_ASSERT(testNode->insertChildren(ANode));
-    CPPUNIT_ASSERT(testNode->insertChildren(longNameANode));
-    CPPUNIT_ASSERT(_syncPal->updateTree(side)->rootNode()->insertChildren(testNode2));
-    CPPUNIT_ASSERT(testNode2->insertChildren(bNode));
-    CPPUNIT_ASSERT(testNode2->insertChildren(BNode));
+    CPPUNIT_ASSERT(_syncPal->updateTree(side)->rootNode()->insertChild(testNode));
+    CPPUNIT_ASSERT(testNode->insertChild(aNode));
+    CPPUNIT_ASSERT(testNode->insertChild(ANode));
+    CPPUNIT_ASSERT(testNode->insertChild(longNameANode));
+    CPPUNIT_ASSERT(_syncPal->updateTree(side)->rootNode()->insertChild(testNode2));
+    CPPUNIT_ASSERT(testNode2->insertChild(bNode));
+    CPPUNIT_ASSERT(testNode2->insertChild(BNode));
 
     _syncPal->updateTree(side)->insertNode(testNode);
     _syncPal->updateTree(side)->insertNode(aNode);

--- a/test/libsyncengine/update_detection/file_system_observer/testfsoperationset.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfsoperationset.cpp
@@ -164,6 +164,39 @@ void TestFsOperationSet::testInsertOp() {
             CPPUNIT_ASSERT(ops2.contains(op->id()));
         }
     }
+
+    // Test that operations are sorted by path depth and then by uniqueId
+    fsOperationSet.clear();
+    auto op11b = std::make_shared<FSOperation>(OperationType::Create, "op11b", NodeType::Directory, 0, 0, 0, "/dir1/dir11");
+    fsOperationSet.insertOp(op11b);
+    auto op112 =
+            std::make_shared<FSOperation>(OperationType::Create, "op112", NodeType::Directory, 0, 0, 0, "/dir1/dir11/dir112");
+    fsOperationSet.insertOp(op112);
+    auto op1111 = std::make_shared<FSOperation>(OperationType::Create, "op1111", NodeType::Directory, 0, 0, 0,
+                                                "/dir1/dir11/dir111/dir1111");
+    fsOperationSet.insertOp(op1111);
+    auto op111 =
+            std::make_shared<FSOperation>(OperationType::Create, "op111", NodeType::Directory, 0, 0, 0, "/dir1/dir11/dir111");
+    fsOperationSet.insertOp(op111);
+    auto op1 = std::make_shared<FSOperation>(OperationType::Create, "op1", NodeType::Directory, 0, 0, 0, "/dir1");
+    fsOperationSet.insertOp(op1);
+    auto op11a = std::make_shared<FSOperation>(OperationType::Create, "op11a", NodeType::Directory, 0, 0, 0, "/dir1/dir11");
+    fsOperationSet.insertOp(op11a);
+
+    const auto ops = fsOperationSet.getOpsByType(OperationType::Create);
+    CPPUNIT_ASSERT_EQUAL(size_t(6), ops.size());
+    auto fsoperationIt = ops.begin();
+    CPPUNIT_ASSERT(*fsoperationIt == op1->id());
+    fsoperationIt++;
+    CPPUNIT_ASSERT(*fsoperationIt == op11b->id());
+    fsoperationIt++;
+    CPPUNIT_ASSERT(*fsoperationIt == op11a->id());
+    fsoperationIt++;
+    CPPUNIT_ASSERT(*fsoperationIt == op112->id());
+    fsoperationIt++;
+    CPPUNIT_ASSERT(*fsoperationIt == op111->id());
+    fsoperationIt++;
+    CPPUNIT_ASSERT(*fsoperationIt == op1111->id());
 }
 
 void TestFsOperationSet::testRemoveOp() {

--- a/test/libsyncengine/update_detection/file_system_observer/testfsoperationset.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testfsoperationset.cpp
@@ -60,7 +60,7 @@ void TestFsOperationSet::testGetOpsByType() {
 
     for (OperationType type: _operationTypes) {
         for (int i = 0; i < 3; i++) {
-            std::unordered_set<UniqueId> ops = fsOperationSet.getOpsByType(type);
+            const auto ops = fsOperationSet.getOpsByType(type);
             CPPUNIT_ASSERT_EQUAL(size_t(i), ops.size());
 
             auto op = std::make_shared<FSOperation>(type, nodeId + nodeIdSuffix);
@@ -155,13 +155,13 @@ void TestFsOperationSet::testInsertOp() {
             auto op = std::make_shared<FSOperation>(type, nodeId + nodeIdSuffix);
             fsOperationSet.insertOp(op);
             nodeIdSuffix++;
-            std::unordered_map<UniqueId, FSOpPtr> opsAll = fsOperationSet.getAllOps();
+            OpMap opsAll = fsOperationSet.getAllOps();
             CPPUNIT_ASSERT(opsAll.contains(op->id()));
             CPPUNIT_ASSERT_EQUAL(uint64_t(i + 1), fsOperationSet.nbOpsByType(type));
-            std::unordered_set<UniqueId> ops = fsOperationSet.getOpsByNodeId(op->nodeId());
+            const auto ops = fsOperationSet.getOpsByNodeId(op->nodeId());
             CPPUNIT_ASSERT(ops.contains(op->id()));
-            ops = fsOperationSet.getOpsByType(type);
-            CPPUNIT_ASSERT(ops.contains(op->id()));
+            const auto ops2 = fsOperationSet.getOpsByType(type);
+            CPPUNIT_ASSERT(ops2.contains(op->id()));
         }
     }
 }
@@ -174,25 +174,25 @@ void TestFsOperationSet::testRemoveOp() {
     auto op2 = std::make_shared<FSOperation>(OperationType::Move, nodeId);
     fsOperationSet.insertOp(op2);
 
-    std::unordered_map<UniqueId, FSOpPtr> allOps;
+    OpMap allOps;
 
     // Test removeOp with an existing operation (uniqueId)
     CPPUNIT_ASSERT(fsOperationSet.removeOp(op1->id()));
     allOps = fsOperationSet.getAllOps();
     CPPUNIT_ASSERT(!allOps.contains(op1->id()));
-    std::unordered_set<UniqueId> ops = fsOperationSet.getOpsByType(OperationType::Create);
+    const auto ops = fsOperationSet.getOpsByType(OperationType::Create);
     CPPUNIT_ASSERT(!ops.contains(op1->id()));
-    ops = fsOperationSet.getOpsByNodeId(nodeId);
-    CPPUNIT_ASSERT(!ops.contains(op1->id()));
+    const auto ops2 = fsOperationSet.getOpsByNodeId(nodeId);
+    CPPUNIT_ASSERT(!ops2.contains(op1->id()));
 
     // Test removeOp with an existing operation (Node id + type)
     CPPUNIT_ASSERT(fsOperationSet.removeOp(nodeId, OperationType::Move));
     allOps = fsOperationSet.getAllOps();
     CPPUNIT_ASSERT(!allOps.contains(op2->id()));
-    ops = fsOperationSet.getOpsByType(OperationType::Move);
-    CPPUNIT_ASSERT(!ops.contains(op2->id()));
-    ops = fsOperationSet.getOpsByNodeId(nodeId);
-    CPPUNIT_ASSERT(!ops.contains(op2->id()));
+    const auto ops3 = fsOperationSet.getOpsByType(OperationType::Move);
+    CPPUNIT_ASSERT(!ops3.contains(op2->id()));
+    const auto ops4 = fsOperationSet.getOpsByNodeId(nodeId);
+    CPPUNIT_ASSERT(!ops4.contains(op2->id()));
 
     // Test removeOp with a not existing operation
     CPPUNIT_ASSERT(!fsOperationSet.removeOp(1));
@@ -239,8 +239,8 @@ void TestFsOperationSet::testOperatorEqual() {
 
     /// ops()
     CPPUNIT_ASSERT_EQUAL(fsOperationSet2.nbOps(), fsOperationSet1.nbOps());
-    std::unordered_map<UniqueId, FSOpPtr> ops1;
-    std::unordered_map<UniqueId, FSOpPtr> ops2;
+    OpMap ops1;
+    OpMap ops2;
     ops1 = fsOperationSet1.getAllOps();
     ops2 = fsOperationSet2.getAllOps();
     for (const auto &[key, value]: ops2) {
@@ -250,10 +250,8 @@ void TestFsOperationSet::testOperatorEqual() {
     /// getOpsByType() and getOpsByNodeId()
     nodeIdSuffix = '0';
     for (OperationType type: _operationTypes) {
-        std::unordered_set<UniqueId> opsByType1;
-        std::unordered_set<UniqueId> opsByType2;
-        opsByType1 = fsOperationSet1.getOpsByType(type);
-        opsByType2 = fsOperationSet2.getOpsByType(type);
+        const auto opsByType1 = fsOperationSet1.getOpsByType(type);
+        const auto opsByType2 = fsOperationSet2.getOpsByType(type);
         CPPUNIT_ASSERT_EQUAL(opsByType2.size(), opsByType1.size());
         for (const auto &id: opsByType2) {
             CPPUNIT_ASSERT(opsByType1.contains(id));
@@ -291,8 +289,8 @@ void TestFsOperationSet::testCopyConstructor() {
 
     FSOperationSet fsOperationSetCopy(fsOperationSet);
     /// ops()
-    std::unordered_map<UniqueId, FSOpPtr> ops;
-    std::unordered_map<UniqueId, FSOpPtr> opsCopy;
+    OpMap ops;
+    OpMap opsCopy;
     ops = fsOperationSetCopy.getAllOps();
     opsCopy = fsOperationSetCopy.getAllOps();
     CPPUNIT_ASSERT_EQUAL(ops.size(), opsCopy.size());
@@ -302,8 +300,8 @@ void TestFsOperationSet::testCopyConstructor() {
     /// getOpsByType() and getOpsByNodeId()
     nodeIdSuffix = '0';
     for (OperationType type: _operationTypes) {
-        std::unordered_set<UniqueId> opsByType1 = fsOperationSet.getOpsByType(type);
-        std::unordered_set<UniqueId> opsByType2 = fsOperationSetCopy.getOpsByType(type);
+        const auto opsByType1 = fsOperationSet.getOpsByType(type);
+        const auto opsByType2 = fsOperationSetCopy.getOpsByType(type);
         CPPUNIT_ASSERT_EQUAL(opsByType2.size(), opsByType1.size());
         for (const auto &id: opsByType2) {
             CPPUNIT_ASSERT(opsByType1.contains(id));

--- a/test/libsyncengine/update_detection/update_detector/testupdatetree.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetree.cpp
@@ -89,17 +89,17 @@ void TestUpdateTree::testClear() {
     _myTree->init();
     auto node1 = std::make_shared<Node>(_myTree->side(), Str("Dir 1"), NodeType::Directory, OperationType::None, "l1", 0, 0,
                                         12345, _myTree->rootNode());
-    CPPUNIT_ASSERT(_myTree->rootNode()->insertChildren(node1));
+    CPPUNIT_ASSERT(_myTree->rootNode()->insertChild(node1));
     _myTree->insertNode(node1);
 
     auto node11 = std::make_shared<Node>(_myTree->side(), Str("Dir 1.1"), NodeType::Directory, OperationType::None, "l11", 0, 0,
                                          12345, node1);
-    CPPUNIT_ASSERT(node1->insertChildren(node11));
+    CPPUNIT_ASSERT(node1->insertChild(node11));
     _myTree->insertNode(node11);
 
     auto node111 = std::make_shared<Node>(_myTree->side(), Str("File 1.1.1"), NodeType::File, OperationType::None, "l111", 0, 0,
                                           12345, node11);
-    CPPUNIT_ASSERT(node11->insertChildren(node111));
+    CPPUNIT_ASSERT(node11->insertChild(node111));
     _myTree->insertNode(node111);
 
     CPPUNIT_ASSERT(node1.use_count() == 4); // Referenced by node1, root, node11, _myTree->_nodes
@@ -161,17 +161,17 @@ void TestUpdateTree::testAll() {
     auto node4111 = std::make_shared<Node>(_myTree->side(), Str("File 4.1.1.1"), NodeType::File, OperationType::None, "l4111", 0,
                                            0, 12345, node411);
 
-    CPPUNIT_ASSERT(_myTree->rootNode()->insertChildren(node1));
-    CPPUNIT_ASSERT(_myTree->rootNode()->insertChildren(node2));
-    CPPUNIT_ASSERT(_myTree->rootNode()->insertChildren(node3));
-    CPPUNIT_ASSERT(_myTree->rootNode()->insertChildren(node4));
-    CPPUNIT_ASSERT(node1->insertChildren(node11));
-    CPPUNIT_ASSERT(node11->insertChildren(node111));
-    CPPUNIT_ASSERT(node111->insertChildren(node1111));
-    CPPUNIT_ASSERT(node3->insertChildren(node31));
-    CPPUNIT_ASSERT(node4->insertChildren(node41));
-    CPPUNIT_ASSERT(node41->insertChildren(node411));
-    CPPUNIT_ASSERT(node411->insertChildren(node4111));
+    CPPUNIT_ASSERT(_myTree->rootNode()->insertChild(node1));
+    CPPUNIT_ASSERT(_myTree->rootNode()->insertChild(node2));
+    CPPUNIT_ASSERT(_myTree->rootNode()->insertChild(node3));
+    CPPUNIT_ASSERT(_myTree->rootNode()->insertChild(node4));
+    CPPUNIT_ASSERT(node1->insertChild(node11));
+    CPPUNIT_ASSERT(node11->insertChild(node111));
+    CPPUNIT_ASSERT(node111->insertChild(node1111));
+    CPPUNIT_ASSERT(node3->insertChild(node31));
+    CPPUNIT_ASSERT(node4->insertChild(node41));
+    CPPUNIT_ASSERT(node41->insertChild(node411));
+    CPPUNIT_ASSERT(node411->insertChild(node4111));
 
     _myTree->insertNode(node1111);
     _myTree->insertNode(node111);

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -715,6 +715,8 @@ void TestUpdateTreeWorker::testStep8() {
 }
 
 void TestUpdateTreeWorker::testStep8b() {
+    setUpUpdateTree(ReplicaSide::Local);
+
     // Moving a directory to a Dir1 will create tmpNode for Dir1
     _operationSet->insertOp(std::make_shared<FSOperation>(OperationType::Move, "id41", NodeType::Directory,
                                                           testhelpers::defaultTime, testhelpers::defaultTime,

--- a/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
+++ b/test/libsyncengine/update_detection/update_detector/testupdatetreeworker.cpp
@@ -285,21 +285,21 @@ void TestUpdateTreeWorker::setUpUpdateTree(ReplicaSide side) {
 
     updateTree->init();
 
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node1));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node2));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node3));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node4));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node6));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node6a));
-    CPPUNIT_ASSERT(updateTree->rootNode()->insertChildren(node7));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node1));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node2));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node3));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node4));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node6));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node6a));
+    CPPUNIT_ASSERT(updateTree->rootNode()->insertChild(node7));
 
-    CPPUNIT_ASSERT(node1->insertChildren(node11));
-    CPPUNIT_ASSERT(node11->insertChildren(node111));
-    CPPUNIT_ASSERT(node111->insertChildren(node1111));
-    CPPUNIT_ASSERT(node3->insertChildren(node31));
-    CPPUNIT_ASSERT(node4->insertChildren(node41));
-    CPPUNIT_ASSERT(node41->insertChildren(node411));
-    CPPUNIT_ASSERT(node411->insertChildren(node4111));
+    CPPUNIT_ASSERT(node1->insertChild(node11));
+    CPPUNIT_ASSERT(node11->insertChild(node111));
+    CPPUNIT_ASSERT(node111->insertChild(node1111));
+    CPPUNIT_ASSERT(node3->insertChild(node31));
+    CPPUNIT_ASSERT(node4->insertChild(node41));
+    CPPUNIT_ASSERT(node41->insertChild(node411));
+    CPPUNIT_ASSERT(node411->insertChild(node4111));
 
     updateTree->insertNode(node1111);
     updateTree->insertNode(node111);
@@ -358,7 +358,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
                                           testhelpers::defaultTime, testhelpers::defaultFileSize, "Dir 5/File 5.1");
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 
@@ -377,7 +377,7 @@ void TestUpdateTreeWorker::testUpdateTmpFileNode() {
 
     {
         std::shared_ptr<Node> newNode;
-        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+        CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
         CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
         CPPUNIT_ASSERT(newNode->isTmp());
 
@@ -1110,19 +1110,19 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
                                                   CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                                   testhelpers::defaultTime, testhelpers::defaultDirSize, updateTree->rootNode());
         updateTree->insertNode(nodeA);
-        (void) updateTree->rootNode()->insertChildren(nodeA);
+        (void) updateTree->rootNode()->insertChild(nodeA);
 
         // Created branch
         const auto nodeAAcreate = std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, nodeA);
         updateTree->insertNode(nodeAAcreate);
-        (void) nodeA->insertChildren(nodeAAcreate);
+        (void) nodeA->insertChild(nodeAAcreate);
 
         const auto nodeAAAcreate =
                 std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Create,
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAcreate);
         updateTree->insertNode(nodeAAAcreate);
-        (void) nodeAAcreate->insertChildren(nodeAAAcreate);
+        (void) nodeAAcreate->insertChild(nodeAAAcreate);
 
         // Deleted branch
         const auto nodeAAdelete =
@@ -1130,20 +1130,20 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
         updateTree->insertNode(nodeAAdelete);
-        (void) nodeA->insertChildren(nodeAAdelete);
+        (void) nodeA->insertChild(nodeAAdelete);
 
         const auto nodeAAAdelete =
                 std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Delete,
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAdelete);
         updateTree->insertNode(nodeAAAdelete);
-        (void) nodeAAdelete->insertChildren(nodeAAAdelete);
+        (void) nodeAAdelete->insertChild(nodeAAAdelete);
 
         updateTree->drawUpdateTree(0);
 
         std::shared_ptr<Node> node = updateTreeWorker->getNodeFromDeletedPath(SyncPath("/A/AA/AAA"));
         CPPUNIT_ASSERT_EQUAL(nodeAAAdelete->id().value(), node->id().value());
-        (void) updateTreeWorker->getOrCreateNodeFromExistingPath(SyncPath("/A/AA/AAA"), node);
+        (void) updateTreeWorker->getOrCreateNodeFromPath(SyncPath("/A/AA/AAA"), node);
         CPPUNIT_ASSERT_EQUAL(nodeAAAcreate->id().value(), node->id().value());
     }
     {
@@ -1156,19 +1156,19 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
                                                   CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                                   testhelpers::defaultTime, testhelpers::defaultDirSize, updateTree->rootNode());
         updateTree->insertNode(nodeA);
-        (void) updateTree->rootNode()->insertChildren(nodeA);
+        (void) updateTree->rootNode()->insertChild(nodeA);
 
         // Created branch
         const auto nodeAAcreate = std::make_shared<Node>(ReplicaSide::Local, Str("AA"), NodeType::Directory, nodeA);
         updateTree->insertNode(nodeAAcreate);
-        (void) nodeA->insertChildren(nodeAAcreate);
+        (void) nodeA->insertChild(nodeAAcreate);
 
         const auto nodeAAAcreate =
                 std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Create,
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAcreate);
         updateTree->insertNode(nodeAAAcreate);
-        (void) nodeAAcreate->insertChildren(nodeAAAcreate);
+        (void) nodeAAcreate->insertChild(nodeAAAcreate);
 
         // Deleted branch
         const auto nodeAAdelete =
@@ -1176,18 +1176,18 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeA);
         updateTree->insertNode(nodeAAdelete);
-        (void) nodeA->insertChildren(nodeAAdelete);
+        (void) nodeA->insertChild(nodeAAdelete);
 
         const auto nodeAAAdelete =
                 std::make_shared<Node>(ReplicaSide::Local, Str("AAA"), NodeType::Directory, OperationType::Delete,
                                        CommonUtility::generateRandomStringAlphaNum(), testhelpers::defaultTime,
                                        testhelpers::defaultTime, testhelpers::defaultDirSize, nodeAAdelete);
         updateTree->insertNode(nodeAAAdelete);
-        (void) nodeAAdelete->insertChildren(nodeAAAdelete);
+        (void) nodeAAdelete->insertChild(nodeAAAdelete);
 
         const auto nodeAAA1delete = std::make_shared<Node>(ReplicaSide::Local, Str("AAA1"), NodeType::Directory, nodeAAdelete);
         updateTree->insertNode(nodeAAA1delete);
-        (void) nodeAAdelete->insertChildren(nodeAAA1delete);
+        (void) nodeAAdelete->insertChild(nodeAAA1delete);
 
         const auto nodeAAAAdelete =
                 std::make_shared<Node>(ReplicaSide::Local, Str("AAAA"), NodeType::File, OperationType::None,
@@ -1196,7 +1196,7 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
         nodeAAAAdelete->setMoveOriginInfos({SyncPath("/A/AA/AAA"), nodeAAA1delete->id().value()});
         nodeAAAAdelete->setChangeEvents(OperationType::Move);
         updateTree->insertNode(nodeAAAAdelete);
-        (void) nodeAAA1delete->insertChildren(nodeAAAAdelete);
+        (void) nodeAAA1delete->insertChild(nodeAAAAdelete);
 
         updateTree->drawUpdateTree(0);
 
@@ -1204,14 +1204,14 @@ void TestUpdateTreeWorker::testGetNodeFromDeletedPath() {
         CPPUNIT_ASSERT_EQUAL(nodeAAAdelete->id().value(), node->id().value());
         node = updateTreeWorker->getNodeFromDeletedPath(SyncPath("/A/AA/AAA1"));
         CPPUNIT_ASSERT_EQUAL(nodeAAA1delete->id().value(), node->id().value());
-        (void) updateTreeWorker->getOrCreateNodeFromExistingPath(SyncPath("/A/AA/AAA"), node);
+        (void) updateTreeWorker->getOrCreateNodeFromPath(SyncPath("/A/AA/AAA"), node);
         CPPUNIT_ASSERT_EQUAL(nodeAAAcreate->id().value(), node->id().value());
     }
 }
 
 void TestUpdateTreeWorker::testIntegrityCheck() {
     std::shared_ptr<Node> newNode;
-    CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromExistingPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
+    CPPUNIT_ASSERT(_localUpdateTreeWorker->getOrCreateNodeFromPath("Dir 5/File 5.1", newNode) == ExitCode::Ok);
     CPPUNIT_ASSERT(newNode->id()->substr(0, 4) == "tmp_");
     CPPUNIT_ASSERT(newNode->isTmp());
 

--- a/test/test_classes/testsituationgenerator.cpp
+++ b/test/test_classes/testsituationgenerator.cpp
@@ -105,9 +105,9 @@ std::shared_ptr<Node> TestSituationGenerator::moveNode(const ReplicaSide side, c
     const auto node = updateTree(side)->getNodeById(generateId(side, id));
 
     node->setMoveOriginInfos({node->getPath(), node->parentNode()->id().value()});
-    (void) node->parentNode()->deleteChildren(node);
+    (void) node->parentNode()->deleteChild(node);
     (void) node->setParentNode(newParentNode);
-    (void) newParentNode->insertChildren(node);
+    (void) newParentNode->insertChild(node);
     if (!newName.empty()) node->setName(newName);
     node->insertChangeEvent(OperationType::Move);
     return node;
@@ -228,7 +228,7 @@ std::shared_ptr<Node> TestSituationGenerator::insertInUpdateTree(
             std::make_shared<Node>(dbNodeId, side, Str2SyncName(CommonUtility::toUpper(id)), itemType, OperationType::None,
                                    generateId(side, id), testhelpers::defaultTime, testhelpers::defaultTime, size, parentNode);
     updateTree(side)->insertNode(node);
-    (void) parentNode->insertChildren(node);
+    (void) parentNode->insertChild(node);
     return node;
 }
 


### PR DESCRIPTION
Optimisation:
In order to minimize the number of tmp nodes, FSOperationSet::getOpsByType returns now a std::set ordered by path depth instead of a std::unordered_set.

Fix:
In the UpdateTreeWorker step 8, we now try to merge the tmp nodes with permanent ones before updating them with the database. Indeed, the update with the DB is done via path and this does not work when there are duplicates.