### PR TITLE
fix(release): remove hardcoded paths in AMD64 release script

### DIFF
--- a/infomaniak-build-tools/linux/build-release-amd64.sh
+++ b/infomaniak-build-tools/linux/build-release-amd64.sh
@@ -128,7 +128,7 @@ build_release() {
   QTDIR="$(find_qt_conan_path "$build_dir")"
   export QTDIR
   export QMAKE="$QTDIR/bin/qmake"
-  export PATH="$QTDIR/bin:$QTDIR/libexec:/home/runner/.local/bin:$PATH"
+  export PATH="$QTDIR/bin:$QTDIR/libexec:$HOME/.local/bin:$PATH"
   export LD_LIBRARY_PATH="$QTDIR/lib:$LD_LIBRARY_PATH"
   export PKG_CONFIG_PATH="$QTDIR/lib/pkgconfig:$PKG_CONFIG_PATH"
 

--- a/infomaniak-build-tools/linux/build-release-amd64.sh
+++ b/infomaniak-build-tools/linux/build-release-amd64.sh
@@ -192,7 +192,7 @@ package_release() {
 
   cp "$QTDIR/lib/libQt6SerialPort.so.6" "$app_dir/usr/lib/"
 
-  "$HOME/desktop-setup/linuxdeploy-x86_64.AppImage" --appdir "$app_dir" -e "$app_dir/usr/bin/kDrive" -i "$app_dir/kdrive-win.png" -d "$app_dir/usr/share/applications/kDrive_client.desktop" --plugin qt --output appimage -v0
+  linuxdeploy --appdir "$app_dir" -e "$app_dir/usr/bin/kDrive" -i "$app_dir/kdrive-win.png" -d "$app_dir/usr/share/applications/kDrive_client.desktop" --plugin qt --output appimage -v0
 
   full_version="$(grep "KDRIVE_VERSION_FULL" "$build_dir/build/version.h" | awk '{print $3}')"
   app_name="kDrive-${full_version}-amd64.AppImage"


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Supprime deux chemins codés en dur dans le script de release AMD64 pour Linux, afin de rendre le script portable quel que soit l'environnement d'exécution (nom d'utilisateur du runner CI, emplacement de `linuxdeploy`).

## Changements
- Remplace `/home/runner/.local/bin` par `$HOME/.local/bin` dans l'export `PATH`, pour ne pas dépendre du nom d'utilisateur du runner CI.
- Remplace l'invocation directe de `$HOME/desktop-setup/linuxdeploy-x86_64.AppImage` par un simple appel à `linuxdeploy`, résolu via le `PATH` du shell.

## Détails techniques
Ces deux corrections rendent le script indépendant de la configuration locale du runner. Le binaire `linuxdeploy` doit désormais être disponible dans le `PATH` de l'environnement CI plutôt qu'à un emplacement absolu dans le répertoire personnel du runner.

</details>

---

## Summary
Removes two hardcoded paths from the AMD64 Linux release script, making it portable across CI environments regardless of runner username or `linuxdeploy` installation path.

## Changes
- Replace `/home/runner/.local/bin` with `$HOME/.local/bin` in the `PATH` export, removing the dependency on a specific CI runner username.
- Replace the direct invocation of `$HOME/desktop-setup/linuxdeploy-x86_64.AppImage` with a plain `linuxdeploy` call resolved via the shell `PATH`.

## Technical Details
Both changes affect `infomaniak-build-tools/linux/build-release-amd64.sh`. The `linuxdeploy` binary must now be present in the CI environment's `PATH` instead of at a fixed absolute path under the runner's home directory.