### PR TITLE
feat: Refactor cleanup logic and add error resolution test

### DIFF
--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -31,26 +31,16 @@
 
 namespace KDC {
 
-MockAppServer *TestAppServer::_sharedAppPtr = nullptr;
-LocalTemporaryDirectory *TestAppServer::_sharedTempDir = nullptr;
-
 void TestAppServer::setUp() {
     TestBase::start();
 
-    // Re-create parmsDb so each test starts with a clean database state
-    if (!_sharedTempDir) {
-        _sharedTempDir = new LocalTemporaryDirectory("TestAppServer");
-    }
-    const SyncPath parmsDbPath = _sharedTempDir->path() / MockDb::makeDbMockFileName();
+    // Create parmsDb
+    const SyncPath parmsDbPath = _localTempDir.path() / MockDb::makeDbMockFileName();
     (void) ParmsDb::instance(parmsDbPath, KDRIVE_VERSION_STRING, true, true);
     ParametersCache::instance()->parameters().setExtendedLog(true);
 
-    if (_sharedAppPtr) {
-        // Reuse the existing AppServer — QCoreApplication must never be destroyed and
-        // recreated within a process lifetime: doing so unloads Windows.Globalization.dll
-        // and friends, causing QLocale::system() to crash on the next call.
-        _sharedAppPtr->setParmsDbPath(parmsDbPath);
-        _appPtr = _sharedAppPtr;
+    if (QCoreApplication::instance()) {
+        _appPtr = dynamic_cast<MockAppServer *>(QCoreApplication::instance());
         return;
     }
 
@@ -77,36 +67,33 @@ void TestAppServer::setUp() {
     const Drive drive(1, driveId, account.dbId());
     (void) ParmsDb::instance()->insertDrive(drive);
 
-    const auto localPath = _sharedTempDir->path() / "local_sync_directory";
+    const auto localPath = _localTempDir.path() / "local_sync_directory";
     std::filesystem::create_directories(localPath);
 
     Sync sync(1, drive.dbId(), localPath, "", testVariables.remotePath);
     (void) ParmsDb::instance()->insertSync(sync);
 
-    // Create AppServer (once per process — QCoreApplication lifetime must span all tests)
+    // Create AppServer
     SyncPath exePath = KDC::CommonUtility::applicationFilePath();
     try {
         const std::vector<std::string> args = {Path2Str(exePath)};
         std::vector<char *> argv;
         for (size_t i = 0; i < args.size(); ++i) argv.push_back(const_cast<char *>(args[i].c_str()));
         auto argc = static_cast<int>(args.size());
-        _sharedAppPtr = new MockAppServer(argc, &argv[0]);
-        _sharedAppPtr->setParmsDbPath(parmsDbPath);
-        _sharedAppPtr->init();
+        _appPtr = new MockAppServer(argc, &argv[0]);
+        _appPtr->setParmsDbPath(parmsDbPath);
+        _appPtr->init();
     } catch (const std::exception &e) {
         std::cerr << "kDrive server initialization error: " << e.what() << std::endl;
         return;
     }
 
-    _appPtr = _sharedAppPtr;
-
     // /!\ No event handling (no call to _appPtr->exec())
 }
 
 void TestAppServer::tearDown() {
-    if (_appPtr) {
-        _appPtr->lightweightCleanup();
-    }
+    _appPtr->cleanup();
+    delete _appPtr;
     TestBase::stop();
 }
 
@@ -364,21 +351,6 @@ std::filesystem::path MockAppServer::makeDbName() {
 
 std::shared_ptr<ParmsDb> MockAppServer::initParmsDB(const std::filesystem::path &dbPath, const std::string &version) {
     return ParmsDb::instance(dbPath, version, false, true);
-}
-
-void MockAppServer::lightweightCleanup() {
-    // Stop any running syncs/vfs without tearing down the QCoreApplication.
-    // Full cleanup (which deletes the object) is deferred to process exit.
-    stopAllSyncPals();
-    stopAllVfs();
-    {
-        const std::scoped_lock lock(syncPalMapMutex);
-        syncPalMap.clear();
-    }
-    {
-        const std::scoped_lock lock(vfsMapMutex);
-        vfsMap.clear();
-    }
 }
 
 void MockAppServer::cleanup() {

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -92,8 +92,6 @@ void TestAppServer::setUp() {
 }
 
 void TestAppServer::tearDown() {
-    _appPtr->cleanup();
-    delete _appPtr;
     TestBase::stop();
 }
 
@@ -217,6 +215,12 @@ void TestAppServer::testStartAndStopSync() {
     CPPUNIT_ASSERT(_appPtr->vfsMap.empty());
     CPPUNIT_ASSERT(IoHelper::checkIfPathExists(syncDbPath, exists, ioError, IoHelper::PathCheckOption::Insensitive));
     CPPUNIT_ASSERT(!exists);
+}
+
+void TestAppServer::testCleanup() {
+    _appPtr->cleanup();
+    delete _appPtr;
+    CPPUNIT_ASSERT(true);
 }
 
 /**

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -92,6 +92,8 @@ void TestAppServer::setUp() {
 }
 
 void TestAppServer::tearDown() {
+    _appPtr->cleanup();
+    delete _appPtr;
     TestBase::stop();
 }
 
@@ -217,12 +219,6 @@ void TestAppServer::testStartAndStopSync() {
     CPPUNIT_ASSERT(!exists);
 }
 
-void TestAppServer::testCleanup() {
-    _appPtr->cleanup();
-    delete _appPtr;
-    CPPUNIT_ASSERT(true);
-}
-
 /**
  * Test:
  * - "driveA" has been moved from "accountA" to "accountB"
@@ -292,6 +288,47 @@ void TestAppServer::testUpdateUserInfo() {
     CPPUNIT_ASSERT(found);
     CPPUNIT_ASSERT(drive.accountDbId() != 11);
     CPPUNIT_ASSERT_EQUAL(accountDbIdB, static_cast<uint64_t>(drive.accountDbId()));
+}
+
+void TestAppServer::testResolveErrorsForNode() {
+    const SyncDbId syncDbId = 1;
+    const NodeId localId = "resolve_local_1";
+    const NodeId remoteId = "resolve_remote_1";
+    const SyncPath path = "dir/file.txt";
+
+    // Resolvable: FileAccessError
+    Error errAccess(syncDbId, localId, remoteId, NodeType::File, path, ConflictType::None, InconsistencyType::None,
+                    CancelType::None, "", ExitCode::SystemError, ExitCause::FileAccessError);
+    CPPUNIT_ASSERT(ParmsDb::instance()->insertError(errAccess));
+
+    // Resolvable: TmpBlacklisted
+    Error errTmp(syncDbId, localId, remoteId, NodeType::File, path, ConflictType::None, InconsistencyType::None,
+                 CancelType::TmpBlacklisted);
+    CPPUNIT_ASSERT(ParmsDb::instance()->insertError(errTmp));
+
+    // Resolvable: ForbiddenChar
+    Error errChar(syncDbId, localId, remoteId, NodeType::File, path, ConflictType::None, InconsistencyType::ForbiddenChar);
+    CPPUNIT_ASSERT(ParmsDb::instance()->insertError(errChar));
+
+    // Non-resolvable: EditEdit conflict — must survive
+    Error errConflict(syncDbId, localId, remoteId, NodeType::File, path, ConflictType::EditEdit, InconsistencyType::None);
+    CPPUNIT_ASSERT(ParmsDb::instance()->insertError(errConflict));
+
+    // Call the actual function under test
+    SyncFileItem item;
+    item.setLocalNodeId(localId);
+    item.setRemoteNodeId(remoteId);
+    item.setPath(path);
+    _appPtr->resolveItemErrors(syncDbId, item);
+
+    // Only the conflict error must remain
+    std::vector<Error> errorList;
+    bool found = false;
+    CPPUNIT_ASSERT(ParmsDb::instance()->selectErrorByNodeInfo(syncDbId, localId, remoteId, std::nullopt, std::nullopt, errorList,
+                                                              found));
+    CPPUNIT_ASSERT(found);
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), errorList.size());
+    CPPUNIT_ASSERT_EQUAL(ConflictType::EditEdit, errorList[0].conflictType());
 }
 
 bool TestAppServer::waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const {

--- a/test/server/appserver/testappserver.cpp
+++ b/test/server/appserver/testappserver.cpp
@@ -31,16 +31,26 @@
 
 namespace KDC {
 
+MockAppServer *TestAppServer::_sharedAppPtr = nullptr;
+LocalTemporaryDirectory *TestAppServer::_sharedTempDir = nullptr;
+
 void TestAppServer::setUp() {
     TestBase::start();
 
-    // Create parmsDb
-    const SyncPath parmsDbPath = _localTempDir.path() / MockDb::makeDbMockFileName();
+    // Re-create parmsDb so each test starts with a clean database state
+    if (!_sharedTempDir) {
+        _sharedTempDir = new LocalTemporaryDirectory("TestAppServer");
+    }
+    const SyncPath parmsDbPath = _sharedTempDir->path() / MockDb::makeDbMockFileName();
     (void) ParmsDb::instance(parmsDbPath, KDRIVE_VERSION_STRING, true, true);
     ParametersCache::instance()->parameters().setExtendedLog(true);
 
-    if (QCoreApplication::instance()) {
-        _appPtr = dynamic_cast<MockAppServer *>(QCoreApplication::instance());
+    if (_sharedAppPtr) {
+        // Reuse the existing AppServer — QCoreApplication must never be destroyed and
+        // recreated within a process lifetime: doing so unloads Windows.Globalization.dll
+        // and friends, causing QLocale::system() to crash on the next call.
+        _sharedAppPtr->setParmsDbPath(parmsDbPath);
+        _appPtr = _sharedAppPtr;
         return;
     }
 
@@ -67,33 +77,36 @@ void TestAppServer::setUp() {
     const Drive drive(1, driveId, account.dbId());
     (void) ParmsDb::instance()->insertDrive(drive);
 
-    const auto localPath = _localTempDir.path() / "local_sync_directory";
+    const auto localPath = _sharedTempDir->path() / "local_sync_directory";
     std::filesystem::create_directories(localPath);
 
     Sync sync(1, drive.dbId(), localPath, "", testVariables.remotePath);
     (void) ParmsDb::instance()->insertSync(sync);
 
-    // Create AppServer
+    // Create AppServer (once per process — QCoreApplication lifetime must span all tests)
     SyncPath exePath = KDC::CommonUtility::applicationFilePath();
     try {
         const std::vector<std::string> args = {Path2Str(exePath)};
         std::vector<char *> argv;
         for (size_t i = 0; i < args.size(); ++i) argv.push_back(const_cast<char *>(args[i].c_str()));
         auto argc = static_cast<int>(args.size());
-        _appPtr = new MockAppServer(argc, &argv[0]);
-        _appPtr->setParmsDbPath(parmsDbPath);
-        _appPtr->init();
+        _sharedAppPtr = new MockAppServer(argc, &argv[0]);
+        _sharedAppPtr->setParmsDbPath(parmsDbPath);
+        _sharedAppPtr->init();
     } catch (const std::exception &e) {
         std::cerr << "kDrive server initialization error: " << e.what() << std::endl;
         return;
     }
 
+    _appPtr = _sharedAppPtr;
+
     // /!\ No event handling (no call to _appPtr->exec())
 }
 
 void TestAppServer::tearDown() {
-    _appPtr->cleanup();
-    delete _appPtr;
+    if (_appPtr) {
+        _appPtr->lightweightCleanup();
+    }
     TestBase::stop();
 }
 
@@ -351,6 +364,21 @@ std::filesystem::path MockAppServer::makeDbName() {
 
 std::shared_ptr<ParmsDb> MockAppServer::initParmsDB(const std::filesystem::path &dbPath, const std::string &version) {
     return ParmsDb::instance(dbPath, version, false, true);
+}
+
+void MockAppServer::lightweightCleanup() {
+    // Stop any running syncs/vfs without tearing down the QCoreApplication.
+    // Full cleanup (which deletes the object) is deferred to process exit.
+    stopAllSyncPals();
+    stopAllVfs();
+    {
+        const std::scoped_lock lock(syncPalMapMutex);
+        syncPalMap.clear();
+    }
+    {
+        const std::scoped_lock lock(vfsMapMutex);
+        vfsMap.clear();
+    }
 }
 
 void MockAppServer::cleanup() {

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -57,7 +57,7 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testInitAndStopSyncPal);
         CPPUNIT_TEST(testStartAndStopSync);
         CPPUNIT_TEST(testUpdateUserInfo);
-        CPPUNIT_TEST(testCleanup); // Must be the last test
+        CPPUNIT_TEST(testResolveErrorsForNode);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -66,8 +66,8 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
 
         void testInitAndStopSyncPal();
         void testStartAndStopSync();
-        void testCleanup();
         void testUpdateUserInfo();
+        void testResolveErrorsForNode();
 
     private:
         MockAppServer *_appPtr;

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -58,6 +58,7 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testStartAndStopSync);
         CPPUNIT_TEST(testUpdateUserInfo);
         CPPUNIT_TEST(testResolveErrorsForNode);
+        CPPUNIT_TEST(testCleanup); // Must be the last test
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -68,6 +69,7 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         void testStartAndStopSync();
         void testUpdateUserInfo();
         void testResolveErrorsForNode();
+        void testCleanup();
 
     private:
         MockAppServer *_appPtr;

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -30,6 +30,7 @@ class MockAppServer : public AppServer {
         std::shared_ptr<ParmsDb> initParmsDB(const std::filesystem::path &dbPath, const std::string &version) override;
         bool startClient() override { return true; }
         void cleanup() override;
+        void lightweightCleanup();
 
         void setParmsDbPath(const std::filesystem::path &path) { _parmsDbPath = path; }
 
@@ -70,8 +71,13 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         void testResolveErrorsForNode();
 
     private:
-        MockAppServer *_appPtr;
-        LocalTemporaryDirectory _localTempDir = LocalTemporaryDirectory("TestAppServer");
+        // The AppServer (QCoreApplication) must not be destroyed and recreated within a
+        // process lifetime: destroying it unloads Windows.Globalization.dll and friends,
+        // causing QLocale::system() to access violation on the next construction.
+        static MockAppServer *_sharedAppPtr;
+        static LocalTemporaryDirectory *_sharedTempDir;
+
+        MockAppServer *_appPtr = nullptr;
 
         bool waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const;
         bool syncIsActive(int syncDbId) const;

--- a/test/server/appserver/testappserver.h
+++ b/test/server/appserver/testappserver.h
@@ -30,7 +30,6 @@ class MockAppServer : public AppServer {
         std::shared_ptr<ParmsDb> initParmsDB(const std::filesystem::path &dbPath, const std::string &version) override;
         bool startClient() override { return true; }
         void cleanup() override;
-        void lightweightCleanup();
 
         void setParmsDbPath(const std::filesystem::path &path) { _parmsDbPath = path; }
 
@@ -71,13 +70,8 @@ class TestAppServer : public CppUnit::TestFixture, public TestBase {
         void testResolveErrorsForNode();
 
     private:
-        // The AppServer (QCoreApplication) must not be destroyed and recreated within a
-        // process lifetime: destroying it unloads Windows.Globalization.dll and friends,
-        // causing QLocale::system() to access violation on the next construction.
-        static MockAppServer *_sharedAppPtr;
-        static LocalTemporaryDirectory *_sharedTempDir;
-
-        MockAppServer *_appPtr = nullptr;
+        MockAppServer *_appPtr;
+        LocalTemporaryDirectory _localTempDir = LocalTemporaryDirectory("TestAppServer");
 
         bool waitForSyncStatus(int syncDbId, SyncStatus targetStatus) const;
         bool syncIsActive(int syncDbId) const;


### PR DESCRIPTION
This pull request adds a new unit test to verify the correct resolution of node errors in the application server. The main focus is to ensure that only non-resolvable errors (such as conflicts) remain after attempting to resolve errors for a node, while resolvable errors are properly cleared.

**New Test for Error Resolution:**

* Added the `testResolveErrorsForNode` method to `TestAppServer`, which:
  * Inserts multiple types of errors for a node (resolvable and non-resolvable).
  * Calls the `resolveItemErrors` method to process these errors.
  * Asserts that only the non-resolvable conflict error remains afterward.

**Test Suite and Declaration Updates:**

* Registered the new test method in the test suite using `CPPUNIT_TEST`.
* Declared the `testResolveErrorsForNode` method in the class definition and adjusted the order of test method declarations.