### PR TITLE
feat: synchronization delay

### DIFF
--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Infomaniak kDrive - Desktop
  * Copyright (C) 2023-2026 Infomaniak Network SA
  *

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -459,25 +459,8 @@ void LocalFileSystemObserverWorker::execute() {
 
     // Sync loop
     for (;;) {
-        if (stopAsked()) {
-            exitInfo = ExitCode::Ok;
-            invalidateSnapshot();
-            break;
-        }
+        if (checkWorkerConditions(exitInfo)) break;
 
-        exitInfo = _syncPal->isRootFolderValid();
-        if (!exitInfo) {
-            LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
-            invalidateSnapshot();
-            break;
-        }
-
-        exitInfo = _folderWatcher->exitInfo();
-        if (!exitInfo) {
-            LOG_SYNCPAL_WARN(_logger, "Error in FolderWatcher: " << _folderWatcher->exitInfo());
-            invalidateSnapshot();
-            break;
-        }
         // We never pause this thread
         if (!_liveSnapshot.isValid()) {
             exitInfo = generateInitialSnapshot();
@@ -487,25 +470,7 @@ void LocalFileSystemObserverWorker::execute() {
             }
         }
 
-        // Wait 1 sec after the last update or 5 if the file has a slow-writing extension, before starting the sync
-        if (_updating) {
-            const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                                       _needUpdateTimerStart);
-            const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
-            if (diff_ms.count() > activeDelay) {
-                // Check if root folder is still valid
-                exitInfo = _syncPal->isRootFolderValid();
-                if (!exitInfo) {
-                    LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
-                    invalidateSnapshot();
-                    break;
-                }
-
-                const std::scoped_lock lock(_recursiveMutex);
-                _updating = false;
-                _useExtendedDelay = false;
-            }
-        }
+        if (checkAndClearUpdateDelay(exitInfo)) break;
 
         if (_initializing) _initializing = false;
         Utility::msleep(LOOP_EXEC_SLEEP_PERIOD);
@@ -513,6 +478,52 @@ void LocalFileSystemObserverWorker::execute() {
     LOG_SYNCPAL_DEBUG(_logger, "Worker stopped: name=" << name());
     setExitCause(exitInfo.cause());
     setDone(exitInfo.code());
+}
+
+bool LocalFileSystemObserverWorker::checkWorkerConditions(ExitInfo &exitInfo) {
+    if (stopAsked()) {
+        exitInfo = ExitCode::Ok;
+        invalidateSnapshot();
+        return true;
+    }
+
+    exitInfo = _syncPal->isRootFolderValid();
+    if (!exitInfo) {
+        LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
+        invalidateSnapshot();
+        return true;
+    }
+
+    exitInfo = _folderWatcher->exitInfo();
+    if (!exitInfo) {
+        LOG_SYNCPAL_WARN(_logger, "Error in FolderWatcher: " << _folderWatcher->exitInfo());
+        invalidateSnapshot();
+        return true;
+    }
+
+    return false;
+}
+
+bool LocalFileSystemObserverWorker::checkAndClearUpdateDelay(ExitInfo &exitInfo) {
+    if (!_updating) return false;
+
+    // Wait 1 sec after the last update or 5 if the file has a slow-writing extension, before starting the sync
+    const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
+                                                                               _needUpdateTimerStart);
+    const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
+    if (diff_ms.count() <= activeDelay) return false;
+
+    exitInfo = _syncPal->isRootFolderValid();
+    if (!exitInfo) {
+        LOG_SYNCPAL_WARN(_logger, "Error in isRootFolderValid: " << exitInfo);
+        invalidateSnapshot();
+        return true;
+    }
+
+    const std::scoped_lock lock(_recursiveMutex);
+    _updating = false;
+    _useExtendedDelay = false;
+    return false;
 }
 
 ExitInfo LocalFileSystemObserverWorker::generateInitialSnapshot() {

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -109,8 +109,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
         _updating = true;
         _needUpdateTimerStart = std::chrono::steady_clock::now();
 
-        auto ext = absolutePath.extension().string();
-
+        const std::string ext = CommonUtility::toLower(absolutePath.extension().string());
         if (std::find(slowWritingExtensions.begin(), slowWritingExtensions.end(), ext) != slowWritingExtensions.end()) {
             _useExtendedDelay = true;
         }

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -32,8 +32,8 @@
 
 #include <log4cplus/loggingmacros.h>
 
+#include <array>
 #include <filesystem>
-#include <unordered_set>
 
 namespace KDC {
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -457,7 +457,7 @@ void LocalFileSystemObserverWorker::execute() {
 
     // Sync loop
     for (;;) {
-        if (checkWorkerConditions(exitInfo)) break;
+        if (checkFatalConditions(exitInfo)) break;
 
         // We never pause this thread
         if (!_liveSnapshot.isValid()) {
@@ -478,7 +478,7 @@ void LocalFileSystemObserverWorker::execute() {
     setDone(exitInfo.code());
 }
 
-bool LocalFileSystemObserverWorker::checkWorkerConditions(ExitInfo &exitInfo) {
+bool LocalFileSystemObserverWorker::checkFatalConditions(ExitInfo &exitInfo) {
     if (stopAsked()) {
         exitInfo = ExitCode::Ok;
         invalidateSnapshot();

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -1,4 +1,4 @@
-/*
+﻿/*
  * Infomaniak kDrive - Desktop
  * Copyright (C) 2023-2026 Infomaniak Network SA
  *
@@ -33,10 +33,19 @@
 #include <log4cplus/loggingmacros.h>
 
 #include <filesystem>
+#include <unordered_set>
 
 namespace KDC {
 
 static const int waitForUpdateDelay = 1000; // 1sec
+static const int waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
+
+static const std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
+        SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),
+        SyncPath(L".indd").native(), SyncPath(L".blend").native(),  SyncPath(L".dwg").native(),
+        SyncPath(L".dxf").native(),  SyncPath(L".pln").native(),    SyncPath(L".pla").native(),
+        SyncPath(L".prproj").native(), SyncPath(L".aep").native(),
+};
 
 LocalFileSystemObserverWorker::LocalFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
                                                              const std::string &shortName) :
@@ -103,6 +112,9 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
         // Raise flag _updating in order to wait 1sec without local changes before starting the sync
         _updating = true;
         _needUpdateTimerStart = std::chrono::steady_clock::now();
+        if (slowWritingExtensions.contains(absolutePath.extension().native())) {
+            _useExtendedDelay = true;
+        }
 
         _syncPal->removeItemFromTmpBlacklist(relativePath);
 
@@ -475,11 +487,12 @@ void LocalFileSystemObserverWorker::execute() {
             }
         }
 
-        // Wait 1 sec after the last update
+        // Wait 1 sec after the last update or 5 if the file has a slow-writing extension, before starting the sync
         if (_updating) {
             const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
                                                                                        _needUpdateTimerStart);
-            if (diff_ms.count() > waitForUpdateDelay) {
+            const int activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
+            if (diff_ms.count() > activeDelay) {
                 // Check if root folder is still valid
                 exitInfo = _syncPal->isRootFolderValid();
                 if (!exitInfo) {
@@ -490,6 +503,7 @@ void LocalFileSystemObserverWorker::execute() {
 
                 const std::scoped_lock lock(_recursiveMutex);
                 _updating = false;
+                _useExtendedDelay = false;
             }
         }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -40,8 +40,8 @@ namespace KDC {
 static const int64_t waitForUpdateDelay = 1000; // 1sec
 static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5; // 5sec, for slow-writing extensions
 
-static constexpr std::array<std::wstring_view, 11> slowWritingExtensions = {
-        L".psd", L".psb", L".ai", L".indd", L".blend", L".dwg", L".dxf", L".pln", L".pla", L".prproj", L".aep"};
+static constexpr std::array<std::string_view, 11> slowWritingExtensions = {
+        ".psd", ".psb", ".ai", ".indd", ".blend", ".dwg", ".dxf", ".pln", ".pla", ".prproj", ".aep"};
 
 LocalFileSystemObserverWorker::LocalFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
                                                              const std::string &shortName) :
@@ -109,7 +109,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
         _updating = true;
         _needUpdateTimerStart = std::chrono::steady_clock::now();
 
-        auto ext = absolutePath.extension().native();
+        auto ext = absolutePath.extension().string();
 
         if (std::find(slowWritingExtensions.begin(), slowWritingExtensions.end(), ext) != slowWritingExtensions.end()) {
             _useExtendedDelay = true;

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -40,8 +40,8 @@ namespace KDC {
 static const int64_t waitForUpdateDelay = 1000; // 1sec
 static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5; // 5sec, for slow-writing extensions
 
-static constexpr std::array<std::string_view, 11> slowWritingExtensions = {
-        ".psd", ".psb", ".ai", ".indd", ".blend", ".dwg", ".dxf", ".pln", ".pla", ".prproj", ".aep"};
+static constexpr std::array<std::string_view, 11> slowWritingExtensions = {".psd", ".psb", ".ai",  ".indd",   ".blend", ".dwg",
+                                                                           ".dxf", ".pln", ".pla", ".prproj", ".aep"};
 
 LocalFileSystemObserverWorker::LocalFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
                                                              const std::string &shortName) :
@@ -503,12 +503,23 @@ bool LocalFileSystemObserverWorker::checkFatalConditions(ExitInfo &exitInfo) {
 }
 
 bool LocalFileSystemObserverWorker::checkAndClearUpdateDelay(ExitInfo &exitInfo) {
-    if (!_updating) return false;
+    std::chrono::steady_clock::time_point needUpdateTimerStart;
+    bool updating = false;
+    bool useExtendedDelay = false;
+
+    {
+        const std::scoped_lock lock(_recursiveMutex);
+        updating = _updating;
+        useExtendedDelay = _useExtendedDelay;
+        needUpdateTimerStart = _needUpdateTimerStart;
+    }
+
+    if (!updating) return false;
 
     // Wait 1 sec after the last update or 5 if the file has a slow-writing extension, before starting the sync
     const auto diff_ms =
-            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _needUpdateTimerStart);
-    const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - needUpdateTimerStart);
+    const auto activeDelay = useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
     if (diff_ms.count() <= activeDelay) return false;
 
     exitInfo = _syncPal->isRootFolderValid();
@@ -518,9 +529,11 @@ bool LocalFileSystemObserverWorker::checkAndClearUpdateDelay(ExitInfo &exitInfo)
         return true;
     }
 
-    const std::scoped_lock lock(_recursiveMutex);
-    _updating = false;
-    _useExtendedDelay = false;
+    {
+        const std::scoped_lock lock(_recursiveMutex);
+        _updating = false;
+        _useExtendedDelay = false;
+    }
     return false;
 }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -40,12 +40,8 @@ namespace KDC {
 static const int64_t waitForUpdateDelay = 1000; // 1sec
 static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5; // 5sec, for slow-writing extensions
 
-static constexpr std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
-        SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),
-        SyncPath(L".indd").native(), SyncPath(L".blend").native(),  SyncPath(L".dwg").native(),
-        SyncPath(L".dxf").native(),  SyncPath(L".pln").native(),    SyncPath(L".pla").native(),
-        SyncPath(L".prproj").native(), SyncPath(L".aep").native(),
-};
+static constexpr std::array<std::wstring_view, 11> slowWritingExtensions = {
+        L".psd", L".psb", L".ai", L".indd", L".blend", L".dwg", L".dxf", L".pln", L".pla", L".prproj", L".aep"};
 
 LocalFileSystemObserverWorker::LocalFileSystemObserverWorker(std::shared_ptr<SyncPal> syncPal, const std::string &name,
                                                              const std::string &shortName) :
@@ -112,7 +108,10 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
         // Raise flag _updating in order to wait 1sec without local changes before starting the sync
         _updating = true;
         _needUpdateTimerStart = std::chrono::steady_clock::now();
-        if (slowWritingExtensions.contains(absolutePath.extension().native())) {
+
+        auto ext = absolutePath.extension().native();
+
+        if (std::find(slowWritingExtensions.begin(), slowWritingExtensions.end(), ext) != slowWritingExtensions.end()) {
             _useExtendedDelay = true;
         }
 
@@ -508,8 +507,8 @@ bool LocalFileSystemObserverWorker::checkAndClearUpdateDelay(ExitInfo &exitInfo)
     if (!_updating) return false;
 
     // Wait 1 sec after the last update or 5 if the file has a slow-writing extension, before starting the sync
-    const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
-                                                                               _needUpdateTimerStart);
+    const auto diff_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - _needUpdateTimerStart);
     const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
     if (diff_ms.count() <= activeDelay) return false;
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -37,8 +37,8 @@
 
 namespace KDC {
 
-static const int waitForUpdateDelay = 1000; // 1sec
-static const int waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
+static const int64_t waitForUpdateDelay = 1000; // 1sec
+static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
 
 static const std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
         SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),
@@ -491,7 +491,7 @@ void LocalFileSystemObserverWorker::execute() {
         if (_updating) {
             const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
                                                                                        _needUpdateTimerStart);
-            const int activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
+            const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
             if (diff_ms.count() > activeDelay) {
                 // Check if root folder is still valid
                 exitInfo = _syncPal->isRootFolderValid();

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -111,7 +111,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
 
         auto ext = absolutePath.extension().native();
 
-        if (std::ranges::find(slowWritingExtensions, ext) != slowWritingExtensions.end()) {
+        if (std::find(slowWritingExtensions.begin(), slowWritingExtensions.end(), ext) != slowWritingExtensions.end()) {
             _useExtendedDelay = true;
         }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -40,7 +40,7 @@ namespace KDC {
 static const int64_t waitForUpdateDelay = 1000; // 1sec
 static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5; // 5sec, for slow-writing extensions
 
-static const std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
+static constexpr std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
         SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),
         SyncPath(L".indd").native(), SyncPath(L".blend").native(),  SyncPath(L".dwg").native(),
         SyncPath(L".dxf").native(),  SyncPath(L".pln").native(),    SyncPath(L".pla").native(),

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -38,7 +38,7 @@
 namespace KDC {
 
 static const int64_t waitForUpdateDelay = 1000; // 1sec
-static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
+static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5; // 5sec, for slow-writing extensions
 
 static const std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
         SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -37,8 +37,8 @@
 
 namespace KDC {
 
-static const int64_t waitForUpdateDelay = 1000; // 1sec
-static const int64_t waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
+static const int waitForUpdateDelay = 1000; // 1sec
+static const int waitForUpdateDelayExtended = waitForUpdateDelay * 5.000; // 5sec, for slow-writing extensions
 
 static const std::unordered_set<SyncPath::string_type> slowWritingExtensions = {
         SyncPath(L".psd").native(),  SyncPath(L".psb").native(),    SyncPath(L".ai").native(),
@@ -491,7 +491,7 @@ void LocalFileSystemObserverWorker::execute() {
         if (_updating) {
             const auto diff_ms = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() -
                                                                                        _needUpdateTimerStart);
-            const auto activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
+            const int activeDelay = _useExtendedDelay ? waitForUpdateDelayExtended : waitForUpdateDelay;
             if (diff_ms.count() > activeDelay) {
                 // Check if root folder is still valid
                 exitInfo = _syncPal->isRootFolderValid();

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -457,7 +457,7 @@ void LocalFileSystemObserverWorker::execute() {
 
     // Sync loop
     for (;;) {
-        if (checkFatalConditions(exitInfo)) break;
+        if (checkStopCondition(exitInfo)) break;
 
         // We never pause this thread
         if (!_liveSnapshot.isValid()) {
@@ -478,7 +478,7 @@ void LocalFileSystemObserverWorker::execute() {
     setDone(exitInfo.code());
 }
 
-bool LocalFileSystemObserverWorker::checkFatalConditions(ExitInfo &exitInfo) {
+bool LocalFileSystemObserverWorker::checkStopCondition(ExitInfo &exitInfo) {
     if (stopAsked()) {
         exitInfo = ExitCode::Ok;
         invalidateSnapshot();

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.cpp
@@ -111,7 +111,7 @@ ExitInfo LocalFileSystemObserverWorker::changesDetected(const std::list<std::pai
 
         auto ext = absolutePath.extension().native();
 
-        if (std::find(slowWritingExtensions.begin(), slowWritingExtensions.end(), ext) != slowWritingExtensions.end()) {
+        if (std::ranges::find(slowWritingExtensions, ext) != slowWritingExtensions.end()) {
             _useExtendedDelay = true;
         }
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -59,6 +59,7 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
         ExitInfo handleIoError(const SyncPath &relativePath, IoError ioError);
 
         std::chrono::steady_clock::time_point _needUpdateTimerStart = std::chrono::steady_clock::now();
+        bool _useExtendedDelay = false;
 
         std::recursive_mutex _recursiveMutex;
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -58,6 +58,11 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
 
         ExitInfo handleIoError(const SyncPath &relativePath, IoError ioError);
 
+        // Returns true if the execute() loop should break.
+        bool checkWorkerConditions(ExitInfo &exitInfo);
+        // Returns true if the execute() loop should break.
+        bool checkAndClearUpdateDelay(ExitInfo &exitInfo);
+
         std::chrono::steady_clock::time_point _needUpdateTimerStart = std::chrono::steady_clock::now();
         bool _useExtendedDelay = false;
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -59,7 +59,7 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
         ExitInfo handleIoError(const SyncPath &relativePath, IoError ioError);
 
         // Returns true if the execute() loop should break.
-        bool checkFatalConditions(ExitInfo &exitInfo);
+        bool checkStopCondition(ExitInfo &exitInfo);
         // Returns true if the execute() loop should break.
         bool checkAndClearUpdateDelay(ExitInfo &exitInfo);
 

--- a/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
+++ b/src/libsyncengine/update_detection/file_system_observer/localfilesystemobserverworker.h
@@ -59,7 +59,7 @@ class LocalFileSystemObserverWorker : public FileSystemObserverWorker {
         ExitInfo handleIoError(const SyncPath &relativePath, IoError ioError);
 
         // Returns true if the execute() loop should break.
-        bool checkWorkerConditions(ExitInfo &exitInfo);
+        bool checkFatalConditions(ExitInfo &exitInfo);
         // Returns true if the execute() loop should break.
         bool checkAndClearUpdateDelay(ExitInfo &exitInfo);
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -682,6 +682,70 @@ void TestLocalFileSystemObserverWorker::testInvalidateCounter() {
     CPPUNIT_ASSERT_EQUAL(false, _syncPal->liveSnapshot(ReplicaSide::Local).isValid()); // Snapshot has been invalidated.
 }
 
+void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
+    auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
+    CPPUNIT_ASSERT(localFSO);
+
+    // Wait for folder watcher to be ready
+    int count = 0;
+    while (!_syncPal->liveSnapshot(ReplicaSide::Local).isValid() || !localFSO->_folderWatcher->isReady()) {
+        Utility::msleep(100);
+        CPPUNIT_ASSERT(count++ < 20);
+    }
+
+    // --- Normal extension (.txt): delay must be < 2s ---
+    {
+        LOGW_DEBUG(_logger, L"***** test normal extension delay (.txt) *****");
+        const SyncPath filePath = _rootFolderPath / Str("test_delay.txt");
+        testhelpers::generateOrEditTestFile(filePath);
+
+        // Wait until _updating becomes true (change detected)
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, std::chrono::seconds(5),
+                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(!localFSO->_useExtendedDelay);
+
+        // Measure how long until _updating goes back to false (sync allowed)
+        bool result = false;
+        CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
+                [&]() {
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(2),
+                                                 std::chrono::milliseconds(10));
+                },
+                result, std::chrono::milliseconds(500), std::chrono::milliseconds(2000)));
+        CPPUNIT_ASSERT(result);
+
+        auto ioError = IoError::Unknown;
+        IoHelper::deleteItem(filePath, ioError);
+        Utility::msleep(1500);
+    }
+
+    // --- Slow-writing extension (.blend): delay must be >= 5s ---
+    {
+        LOGW_DEBUG(_logger, L"***** test slow-writing extension delay (.blend) *****");
+        const SyncPath filePath = _rootFolderPath / Str("test_delay.blend");
+        testhelpers::generateOrEditTestFile(filePath);
+
+        // Wait until _updating becomes true (change detected)
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, std::chrono::seconds(5),
+                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(localFSO->_useExtendedDelay);
+
+        // Measure how long until _updating goes back to false (sync allowed)
+        bool result = false;
+        CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
+                [&]() {
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(15),
+                                                  std::chrono::milliseconds(10));
+                },
+                result, std::chrono::milliseconds(4500), std::chrono::milliseconds(7000)));
+        CPPUNIT_ASSERT(result);
+
+        auto ioError = IoError::Unknown;
+        IoHelper::deleteItem(filePath, ioError);
+        Utility::msleep(6000);
+    }
+}
+
 void MockLocalFileSystemObserverWorker::waitForUpdate(SnapshotRevision previousRevision,
                                                       const std::chrono::milliseconds timeoutMs) const {
     using namespace std::chrono;

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -685,14 +685,26 @@ void TestLocalFileSystemObserverWorker::testInvalidateCounter() {
 void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
     if (!testhelpers::isExtendedTest()) return;
 
+    constexpr int64_t watcherReadyPollMs = 100;
+    constexpr int64_t maxWatcherReadyPolls = 20;
+    constexpr auto loopPollInterval = std::chrono::milliseconds(10);
+    constexpr auto changeDetectionTimeout = std::chrono::seconds(5);
+    constexpr auto normalUpdateDelayMin = std::chrono::milliseconds(500);
+    constexpr auto normalUpdateDelayMax = std::chrono::milliseconds(2000);
+    constexpr auto normalUpdateClearTimeout = std::chrono::seconds(2);
+    constexpr auto extendedUpdateWaitTimeout = std::chrono::seconds(15);
+    constexpr auto extendedUpdateDelayMin = std::chrono::milliseconds(4500);
+    constexpr auto extendedUpdateDelayMax = std::chrono::milliseconds(7000);
+    constexpr auto extendedUpdateClearTimeout = std::chrono::seconds(6);
+
     auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
     CPPUNIT_ASSERT(localFSO);
 
     // Wait for folder watcher to be ready
     int64_t count = 0;
     while (!_syncPal->liveSnapshot(ReplicaSide::Local).isValid() || !localFSO->_folderWatcher->isReady()) {
-        Utility::msleep(100);
-        CPPUNIT_ASSERT(count++ < 20);
+        Utility::msleep(watcherReadyPollMs);
+        CPPUNIT_ASSERT(count++ < maxWatcherReadyPolls);
     }
 
     // --- Normal extension (.txt): delay must be < 2s ---
@@ -702,25 +714,25 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         testhelpers::generateOrEditTestFile(filePath);
 
         // Wait until _updating becomes true (change detected)
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, std::chrono::seconds(5),
-                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout,
+                                              loopPollInterval));
         CPPUNIT_ASSERT(!localFSO->_useExtendedDelay);
 
         // Measure how long until _updating goes back to false (sync allowed)
         bool result = false;
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
-                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(2),
-                                                  std::chrono::milliseconds(10));
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateClearTimeout,
+                                                  loopPollInterval);
                 },
-                result, std::chrono::milliseconds(500), std::chrono::milliseconds(2000)));
+                result, normalUpdateDelayMin, normalUpdateDelayMax));
         CPPUNIT_ASSERT(result);
 
         auto ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(2),
-                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateClearTimeout,
+                                              loopPollInterval));
     }
 
     // --- Slow-writing extension (.blend): delay must be >= 5s ---
@@ -730,25 +742,25 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         testhelpers::generateOrEditTestFile(filePath);
 
         // Wait until _updating becomes true (change detected)
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, std::chrono::seconds(5),
-                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return localFSO->updating(); }, changeDetectionTimeout,
+                                              loopPollInterval));
         CPPUNIT_ASSERT(localFSO->_useExtendedDelay);
 
         // Measure how long until _updating goes back to false (sync allowed)
         bool result = false;
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
-                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(15),
-                                                  std::chrono::milliseconds(10));
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, extendedUpdateWaitTimeout,
+                                                  loopPollInterval);
                 },
-                result, std::chrono::milliseconds(4500), std::chrono::milliseconds(7000)));
+                result, extendedUpdateDelayMin, extendedUpdateDelayMax));
         CPPUNIT_ASSERT(result);
 
         auto ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
         CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(6),
-                                              std::chrono::milliseconds(10)));
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, extendedUpdateClearTimeout,
+                                              loopPollInterval));
     }
 }
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -148,7 +148,6 @@ void TestLocalFileSystemObserverWorker::testSyncDirChange() {
     CPPUNIT_ASSERT_EQUAL(ExitInfo(ExitCode::SystemError, ExitCause::SyncDirChanged), exitInfo);
 }
 
-
 void TestLocalFileSystemObserverWorker::testLFSOWithInitialSnapshot() {
     NodeSet ids;
     _syncPal->copySnapshots();
@@ -689,13 +688,12 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
     constexpr int64_t maxWatcherReadyPolls = 20;
     constexpr auto loopPollInterval = std::chrono::milliseconds(10);
     constexpr auto changeDetectionTimeout = std::chrono::seconds(5);
+    constexpr auto normalUpdateWaitTimeout = std::chrono::seconds(4);
     constexpr auto normalUpdateDelayMin = std::chrono::milliseconds(500);
     constexpr auto normalUpdateDelayMax = std::chrono::milliseconds(2000);
-    constexpr auto normalUpdateClearTimeout = std::chrono::seconds(2);
     constexpr auto extendedUpdateWaitTimeout = std::chrono::seconds(15);
     constexpr auto extendedUpdateDelayMin = std::chrono::milliseconds(4500);
     constexpr auto extendedUpdateDelayMax = std::chrono::milliseconds(7000);
-    constexpr auto extendedUpdateClearTimeout = std::chrono::seconds(6);
 
     auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
     CPPUNIT_ASSERT(localFSO);
@@ -722,17 +720,11 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         bool result = false;
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
-                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateClearTimeout,
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateWaitTimeout,
                                                   loopPollInterval);
                 },
                 result, normalUpdateDelayMin, normalUpdateDelayMax));
         CPPUNIT_ASSERT(result);
-
-        auto ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateClearTimeout,
-                                              loopPollInterval));
     }
 
     // --- Slow-writing extension (.blend): delay must be >= 5s ---
@@ -755,12 +747,6 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
                 },
                 result, extendedUpdateDelayMin, extendedUpdateDelayMax));
         CPPUNIT_ASSERT(result);
-
-        auto ioError = IoError::Unknown;
-        CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
-        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
-        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, extendedUpdateClearTimeout,
-                                              loopPollInterval));
     }
 }
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -715,7 +715,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         CPPUNIT_ASSERT(result);
 
         auto ioError = IoError::Unknown;
-        IoHelper::deleteItem(filePath, ioError);
+        CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
         Utility::msleep(1500);
     }
 
@@ -741,7 +741,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         CPPUNIT_ASSERT(result);
 
         auto ioError = IoError::Unknown;
-        IoHelper::deleteItem(filePath, ioError);
+        CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
         Utility::msleep(6000);
     }
 }

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -683,6 +683,8 @@ void TestLocalFileSystemObserverWorker::testInvalidateCounter() {
 }
 
 void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
+    if (!testhelpers::isExtendedTest()) return;
+
     auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
     CPPUNIT_ASSERT(localFSO);
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -711,14 +711,16 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
                     return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(2),
-                                                 std::chrono::milliseconds(10));
+                                                  std::chrono::milliseconds(10));
                 },
                 result, std::chrono::milliseconds(500), std::chrono::milliseconds(2000)));
         CPPUNIT_ASSERT(result);
 
         auto ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
-        Utility::msleep(1500);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(2),
+                                              std::chrono::milliseconds(10)));
     }
 
     // --- Slow-writing extension (.blend): delay must be >= 5s ---
@@ -744,7 +746,9 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
 
         auto ioError = IoError::Unknown;
         CPPUNIT_ASSERT(IoHelper::deleteItem(filePath, ioError));
-        Utility::msleep(6000);
+        CPPUNIT_ASSERT_EQUAL(IoError::Success, ioError);
+        CPPUNIT_ASSERT(TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, std::chrono::seconds(6),
+                                              std::chrono::milliseconds(10)));
     }
 }
 

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -688,12 +688,10 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
     constexpr int64_t maxWatcherReadyPolls = 20;
     constexpr auto loopPollInterval = std::chrono::milliseconds(10);
     constexpr auto changeDetectionTimeout = std::chrono::seconds(5);
-    constexpr auto normalUpdateWaitTimeout = std::chrono::seconds(4);
     constexpr auto normalUpdateDelayMin = std::chrono::milliseconds(500);
     constexpr auto normalUpdateDelayMax = std::chrono::milliseconds(2000);
-    constexpr auto extendedUpdateWaitTimeout = std::chrono::seconds(15);
     constexpr auto extendedUpdateDelayMin = std::chrono::milliseconds(4500);
-    constexpr auto extendedUpdateDelayMax = std::chrono::milliseconds(7000);
+    constexpr auto extendedUpdateDelayMax = std::chrono::seconds(6);
 
     auto localFSO = std::dynamic_pointer_cast<LocalFileSystemObserverWorker>(_syncPal->_localFSObserverWorker);
     CPPUNIT_ASSERT(localFSO);
@@ -720,7 +718,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         bool result = false;
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
-                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateWaitTimeout,
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, normalUpdateDelayMax,
                                                   loopPollInterval);
                 },
                 result, normalUpdateDelayMin, normalUpdateDelayMax));
@@ -742,7 +740,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
         bool result = false;
         CPPUNIT_ASSERT(TimeoutHelper::checkExecutionTime<bool>(
                 [&]() {
-                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, extendedUpdateWaitTimeout,
+                    return TimeoutHelper::waitFor([&]() { return !localFSO->updating(); }, extendedUpdateDelayMax,
                                                   loopPollInterval);
                 },
                 result, extendedUpdateDelayMin, extendedUpdateDelayMax));

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.cpp
@@ -687,7 +687,7 @@ void TestLocalFileSystemObserverWorker::testSlowWritingExtensionDelay() {
     CPPUNIT_ASSERT(localFSO);
 
     // Wait for folder watcher to be ready
-    int count = 0;
+    int64_t count = 0;
     while (!_syncPal->liveSnapshot(ReplicaSide::Local).isValid() || !localFSO->_folderWatcher->isReady()) {
         Utility::msleep(100);
         CPPUNIT_ASSERT(count++ < 20);

--- a/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
+++ b/test/libsyncengine/update_detection/file_system_observer/testlocalfilesystemobserverworker.h
@@ -78,6 +78,7 @@ class TestLocalFileSystemObserverWorker final : public CppUnit::TestFixture, pub
         CPPUNIT_TEST(testLFSODirReplacement);
         CPPUNIT_TEST(testInvalidateCounter);
         CPPUNIT_TEST(testInvalidateSnapshot);
+        CPPUNIT_TEST(testSlowWritingExtensionDelay);
         CPPUNIT_TEST_SUITE_END();
 
     public:
@@ -106,6 +107,7 @@ class TestLocalFileSystemObserverWorker final : public CppUnit::TestFixture, pub
         void testLFSODirReplacement();
         void testInvalidateCounter();
         void testInvalidateSnapshot();
+        void testSlowWritingExtensionDelay();
         void testSyncDirChange();
         static bool vfsStatus(int, const SyncPath &, bool &, bool &, bool &, int &) { return true; }
         static bool vfsPinState(int, const SyncPath &, PinState &) { return true; }


### PR DESCRIPTION
This pull request introduces support for handling "slow-writing" file extensions in the local file system observer, ensuring that files with certain extensions (like `.blend`, `.psd`, etc.) are given more time to finish writing before synchronization starts. This helps prevent syncing incomplete files. The update also includes a comprehensive test to verify this behavior.

**Enhancements to file synchronization timing:**

* Added a list of slow-writing file extensions (e.g., `.psd`, `.blend`, `.ai`, etc.) in `localfilesystemobserverworker.cpp` and introduced a longer (5s) delay before starting sync for these files (`waitForUpdateDelayExtended` and `slowWritingExtensions`).
* Updated the sync logic to use the extended delay if a detected file change matches a slow-writing extension, and reset the delay flag after syncing [[1]](diffhunk://#diff-ff42c7a015729e64cf90fec7464a10bfd27d8297fda389d5893a5768c21b3961R115-R117) [[2]](diffhunk://#diff-ff42c7a015729e64cf90fec7464a10bfd27d8297fda389d5893a5768c21b3961L478-R495) [[3]](diffhunk://#diff-ff42c7a015729e64cf90fec7464a10bfd27d8297fda389d5893a5768c21b3961R506).
* Added a new boolean member `_useExtendedDelay` to `LocalFileSystemObserverWorker` to track when the extended delay should be applied.

**Testing improvements:**

* Added a new test `testSlowWritingExtensionDelay` in `testlocalfilesystemobserverworker.cpp` to verify that normal files use the standard delay and slow-writing files use the extended delay before syncing.
* Registered the new test in the test suite in `testlocalfilesystemobserverworker.h` [[1]](diffhunk://#diff-5b0d1b88a440702b6dc63d7920fcd424c617603389dee92b2263367306d14b58R81) [[2]](diffhunk://#diff-5b0d1b88a440702b6dc63d7920fcd424c617603389dee92b2263367306d14b58R110).