### PR TITLE
fix(server): parse options before logging init and handle auth code early exit

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -180,15 +180,15 @@ void AppServer::init() {
     setWindowIcon(_theme->applicationIcon());
     setApplicationVersion(QString::fromStdString(_theme->version()));
 
+    parseOptions(_arguments);
+    if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked || !_authorizationCodeStr.isEmpty()) {
+        std::cout << "Command line options processed";
+        return;
+    }
+
     // Setup logging with default parameters
     if (!initLogging()) {
         throw std::runtime_error("Unable to init logging.");
-    }
-
-    parseOptions(_arguments);
-    if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked) {
-        LOG_INFO(_logger, "Command line options processed");
-        return;
     }
 
     if (isRunning()) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -181,14 +181,19 @@ void AppServer::init() {
     setApplicationVersion(QString::fromStdString(_theme->version()));
 
     parseOptions(_arguments);
-    if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked || !_authorizationCodeStr.isEmpty()) {
-        std::cout << "Command line options processed";
+    if (!_authorizationCodeStr.isEmpty()) {
+        std::cout << "Authorization code received";
         return;
     }
 
     // Setup logging with default parameters
     if (!initLogging()) {
         throw std::runtime_error("Unable to init logging.");
+    }
+
+    if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked) {
+        LOG_INFO(_logger, "Command line options processed");
+        return;
     }
 
     if (isRunning()) {


### PR DESCRIPTION
## Summary
Move parseOptions() call before initLogging() so that command-line options (help, version, clear sync nodes, clear keychain keys, and authorization code) are handled before the logging system is initialized. This avoids unnecessary logging setup when the app is invoked for CLI-only operations.
It fixes a bug where the logs were archived after user login, leading to the app not being able to log anymore.
### Changes
- parseOptions(_arguments) is now called before initLogging()
- Added !_authorizationCodeStr.isEmpty() to the early-exit condition
- Replaced LOG_INFO with std::cout for the early-exit message (logger not yet initialized at that point)