### PR TITLE
fix: Update dark mode issue in the SynchroFolderTypeLabel view

### DIFF
--- a/src/gui4/macOS/kDrive/UI/Views/SynchroConfiguration/Components/SynchroFolderTypeLabel.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/SynchroConfiguration/Components/SynchroFolderTypeLabel.swift
@@ -33,7 +33,7 @@ struct SynchroFolderTypeLabel: View {
                 .foregroundStyle(ColorToken.Text.primary.asColor)
         }
         .padding(AppPadding.padding8)
-        .background(Color.white, in: .rect(cornerRadius: AppRadius.radius8))
+        .background(Color(NSColor.windowBackgroundColor), in: .rect(cornerRadius: AppRadius.radius8))
     }
 }
 


### PR DESCRIPTION
<img width="962" height="982" alt="CleanShot 2026-06-25 at 09 49 33@2x" src="https://github.com/user-attachments/assets/cc501421-0523-4911-a45c-6dbdb925070c" />
