### PR TITLE
feat: Refactor system-specific release notes handling

### DIFF
--- a/infomaniak-build-tools/translate_release_notes.py
+++ b/infomaniak-build-tools/translate_release_notes.py
@@ -29,12 +29,6 @@ import shutil
 import subprocess
 import sys
 
-def prettify_html(html_filepath):
-    with open(html_filepath, "r") as f:
-        soup = BeautifulSoup(f.read(), "html.parser")
-    with open(html_filepath, "w") as f:
-        f.write(soup.prettify())
-
 def version_regex(arg_value, pattern=re.compile(r'^(\d+\.)?(\d+\.)?(\*|\d+)')):
     if not pattern.match(arg_value):
         raise argparse.ArgumentTypeError("invalid version")
@@ -53,8 +47,8 @@ To add more languages in the future, edit the script to append the new language 
     Language list : https://developers.deepl.com/docs/api-reference/languages
 
 To add more systems, edit the script to append the new system to the list.
-    System specific Release Notes entries must start with the system name.
-    eg: "Windows - Added new feature" for Windows specific feature.
+    System specific Release Notes entries must use the data-os HTML attribute matching the system name.
+    eg: <li data-os="win">Windows specific fix.</li>
     """,
     formatter_class=argparse.RawTextHelpFormatter)
 
@@ -89,33 +83,25 @@ os_list = [
     'linux',
     'macos'
 ]
-os_keys = [
-    '$windows',
-    '$linux',
-    '$macos'
-]
+
+# OS-specific entries in the template must use the data-os attribute with one of the values above.
+# eg: <li data-os="win">Windows specific fix.</li>
 
 def split_os(lang, fullName):
     lang_ext = lang.lower()
 
-    count = 0;
     for os_name in os_list:
         os_ext = os_name.lower()
-        os_key = os_keys[count]
-        count += 1
         shutil.copyfile(f"{fullName}-{lang_ext}.html", f"{fullName}-{os_ext}-{lang_ext}.html")
         with open(f"{fullName}-{os_ext}-{lang_ext}.html", "r") as f:
-            lines = f.readlines()
+            soup = BeautifulSoup(f.read(), "html.parser")
+        for tag in soup.find_all(attrs={"data-os": True}):
+            if tag["data-os"] != os_ext:
+                tag.decompose()
+            else:
+                del tag["data-os"]
         with open(f"{fullName}-{os_ext}-{lang_ext}.html", "w") as f:
-            for line in lines:
-                lowered = line.lower()
-                if any(key in lowered for key in os_keys):
-                    if os_key in lowered:
-                        f.write(f"\t\t<li>{line[line.find(os_key) + len(os_key):]}")
-                else:
-                    f.write(line)
-
-        prettify_html(f"{fullName}-{os_ext}-{lang_ext}.html")
+            f.write(soup.prettify())
         
 
 print(f"Generating Release Notes for kDrive-{args.version}")

--- a/infomaniak-build-tools/translate_release_notes.py
+++ b/infomaniak-build-tools/translate_release_notes.py
@@ -47,7 +47,7 @@ To add more languages in the future, edit the script to append the new language 
     Language list : https://developers.deepl.com/docs/api-reference/languages
 
 To add more systems, edit the script to append the new system to the list.
-    System specific Release Notes entries must use the data-os HTML attribute matching the system name.
+    System specific Release Notes entries must use the data-os HTML attribute matching the system name (win, linux, macos).
     eg: <li data-os="win">Windows specific fix.</li>
     """,
     formatter_class=argparse.RawTextHelpFormatter)

--- a/release_notes/kDrive-template.html
+++ b/release_notes/kDrive-template.html
@@ -24,6 +24,9 @@
     <h2><b>New features</b></h2>
     <ul>
         <li>Extension of the retention period for debug logs to 1 month and move to a persistent folder.</li>
+        <li data-os="win">Windows specific feature.</li>
+        <li data-os="linux">Linux specific feature.</li>
+        <li data-os="macos">macOS specific feature.</li>
     </ul>
 
     <h2><b>Bug fixes</b></h2>


### PR DESCRIPTION
This pull request updates the way OS-specific release notes are handled in the `translate_release_notes.py` script and the release notes template. The main improvement is switching from a keyword-based approach to using the `data-os` HTML attribute for identifying OS-specific entries, making the process more robust and maintainable.

**Release Notes Template and Script Improvements:**

* Updated the release notes template (`kDrive-template.html`) to include OS-specific entries using the `data-os` HTML attribute (e.g., `<li data-os="win">Windows specific feature.</li>`).
* Modified the script's documentation and help text to instruct users to use the `data-os` attribute for OS-specific entries instead of system name prefixes.
* Refactored the `split_os` function to parse the HTML, remove entries not matching the target OS using the `data-os` attribute, and clean up the attribute for matching entries. This replaces the previous string-based filtering approach.

**Code Cleanup:**

* Removed the now-unnecessary `os_keys` list and the obsolete `prettify_html` function, as HTML prettification is now handled inline after filtering. [[1]](diffhunk://#diff-1130bbcc12b313386106304fe56ae4e44872b745f13b9d8be0a7fd590c64b015L32-L37) [[2]](diffhunk://#diff-1130bbcc12b313386106304fe56ae4e44872b745f13b9d8be0a7fd590c64b015L92-R104)