### PR TITLE
feat(unit-tests): Enables trash-related unit tests on Linux CI runners

### DIFF
--- a/infomaniak-build-tools/run-test.sh
+++ b/infomaniak-build-tools/run-test.sh
@@ -46,6 +46,15 @@ if [ ! -f "$tester" ]; then
     exit 1
 fi
 
+# Create trash folders compliant with freedesktop specifications
+# (see https://www.freedesktop.org/wiki/Specifications/trash-spec)
+# to enable trash-related tests.
+export XDG_DATA_HOME="$HOME/.local/share"
+mkdir -p "$HOME/.local/share/Trash/files"
+mkdir -p "$HOME/.local/share/Trash/info"
+chmod 700 "$HOME/.local/share/Trash"
+
+# Launch the tests
 chmod +x "$tester"
 export DYLD_LIBRARY_PATH="$PWD:/usr/local/lib:/usr/lib:$DYLD_LIBRARY_PATH"
 ls -lah /usr/local/lib /usr/lib $PWD 2>/dev/null || true

--- a/infomaniak-build-tools/run-test.sh
+++ b/infomaniak-build-tools/run-test.sh
@@ -46,14 +46,6 @@ if [ ! -f "$tester" ]; then
     exit 1
 fi
 
-# Create trash folders compliant with freedesktop specifications
-# (see https://www.freedesktop.org/wiki/Specifications/trash-spec)
-# to enable trash-related tests.
-export XDG_DATA_HOME="$HOME/.local/share"
-mkdir -p "$HOME/.local/share/Trash/files"
-mkdir -p "$HOME/.local/share/Trash/info"
-chmod 700 "$HOME/.local/share/Trash"
-
 # Launch the tests
 chmod +x "$tester"
 export DYLD_LIBRARY_PATH="$PWD:/usr/local/lib:/usr/lib:$DYLD_LIBRARY_PATH"

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -314,7 +314,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo());
     CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -314,6 +314,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
 #if defined(KD_LINUX)
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo())
     CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -331,7 +331,7 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
     CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));

--- a/test/libsyncengine/integration/testintegration.cpp
+++ b/test/libsyncengine/integration/testintegration.cpp
@@ -314,8 +314,8 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(dirpath));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo());
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
+    CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
 #endif
@@ -331,7 +331,8 @@ void TestIntegration::testBlacklist() {
 
     CPPUNIT_ASSERT(!std::filesystem::exists(_syncPal->localPath() / filename));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(_syncPal->localPath() / filename));
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif
@@ -492,8 +493,8 @@ void TestIntegration::testExclusionTemplates() {
                                             filename)); // The local file has been moved to trash.
     CPPUNIT_ASSERT(!std::filesystem::exists(filename));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() ||
-                   testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
+    CPPUNIT_ASSERT(testhelpers::isInTrash(_syncPal->localPath() / tmpRemoteDir.name() / filename));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(filename));
 #endif

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -101,7 +101,7 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));

--- a/test/libsyncengine/integration/testintegration_basics.cpp
+++ b/test/libsyncengine/integration/testintegration_basics.cpp
@@ -101,7 +101,8 @@ void TestIntegration::testLocalChanges() {
     CPPUNIT_ASSERT(!remoteTestFileInfo.isValid());
 
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(subDirPath));
+    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif
@@ -179,7 +180,8 @@ void TestIntegration::testRemoteChanges() {
     CPPUNIT_ASSERT(!std::filesystem::exists(subDirPath));
     CPPUNIT_ASSERT(!std::filesystem::exists(filePath));
 #if defined(KD_LINUX)
-    CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(subDirPath));
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
+    CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath));
 #else
     CPPUNIT_ASSERT(testhelpers::isInTrash(subDirPath.filename()));
 #endif

--- a/test/libsyncengine/integration/testintegration_conflicts.cpp
+++ b/test/libsyncengine/integration/testintegration_conflicts.cpp
@@ -257,7 +257,8 @@ void TestIntegration::testEditDeleteConflict() {
         CPPUNIT_ASSERT(std::filesystem::exists(_syncPal->localPath() / FileRescuer::rescueFolderName() / filepath.filename()));
 
 #if defined(KD_LINUX)
-        CPPUNIT_ASSERT(!testhelpers::hasTrashInfo() || testhelpers::isInTrash(dirpath));
+        CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
+        CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath));
 #else
         CPPUNIT_ASSERT(testhelpers::isInTrash(dirpath.filename()));
 #endif

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -186,7 +186,7 @@ void KDC::TestLocalJobs::testLocalJobs() {
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
 #else
-    CPPUNIT_ASSERT(testhelpers::hasTrashInfo())
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo());
 
     if (!testhelpers::isInTrash(copyDirPath)) {
         std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;

--- a/test/libsyncengine/jobs/local/testlocaljobs.cpp
+++ b/test/libsyncengine/jobs/local/testlocaljobs.cpp
@@ -40,7 +40,7 @@ namespace KDC {
 class LocalDeleteJobMockingTrash : public SyncLocalDeleteJob {
     public:
         explicit LocalDeleteJobMockingTrash(const std::shared_ptr<SyncPal> syncPal, const SyncPath &absolutePath) :
-            SyncLocalDeleteJob(syncPal, absolutePath) {};
+            SyncLocalDeleteJob(syncPal, absolutePath){};
         void setMoveToTrashFailed(const bool failed) { _moveToTrashFailed = failed; };
         void setLiteSyncEnabled(const bool enabled) { _liteSyncIsEnabled = enabled; };
         void setMockMoveToTrash(const bool mocked) { _moveToTrashIsMocked = mocked; }
@@ -186,16 +186,17 @@ void KDC::TestLocalJobs::testLocalJobs() {
     CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath.filename() / testDirName / "tmp_picture.jpg"));
     CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath.filename() / testDirName / "dehydrated_placeholder.jpg"));
 #else
-    if (testhelpers::hasTrashInfo()) {
-        if (!testhelpers::isInTrash(copyDirPath)) {
-            std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;
-            testhelpers::showTrashInfo();
-        }
+    CPPUNIT_ASSERT(testhelpers::hasTrashInfo())
 
-        CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
-        CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
-        CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
+    if (!testhelpers::isInTrash(copyDirPath)) {
+        std::cout << "\n The item " << copyDirPath << " was not found in trash." << std::endl;
+        testhelpers::showTrashInfo();
     }
+
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath));
+    CPPUNIT_ASSERT(testhelpers::isInTrash(copyDirPath / testDirName / "tmp_picture.jpg"));
+    CPPUNIT_ASSERT(!testhelpers::isInTrash(copyDirPath / testDirName / "dehydrated_placeholder.jpg"));
+
 #endif
 #if defined(KD_MACOS) || defined(KD_LINUX)
     testhelpers::eraseFromTrash(copyDirPath.filename());
@@ -273,7 +274,7 @@ void KDC::TestLocalJobs::testLocalDeleteJob() {
         public:
             LocalDeleteJobMock(const std::shared_ptr<SyncPal> syncPal, const SyncPath &relativePath, const bool isLiteSyncEnabled,
                                RemoteNodeId remoteNodeId, ForceToTrash forceToTrash = ForceToTrash::No) :
-                SyncLocalDeleteJob(syncPal, relativePath, isLiteSyncEnabled, std::move(remoteNodeId), forceToTrash) {
+                SyncLocalDeleteJob(syncPal, relativePath, isLiteSyncEnabled, std::move(remoteNodeId), forceToTrash){
 
                 };
             void setRemoteItemRelativePath(const SyncPath &remoteItemPath) { _remoteItemRelativePath = remoteItemPath; }

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -56,6 +56,10 @@ int runTestSuite(const std::string &logFileName) {
         LOG_INFO(KDC::Log::instance()->getLogger(), "Running extended tests.");
     }
 
+#if defined(KD_LINUX)
+    if (!testhelpers::hasTrashInfo()) testhelpers::createTrashInfo();
+#endif
+
     // Informs test-listener about testresults
     CPPUNIT_NS::TestResult testresult;
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -57,7 +57,7 @@ int runTestSuite(const std::string &logFileName) {
     }
 
 #if defined(KD_LINUX)
-    if (!testhelpers::hasTrashInfo()) testhelpers::createTrashInfo();
+    if (!KDC::testhelpers::hasTrashInfo()) KDC::testhelpers::createTrashInfo();
 #endif
 
     // Informs test-listener about testresults

--- a/test/test_utility/testhelpers.h
+++ b/test/test_utility/testhelpers.h
@@ -136,6 +136,7 @@ bool isInTrash(const SyncPath &path);
 
 #if defined(KD_LINUX)
 bool hasTrashInfo();
+void createTrashInfo();
 void showTrashInfo();
 #endif
 

--- a/test/test_utility/testhelpers_linux.cpp
+++ b/test/test_utility/testhelpers_linux.cpp
@@ -102,6 +102,24 @@ SyncPath getTrashSubDir(const TrashSubDirectory trashSubDir) {
     return {};
 }
 
+void createTrashInfo() {
+    for (const auto trashSubDir: {TrashSubDirectory::Info, TrashSubDirectory::Files}) {
+        const auto trashSubDirPath = getTrashSubDir(trashSubDir);
+        std::error_code ec;
+        if (!std::filesystem::exists(trashSubDirPath, ec) || ec) {
+            (void) std::filesystem::create_directories(trashSubDirPath, ec);
+            if (ec) {
+                LOGW_WARN(Log::instance()->getLogger(),
+                          L"Error in std::filesystem::create_directories: " << Utility::formatStdError(ec));
+            }
+        }
+    }
+
+    const auto overwrite = 0; // Do not overwrite if the variable already exists.
+    const auto homeData = CommonUtility::envVarValue("HOME") + "/.local/share";
+    (void) CommonUtility::setenv("XDG_DATA_HOME", homeData.c_str(), overwrite);
+}
+
 bool hasTrashInfo() {
     std::error_code ec;
     const auto trashInfoPath = getTrashSubDir(TrashSubDirectory::Info);


### PR DESCRIPTION
This pull-request creates trash folders in keeping with the [freedesktop.org](https://www.freedesktop.org/) specifications in the home folder of the CI Linux runners, if those folders do not exist already.

This way, the unit tests which check the content of the trash can be executed on every CI Linux runner. 