### PR TITLE
feat(onboarding): complete the flow with automatic sync creation

### DIFF
--- a/src/gui4/linux/.import_loco.yml
+++ b/src/gui4/linux/.import_loco.yml
@@ -1,0 +1,3 @@
+platform: qt
+localizable_path: ./translations
+languages: [ da, de, el, en, es, fi, fr, it, nb, nl, pl, pt, sv ]

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -118,13 +118,15 @@
   login-specific workflow logic.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It derives
   collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only failed and
-  not-yet-attempted work for retry, and temporarily opens every configured sync root in the system file manager from the
-  ready screen.
+  not-yet-attempted work for retry, reconciles the parent-first cache snapshot after a failed `SYNC_ADD`, and temporarily
+  opens every configured sync root in the system file manager from the ready screen.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
-- `app/services/cachepopulator.*`: sequential initial snapshot loader for users, accounts, drives, syncs, and sync
-  errors; after bootstrap, activates the server live-info refresh so only drive updates reach `CachePipeline`.
+- `app/services/cachepopulator.*`: sequential parent-first snapshot loader for users, accounts, drives, syncs, and sync
+  errors. It is used at initial connection and for explicit reconciliation after a non-transactional backend mutation
+  may have persisted parents without emitting their normal pushes; after each snapshot, it activates the server
+  live-info refresh so only drive updates reach `CachePipeline`.
 - `app/services/driveservice.*`: targeted drive use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
 - `app/services/syncservice.*`: targeted sync use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
@@ -226,8 +228,8 @@ cmake --build build-linux/build/build/Debug --target kDrive kDrive_client kdrive
 - `CachePipeline` must not let server pushes mutate `AppCache` before the initial `CachePopulator` snapshot has
   completed.
 - Full graph snapshots (`USER_INFOLIST`, `ACCOUNT_INFOLIST`, `DRIVE_INFOLIST`, `SYNC_INFOLIST`, initial error list)
-  belong to `CachePopulator` bootstrap/reconnect only. Do not expose user/drive/sync full-refresh methods to QML
-  services.
+  belong to `CachePopulator` for bootstrap/reconnect and explicit parent-first reconciliation after a non-transactional
+  mutation failure. Do not expose user/drive/sync full-refresh methods to QML services.
 - QML-facing services should provide targeted actions only; user/account/drive/sync cache consistency is
   push-signal-driven.
 - Onboarding navigation belongs in `OnboardingFlowController`; keep long-running backend work in service facades and

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -110,11 +110,16 @@
   no displayable session exists.
 - `app/onboarding/onboardingflowcontroller.*`: QML-facing onboarding flow controller aligned with the macOS flow
   (`login -> drive selection -> synchronization -> ready`, with macOS permission steps omitted on Linux). It owns simple
-  onboarding UI actions such as opening account signup and drive-offer URLs; OAuth launch, `LOGIN_REQUESTTOKEN`,
-  available-drive loading, and sync creation stay outside QML-facing flow state.
+  onboarding UI actions such as opening account signup and drive-offer URLs, plus synchronization/ready presentation
+  state; OAuth launch, `LOGIN_REQUESTTOKEN`, available-drive loading, and sync creation stay outside QML-facing flow
+  state.
 - `app/onboarding/onboardinglogincoordinator.*`: login workflow coordinator for onboarding. It wires the flow controller,
   OAuth service, comm service, user service, app cache, and onboarding state so `AppClientLinux` does not accumulate
   login-specific workflow logic.
+- `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It derives
+  collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only failed and
+  not-yet-attempted work for retry, and temporarily opens every configured sync root in the system file manager from the
+  ready screen.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -47,6 +47,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/onboarding/onboardingsession.h
         app/onboarding/onboardingsessionmanager.cpp
         app/onboarding/onboardingsessionmanager.h
+        app/onboarding/onboardingsynccreationcoordinator.cpp
+        app/onboarding/onboardingsynccreationcoordinator.h
         app/onboarding/oauthloginservice.cpp
         app/onboarding/oauthloginservice.h
         communicationlayer/ipcclient.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -114,6 +114,8 @@ set(GUI_QML_FILES # .qml files for the app
         ui/onboarding/NoDriveAvailableView.qml
         ui/onboarding/OnboardingAnimationsView.qml
         ui/onboarding/OnboardingWindow.qml
+        ui/onboarding/ReadyView.qml
+        ui/onboarding/SynchronizationView.qml
         ${GUI_QML_SINGLETON_FILES}
 )
 

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -5,7 +5,7 @@ endif ()
 project(${APPLICATION_CLIENTV4_EXECUTABLE} LANGUAGES C CXX)
 
 
-find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui Network Qml Quick Sql Widgets QuickControls2 QuickEffects)
+find_package(Qt6 6.11 REQUIRED COMPONENTS Core Gui Network Qml Quick Sql Widgets QuickControls2 QuickEffects LinguistTools)
 if (QT_FEATURE_xcb)
     find_package(X11 REQUIRED COMPONENTS Xext)
 endif ()
@@ -149,6 +149,29 @@ qt_add_qml_module(${APPLICATION_CLIENTV4_EXECUTABLE}
         ${GUI_QML_FILES}
         RESOURCES
         ${GUI_QML_RESOURCE_FILES}
+)
+
+# Compile the Loco-exported Qt catalogs to .qm and embed them under :/i18n.
+# The catalogs are id-based (each <message> has an id, in an empty context) and resolved at
+# runtime via qsTrId(); qtTrId looks up the empty context, which is why the exporter/normalizer
+# must leave the <context> name empty. Do not run the generated `update_translations` (lupdate)
+# target: Loco owns the .ts files.
+qt_add_translations(${APPLICATION_CLIENTV4_EXECUTABLE}
+        TS_FILES
+        translations/client_da.ts
+        translations/client_de.ts
+        translations/client_el.ts
+        translations/client_en.ts
+        translations/client_es.ts
+        translations/client_fi.ts
+        translations/client_fr.ts
+        translations/client_it.ts
+        translations/client_nb.ts
+        translations/client_nl.ts
+        translations/client_pl.ts
+        translations/client_pt.ts
+        translations/client_sv.ts
+        RESOURCE_PREFIX "/i18n"
 )
 
 qt_add_resources(${APPLICATION_CLIENTV4_EXECUTABLE} "linux_gui_assets"

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -151,26 +151,13 @@ qt_add_qml_module(${APPLICATION_CLIENTV4_EXECUTABLE}
         ${GUI_QML_RESOURCE_FILES}
 )
 
-# Compile the Loco-exported Qt catalogs to .qm and embed them under :/i18n.
-# The catalogs are id-based (each <message> has an id, in an empty context) and resolved at
-# runtime via qsTrId(); qtTrId looks up the empty context, which is why the exporter/normalizer
-# must leave the <context> name empty. Do not run the generated `update_translations` (lupdate)
-# target: Loco owns the .ts files.
+# Compile the .ts catalogs to .qm and embed them under :/i18n (loaded in setupTranslations()).
+# The .ts files are owned by Loco: update them by running `import_loco`
+# (https://github.com/Infomaniak/importloco) from src/gui4/linux, not the generated
+# `update_translations` (lupdate) target.
+file(GLOB CLIENT_TS_FILES CONFIGURE_DEPENDS "${CMAKE_CURRENT_SOURCE_DIR}/translations/client_*.ts")
 qt_add_translations(${APPLICATION_CLIENTV4_EXECUTABLE}
-        TS_FILES
-        translations/client_da.ts
-        translations/client_de.ts
-        translations/client_el.ts
-        translations/client_en.ts
-        translations/client_es.ts
-        translations/client_fi.ts
-        translations/client_fr.ts
-        translations/client_it.ts
-        translations/client_nb.ts
-        translations/client_nl.ts
-        translations/client_pl.ts
-        translations/client_pt.ts
-        translations/client_sv.ts
+        TS_FILES ${CLIENT_TS_FILES}
         RESOURCE_PREFIX "/i18n"
 )
 

--- a/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
+++ b/src/gui4/linux/app/onboarding/availabledrivesmodel.cpp
@@ -19,6 +19,7 @@
 #include "availabledrivesmodel.h"
 
 #include <QColor>
+#include <QCoreApplication>
 
 #include <algorithm>
 #include <cstddef>
@@ -118,8 +119,7 @@ QVariant AvailableDrivesModel::data(const QModelIndex &index, const int role) co
         case EnabledRole:
             return !context.alreadyConfigured;
         case TooltipRole:
-            return context.alreadyConfigured ? tr("This kDrive is already configured.\nGo to your settings to modify it.")
-                                             : QString();
+            return context.alreadyConfigured ? qtTrId("onboardingAlreadySyncedDriveTooltip") : QString();
         default:
             return {};
     }

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -20,6 +20,7 @@
 
 #include "app/appconstants.h"
 
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QMetaEnum>
 
@@ -64,13 +65,13 @@ bool OnboardingFlowController::readyActive() const {
 QString OnboardingFlowController::title() const {
     switch (_currentStep) {
         case Login:
-            return tr("Welcome to kDrive");
+            return qtTrId("onboardingLoginTitle");
         case DriveSelection:
             return tr("Welcome back!");
         case Synchronization:
-            return tr("Synchronization in progress..");
+            return qtTrId("onboardingSynchronizationInProgressTitle");
         case Ready:
-            return tr("All set!");
+            return qtTrId("onboardingSynchronizationAppReadyTitle");
     }
     return {};
 }

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -53,6 +53,14 @@ bool OnboardingFlowController::driveSelectionActive() const {
     return _currentStep == DriveSelection;
 }
 
+bool OnboardingFlowController::synchronizationActive() const {
+    return _currentStep == Synchronization;
+}
+
+bool OnboardingFlowController::readyActive() const {
+    return _currentStep == Ready;
+}
+
 QString OnboardingFlowController::title() const {
     switch (_currentStep) {
         case Login:
@@ -131,6 +139,26 @@ void OnboardingFlowController::requestDriveSelectionContinue() {
     emit driveSelectionContinueRequested();
 }
 
+void OnboardingFlowController::retrySynchronization() {
+    if (_currentStep != Synchronization || !_synchronizationFailed) {
+        return;
+    }
+
+    qCInfo(lcOnboardingFlowController) << "Onboarding synchronization retry requested";
+    _synchronizationFailed = false;
+    emit synchronizationFailedChanged();
+    emit synchronizationRetryRequested();
+}
+
+void OnboardingFlowController::openSynchronizedFolders() {
+    if (_currentStep != Ready) {
+        return;
+    }
+
+    qCInfo(lcOnboardingFlowController) << "Opening synchronized folders from onboarding";
+    emit synchronizedFoldersOpenRequested();
+}
+
 void OnboardingFlowController::cancel() {
     qCInfo(lcOnboardingFlowController) << "Onboarding cancel requested";
     emit cancelRequested();
@@ -162,6 +190,45 @@ void OnboardingFlowController::handleAuthorizationCodeReady() {
     if (_loginState == LoginIdle || _loginState == WaitingForWebAuthentication || _loginState == LoginError) {
         setLoginState(LoadingUser);
     }
+}
+
+void OnboardingFlowController::beginSynchronization() {
+    if (_synchronizationFailed) {
+        _synchronizationFailed = false;
+        emit synchronizationFailedChanged();
+    }
+    setCurrentStep(Synchronization);
+}
+
+void OnboardingFlowController::failSynchronization() {
+    if (_currentStep != Synchronization || _synchronizationFailed) {
+        return;
+    }
+
+    qCWarning(lcOnboardingFlowController) << "Onboarding synchronization creation failed";
+    _synchronizationFailed = true;
+    emit synchronizationFailedChanged();
+}
+
+void OnboardingFlowController::completeSynchronization() {
+    if (_currentStep != Synchronization) {
+        return;
+    }
+
+    if (_synchronizationFailed) {
+        _synchronizationFailed = false;
+        emit synchronizationFailedChanged();
+    }
+    setCurrentStep(Ready);
+}
+
+void OnboardingFlowController::completeOnboarding() {
+    if (_currentStep != Ready) {
+        return;
+    }
+
+    qCInfo(lcOnboardingFlowController) << "Onboarding completed";
+    emit completed();
 }
 
 void OnboardingFlowController::handleLoginTokenSucceeded(const qint64 userDbId) {

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -151,11 +151,13 @@ void OnboardingFlowController::retrySynchronization() {
 }
 
 void OnboardingFlowController::openSynchronizedFolders() {
-    if (_currentStep != Ready) {
+    if (_currentStep != Ready || !_readyActionEnabled) {
         return;
     }
 
     qCInfo(lcOnboardingFlowController) << "Opening synchronized folders from onboarding";
+    _readyActionEnabled = false;
+    emit readyActionEnabledChanged();
     emit synchronizedFoldersOpenRequested();
 }
 
@@ -219,15 +221,21 @@ void OnboardingFlowController::completeSynchronization() {
         _synchronizationFailed = false;
         emit synchronizationFailedChanged();
     }
+    if (!_readyActionEnabled) {
+        _readyActionEnabled = true;
+        emit readyActionEnabledChanged();
+    }
+    _onboardingCompleted = false;
     setCurrentStep(Ready);
 }
 
 void OnboardingFlowController::completeOnboarding() {
-    if (_currentStep != Ready) {
+    if (_currentStep != Ready || _onboardingCompleted) {
         return;
     }
 
     qCInfo(lcOnboardingFlowController) << "Onboarding completed";
+    _onboardingCompleted = true;
     emit completed();
 }
 

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -225,7 +225,6 @@ void OnboardingFlowController::completeSynchronization() {
         _readyActionEnabled = true;
         emit readyActionEnabledChanged();
     }
-    _onboardingCompleted = false;
     setCurrentStep(Ready);
 }
 

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
@@ -42,6 +42,9 @@ class OnboardingFlowController final : public QObject {
         Q_PROPERTY(bool waitingForWebAuthentication READ waitingForWebAuthentication NOTIFY loginStateChanged)
         Q_PROPERTY(bool loginFailed READ loginFailed NOTIFY loginStateChanged)
         Q_PROPERTY(bool driveSelectionActive READ driveSelectionActive NOTIFY currentStepChanged)
+        Q_PROPERTY(bool synchronizationActive READ synchronizationActive NOTIFY currentStepChanged)
+        Q_PROPERTY(bool synchronizationFailed READ synchronizationFailed NOTIFY synchronizationFailedChanged)
+        Q_PROPERTY(bool readyActive READ readyActive NOTIFY currentStepChanged)
         Q_PROPERTY(QString title READ title NOTIFY currentStepChanged)
 
     public:
@@ -69,6 +72,9 @@ class OnboardingFlowController final : public QObject {
         [[nodiscard]] bool waitingForWebAuthentication() const;
         [[nodiscard]] bool loginFailed() const;
         [[nodiscard]] bool driveSelectionActive() const;
+        [[nodiscard]] bool synchronizationActive() const;
+        [[nodiscard]] bool synchronizationFailed() const { return _synchronizationFailed; }
+        [[nodiscard]] bool readyActive() const;
         [[nodiscard]] QString title() const;
 
         Q_INVOKABLE void requestLogin();
@@ -77,9 +83,15 @@ class OnboardingFlowController final : public QObject {
         Q_INVOKABLE void requestFreeDriveOrder() const;
         Q_INVOKABLE void requestAdvancedSettings();
         Q_INVOKABLE void requestDriveSelectionContinue();
+        Q_INVOKABLE void retrySynchronization();
+        Q_INVOKABLE void openSynchronizedFolders();
         Q_INVOKABLE void cancel();
         Q_INVOKABLE void setCurrentStep(Step step);
         void handleAuthorizationCodeReady();
+        void beginSynchronization();
+        void failSynchronization();
+        void completeSynchronization();
+        void completeOnboarding();
 
     public slots:
         void handleLoginTokenSucceeded(qint64 userDbId);
@@ -93,6 +105,9 @@ class OnboardingFlowController final : public QObject {
         void cancelRequested();
         void advancedSettingsRequested();
         void driveSelectionContinueRequested();
+        void synchronizationRetryRequested();
+        void synchronizedFoldersOpenRequested();
+        void synchronizationFailedChanged();
         void completed();
 
     private:
@@ -102,6 +117,7 @@ class OnboardingFlowController final : public QObject {
 
         Step _currentStep{Login};
         LoginState _loginState{LoginIdle};
+        bool _synchronizationFailed{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
@@ -45,6 +45,7 @@ class OnboardingFlowController final : public QObject {
         Q_PROPERTY(bool synchronizationActive READ synchronizationActive NOTIFY currentStepChanged)
         Q_PROPERTY(bool synchronizationFailed READ synchronizationFailed NOTIFY synchronizationFailedChanged)
         Q_PROPERTY(bool readyActive READ readyActive NOTIFY currentStepChanged)
+        Q_PROPERTY(bool readyActionEnabled READ readyActionEnabled NOTIFY readyActionEnabledChanged)
         Q_PROPERTY(QString title READ title NOTIFY currentStepChanged)
 
     public:
@@ -75,6 +76,7 @@ class OnboardingFlowController final : public QObject {
         [[nodiscard]] bool synchronizationActive() const;
         [[nodiscard]] bool synchronizationFailed() const { return _synchronizationFailed; }
         [[nodiscard]] bool readyActive() const;
+        [[nodiscard]] bool readyActionEnabled() const { return _readyActionEnabled; }
         [[nodiscard]] QString title() const;
 
         Q_INVOKABLE void requestLogin();
@@ -108,6 +110,7 @@ class OnboardingFlowController final : public QObject {
         void synchronizationRetryRequested();
         void synchronizedFoldersOpenRequested();
         void synchronizationFailedChanged();
+        void readyActionEnabledChanged();
         void completed();
 
     private:
@@ -118,6 +121,8 @@ class OnboardingFlowController final : public QObject {
         Step _currentStep{Login};
         LoginState _loginState{LoginIdle};
         bool _synchronizationFailed{false};
+        bool _readyActionEnabled{true};
+        bool _onboardingCompleted{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingsession.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsession.cpp
@@ -19,6 +19,7 @@
 #include "onboardingsession.h"
 
 #include "app/cache/appcache.h"
+#include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
 #include "app/services/serviceeventbus.h"
 #include "app/services/userservice.h"
@@ -32,15 +33,15 @@ Q_LOGGING_CATEGORY(lcOnboardingSession, "gui.v4.onboardingsession", QtInfoMsg)
 } // namespace
 
 OnboardingSession::OnboardingSession(AppCache &appCache, CommService &commService, UserService &userService,
-                                     ServiceEventBus &serviceEventBus, const EntryPoint entryPoint,
-                                     const std::optional<UserDbId> selectedUserDbId, const uint64_t generation,
-                                     QObject *const parent) :
+                                     CachePopulator &cachePopulator, ServiceEventBus &serviceEventBus,
+                                     const EntryPoint entryPoint, const std::optional<UserDbId> selectedUserDbId,
+                                     const uint64_t generation, QObject *const parent) :
     QObject(parent),
     _userService(userService),
     _onboardingState(appCache),
     _loginCoordinator(_flowController, commService, userService, appCache, _onboardingState),
     _driveSelectionController(appCache, _onboardingState, userService, _flowController),
-    _syncCreationCoordinator(_flowController, _onboardingState, appCache, commService, serviceEventBus),
+    _syncCreationCoordinator(_flowController, _onboardingState, appCache, commService, cachePopulator, serviceEventBus),
     _generation(generation) {
     (void) connect(&_loginCoordinator, &OnboardingLoginCoordinator::openWindowRequested, this,
                    &OnboardingSession::openWindowRequested);

--- a/src/gui4/linux/app/onboarding/onboardingsession.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsession.cpp
@@ -20,6 +20,7 @@
 
 #include "app/cache/appcache.h"
 #include "app/services/commservice.h"
+#include "app/services/serviceeventbus.h"
 #include "app/services/userservice.h"
 
 #include <QLoggingCategory>
@@ -31,13 +32,15 @@ Q_LOGGING_CATEGORY(lcOnboardingSession, "gui.v4.onboardingsession", QtInfoMsg)
 } // namespace
 
 OnboardingSession::OnboardingSession(AppCache &appCache, CommService &commService, UserService &userService,
-                                     const EntryPoint entryPoint, const std::optional<UserDbId> selectedUserDbId,
-                                     const uint64_t generation, QObject *const parent) :
+                                     ServiceEventBus &serviceEventBus, const EntryPoint entryPoint,
+                                     const std::optional<UserDbId> selectedUserDbId, const uint64_t generation,
+                                     QObject *const parent) :
     QObject(parent),
     _userService(userService),
     _onboardingState(appCache),
     _loginCoordinator(_flowController, commService, userService, appCache, _onboardingState),
     _driveSelectionController(appCache, _onboardingState, userService, _flowController),
+    _syncCreationCoordinator(_flowController, _onboardingState, appCache, commService, serviceEventBus),
     _generation(generation) {
     (void) connect(&_loginCoordinator, &OnboardingLoginCoordinator::openWindowRequested, this,
                    &OnboardingSession::openWindowRequested);

--- a/src/gui4/linux/app/onboarding/onboardingsession.h
+++ b/src/gui4/linux/app/onboarding/onboardingsession.h
@@ -22,6 +22,7 @@
 #include "app/onboarding/driveselectioncontroller.h"
 #include "app/onboarding/onboardingflowcontroller.h"
 #include "app/onboarding/onboardinglogincoordinator.h"
+#include "app/onboarding/onboardingsynccreationcoordinator.h"
 
 #include <QObject>
 
@@ -33,6 +34,7 @@ namespace KDC {
 class AppCache;
 class AvailableDrivesModel;
 class CommService;
+class ServiceEventBus;
 class UserService;
 
 /**
@@ -53,7 +55,8 @@ class OnboardingSession final : public QObject {
             DriveSelection,
         };
 
-        explicit OnboardingSession(AppCache &appCache, CommService &commService, UserService &userService, EntryPoint entryPoint,
+        explicit OnboardingSession(AppCache &appCache, CommService &commService, UserService &userService,
+                                   ServiceEventBus &serviceEventBus, EntryPoint entryPoint,
                                    std::optional<UserDbId> selectedUserDbId, uint64_t generation, QObject *parent = nullptr);
 
         [[nodiscard]] OnboardingFlowController *flowController() { return &_flowController; }
@@ -71,6 +74,7 @@ class OnboardingSession final : public QObject {
         OnboardingFlowController _flowController;
         OnboardingLoginCoordinator _loginCoordinator;
         DriveSelectionController _driveSelectionController;
+        OnboardingSyncCreationCoordinator _syncCreationCoordinator;
         const uint64_t _generation;
 };
 

--- a/src/gui4/linux/app/onboarding/onboardingsession.h
+++ b/src/gui4/linux/app/onboarding/onboardingsession.h
@@ -33,6 +33,7 @@ namespace KDC {
 
 class AppCache;
 class AvailableDrivesModel;
+class CachePopulator;
 class CommService;
 class ServiceEventBus;
 class UserService;
@@ -56,7 +57,7 @@ class OnboardingSession final : public QObject {
         };
 
         explicit OnboardingSession(AppCache &appCache, CommService &commService, UserService &userService,
-                                   ServiceEventBus &serviceEventBus, EntryPoint entryPoint,
+                                   CachePopulator &cachePopulator, ServiceEventBus &serviceEventBus, EntryPoint entryPoint,
                                    std::optional<UserDbId> selectedUserDbId, uint64_t generation, QObject *parent = nullptr);
 
         [[nodiscard]] OnboardingFlowController *flowController() { return &_flowController; }

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
@@ -22,6 +22,7 @@
 #include "app/onboarding/onboardingflowcontroller.h"
 #include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
+#include "app/services/serviceeventbus.h"
 #include "app/services/userservice.h"
 
 #include <QLoggingCategory>
@@ -33,11 +34,13 @@ Q_LOGGING_CATEGORY(lcOnboardingSessionManager, "gui.v4.onboardingsessionmanager"
 } // namespace
 
 OnboardingSessionManager::OnboardingSessionManager(const CachePopulator &cachePopulator, AppCache &appCache,
-                                                   CommService &commService, UserService &userService, QObject *const parent) :
+                                                   CommService &commService, UserService &userService,
+                                                   ServiceEventBus &serviceEventBus, QObject *const parent) :
     QObject(parent),
     _appCache(appCache),
     _commService(commService),
-    _userService(userService) {
+    _userService(userService),
+    _serviceEventBus(serviceEventBus) {
     (void) connect(&cachePopulator, &CachePopulator::bootstrapCompleted, this,
                    &OnboardingSessionManager::handleBootstrapCompleted);
 }
@@ -115,8 +118,8 @@ void OnboardingSessionManager::startSession(const OnboardingSession::EntryPoint 
     }
 
     const auto generation = _nextGeneration++;
-    auto *const session =
-            new OnboardingSession(_appCache, _commService, _userService, entryPoint, selectedUserDbId, generation, this);
+    auto *const session = new OnboardingSession(_appCache, _commService, _userService, _serviceEventBus, entryPoint,
+                                                selectedUserDbId, generation, this);
     _activeSession = session;
     _state = LifecycleState::Active;
 

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
@@ -33,10 +33,11 @@ namespace {
 Q_LOGGING_CATEGORY(lcOnboardingSessionManager, "gui.v4.onboardingsessionmanager", QtInfoMsg)
 } // namespace
 
-OnboardingSessionManager::OnboardingSessionManager(const CachePopulator &cachePopulator, AppCache &appCache,
-                                                   CommService &commService, UserService &userService,
-                                                   ServiceEventBus &serviceEventBus, QObject *const parent) :
+OnboardingSessionManager::OnboardingSessionManager(CachePopulator &cachePopulator, AppCache &appCache, CommService &commService,
+                                                   UserService &userService, ServiceEventBus &serviceEventBus,
+                                                   QObject *const parent) :
     QObject(parent),
+    _cachePopulator(cachePopulator),
     _appCache(appCache),
     _commService(commService),
     _userService(userService),
@@ -118,8 +119,8 @@ void OnboardingSessionManager::startSession(const OnboardingSession::EntryPoint 
     }
 
     const auto generation = _nextGeneration++;
-    auto *const session = new OnboardingSession(_appCache, _commService, _userService, _serviceEventBus, entryPoint,
-                                                selectedUserDbId, generation, this);
+    auto *const session = new OnboardingSession(_appCache, _commService, _userService, _cachePopulator, _serviceEventBus,
+                                                entryPoint, selectedUserDbId, generation, this);
     _activeSession = session;
     _state = LifecycleState::Active;
 

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
@@ -31,6 +31,7 @@ namespace KDC {
 class AppCache;
 class CachePopulator;
 class CommService;
+class ServiceEventBus;
 class UserService;
 
 /**
@@ -45,7 +46,7 @@ class OnboardingSessionManager final : public QObject {
 
     public:
         explicit OnboardingSessionManager(const CachePopulator &cachePopulator, AppCache &appCache, CommService &commService,
-                                          UserService &userService, QObject *parent = nullptr);
+                                          UserService &userService, ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
 
         [[nodiscard]] OnboardingSession *activeSession() const { return _activeSession; }
 
@@ -76,6 +77,7 @@ class OnboardingSessionManager final : public QObject {
         AppCache &_appCache;
         CommService &_commService;
         UserService &_userService;
+        ServiceEventBus &_serviceEventBus;
         OnboardingSession *_activeSession = nullptr;
         LifecycleState _state{LifecycleState::Determining};
         uint64_t _nextGeneration{1};

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
@@ -45,7 +45,7 @@ class OnboardingSessionManager final : public QObject {
         Q_PROPERTY(OnboardingSession *activeSession READ activeSession NOTIFY activeSessionChanged)
 
     public:
-        explicit OnboardingSessionManager(const CachePopulator &cachePopulator, AppCache &appCache, CommService &commService,
+        explicit OnboardingSessionManager(CachePopulator &cachePopulator, AppCache &appCache, CommService &commService,
                                           UserService &userService, ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
 
         [[nodiscard]] OnboardingSession *activeSession() const { return _activeSession; }
@@ -74,6 +74,7 @@ class OnboardingSessionManager final : public QObject {
         void startSession(OnboardingSession::EntryPoint entryPoint, std::optional<UserDbId> selectedUserDbId);
         void stopSession(bool closeWindow);
         void handleRetiringSessionDestroyed();
+        CachePopulator &_cachePopulator;
         AppCache &_appCache;
         CommService &_commService;
         UserService &_userService;

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -21,6 +21,7 @@
 #include "app/cache/appcache.h"
 #include "app/cache/onboardingstate.h"
 #include "app/onboarding/onboardingflowcontroller.h"
+#include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
 #include "app/services/serviceeventbus.h"
 #include "libcommon/utility/types.h"
@@ -39,13 +40,14 @@ Q_LOGGING_CATEGORY(lcOnboardingSyncCreationCoordinator, "gui.v4.onboardingsynccr
 
 OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingFlowController &flowController,
                                                                      OnboardingState &onboardingState, AppCache &appCache,
-                                                                     CommService &commService, ServiceEventBus &serviceEventBus,
-                                                                     QObject *const parent) :
+                                                                     CommService &commService, CachePopulator &cachePopulator,
+                                                                     ServiceEventBus &serviceEventBus, QObject *const parent) :
     QObject(parent),
     _flowController(flowController),
     _onboardingState(onboardingState),
     _appCache(appCache),
     _commService(commService),
+    _cachePopulator(cachePopulator),
     _serviceEventBus(serviceEventBus) {
     (void) connect(&_flowController, &OnboardingFlowController::driveSelectionContinueRequested, this,
                    &OnboardingSyncCreationCoordinator::startSynchronization);
@@ -53,6 +55,8 @@ OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingF
                    &OnboardingSyncCreationCoordinator::createNextSynchronization);
     (void) connect(&_flowController, &OnboardingFlowController::synchronizedFoldersOpenRequested, this,
                    &OnboardingSyncCreationCoordinator::openSynchronizedFolders);
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this,
+                   &OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted);
 }
 
 void OnboardingSyncCreationCoordinator::startSynchronization() {
@@ -86,11 +90,11 @@ void OnboardingSyncCreationCoordinator::createNextSynchronization() {
 
 void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDriveKey &key) {
     const auto availableDrive = _appCache.availableDrive(key);
-    if (!availableDrive.has_value()) {
+    if (!availableDrive.has_value() || !_onboardingState.isAvailableDriveSelected(key)) {
         qCWarning(lcOnboardingSyncCreationCoordinator)
-                << "Cannot prepare onboarding sync: available drive disappeared | userDbId:" << key.userDbId
+                << "Skipping onboarding sync: available drive is no longer selectable | userDbId:" << key.userDbId
                 << "/ driveId:" << key.driveId;
-        handleCreationFailure();
+        discardPendingSynchronization(key);
         return;
     }
 
@@ -102,6 +106,14 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
                 if (!exitInfo) {
                     _serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
                     handleCreationFailure();
+                    return;
+                }
+
+                if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value()) {
+                    qCWarning(lcOnboardingSyncCreationCoordinator)
+                            << "Discarding prepared onboarding sync: drive is no longer selectable | userDbId:" << key.userDbId
+                            << "/ driveId:" << key.driveId;
+                    discardPendingSynchronization(key);
                     return;
                 }
 
@@ -120,6 +132,14 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
 }
 
 void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config) {
+    if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value()) {
+        qCWarning(lcOnboardingSyncCreationCoordinator)
+                << "Skipping onboarding sync creation: drive is no longer selectable | userDbId:" << key.userDbId
+                << "/ driveId:" << key.driveId;
+        discardPendingSynchronization(key);
+        return;
+    }
+
     SyncAddRequest request;
     request.userDbId = key.userDbId;
     request.accountId = key.accountId;
@@ -135,7 +155,7 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
             request, [this, key, localPath = config.localPath](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
                 if (!exitInfo) {
                     _serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
-                    handleCreationFailure();
+                    handleCreationFailure(true);
                     return;
                 }
 
@@ -150,7 +170,15 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
             });
 }
 
-void OnboardingSyncCreationCoordinator::handleCreationFailure() {
+void OnboardingSyncCreationCoordinator::discardPendingSynchronization(const AvailableDriveKey &key) {
+    _onboardingState.unselectAvailableDrive(key);
+    if (!_pendingDriveKeys.empty() && _pendingDriveKeys.front() == key) {
+        _pendingDriveKeys.pop_front();
+    }
+    createNextSynchronization();
+}
+
+void OnboardingSyncCreationCoordinator::handleCreationFailure(const bool cacheReconciliationRequired) {
     /*
      * IMPORTANT: a batch of onboarding sync creations is not transactional on the server.
      *
@@ -159,13 +187,40 @@ void OnboardingSyncCreationCoordinator::handleCreationFailure() {
      * later request fails. Rolling those successful creations back from the GUI would be unsafe, and replaying the whole
      * original selection would risk creating duplicate syncs or choosing new suffixed local folders.
      *
-     * The coordinator therefore stops at the first failure and keeps the current key plus every not-yet-attempted key in
+     * Account and drive creation also happen before sync creation and are not one database transaction. A failed SYNC_ADD
+     * can therefore leave a newly persisted parent that was not emitted through ACCOUNT_ADDED or DRIVE_ADDED because the
+     * job reports its signals only after complete success. Before exposing Retry, the coordinator asks CachePopulator to
+     * rebuild the graph parent-first so a successful retry cannot emit DRIVE_ADDED/SYNC_ADDED into a cache that still lacks
+     * their account parent.
+     *
+     * The coordinator stops at the first failure and keeps the current key plus every not-yet-attempted key in
      * _pendingDriveKeys. Keys that completed successfully were already removed from both this queue and OnboardingState.
      * The pending config of the failed key is deliberately preserved so Retry reuses the exact same local path instead of
-     * asking the server for another candidate. Retry then resumes from the queue front and Ready is reached only after the
-     * queue is empty.
+     * asking the server for another candidate. Retry resumes from the queue front and Ready is reached only after the queue
+     * is empty.
+     *
+     * Transport failures cannot reach this retry path: IpcClient treats every post-connection socket error as fatal. An
+     * error callback here is therefore a server response, not an ambiguous timeout after a successful response was lost.
      */
     qCWarning(lcOnboardingSyncCreationCoordinator) << "Onboarding sync creation paused | remaining:" << _pendingDriveKeys.size();
+
+    if (cacheReconciliationRequired) {
+        _cacheReconciliationPending = true;
+        qCInfo(lcOnboardingSyncCreationCoordinator) << "Reconciling cache after failed onboarding SYNC_ADD";
+        _cachePopulator.bootstrap();
+        return;
+    }
+
+    _flowController.failSynchronization();
+}
+
+void OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted() {
+    if (!_cacheReconciliationPending) {
+        return;
+    }
+
+    _cacheReconciliationPending = false;
+    qCInfo(lcOnboardingSyncCreationCoordinator) << "Cache reconciled after failed onboarding SYNC_ADD";
     _flowController.failSynchronization();
 }
 

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -1,0 +1,206 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "onboardingsynccreationcoordinator.h"
+
+#include "app/cache/appcache.h"
+#include "app/cache/onboardingstate.h"
+#include "app/onboarding/onboardingflowcontroller.h"
+#include "app/services/commservice.h"
+#include "app/services/serviceeventbus.h"
+#include "libcommon/utility/types.h"
+
+#include <QDesktopServices>
+#include <QDir>
+#include <QLoggingCategory>
+#include <QSet>
+#include <QUrl>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcOnboardingSyncCreationCoordinator, "gui.v4.onboardingsynccreationcoordinator", QtInfoMsg)
+}
+
+OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingFlowController &flowController,
+                                                                     OnboardingState &onboardingState, AppCache &appCache,
+                                                                     CommService &commService, ServiceEventBus &serviceEventBus,
+                                                                     QObject *const parent) :
+    QObject(parent),
+    _flowController(flowController),
+    _onboardingState(onboardingState),
+    _appCache(appCache),
+    _commService(commService),
+    _serviceEventBus(serviceEventBus) {
+    (void) connect(&_flowController, &OnboardingFlowController::driveSelectionContinueRequested, this,
+                   &OnboardingSyncCreationCoordinator::startSynchronization);
+    (void) connect(&_flowController, &OnboardingFlowController::synchronizationRetryRequested, this,
+                   &OnboardingSyncCreationCoordinator::createNextSynchronization);
+    (void) connect(&_flowController, &OnboardingFlowController::synchronizedFoldersOpenRequested, this,
+                   &OnboardingSyncCreationCoordinator::openSynchronizedFolders);
+}
+
+void OnboardingSyncCreationCoordinator::startSynchronization() {
+    _pendingDriveKeys.clear();
+    _createdLocalPaths.clear();
+
+    const auto selectedDriveKeys = _onboardingState.selectedAvailableDriveKeys();
+    _pendingDriveKeys.insert(_pendingDriveKeys.end(), selectedDriveKeys.begin(), selectedDriveKeys.end());
+
+    qCInfo(lcOnboardingSyncCreationCoordinator) << "Starting onboarding sync creation | count:" << _pendingDriveKeys.size();
+    _flowController.beginSynchronization();
+    createNextSynchronization();
+}
+
+void OnboardingSyncCreationCoordinator::createNextSynchronization() {
+    if (_pendingDriveKeys.empty()) {
+        qCInfo(lcOnboardingSyncCreationCoordinator) << "All onboarding syncs created successfully";
+        _flowController.completeSynchronization();
+        return;
+    }
+
+    const auto &key = _pendingDriveKeys.front();
+    if (const auto pendingConfig = _onboardingState.pendingSyncConfig(key);
+        pendingConfig.has_value() && !pendingConfig->localPath.isEmpty()) {
+        createSynchronization(key, *pendingConfig);
+        return;
+    }
+
+    prepareSynchronization(key);
+}
+
+void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDriveKey &key) {
+    const auto availableDrive = _appCache.availableDrive(key);
+    if (!availableDrive.has_value()) {
+        qCWarning(lcOnboardingSyncCreationCoordinator)
+                << "Cannot prepare onboarding sync: available drive disappeared | userDbId:" << key.userDbId
+                << "/ driveId:" << key.driveId;
+        handleCreationFailure();
+        return;
+    }
+
+    const auto basePath = defaultLocalPath(availableDrive->name());
+    qCInfo(lcOnboardingSyncCreationCoordinator)
+            << "Requesting onboarding sync path | driveId:" << key.driveId << "/ basePath:" << basePath;
+    _commService.requestFindGoodPathForNewSync(
+            QStr2Path(basePath), [this, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                if (!exitInfo) {
+                    _serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
+                    handleCreationFailure();
+                    return;
+                }
+
+                PendingSyncConfig config;
+                config.localPath = Path2QStr(result.goodPath);
+                if (config.localPath.isEmpty()) {
+                    qCWarning(lcOnboardingSyncCreationCoordinator)
+                            << "Server returned an empty onboarding sync path | driveId:" << key.driveId;
+                    handleCreationFailure();
+                    return;
+                }
+
+                _onboardingState.setPendingSyncConfig(key, config);
+                createSynchronization(key, config);
+            });
+}
+
+void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config) {
+    SyncAddRequest request;
+    request.userDbId = key.userDbId;
+    request.accountId = key.accountId;
+    request.driveId = key.driveId;
+    request.localFolderPath = QStr2Path(config.localPath);
+    request.serverFolderPath = QStr2Path(config.targetPath);
+    request.serverFolderNodeId = QStr2Str(config.targetNodeId);
+    request.liteSync = false;
+
+    qCInfo(lcOnboardingSyncCreationCoordinator)
+            << "Creating onboarding sync | driveId:" << key.driveId << "/ localPath:" << config.localPath;
+    _commService.requestSyncAdd(
+            request, [this, key, localPath = config.localPath](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+                if (!exitInfo) {
+                    _serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
+                    handleCreationFailure();
+                    return;
+                }
+
+                qCInfo(lcOnboardingSyncCreationCoordinator)
+                        << "Onboarding sync created | driveId:" << key.driveId << "/ syncDbId:" << syncInfo.dbId();
+                _createdLocalPaths.push_back(localPath);
+                _onboardingState.unselectAvailableDrive(key);
+                if (!_pendingDriveKeys.empty() && _pendingDriveKeys.front() == key) {
+                    _pendingDriveKeys.pop_front();
+                }
+                createNextSynchronization();
+            });
+}
+
+void OnboardingSyncCreationCoordinator::handleCreationFailure() {
+    /*
+     * IMPORTANT: a batch of onboarding sync creations is not transactional on the server.
+     *
+     * SYNC_ADD persists the account, drive and sync before returning its response. It also emits ACCOUNT_ADDED,
+     * DRIVE_ADDED and SYNC_ADDED pushes, so every successful request has already become durable application state when a
+     * later request fails. Rolling those successful creations back from the GUI would be unsafe, and replaying the whole
+     * original selection would risk creating duplicate syncs or choosing new suffixed local folders.
+     *
+     * The coordinator therefore stops at the first failure and keeps the current key plus every not-yet-attempted key in
+     * _pendingDriveKeys. Keys that completed successfully were already removed from both this queue and OnboardingState.
+     * The pending config of the failed key is deliberately preserved so Retry reuses the exact same local path instead of
+     * asking the server for another candidate. Retry then resumes from the queue front and Ready is reached only after the
+     * queue is empty.
+     */
+    qCWarning(lcOnboardingSyncCreationCoordinator) << "Onboarding sync creation paused | remaining:" << _pendingDriveKeys.size();
+    _flowController.failSynchronization();
+}
+
+void OnboardingSyncCreationCoordinator::openSynchronizedFolders() {
+    QSet<QString> localPaths;
+    for (const auto &syncInfo: _appCache.syncs()) {
+        if (!syncInfo.localPath().isEmpty()) {
+            localPaths.insert(QDir::cleanPath(syncInfo.localPath()));
+        }
+    }
+    for (const auto &localPath: _createdLocalPaths) {
+        if (!localPath.isEmpty()) {
+            localPaths.insert(QDir::cleanPath(localPath));
+        }
+    }
+
+    for (const auto &localPath: localPaths) {
+        qCInfo(lcOnboardingSyncCreationCoordinator) << "Opening synchronized folder:" << localPath;
+        if (!QDesktopServices::openUrl(QUrl::fromLocalFile(localPath))) {
+            qCWarning(lcOnboardingSyncCreationCoordinator) << "Failed to open synchronized folder:" << localPath;
+        }
+    }
+
+    _flowController.completeOnboarding();
+}
+
+QString OnboardingSyncCreationCoordinator::defaultLocalPath(const QString &driveName) const {
+    auto normalizedName = driveName.trimmed();
+    if (normalizedName.startsWith(QStringLiteral("kDrive"), Qt::CaseInsensitive)) {
+        normalizedName.remove(0, QStringLiteral("kDrive").size());
+        normalizedName = normalizedName.trimmed();
+    }
+
+    const auto folderName = normalizedName.isEmpty() ? QStringLiteral("kDrive") : QStringLiteral("kDrive %1").arg(normalizedName);
+    return QDir(QDir::homePath()).filePath(folderName);
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -64,7 +64,7 @@ void OnboardingSyncCreationCoordinator::startSynchronization() {
     _createdLocalPaths.clear();
 
     const auto selectedDriveKeys = _onboardingState.selectedAvailableDriveKeys();
-    _pendingDriveKeys.insert(_pendingDriveKeys.end(), selectedDriveKeys.begin(), selectedDriveKeys.end());
+    (void) _pendingDriveKeys.insert(_pendingDriveKeys.end(), selectedDriveKeys.begin(), selectedDriveKeys.end());
 
     qCInfo(lcOnboardingSyncCreationCoordinator) << "Starting onboarding sync creation | count:" << _pendingDriveKeys.size();
     _flowController.beginSynchronization();
@@ -228,12 +228,12 @@ void OnboardingSyncCreationCoordinator::openSynchronizedFolders() {
     QSet<QString> localPaths;
     for (const auto &syncInfo: _appCache.syncs()) {
         if (!syncInfo.localPath().isEmpty()) {
-            localPaths.insert(QDir::cleanPath(syncInfo.localPath()));
+            (void) localPaths.insert(QDir::cleanPath(syncInfo.localPath()));
         }
     }
     for (const auto &localPath: _createdLocalPaths) {
         if (!localPath.isEmpty()) {
-            localPaths.insert(QDir::cleanPath(localPath));
+            (void) localPaths.insert(QDir::cleanPath(localPath));
         }
     }
 
@@ -250,7 +250,7 @@ void OnboardingSyncCreationCoordinator::openSynchronizedFolders() {
 QString OnboardingSyncCreationCoordinator::defaultLocalPath(const QString &driveName) const {
     auto normalizedName = driveName.trimmed();
     if (normalizedName.startsWith(QStringLiteral("kDrive"), Qt::CaseInsensitive)) {
-        normalizedName.remove(0, QStringLiteral("kDrive").size());
+        (void) normalizedName.remove(0, QStringLiteral("kDrive").size());
         normalizedName = normalizedName.trimmed();
     }
 

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -29,6 +29,7 @@
 #include <QDesktopServices>
 #include <QDir>
 #include <QLoggingCategory>
+#include <QPointer>
 #include <QSet>
 #include <QUrl>
 
@@ -55,8 +56,10 @@ OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingF
                    &OnboardingSyncCreationCoordinator::createNextSynchronization);
     (void) connect(&_flowController, &OnboardingFlowController::synchronizedFoldersOpenRequested, this,
                    &OnboardingSyncCreationCoordinator::openSynchronizedFolders);
-    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this,
+    (void) connect(&_cachePopulator, &CachePopulator::reconciliationCompleted, this,
                    &OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted);
+    (void) connect(&_cachePopulator, &CachePopulator::reconciliationFailed, this,
+                   &OnboardingSyncCreationCoordinator::handleCacheReconciliationFailed);
 }
 
 void OnboardingSyncCreationCoordinator::startSynchronization() {
@@ -101,19 +104,24 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
     const auto basePath = defaultLocalPath(QString::fromStdString(availableDrive->name()));
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Requesting onboarding sync path | driveId:" << key.driveId << "/ basePath:" << basePath;
+    const QPointer<OnboardingSyncCreationCoordinator> self(this);
     _commService.requestFindGoodPathForNewSync(
-            QStr2Path(basePath), [this, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                if (!exitInfo) {
-                    _serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
-                    handleCreationFailure();
+            QStr2Path(basePath), [self, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                if (!self) {
                     return;
                 }
 
-                if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value()) {
+                if (!exitInfo) {
+                    self->_serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
+                    self->handleCreationFailure();
+                    return;
+                }
+
+                if (!self->_onboardingState.isAvailableDriveSelected(key) || !self->_appCache.availableDrive(key).has_value()) {
                     qCWarning(lcOnboardingSyncCreationCoordinator)
                             << "Discarding prepared onboarding sync: drive is no longer selectable | userDbId:" << key.userDbId
                             << "/ driveId:" << key.driveId;
-                    discardPendingSynchronization(key);
+                    self->discardPendingSynchronization(key);
                     return;
                 }
 
@@ -122,12 +130,12 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
                 if (config.localPath.isEmpty()) {
                     qCWarning(lcOnboardingSyncCreationCoordinator)
                             << "Server returned an empty onboarding sync path | driveId:" << key.driveId;
-                    handleCreationFailure();
+                    self->handleCreationFailure();
                     return;
                 }
 
-                _onboardingState.setPendingSyncConfig(key, config);
-                createSynchronization(key, config);
+                self->_onboardingState.setPendingSyncConfig(key, config);
+                self->createSynchronization(key, config);
             });
 }
 
@@ -151,22 +159,27 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
 
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Creating onboarding sync | driveId:" << key.driveId << "/ localPath:" << config.localPath;
+    const QPointer<OnboardingSyncCreationCoordinator> self(this);
     _commService.requestSyncAdd(
-            request, [this, key, localPath = config.localPath](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+            request, [self, key, localPath = config.localPath](const ExitInfo &exitInfo, const SyncInfo &syncInfo) {
+                if (!self) {
+                    return;
+                }
+
                 if (!exitInfo) {
-                    _serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
-                    handleCreationFailure(true);
+                    self->_serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
+                    self->handleCreationFailure(true);
                     return;
                 }
 
                 qCInfo(lcOnboardingSyncCreationCoordinator)
                         << "Onboarding sync created | driveId:" << key.driveId << "/ syncDbId:" << syncInfo.dbId();
-                _createdLocalPaths.push_back(localPath);
-                _onboardingState.unselectAvailableDrive(key);
-                if (!_pendingDriveKeys.empty() && _pendingDriveKeys.front() == key) {
-                    _pendingDriveKeys.pop_front();
+                self->_createdLocalPaths.push_back(localPath);
+                self->_onboardingState.unselectAvailableDrive(key);
+                if (!self->_pendingDriveKeys.empty() && self->_pendingDriveKeys.front() == key) {
+                    self->_pendingDriveKeys.pop_front();
                 }
-                createNextSynchronization();
+                self->createNextSynchronization();
             });
 }
 
@@ -207,7 +220,7 @@ void OnboardingSyncCreationCoordinator::handleCreationFailure(const bool cacheRe
     if (cacheReconciliationRequired) {
         _cacheReconciliationPending = true;
         qCInfo(lcOnboardingSyncCreationCoordinator) << "Reconciling cache after failed onboarding SYNC_ADD";
-        _cachePopulator.bootstrap();
+        _cachePopulator.reconcile();
         return;
     }
 
@@ -221,6 +234,16 @@ void OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted() {
 
     _cacheReconciliationPending = false;
     qCInfo(lcOnboardingSyncCreationCoordinator) << "Cache reconciled after failed onboarding SYNC_ADD";
+    _flowController.failSynchronization();
+}
+
+void OnboardingSyncCreationCoordinator::handleCacheReconciliationFailed() {
+    if (!_cacheReconciliationPending) {
+        return;
+    }
+
+    _cacheReconciliationPending = false;
+    qCWarning(lcOnboardingSyncCreationCoordinator) << "Cache reconciliation failed after onboarding SYNC_ADD failure";
     _flowController.failSynchronization();
 }
 

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -98,7 +98,7 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
         return;
     }
 
-    const auto basePath = defaultLocalPath(availableDrive->name());
+    const auto basePath = defaultLocalPath(QString::fromStdString(availableDrive->name()));
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Requesting onboarding sync path | driveId:" << key.driveId << "/ basePath:" << basePath;
     _commService.requestFindGoodPathForNewSync(

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -29,6 +29,7 @@
 namespace KDC {
 
 class AppCache;
+class CachePopulator;
 class CommService;
 class OnboardingFlowController;
 class OnboardingState;
@@ -45,15 +46,17 @@ class OnboardingSyncCreationCoordinator final : public QObject {
 
     public:
         explicit OnboardingSyncCreationCoordinator(OnboardingFlowController &flowController, OnboardingState &onboardingState,
-                                                   AppCache &appCache, CommService &commService, ServiceEventBus &serviceEventBus,
-                                                   QObject *parent = nullptr);
+                                                   AppCache &appCache, CommService &commService, CachePopulator &cachePopulator,
+                                                   ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
 
     private:
         void startSynchronization();
         void createNextSynchronization();
         void prepareSynchronization(const AvailableDriveKey &key);
         void createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config);
-        void handleCreationFailure();
+        void discardPendingSynchronization(const AvailableDriveKey &key);
+        void handleCreationFailure(bool cacheReconciliationRequired = false);
+        void handleCacheReconciliationCompleted();
         void openSynchronizedFolders();
         [[nodiscard]] QString defaultLocalPath(const QString &driveName) const;
 
@@ -61,9 +64,11 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         OnboardingState &_onboardingState;
         AppCache &_appCache;
         CommService &_commService;
+        CachePopulator &_cachePopulator;
         ServiceEventBus &_serviceEventBus;
         std::deque<AvailableDriveKey> _pendingDriveKeys;
         std::vector<QString> _createdLocalPaths;
+        bool _cacheReconciliationPending{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -57,6 +57,7 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         void discardPendingSynchronization(const AvailableDriveKey &key);
         void handleCreationFailure(bool cacheReconciliationRequired = false);
         void handleCacheReconciliationCompleted();
+        void handleCacheReconciliationFailed();
         void openSynchronizedFolders();
         [[nodiscard]] QString defaultLocalPath(const QString &driveName) const;
 

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -1,0 +1,69 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/cachetypes.h"
+
+#include <QObject>
+#include <QString>
+
+#include <deque>
+#include <vector>
+
+namespace KDC {
+
+class AppCache;
+class CommService;
+class OnboardingFlowController;
+class OnboardingState;
+class ServiceEventBus;
+
+/**
+ * Coordinates automatic sync creation at the end of Linux v4 onboarding.
+ *
+ * Selected drives are configured sequentially with a collision-free local path and the kDrive root as remote target.
+ * Successful creations are removed from the retry queue, while failed and not-yet-attempted creations remain pending.
+ */
+class OnboardingSyncCreationCoordinator final : public QObject {
+        Q_OBJECT
+
+    public:
+        explicit OnboardingSyncCreationCoordinator(OnboardingFlowController &flowController, OnboardingState &onboardingState,
+                                                   AppCache &appCache, CommService &commService, ServiceEventBus &serviceEventBus,
+                                                   QObject *parent = nullptr);
+
+    private:
+        void startSynchronization();
+        void createNextSynchronization();
+        void prepareSynchronization(const AvailableDriveKey &key);
+        void createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config);
+        void handleCreationFailure();
+        void openSynchronizedFolders();
+        [[nodiscard]] QString defaultLocalPath(const QString &driveName) const;
+
+        OnboardingFlowController &_flowController;
+        OnboardingState &_onboardingState;
+        AppCache &_appCache;
+        CommService &_commService;
+        ServiceEventBus &_serviceEventBus;
+        std::deque<AvailableDriveKey> _pendingDriveKeys;
+        std::vector<QString> _createdLocalPaths;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/cachepopulator.cpp
+++ b/src/gui4/linux/app/services/cachepopulator.cpp
@@ -43,57 +43,61 @@ CachePopulator::CachePopulator(CommService &commService, AppCache &appCache, QOb
     _appCache(appCache) {}
 
 void CachePopulator::bootstrap() {
-    loadUsers();
+    loadUsers(PopulationMode::Bootstrap);
 }
 
-void CachePopulator::loadUsers() {
-    _commService.requestUserDisplayInfoList([this](const ExitInfo &exitInfo, const std::vector<UserDisplayInfo> &list) {
-        if (!exitInfo) {
-            exitOnPopulationFailure("users", exitInfo);
+void CachePopulator::reconcile() {
+    loadUsers(PopulationMode::Reconciliation);
+}
+
+void CachePopulator::loadUsers(const PopulationMode mode) {
+    _commService.requestUserDisplayInfoList([this, mode](const ExitInfo &exitInfo, const std::vector<UserDisplayInfo> &list) {
+        if (!exitInfo && handlePopulationFailure("users", exitInfo, mode)) {
+            return;
         }
 
         _appCache.replaceUsers(list);
-        loadAccounts();
+        loadAccounts(mode);
     });
 }
 
-void CachePopulator::loadAccounts() {
-    _commService.requestAccountInfoList([this](const ExitInfo &exitInfo, const std::vector<Account> &list) {
-        if (!exitInfo) {
-            exitOnPopulationFailure("accounts", exitInfo);
+void CachePopulator::loadAccounts(const PopulationMode mode) {
+    _commService.requestAccountInfoList([this, mode](const ExitInfo &exitInfo, const std::vector<Account> &list) {
+        if (!exitInfo && handlePopulationFailure("accounts", exitInfo, mode)) {
+            return;
         }
 
         _appCache.replaceAccounts(list);
-        loadDrives();
+        loadDrives(mode);
     });
 }
 
-void CachePopulator::loadDrives() {
-    _commService.requestDriveList([this](const ExitInfo &exitInfo, const std::vector<Drive> &list) {
-        if (!exitInfo) {
-            exitOnPopulationFailure("drives", exitInfo);
+void CachePopulator::loadDrives(const PopulationMode mode) {
+    _commService.requestDriveList([this, mode](const ExitInfo &exitInfo, const std::vector<Drive> &list) {
+        if (!exitInfo && handlePopulationFailure("drives", exitInfo, mode)) {
+            return;
         }
 
         _appCache.replaceDrives(list);
-        loadSyncs();
+        loadSyncs(mode);
     });
 }
 
-void CachePopulator::loadSyncs() {
-    _commService.requestSyncInfoList([this](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
-        if (!exitInfo) {
-            exitOnPopulationFailure("syncs", exitInfo);
+void CachePopulator::loadSyncs(const PopulationMode mode) {
+    _commService.requestSyncInfoList([this, mode](const ExitInfo &exitInfo, const std::vector<SyncInfo> &list) {
+        if (!exitInfo && handlePopulationFailure("syncs", exitInfo, mode)) {
+            return;
         }
 
         _appCache.replaceSyncs(list);
-        loadSyncErrors();
+        loadSyncErrors(mode);
     });
 }
 
-void CachePopulator::loadSyncErrors() {
-    _commService.requestErrorInfoList([this](const ExitInfo &exitInfo, const std::vector<ErrorInfo> &list) {
-        if (!exitInfo) {
-            exitOnPopulationFailure("errors", exitInfo);
+void CachePopulator::loadSyncErrors(const PopulationMode mode) {
+    _commService.requestErrorInfoList([this, mode](const ExitInfo &exitInfo, const std::vector<ErrorInfo> &list) {
+        if (!exitInfo && handlePopulationFailure("errors", exitInfo, mode)) {
+            return;
         }
 
         std::vector<ErrorInfo> syncErrors;
@@ -119,7 +123,11 @@ void CachePopulator::loadSyncErrors() {
 
         _appCache.replaceSyncErrors(syncErrors);
         _appCache.replaceServerErrors(serverErrors);
-        emit bootstrapCompleted();
+        if (mode == PopulationMode::Bootstrap) {
+            emit bootstrapCompleted();
+        } else {
+            emit reconciliationCompleted();
+        }
         activateLiveInfoRefresh();
     });
 }
@@ -131,6 +139,17 @@ void CachePopulator::activateLiveInfoRefresh() const {
                                         << "/ cause:" << exitInfo.cause();
         }
     });
+}
+
+bool CachePopulator::handlePopulationFailure(const char *const stage, const ExitInfo &exitInfo, const PopulationMode mode) {
+    if (mode == PopulationMode::Bootstrap) {
+        exitOnPopulationFailure(stage, exitInfo);
+    }
+
+    qCWarning(lcCachePopulator) << "Cache reconciliation failed at" << stage << "| code:" << exitInfo.code()
+                                << "/ cause:" << exitInfo.cause();
+    emit reconciliationFailed();
+    return true;
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/cachepopulator.h
+++ b/src/gui4/linux/app/services/cachepopulator.h
@@ -26,12 +26,12 @@
 namespace KDC {
 
 /**
- * Sequential initial snapshot loader for Linux v4 cache population.
+ * Sequential parent-first snapshot loader for Linux v4 cache population and explicit reconciliation.
  *
- * Loads users, then accounts, then drives, then syncs, then errors so the
- * graph-backed AppCache is populated in parent-first order. Once the initial
- * cache snapshot is complete, asks the server to refresh live user/account/drive
- * metadata so quota-only drive updates are pushed through CachePipeline.
+ * Loads users, then accounts, then drives, then syncs, then errors so the graph-backed AppCache is populated in
+ * parent-first order. Used at initial connection and when a non-transactional backend mutation may have persisted parent
+ * entities without emitting their normal push signals. Once the snapshot is complete, asks the server to refresh live
+ * user/account/drive metadata so quota-only drive updates are pushed through CachePipeline.
  */
 class CachePopulator : public QObject {
         Q_OBJECT

--- a/src/gui4/linux/app/services/cachepopulator.h
+++ b/src/gui4/linux/app/services/cachepopulator.h
@@ -23,33 +23,59 @@
 
 #include <QObject>
 
+#include <cstdint>
+
 namespace KDC {
 
 /**
  * Sequential parent-first snapshot loader for Linux v4 cache population and explicit reconciliation.
  *
  * Loads users, then accounts, then drives, then syncs, then errors so the graph-backed AppCache is populated in
- * parent-first order. Used at initial connection and when a non-transactional backend mutation may have persisted parent
- * entities without emitting their normal push signals. Once the snapshot is complete, asks the server to refresh live
- * user/account/drive metadata so quota-only drive updates are pushed through CachePipeline.
+ * parent-first order. Initial bootstrap remains fatal on failure because the app has no coherent cache to run from.
+ * Reconciliation reuses the same sequence after recoverable mutations and reports failures to the caller without
+ * emitting the bootstrap signal. Once a snapshot is complete, asks the server to refresh live user/account/drive metadata
+ * so quota-only drive updates are pushed through CachePipeline.
  */
 class CachePopulator : public QObject {
         Q_OBJECT
 
     public:
         explicit CachePopulator(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+        /**
+         * Populates the initial cache snapshot.
+         *
+         * Failure is fatal because Linux v4 cannot safely start without a coherent user/account/drive/sync graph.
+         */
         void bootstrap();
 
+        /**
+         * Repairs the cache snapshot while the app is already running.
+         *
+         * Failure is reported through reconciliationFailed() so the caller can keep the UI in a recoverable state.
+         */
+        void reconcile();
+
     signals:
+        /// Emitted only after the initial startup snapshot completes successfully.
         void bootstrapCompleted();
+        /// Emitted after an explicit recoverable cache repair completes successfully.
+        void reconciliationCompleted();
+        /// Emitted when an explicit recoverable cache repair fails.
+        void reconciliationFailed();
 
     private:
-        void loadUsers();
-        void loadAccounts();
-        void loadDrives();
-        void loadSyncs();
-        void loadSyncErrors();
+        enum class PopulationMode : uint8_t {
+            Bootstrap,
+            Reconciliation,
+        };
+
+        void loadUsers(PopulationMode mode);
+        void loadAccounts(PopulationMode mode);
+        void loadDrives(PopulationMode mode);
+        void loadSyncs(PopulationMode mode);
+        void loadSyncErrors(PopulationMode mode);
         void activateLiveInfoRefresh() const;
+        [[nodiscard]] bool handlePopulationFailure(const char *stage, const ExitInfo &exitInfo, PopulationMode mode);
 
         CommService &_commService;
         AppCache &_appCache;

--- a/src/gui4/linux/app/services/serviceactiontracker.cpp
+++ b/src/gui4/linux/app/services/serviceactiontracker.cpp
@@ -72,9 +72,20 @@ void ServiceActionTracker::beginAction(const ServiceKey &serviceKey, const Actio
 }
 
 void ServiceActionTracker::endAction(const ServiceKey &serviceKey, const ActionKey &actionKey, const ScopeId scopeId) {
+    endActions(serviceKey, actionKey, scopeId, EndActionMode::One);
+}
+
+void ServiceActionTracker::endAllActions(const ServiceKey &serviceKey, const ActionKey &actionKey, const ScopeId scopeId) {
+    endActions(serviceKey, actionKey, scopeId, EndActionMode::All);
+}
+
+void ServiceActionTracker::endActions(const ServiceKey &serviceKey, const ActionKey &actionKey, const ScopeId scopeId,
+                                      const EndActionMode mode) {
+    const char *const operation = mode == EndActionMode::One ? "endAction" : "endAllActions";
+
     const auto serviceIt = _pendingByServiceAndAction.find(serviceKey);
     if (serviceIt == _pendingByServiceAndAction.end()) {
-        qCWarning(lcServiceActionTracker) << "endAction called for unknown serviceKey:" << serviceKey
+        qCWarning(lcServiceActionTracker) << operation << "called for unknown serviceKey:" << serviceKey
                                           << "| actionKey:" << actionKey << "| scopeId:" << scopeId;
         return;
     }
@@ -82,29 +93,31 @@ void ServiceActionTracker::endAction(const ServiceKey &serviceKey, const ActionK
     auto &serviceActions = serviceIt.value();
     auto actionIt = serviceActions.find(actionKey);
     if (actionIt == serviceActions.end()) {
-        qCWarning(lcServiceActionTracker) << "endAction called for unknown actionKey:" << actionKey
+        qCWarning(lcServiceActionTracker) << operation << "called for unknown actionKey:" << actionKey
                                           << "| serviceKey:" << serviceKey << "| scopeId:" << scopeId;
         return;
     }
 
-    auto &actionState = actionIt.value();
-    const auto scopeIt = actionState.pendingCountByScope.find(scopeId);
-    if (scopeIt == actionState.pendingCountByScope.end() || scopeIt.value() == 0) {
-        qCWarning(lcServiceActionTracker) << "endAction called for non-pending scope | serviceKey:" << serviceKey
+    auto &[pendingCountByScope, totalPendingCount] = actionIt.value();
+    const auto scopeIt = pendingCountByScope.find(scopeId);
+    if (scopeIt == pendingCountByScope.end() || scopeIt.value() == 0) {
+        qCWarning(lcServiceActionTracker) << operation << "called for non-pending scope | serviceKey:" << serviceKey
                                           << "| actionKey:" << actionKey << "| scopeId:" << scopeId;
         return;
     }
 
-    scopeIt.value() -= 1;
-    actionState.totalPendingCount -= 1;
-    _pendingCountByService[serviceKey] -= 1;
+    const uint32_t pendingScopeCount = scopeIt.value();
+    const uint32_t endedScopeCount = mode == EndActionMode::One ? uint32_t{1} : pendingScopeCount;
+    scopeIt.value() -= endedScopeCount;
+    totalPendingCount -= endedScopeCount;
+    _pendingCountByService[serviceKey] -= endedScopeCount;
 
     if (scopeIt.value() == 0) {
-        (void) actionState.pendingCountByScope.erase(scopeIt);
+        (void) pendingCountByScope.erase(scopeIt);
         emit actionPendingChanged(serviceKey, actionKey, scopeId, false);
     }
 
-    if (actionState.totalPendingCount == 0) {
+    if (totalPendingCount == 0) {
         (void) serviceActions.erase(actionIt);
     }
 

--- a/src/gui4/linux/app/services/serviceactiontracker.h
+++ b/src/gui4/linux/app/services/serviceactiontracker.h
@@ -29,16 +29,31 @@ namespace KDC {
 /**
  * Centralized state tracker for in-flight service actions.
  *
- * Role:
- * - Owns durable UI-facing "pending" state for service actions.
- * - Tracks pending status per (serviceKey, actionKey, scopeId) with reference-count semantics.
- * - Exposes pending lookup by action and by service scope.
+ * Service objects use this class to expose durable UI-facing "pending" state without each service having to keep its own
+ * loading counters. An action is identified by three keys:
+ * - `serviceKey`: stable service identifier, for example "user", "drive", or "sync".
+ * - `actionKey`: stable action identifier inside that service, for example "deleteUser" or "requestLoginToken".
+ * - `scopeId`: optional discriminator for concurrent actions of the same type, for example a userDbId, driveDbId, or
+ *   syncDbId.
  *
- * Contract:
- * - `serviceKey` must be a stable service identifier (example: "user", "drive", "sync").
- * - `actionKey` must be a stable action identifier local to a service (example: "deleteUser").
- * - `scopeId` can disambiguate concurrent actions of the same type (example: per userDbId).
- * - Every `beginAction(...)` call must be paired with exactly one `endAction(...)`.
+ * The default `scopeId` value, 0, is not a special "no scope" sentinel. It is a regular scope key stored in
+ * `pendingCountByScope`, exactly like any other scope id. Calling `beginAction(service, action)` increments the counter
+ * for scope 0, and calling `endAction(service, action)` decrements that same counter.
+ *
+ * Counts are reference-counted per `(serviceKey, actionKey, scopeId)`. This allows several identical requests to be
+ * pending at the same time. `actionPendingChanged(..., true)` is emitted only when a scope counter transitions from 0 to
+ * 1, and `actionPendingChanged(..., false)` is emitted only when that same scope counter returns to 0. Intermediate
+ * increments and decrements do not emit action-level changes because the visible pending state did not change.
+ * `endAllActions(...)` drains every pending occurrence for one exact `(serviceKey, actionKey, scopeId)` triplet and
+ * emits the same state changes as the final matching `endAction(...)` call would emit.
+ *
+ * A service-level counter is also maintained across all actions and scopes for a given service. `servicePendingChanged`
+ * follows the same transition rule: it is emitted when the first pending action starts for a service and when the last
+ * pending action ends.
+ *
+ * Every `beginAction(...)` call must eventually be balanced either by one matching `endAction(...)` call or by an
+ * `endAllActions(...)` call for the same `(serviceKey, actionKey, scopeId)`. Ending an unknown or non-pending action is
+ * treated as a programming error: the tracker logs a warning and leaves its state unchanged.
  */
 class ServiceActionTracker : public QObject {
         Q_OBJECT
@@ -55,16 +70,24 @@ class ServiceActionTracker : public QObject {
         Q_INVOKABLE [[nodiscard]] bool isServicePending(const ServiceKey &serviceKey) const;
         void beginAction(const ServiceKey &serviceKey, const ActionKey &actionKey, ScopeId scopeId = 0);
         void endAction(const ServiceKey &serviceKey, const ActionKey &actionKey, ScopeId scopeId = 0);
+        void endAllActions(const ServiceKey &serviceKey, const ActionKey &actionKey, ScopeId scopeId = 0);
 
     signals:
         void servicePendingChanged(const ServiceKey &serviceKey, bool pending);
         void actionPendingChanged(const ServiceKey &serviceKey, const ActionKey &actionKey, ScopeId scopeId, bool pending);
 
     private:
+        enum class EndActionMode : uint8_t {
+            One,
+            All,
+        };
+
         struct ActionPendingState {
                 QHash<ScopeId, uint32_t> pendingCountByScope;
                 uint32_t totalPendingCount{0};
         };
+
+        void endActions(const ServiceKey &serviceKey, const ActionKey &actionKey, ScopeId scopeId, EndActionMode mode);
 
         QHash<ServiceKey, QHash<ActionKey, ActionPendingState>> _pendingByServiceAndAction;
         QHash<ServiceKey, uint32_t> _pendingCountByService;

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -82,7 +82,7 @@ void UserService::invalidateAvailableDrivesRequest(const UserDbId userDbId) {
     }
 
     for (const auto generation: pendingIt->second) {
-        static_cast<void>(generation);
+        (void) generation;
         endAction(actionLoadAvailableDrives, userDbId);
     }
     (void) _pendingAvailableDriveLoadGenerations.erase(pendingIt);
@@ -144,7 +144,7 @@ void UserService::requestLoginToken(const QString &code, const QString &codeVeri
 void UserService::invalidateLoginTokenRequest() {
     ++_loginTokenGeneration;
     for (const auto generation: _pendingLoginTokenGenerations) {
-        static_cast<void>(generation);
+        (void) generation;
         endAction(actionRequestLoginToken);
     }
     _pendingLoginTokenGenerations.clear();
@@ -172,7 +172,7 @@ void UserService::pruneStaleAvailableDriveGenerations() {
         if (const auto pendingIt = _pendingAvailableDriveLoadGenerations.find(it->first);
             pendingIt != _pendingAvailableDriveLoadGenerations.end()) {
             for (const auto generation: pendingIt->second) {
-                static_cast<void>(generation);
+                (void) generation;
                 endAction(actionLoadAvailableDrives, it->first);
             }
             (void) _pendingAvailableDriveLoadGenerations.erase(pendingIt);

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -81,10 +81,7 @@ void UserService::invalidateAvailableDrivesRequest(const UserDbId userDbId) {
         return;
     }
 
-    for (const auto generation: pendingIt->second) {
-        (void) generation;
-        endAction(actionLoadAvailableDrives, userDbId);
-    }
+    endAllActions(actionLoadAvailableDrives, userDbId);
     (void) _pendingAvailableDriveLoadGenerations.erase(pendingIt);
 }
 
@@ -143,11 +140,10 @@ void UserService::requestLoginToken(const QString &code, const QString &codeVeri
 
 void UserService::invalidateLoginTokenRequest() {
     ++_loginTokenGeneration;
-    for (const auto generation: _pendingLoginTokenGenerations) {
-        (void) generation;
-        endAction(actionRequestLoginToken);
+    if (!_pendingLoginTokenGenerations.empty()) {
+        endAllActions(actionRequestLoginToken);
+        _pendingLoginTokenGenerations.clear();
     }
-    _pendingLoginTokenGenerations.clear();
 }
 
 bool UserService::isLoadAvailableDrivesPending(const qint64 userDbId) const {
@@ -171,10 +167,7 @@ void UserService::pruneStaleAvailableDriveGenerations() {
 
         if (const auto pendingIt = _pendingAvailableDriveLoadGenerations.find(it->first);
             pendingIt != _pendingAvailableDriveLoadGenerations.end()) {
-            for (const auto generation: pendingIt->second) {
-                (void) generation;
-                endAction(actionLoadAvailableDrives, it->first);
-            }
+            endAllActions(actionLoadAvailableDrives, it->first);
             (void) _pendingAvailableDriveLoadGenerations.erase(pendingIt);
         }
         it = _availableDriveLoadGenerations.erase(it);
@@ -213,12 +206,18 @@ void UserService::handleAvailableDrivesLoaded(const UserDbId userDbId, const uin
     emit availableDrivesLoaded(userDbId);
 }
 
-void UserService::beginAction(const ServiceActionTracker::ActionKey &actionKey, const ServiceActionTracker::ScopeId scopeId) {
+void UserService::beginAction(const ServiceActionTracker::ActionKey &actionKey,
+                              const ServiceActionTracker::ScopeId scopeId) const {
     _serviceActionTracker.beginAction(serviceKeyUser, actionKey, scopeId);
 }
 
-void UserService::endAction(const ServiceActionTracker::ActionKey &actionKey, const ServiceActionTracker::ScopeId scopeId) {
+void UserService::endAction(const ServiceActionTracker::ActionKey &actionKey, const ServiceActionTracker::ScopeId scopeId) const {
     _serviceActionTracker.endAction(serviceKeyUser, actionKey, scopeId);
+}
+
+void UserService::endAllActions(const ServiceActionTracker::ActionKey &actionKey,
+                                const ServiceActionTracker::ScopeId scopeId) const {
+    _serviceActionTracker.endAllActions(serviceKeyUser, actionKey, scopeId);
 }
 
 bool UserService::isActionPending(const ServiceActionTracker::ActionKey &actionKey,

--- a/src/gui4/linux/app/services/userservice.h
+++ b/src/gui4/linux/app/services/userservice.h
@@ -69,8 +69,9 @@ class UserService : public QObject {
         void availableDrivesLoadFailed(UserDbId userDbId);
 
     private:
-        void beginAction(const ServiceActionTracker::ActionKey &actionKey, ServiceActionTracker::ScopeId scopeId = 0);
-        void endAction(const ServiceActionTracker::ActionKey &actionKey, ServiceActionTracker::ScopeId scopeId = 0);
+        void beginAction(const ServiceActionTracker::ActionKey &actionKey, ServiceActionTracker::ScopeId scopeId = 0) const;
+        void endAction(const ServiceActionTracker::ActionKey &actionKey, ServiceActionTracker::ScopeId scopeId = 0) const;
+        void endAllActions(const ServiceActionTracker::ActionKey &actionKey, ServiceActionTracker::ScopeId scopeId = 0) const;
         void setLoading(bool loading);
         void pruneStaleAvailableDriveGenerations();
         void handleAvailableDrivesLoaded(UserDbId userDbId, uint64_t generation, const ExitInfo &exitInfo,

--- a/src/gui4/linux/app/systraycontroller.cpp
+++ b/src/gui4/linux/app/systraycontroller.cpp
@@ -123,10 +123,10 @@ void SystemTrayController::initialize() {
     _trayIcon.setIcon(QIcon(trayIconPath(_iconState)));
     _trayIcon.setToolTip(tr("kDrive"));
 
-    _openAction = _trayMenu.addAction(tr("Open kDrive"));
-    _settingsAction = _trayMenu.addAction(tr("Settings"));
+    _openAction = _trayMenu.addAction(qtTrId("statusBarOpenApp"));
+    _settingsAction = _trayMenu.addAction(qtTrId("statusBarSettings"));
     (void) _trayMenu.addSeparator();
-    _quitAction = _trayMenu.addAction(tr("Quit"));
+    _quitAction = _trayMenu.addAction(qtTrId("statusBarQuitApp"));
     _trayIcon.setContextMenu(&_trayMenu);
 
     (void) connect(_openAction, &QAction::triggered, this, &SystemTrayController::openMainWindowRequested);

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -29,8 +29,8 @@
 #include <QLocale>
 #include <QQmlContext>
 #include <QScreen>
-#include <QStringList>
 #include <QSysInfo>
+#include <QTranslator>
 #include <QVariant>
 #include <QWindow>
 
@@ -45,6 +45,7 @@ Q_LOGGING_CATEGORY(lcAppClientLinux, "gui.v4.app", QtInfoMsg)
 AppClientLinux::AppClientLinux(int &argc, char **argv) :
     QApplication(argc, argv) {
     setupLogging();
+    setupTranslations();
     setQuitOnLastWindowClosed(false);
     QIcon appIcon;
     ApplicationIdentity::configureApplication(appIcon);
@@ -136,6 +137,29 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
         SentryService::reportFatalAndExit("Missing server communication port argument",
                                           "Release and RelWithDebInfo clients must be launched by the server with its TCP port.");
 #endif
+    }
+}
+
+void AppClientLinux::setupTranslations() {
+    // Catalogs are id-based: qsTrId(id) returns the raw id when no translation is loaded. Install
+    // client_en as a base so every id always resolves (keys not yet translated degrade to English),
+    // then overlay the system locale on top. Qt queries translators last-installed-first, so the
+    // locale wins where it has a translation and falls back to the English base otherwise.
+    if (auto *const base = new QTranslator(this);
+        base->load(QStringLiteral("client_en"), QStringLiteral(":/i18n"))) {
+        static_cast<void>(QCoreApplication::installTranslator(base));
+    } else {
+        qCWarning(lcAppClientLinux) << "base English translation catalog missing; UI may show source ids";
+    }
+
+    const QLocale locale = QLocale::system();
+    auto *const localized = new QTranslator(this);
+    if (localized->load(locale, QStringLiteral("client"), QStringLiteral("_"), QStringLiteral(":/i18n"))) {
+        static_cast<void>(QCoreApplication::installTranslator(localized));
+        qCInfo(lcAppClientLinux) << "translations loaded for locale" << locale.name();
+    } else {
+        delete localized;
+        qCInfo(lcAppClientLinux) << "no catalog for locale" << locale.name() << "- using English base";
     }
 }
 

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -19,8 +19,8 @@
 #include "appclientlinux.h"
 
 #include "app/applicationidentity.h"
-#include "libcommongui/logger.h"
 #include "libcommon/utility/utility.h"
+#include "libcommongui/logger.h"
 
 #include <Poco/Dynamic/Struct.h>
 

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -29,6 +29,7 @@
 #include <QLocale>
 #include <QQmlContext>
 #include <QScreen>
+#include <QStringList>
 #include <QSysInfo>
 #include <QTranslator>
 #include <QVariant>

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -146,20 +146,17 @@ void AppClientLinux::setupTranslations() {
     // client_en as a base so every id always resolves (keys not yet translated degrade to English),
     // then overlay the system locale on top. Qt queries translators last-installed-first, so the
     // locale wins where it has a translation and falls back to the English base otherwise.
-    if (auto *const base = new QTranslator(this);
-        base->load(QStringLiteral("client_en"), QStringLiteral(":/i18n"))) {
-        static_cast<void>(QCoreApplication::installTranslator(base));
+    if (_baseTranslator.load(QStringLiteral("client_en"), QStringLiteral(":/i18n"))) {
+        (void) installTranslator(&_baseTranslator);
     } else {
         qCWarning(lcAppClientLinux) << "base English translation catalog missing; UI may show source ids";
     }
 
-    const QLocale locale = QLocale::system();
-    auto *const localized = new QTranslator(this);
-    if (localized->load(locale, QStringLiteral("client"), QStringLiteral("_"), QStringLiteral(":/i18n"))) {
-        static_cast<void>(QCoreApplication::installTranslator(localized));
+    if (const QLocale locale = QLocale::system();
+        _localizedTranslator.load(locale, QStringLiteral("client"), QStringLiteral("_"), QStringLiteral(":/i18n"))) {
+        (void) installTranslator(&_localizedTranslator);
         qCInfo(lcAppClientLinux) << "translations loaded for locale" << locale.name();
     } else {
-        delete localized;
         qCInfo(lcAppClientLinux) << "no catalog for locale" << locale.name() << "- using English base";
     }
 }

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -96,7 +96,8 @@ class AppClientLinux : public QApplication {
         SentryService _sentryService{_serverCommService, _appCache, this};
         CachePopulator _cachePopulator{_serverCommService, _appCache, this};
         UserService _userService{_serverCommService, _appCache, _serviceActionTracker, _serviceEventBus, this};
-        OnboardingSessionManager _onboardingSessionManager{_cachePopulator, _appCache, _serverCommService, _userService, this};
+        OnboardingSessionManager _onboardingSessionManager{_cachePopulator, _appCache,        _serverCommService,
+                                                           _userService,    _serviceEventBus, this};
         DriveService _driveService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         SyncService _syncService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         WindowDecorationController _windowDecorationController{this};

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -103,6 +103,8 @@ class AppClientLinux : public QApplication {
         SyncService _syncService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         WindowDecorationController _windowDecorationController{this};
         SystemTrayController _systemTrayController{this};
+        QTranslator _baseTranslator{this};
+        QTranslator _localizedTranslator{this};
         QQmlApplicationEngine _qmlEngine;
 };
 

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -38,6 +38,7 @@
 #include <QApplication>
 #include <QLoggingCategory>
 #include <QQmlApplicationEngine>
+#include <QTranslator>
 
 namespace KDC {
 

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -83,6 +83,7 @@ class AppClientLinux : public QApplication {
 
     private:
         static void setupLogging();
+        void setupTranslations();
         void openMainWindow();
 
         IpcClient _ipcClient{this};

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: da, Danish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="da"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Om</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Om kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Udviklet og hostet udelukkende i Schweiz sikrer kDrive total beskyttelse af dine data, uden videresalg eller overvågning, i ISO-certificerede datacentre, med kryptering og sikkerhedskopi på flere medier.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Synlige aktiviteter</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Vælg en distributionskanal</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Vis flere oplysninger</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Vælg en synkroniseringstilstand</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synkronisering fuldført</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synkronisering i gang</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Ingen nylig aktivitet</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Du er offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synkronisering sat på pause</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Alle aktiviteter</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Kun min aktivitet</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkroniser en mappe med kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Vælg mappen på din computer, der skal synkroniseres med kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synkroniseret mappe</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Tilpas placeringen af din computermappe på kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Vælg mappeplaceringen på kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-placering</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Vælg en mappe på din computer, der skal synkroniseres med kDrive.
+Du kan få adgang til dine avancerede synkroniseringer fra drevvælgeren på startsiden.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkroniser en mappe med kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Avanceret synkronisering</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>App, der skal udelukkes</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Programmet er opdateret</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Sletter logfiler ældre end 7 dage for at spare diskplads.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatisk oprydning</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatiske opdateringer</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Tilgængelig offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Dine filer kopieres til din computer.
+Du kan åbne dem til enhver tid, selv uden en internetforbindelse.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Du kan vække den fra webgrænsefladen.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Få tidlig adgang til nye versioner af programmet, før de udgives til offentligheden, og hjælp med at forbedre appen ved at dele dine forbedringsidéer med os.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Deltag i betaprogrammet</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Din browser bør åbne automatisk for at fuldføre login. Når du er logget ind, returnerer du automatisk til kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktivér offline-synkronisering</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synkroniser en mappe</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Tilføj en regel</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Tilføj lagerplads</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Avancerede indstillinger</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Anvend på %1 filer</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Anmod om adgang</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Annuller</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Skift mappe</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Gem offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Gem online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Skift bruger</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Luk</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Luk kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Konfigurer</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Bekræft</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Log ind</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Tilslut en konto</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Kontakt support</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Fortsæt</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Kopiér delingslink</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Opret en konto</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Opret en ny synkronisering</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Brugerdefineret placering</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Frakobl denne konto</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Downloader…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Download manuelt</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Aktivér</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Aktivér i Windows-indstillinger</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Forstå problemet</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Del en idé</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Afslut installation</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Ret fejl</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Jeg har aktiveret kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Behold konto</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Log ud</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Log ind</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Administrer</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Håndter filer individuelt</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Administrer lager</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Åbn fejlfindingsmappe</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Åbn Stifinder</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Åbn mappe</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Åbn i browser</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Åbn i Stifinder</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Åbn i Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Åbn i kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Åbn kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Administrer undtagelser</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Åbn synkroniseringsindstillinger</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pause</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Opdater</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Udgivelsesnoter</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Fjern</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Fjern (%n element)</numerusform> 
+                <numerusform>Fjern (%n elementer)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Fjern synkronisering</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Omdøb %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Genstart login</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Genoptag synkronisering</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Genstart synkronisering</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Prøv igen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Vend tilbage til standardmappe</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Gem</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Gem mine valg</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Søg</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Vis aktiviteter</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Vælg</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Vælg en mappe</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Vælg mapper</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Vælg en placering</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Valgt</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Send</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Send fejlfindingsmappe</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Åbn indstillinger</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Vis tilbud</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Vis muligheder</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Log ud</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Start</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Start versionsvalgning</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Kom gratis i gang</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synkroniser offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Opdater nu</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Opdater abonnement</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Opgradering</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Bekræft</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Bekræft og gå til næste</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Vågn op</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Vælg en version</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>To forskellige versioner af disse filer blev registreret.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versionskonflikter</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Søg efter en fil</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopierer link…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Opretter delingslink…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Du kan tilpasse brugs- og driftsdata, der indsamles af Infomaniak for at rette fejl og forbedre programmet. Begge anvendte værktøjer er hostet og administreret udelukkende af os.
+
+Kildekoden til dette program kan verificeres, de indsamlede oplysninger er anonyme, og dine personlige oplysninger forbliver strengt fortrolige og deles aldrig med tredjeparter.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Datastyring</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respekterer dit privatliv</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Vælg mængden af oplysninger, der skal logges.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Giver Infomaniak support mulighed for at identificere årsagen til en hændelse.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Fejlfindingslogfiler</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Disse apps ignoreres som standard og kan ikke ændres.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Disse filer er som standard udelukket og kan ikke ændres.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatisk udelukkelse</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>I disse situationer er en ny synkronisering nødvendig for at fortsætte med at bruge kDrive korrekt.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Vælg venligst en tom mappe, der ikke er i roden af et drev.
+
+Denne mappe må ikke være inkluderet i en anden synkroniseringsmappe og må ikke indeholde en synkroniseringsundermappe.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Denne mappe kan ikke vælges</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Tilføj en regel</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Tilføj en udelukkelsesregel</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Du er ved at frakoble %1 fra programmet.
+Synkroniseringsmappen forbliver på din computer, men vil ikke længere blive synkroniseret med kDrive.
+
+Alle dine data forbliver tilgængelige online på kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Log ud af denne konto?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Den lokale mappe forbliver på din computer, men den vil ikke længere blive synkroniseret med kDrive.
+Denne handling er permanent.
+For at synkronisere dit drev igen skal du tilslutte det igen senere.
+
+Inden du fortsætter, skal du sørge for, at alle dine filer er opdaterede og fuldt synkroniserede.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Fjern synkronisering?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Ændringen af synkroniseringstilstand blev annulleret.
+
+Den aktuelle synkronisering forbliver uændret. Men hvis der opstår unormal adfærd, skal du muligvis slette og genskabe synkroniseringen for at genoprette korrekt drift.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Der opstod en fejl</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Denne handling kan tage noget tid afhængigt af størrelsen på dine data. Hvis den mislykkes, kan en fuld gensynkronisering af drevet være nødvendig.
+
+Inden du fortsætter, skal du sørge for, at alle dine filer er opdaterede og synkroniserede.
+
+Luk ikke programmet under processen.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Skift synkroniseringstilstand?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Sådan gendanner du synkroniseringen:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Disken, der indeholder din synkroniseringsmappe, er ikke længere tilsluttet</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Tilslut den igen for at genoptage synkroniseringen.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Deaktiver notifikationer</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Deltag ikke</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Du har ikke tilladelse til at få adgang til dette kDrive.
+Kontrollér dine tilladelser eller kontakt din administrator.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Adgang nægtet til kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Dit kDrive er i dvaletilstand</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Dette kDrive er ikke blevet fornyet. Du kan ikke længere få adgang til det.
+Forny dit abonnement for at genaktivere tjenesten.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Dette kDrive er ikke blevet fornyet. Du kan ikke længere få adgang til det.
+Kontakt din administrator for at genaktivere tjenesten.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Dit kDrive er udløbet</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Log ind igen for at fortsætte med at bruge kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Du er blevet logget ud</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Kontoen, der bruges til denne forbindelse, svarer ikke til den for dette kDrive.
+Log venligst ind igen med den korrekte e-mailadresse %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Denne konto stemmer ikke overens</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive vågner op… dette kan tage et par øjeblikke.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive vågner op</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Optag diagnostiske oplysninger på min computer.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Aktivér fejlfindingslogning</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Indtast din adgangskode</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>En anden %1, hvis navn kun adskiller sig ved store/små bogstaver, findes allerede i denne mappe. Denne type navn understøttes ikke af kDrive Windows-applikationen. Omdøb en af %2-mapperne fra kDrive online, så du kan synkronisere den på din pc.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Modstridende navne, skelner mellem store og små bogstaver</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>En ændring blev registreret i din konfiguration</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>I disse situationer kan en ny synkronisering være nødvendig for at fortsætte med at bruge kDrive korrekt.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Tjek %1 for at gendanne adgang</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Seneste placering af %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Ekstern disk frakoblet</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Denne operation kan tage noget tid afhængigt af mængden af data, der skal behandles.
+
+Luk ikke programmet under processen.
+
+Hvis det mislykkes, kan du nemt starte en fuld gensynkronisering af drevet eller kontakte vores support.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktivér offline-synkronisering</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Dette kDrive er midlertidigt utilgængeligt på grund af vedligeholdelse.
+Prøv venligst igen om et par minutter.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Vedligeholdelse i gang</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Efterfølgende mellemrum i %1-navn</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Udelukket fra synkronisering</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Fil låst</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Fil gendannet</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Denne fil overskrider den maksimalt tilladte størrelse (50 GB).
+Kontakt support for at ophæve grænsen.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Fil for stor</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Adgang forbudt</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Navnet på dette %1 indeholder et eller flere tegn, der ikke understøttes af kDrive Windows-programmet. Omdøb %2 fra kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Ugyldigt navn</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Ikke-understøttet tegn</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Du har ikke de nødvendige tilladelser til at udføre denne handling.
+Anmod om adgang fra ejeren eller administratoren.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Adgang forbudt</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Ikke-understøttet filtype</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Denne mappe er ikke længere tilgængelig på sin oprindelige placering.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmappe ikke fundet</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Et af dine kDrive er synkroniseret inde i synkroniseringsmappen for et andet kDrive.
+Flyt en af mapperne, så de ikke længere er indlejrede, eller slet din synkronisering for at genskabe den.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Indlejrede kDrive</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Kan ikke få adgang til dette %1 på din computer. Kontrollér, at det stadig eksisterer, og at du har rettighederne til at få adgang til det.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 utilgængelig</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>%1-navn for langt</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Kan ikke oprette forbindelse til kDrive.
+Synkronisering genoptages automatisk, når forbindelsen er genoprettet.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Forbindelsen midlertidigt utilgængelig</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Utilstrækkelig diskplads</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Navnet på denne fil indeholder et eller flere tegn, der endnu ikke understøttes af kDrive-programmet. Omdøb filen fra kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Ikke-understøttet tegn</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Stien til dette %1 er for lang til at blive synkroniseret. Omdøb en eller flere mapper, det er placeret i, for at forkorte stien.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Sti til %1 for lang</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Dit kDrive er fuldt. Frigør plads eller opgrader dit abonnement for at synkronisere dette %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Lagergrænse nået</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Dette navn er reserveret af din computers system. Omdøb %1 fra kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>%1-navn reserveret</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Kontrollér placeringen eller adgangsrettighederne for mappen.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synkroniseringsmappe utilgængelig</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync har ikke de nødvendige tilladelser til at fungere.
+åbn macOS-indstillingerne for at aktivere dem.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorisation påkrævet</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Din enheds diskplads er fuld. Synkronisering er sat på pause. Frigør plads for at genoptage synkronisering.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Utilstrækkelig diskplads</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Denne mappe er ikke længere tilgængelig på sin oprindelige placering.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Denne mappe er ikke længere tilgængelig. Der kræves handling for at genoptage synkronisering.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmappe ikke fundet</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync kan ikke starte. Du kan fortsætte med at synkronisere dine filer ved at aktivere offline-synkronisering i indstillingerne. Kontakt support, hvis problemet fortsætter.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Kan ikke starte Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Synkronisering af dette element mislykkedes. Det prøves automatisk igen senere.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synkronisering midlertidigt mislykket</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Overførslen kunne ikke fuldføres. Prøv venligst igen senere.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Det ser ud til, at vi ikke kan indlæse appen…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Der opstod en fejl under sletning af din konto.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Filer der skal verificeres</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Andet</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System og tilladelser</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Det lykkedes ikke at åbne URL'en %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Fejl der skal rettes</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Denne mappe kan ikke synkroniseres. Vælg en anden mappe.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Fejl ved forsøg på at starte installationsprogrammet</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Fejl ved ændring af synkroniseringstilstand</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blokér apps, der kan downloade eller ændre dine filer.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Filer, der matcher denne regel, synkroniseres ikke.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Undgå, at visse midlertidige filer eller systemfiler kopieres til kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Muliggør indsamling af yderligere oplysninger nyttige for support.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Udvidet detaljeret log</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Når denne mulighed er aktiveret, kører kDrive langsommere.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Kunne ikke oprette et delingslink</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Hjælp os med at forbedre kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>En notifikation underretter dig, når en fil udelukkes af denne regel.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Filen eksisterer allerede</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Filsynkroniseringstilstand</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Definer, hvordan dine filer gemmes og tilgås.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Filer der skal udelukkes</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoritter</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Delinger</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Papirkurv</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>I 1 time</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>I en uge</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>I tre dage</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hej %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Support</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Frigør plads eller opgrader din plan for at fortsætte med at synkronisere dine filer.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Dit kDrive er fuldt</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Nogle filer kunne ikke synkroniseres.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Du har &lt;b&gt;en synkroniseringsfejl&lt;/b&gt;</numerusform> 
+                <numerusform>Du har &lt;b&gt;%n synkroniseringsfejl&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Vi kan ikke få adgang til dine filer. Genstart programmet for at genoptage synkronisering. Hvis problemet fortsætter, kontakt support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Forbindelsen til kDrive afbrudt</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktivér kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Du skal aktivere kDrive.app, inden du fortsætter</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktivér kDrive og kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Du skal aktivere tilladelserne, inden du fortsætter</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Gå til Privatliv og sikkerhed &gt; Fuld diskadgang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Fuld diskadgang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Privatliv og sikkerhed</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Vælg Åbning og udvidelser &gt; Sikkerhedsudvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Sikkerhedsudvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Åbning og udvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Åbn Systemindstillinger &gt; Generelt</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Systemindstillinger</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Genstart programmet, hvis det kræves</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Dette element er ikke tilgængeligt på denne enhed.
+Det åbnes i din browser.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Adgangsrettigheder ændret</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Aktiveret</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>for %1 siden</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Alle mapper</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Hele kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Tillad sporing</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Programidentifikator</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Programnavn</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Forfatter</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Som standard</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Vælg hvilken version af dine filer du vil beholde.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>For hver fil skal du vælge den version, der skal beholdes.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Hvilken version vil du beholde?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Vælg versionen der skal beholdes</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>De online versioner af disse %1 filer erstattes af dine lokale versioner.
+Vær opmærksom på, at dette kan overskrive dine samarbejdspartneres arbejde.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Behold kun lokale versioner</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>For hver konflikt bevarer vi automatisk den version (lokal eller online), der er ændret senest. Dette er det sikreste valg i de fleste tilfælde.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Behold de nyeste versioner</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Alle lokale ændringer for disse %1 filer kasseres.
+Nyttigt, hvis du ved, at det vigtige arbejde er online på kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Behold kun online versioner</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Log ind for at komme i gang.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Opret en %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Dato</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Deaktiveret</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>fil</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Mappe</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Mappe slettet</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Mappe flyttet eller ændret</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen er muligvis blevet flyttet til en anden disk og derefter returneret til sin oprindelige placering.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>mappe</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Mappe flyttet eller omdøbt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Mappe genskabt eller erstattet</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Mappen blev slettet og genskabt, eller erstattet af en anden mappe med samme navn.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Lige nu</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokal</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 filer er blevet ændret både på din computer og på kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Nyeste</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Navn</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Ny enhed registreret</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Du bruger kDrive på en ny computer, efter en gendannelse fra en sikkerhedskopi.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Ny mappe</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>ny synkronisering</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Ingen konflikter matcher din søgning</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Ingen fejl at rette</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notifikation</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Giv besked, hvis fil er ekskluderet</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Fra</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Online mappe slettet</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Den synkroniserede mappe blev slettet på kDrive online eller er ikke længere tilgængelig.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Oprindelig placering:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Anbefalet</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen er muligvis blevet flyttet til en anden disk og derefter returneret til sin oprindelige placering.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Gendan den til sin oprindelige placering.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regler</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Samme som system</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>t</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sek</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Siden: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Størrelse</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 ledig</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 ledige</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Beregner…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 brugt</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 brugte</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkroniseret fra kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkroniseret fra din computer</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Dette kDrive indeholder kun filer. Alle filer synkroniseres på denne enhed.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Ingen mappe at vælge</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synkroniseringsmapper</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Placering</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synkroniser dine kDrive på denne enhed</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserede mapper</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tid</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Velkommen til kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 af %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive-administration</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Sprog</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Genstart programmet for at afslutte anvendelsen af det nye sprog.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Lær mere</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3-licens - Git-kilder</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link kopieret til udklipsholder</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Inkompatibelt drev eller mappe direkte i roden af drevet (f.eks. vælg en mappe som /Mit drev i stedet for /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Inkompatibelt drev eller mappe direkte i roden af drevet (f.eks. vælg en mappe som D:/Mit drev i stedet for D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Placering på computer</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Debug</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Fejl</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Udvidet</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Kritisk</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Advarsel</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Send fejlfindingsmappe til Infomaniak support</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Nogle filnavne kan indeholde specialtegn, der ikke understøttes (såsom dobbelte anførselstegn, backslashes eller linjeskift).
+
+Kontrollér venligst og omdøb filer med usædvanlige tegn, og prøv derefter igen.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Ugyldigt filnavn</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Komprimerer logfiler…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Uploader logfiler til support…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Den seneste upload mislykkedes. Kontrollér venligst din internetforbindelse og sørg for, at mindst én kDrive-bruger er logget ind. Upload er begrænset til 10 om dagen.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Forskellige versioner af disse filer blev registreret.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 versionskonflikter registreret</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo er et analyseværktøj hostet og administreret udelukkende af Infomaniak for at forstå, hvordan programmet bruges.
+
+Analyse af disse data giver vores team mulighed for løbende at forbedre programmets grænseflade.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Flytning annulleret</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Flyt slettede filer til computerens papirkurv</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Nogle elementer kan muligvis ikke flyttes.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Mere lagerplads, flere funktioner med my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Brug for hjælp?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Netværk</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Tilføj en konto for at komme i gang</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Ingen resultater fundet</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Ikke synkroniseret</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Altid</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Aldrig</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Modtag en notifikation, når en fil udelukkes</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Konfigurer synkronisering for dette kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Tilpas placeringen af din kDrive-mappe på din computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Den valgte mappe skal være tom for at synkronisering fungerer korrekt.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Vælg de mapper, der skal synkroniseres på denne computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserede mapper</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>For hvert kDrive kan du vælge, hvor det synkroniseres på din computer, og hvilke mapper du vil synkronisere.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synkroniseret indhold:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synkroniseret indhold: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Placering:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Placering: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Konfigurer dine kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Vælg de mapper, der skal synkroniseres på denne computer</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Filer downloades kun, når de åbnes, for at spare diskplads.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Aktivér Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Dette kDrive er allerede konfigureret.
+Gå til dine indstillinger for at ændre det.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autorisér kDrive i macOS-indstillinger:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktivér kDrive på din Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>For at fuldføre installationen skal du autorisere kDrive til at få adgang til dine:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autorisér adgang til filer</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Kom gratis i gang med my kSuite,
+eller vælg en plan, der passer til dine behov.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Du har ikke et kDrive endnu.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Vælg de kDrive, der skal synkroniseres på denne computer:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering i gang</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Godt at se dig!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Alle kDrive-mapper</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Brugerdefineret valg</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Det private, hurtige og sikre cloud, hostet i Schweiz.
+
+Log ind, og hold dine dokumenter synkroniserede på alle dine enheder.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Der opstod en fejl. Prøv venligst igen.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Loginfejl</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Bare et øjeblik, vi indlæser din konto…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Logger ind fra din browser…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Henter dine oplysninger…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Et øjeblik…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Velkommen til kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Dine filer er klar til at blive synkroniseret
+sikkert på din computer.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Klar!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Vi afslutter konfigurationen af dine kDrive.
+
+Vent venligst et øjeblik.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synkronisering i gang…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Åbn kDrive, når computeren starter</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Åbn login-siden</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Sti kopieret til udklipsholder</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Definer, hvordan kDrive opretter forbindelse til internettet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Godkendelse krævet</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Adgangskode</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxy-indstillinger</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxy-type</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manuel konfiguration</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Ingen</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Brugernavn</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Intern</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Placering på kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Søg i %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Vælg de mapper, der skal synkroniseres på denne computer.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Ikke-valgte mapper downloades ikke til din enhed. De forbliver tilgængelige online og slettes ikke.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Ikke-valgte mapper downloades ikke til din enhed. De forbliver tilgængelige online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry er et værktøj hostet og administreret udelukkende af Infomaniak for at overvåge stabiliteten af programmet i realtid og automatisk rapportere tekniske fejl til vores udviklere.
+
+Disse data giver vores team mulighed for hurtigt at rette og optimere programmet, hvilket resulterer i en bedre brugeroplevelse for dig.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Indstillinger</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Konti &amp; synkroniseringer</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avanceret</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Generelt</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-mappe</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Log ind via din browser</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Åbn kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Afslut</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Indstillinger</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Ledig plads på computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-filer gemt på computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Andre filer på computer</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Indlæser pladsforbrug…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Ledig plads</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Andre filer</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>kDrive-filer, der er gemt på din enhed</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive kan ikke få adgang til drevet
+Sørg for, at det er tilsluttet,
+oplåst og tilgængeligt fra din computer.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Drevet er ikke tilgængeligt</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Administrer synkroniserede mapper for at frigøre plads på din Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Denne PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 af %2 brugt</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Gemt online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Dine filer forbliver i skyen og bruger ikke plads på din computer.
+En internetforbindelse er nødvendig for at få adgang til dem.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synkroniseringsfejl</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Brugerdefineret mappe</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Standardmappe</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Din nye synkroniseringstilstand anvendes…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synkroniseringsregler</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Der opstod en fejl</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Seneste synkronisering lykkedes</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synkronisering er sat på pause</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synkronisering kører</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synkroniseret</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synkroniseret</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkroniseret fra din computer</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkroniseret fra kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>dine filer synkroniseres</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synkroniseringen er sat på pause</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Dine seneste filer opdateres.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering i gang</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Dine downloadede filer forbliver tilgængelige.
+Synkroniseringen genoptages automatisk, så snart du er online igen.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Synkronisering er midlertidigt stoppet.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synkronisering under pause</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Dine filer er tilgængelige og synkroniserede.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Ingen aktivitet i gang</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>dine filer er opdaterede</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>En fil eller mappe i din synkroniseringsmappe ser ud til at være beskadiget.
+Synkronisering er sat på pause. Kontrollér venligst dine filer og prøv igen.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Beskadiget fil registreret</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Aktivitet</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Hjem</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Lager</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen må ikke være roden af et drev og må ikke indeholde eller være inde i en allerede synkroniseret mappe.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen skal være tom, må ikke være roden af et drev, og må ikke indeholde eller være inde i en allerede synkroniseret mappe.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Denne mappe kan ikke bruges</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Individuel håndtering</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Administrer synkronisering</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>En notifikation informerer dig, når en fil udelukkes af denne regel</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Luk kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Åbn kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Indstillinger</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Kontrollér, at din internetforbindelse er aktiv, at dette navn ikke allerede er i brug, og at det ikke indeholder ugyldige tegn.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Kan ikke oprette denne mappe</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Uautoriseret adgang</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Dine filer er tilgængelige og synkroniserede.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Ingen nylig aktivitet</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Prøv venligst igen om et øjeblik.
+Hvis problemet fortsætter, kontakt venligst support.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Der opstod en uventet fejl</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Indtil i morgen</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 tilgængelig</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Installationen tager mindre end et minut.
+Din synkronisering genoptages automatisk til sidst.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorér denne version</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Installér nu</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Påmind mig senere</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Se nyheder</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Version %1 · Du bruger %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Opdatering tilgængelig</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>En ny version af kDrive er påkrævet for at fortsætte.
+Opdater programmet for at få adgang til dine filer og genoptage synkronisering.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Opdatering påkrævet</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Opdater</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Ufuldstændig upload</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Udeluk bestemte apps fra synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Tilføj filer til at udelukke fra synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Brugerdefinerede udelukkelsesregler</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Udeluk bestemte filtyper fra synkronisering.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Se kildekode</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Du har en synkroniseringsfejl</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Du har {0} synkroniseringsfejl</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive kan ikke få adgang til disk %1
+Sørg for, at den er tilsluttet,
+oplåst og tilgængelig fra din computer.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Lagerdisk %1 er ikke tilgængelig</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Fjern</numerusform> 
+                <numerusform>Fjern (%1 regler)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Anvender ændring…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Administrer diskplads</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Åbn overordnet mappe</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Opdater</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Fejlfindingsniveau</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synkronisering genstarter automatisk.
+Hvis problemet fortsætter, kontakt vores support og vedhæft de tekniske detaljer nedenfor.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Tekniske detaljer</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Der opstod en uventet fejl</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Sletning annulleret</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Dobbelte navne</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Du har ikke de nødvendige tilladelser til at tilføje en %1 til denne placering.
+Anmod om adgang fra ejeren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke tilladelse til at slette dette %1. Det er blevet gendannet til sin oprindelige placering. Anmod om adgang fra ejeren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Adgangstilladelserne for %1 blev ændret, hvilket forhindrer den i at blive synkroniseret.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Der findes allerede en fil eller mappe med dette navn.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke rettighederne til at redigere denne fil.
+Originalversionen er bevaret, og din redigering er gemt i en separat fil med "konflikt" i dens navn. Anmod om adgang fra ejeren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Navnet på dette %1 slutter med et mellemrum, hvilket forhindrer det i at blive synkroniseret. Omdøb %2 fra kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>En udelukkelsesregel forhindrer denne %1 i at blive synkroniseret.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Der findes allerede en fil med dette navn.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Denne fil bruges i øjeblikket af en anden bruger.
+Dine ændringer synkroniseres senere.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Denne fil blev slettet på kDrive online, mens du redigerede den. En kopi er bevaret på din computer i gendannelsesmappen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Denne fil overskrider den maksimalt tilladte størrelse (50 GB).
+Kontakt din administrator for at øge filstørrelsesgrænsen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Dette navn indeholder kun mellemrum og kan ikke bruges. Omdøb %1 fra kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Denne fil er et hardlink, der ikke kan synkroniseres.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke rettighederne til at flytte dette %1 hertil; det vil blive gendannet til sin oprindelige placering. Anmod om adgang fra ejeren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Dette navn overskrider den tilladte længde (250 tegn). Omdøb %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Der er ikke nok plads på din computer til at synkronisere denne fil.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Den fulde mappe er stor.
+For at fremskynde overførslen anbefaler vi at sende kun den seneste kDrive-session.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Send kun seneste session</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: da, Danish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="da"> 
     <context>
@@ -344,6 +344,16 @@ Du kan åbne dem til enhver tid, selv uden en internetforbindelse.</translation>
             <source>Manage storage</source> 
             <translation>Administrer lager</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maksimer</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimer</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Åbn fejlfindingsmappe</translation> 
@@ -427,6 +437,11 @@ Du kan åbne dem til enhver tid, selv uden en internetforbindelse.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Genstart synkronisering</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Gendan</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="da"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ oplåst og tilgængelig fra din computer.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Anvender ændring…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Administrer diskplads</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Åbn overordnet mappe</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Opdater</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Fejlfindingsniveau</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Hvis problemet fortsætter, kontakt vores support og vedhæft de tekniske detalj
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Tekniske detaljer</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Der opstod en uventet fejl</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Sletning annulleret</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Dobbelte navne</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Anmod om adgang fra ejeren eller administratoren.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har ikke tilladelse til at slette dette %1. Det er blevet gendannet til sin oprindelige placering. Anmod om adgang fra ejeren eller administratoren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Adgangstilladelserne for %1 blev ændret, hvilket forhindrer den i at blive synkroniseret.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Der findes allerede en fil eller mappe med dette navn.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ Originalversionen er bevaret, og din redigering er gemt i en separat fil med "ko
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Navnet på dette %1 slutter med et mellemrum, hvilket forhindrer det i at blive synkroniseret. Omdøb %2 fra kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>En udelukkelsesregel forhindrer denne %1 i at blive synkroniseret.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Der findes allerede en fil med dette navn.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Dine ændringer synkroniseres senere.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Denne fil blev slettet på kDrive online, mens du redigerede den. En kopi er bevaret på din computer i gendannelsesmappen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Kontakt din administrator for at øge filstørrelsesgrænsen.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Dette navn indeholder kun mellemrum og kan ikke bruges. Omdøb %1 fra kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Denne fil er et hardlink, der ikke kan synkroniseres.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har ikke rettighederne til at flytte dette %1 hertil; det vil blive gendannet til sin oprindelige placering. Anmod om adgang fra ejeren eller administratoren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Dette navn overskrider den tilladte længde (250 tegn). Omdøb %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Der er ikke nok plads på din computer til at synkronisere denne fil.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_da.ts
+++ b/src/gui4/linux/translations/client_da.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: da, Danish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="da"> 
     <context>
@@ -2077,7 +2077,7 @@ Disse data giver vores team mulighed for hurtigt at rette og optimere programmet
             <translation>kDrive-mappe</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Log ind via din browser</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: de, German
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="de"> 
     <context>
@@ -2076,7 +2076,7 @@ Diese Daten ermöglichen es unserem Team, die Anwendung schnell zu beheben und z
             <translation>kDrive-Ordner</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>In Ihrem Browser anmelden</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="de"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2466,42 +2466,42 @@ entriegelt und von Ihrem Computer aus zugänglich ist.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Änderung wird angewendet…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Speicherplatz verwalten</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Übergeordneten Ordner öffnen</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Aktualisieren</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Debug-Stufe</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2510,35 +2510,35 @@ Wenn das Problem weiterhin besteht, wenden Sie sich an unseren Support und füge
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Technische Details</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Ein unerwarteter Fehler ist aufgetreten</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Löschvorgang abgebrochen</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Doppelte Namen</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2547,28 +2547,28 @@ Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Sie haben keine Berechtigung, %1 zu löschen. Es wurde an seinen ursprünglichen Speicherort wiederhergestellt. Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Die Zugriffsberechtigungen für %1 wurden geändert, was die Synchronisierung verhindert.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Eine Datei oder ein Ordner mit diesem Namen existiert bereits.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2577,28 +2577,28 @@ Die Originalversion wurde beibehalten und Ihre Bearbeitung wurde in einer separa
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Der Name dieses %1 endet mit einem Leerzeichen, was die Synchronisierung verhindert. Benennen Sie %2 über kDrive online um.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Eine Ausschlussregel verhindert die Synchronisierung dieses %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Eine Datei mit diesem Namen existiert bereits.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2607,14 +2607,14 @@ Ihre Änderungen werden später synchronisiert.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Diese Datei wurde auf kDrive online gelöscht, während Sie sie bearbeiteten. Eine Kopie wurde auf Ihrem Computer im Wiederherstellungsordner gespeichert.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2623,49 +2623,49 @@ Wenden Sie sich an Ihren Administrator, um das Dateigrössenlimit zu erhöhen.</
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Dieser Name enthält nur Leerzeichen und kann nicht verwendet werden. Benennen Sie %1 über kDrive online um.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Diese Datei ist ein Hardlink, der nicht synchronisiert werden kann.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Sie haben keine Rechte, %1 hierhin zu verschieben; es wird an seinen ursprünglichen Speicherort wiederhergestellt. Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Dieser Name überschreitet die zulässige Länge (250 Zeichen). Benennen Sie %1 um.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Auf Ihrem Computer ist nicht genügend Speicherplatz vorhanden, um diese Datei zu synchronisieren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: de, German
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="de"> 
     <context>
@@ -344,6 +344,16 @@ Sie können sie jederzeit öffnen, auch ohne Internetverbindung.</translation>
             <source>Manage storage</source> 
             <translation>Speicher verwalten</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximieren</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimieren</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Debug-Ordner öffnen</translation> 
@@ -427,6 +437,11 @@ Sie können sie jederzeit öffnen, auch ohne Internetverbindung.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Synchronisierung neu starten</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Wiederherstellen</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_de.ts
+++ b/src/gui4/linux/translations/client_de.ts
@@ -1,0 +1,2680 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: de, German
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="de"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Version %1 (Build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Über</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Über kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>In der Schweiz entwickelt und gehostet, gewährleistet kDrive den vollständigen Schutz Ihrer Daten, ohne Weiterverkauf oder Überwachung, in ISO-zertifizierten Rechenzentren, mit Verschlüsselung und Sicherung auf mehreren Medien.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Sichtbare Aktivitäten</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Wählen Sie den Vertriebskanal</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Weitere Informationen anzeigen</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Suche löschen</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Dateien durchsuchen</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Suche läuft…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Wählen Sie einen Synchronisationsmodus</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synchronisierung abgeschlossen</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synchronisierung läuft</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Keine aktuellen Aktivitäten</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Sie sind offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synchronisierung pausiert</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Alle Aktivitäten</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Nur meine Aktivitäten</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Einen Ordner mit kDrive synchronisieren</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Wählen Sie den Ordner auf Ihrem Computer aus, der mit kDrive synchronisiert werden soll:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synchronisierter Ordner</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Passen Sie den Speicherort Ihres Computerordners auf kDrive an:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Wählen Sie den Ordnerstandort auf kDrive aus</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-Speicherort</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Wählen Sie einen Ordner auf Ihrem Computer aus, der mit kDrive synchronisiert werden soll.
+Sie können auf Ihre erweiterten Synchronisierungen über die Laufwerksauswahl auf der Startseite zugreifen.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Einen Ordner mit kDrive synchronisieren</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Erweiterte Synchronisierung</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Auszuschliessende App</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Die Anwendung ist auf dem neuesten Stand</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Löscht Protokolle, die älter als 7 Tage sind, um Speicherplatz zu sparen.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatische Bereinigung</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatische Aktualisierungen</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Offline verfügbar</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Ihre Dateien werden auf Ihren Computer kopiert.
+Sie können sie jederzeit öffnen, auch ohne Internetverbindung.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Sie können es über die Web-Oberfläche aktivieren.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Erhalten Sie frühzeitigen Zugriff auf neue Versionen der Anwendung, bevor diese für die Öffentlichkeit veröffentlicht werden, und helfen Sie, die App zu verbessern, indem Sie Ihre Verbesserungsideen mit uns teilen.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Am Beta-Programm teilnehmen</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Ihr Browser sollte sich automatisch öffnen, um die Anmeldung abzuschliessen. Nach der Anmeldung werden Sie automatisch zu kDrive zurückgeleitet.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Offline-Synchronisierung aktivieren</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Einen Ordner synchronisieren</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Eine Regel hinzufügen</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Speicher hinzufügen</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Erweiterte Einstellungen</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Auf %1 Dateien anwenden</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Zugriff anfragen</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Abbrechen</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Ordner ändern</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Offline speichern</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Online speichern</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Benutzer wechseln</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Schliessen</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>kDrive schliessen</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Konfigurieren</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Bestätigen</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Anmelden</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Ein Konto verbinden</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Support kontaktieren</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Weiter</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Freigabelink kopieren</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Ein Konto erstellen</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Eine neue Synchronisierung erstellen</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Benutzerdefinierter Speicherort</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Dieses Konto trennen</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Download läuft…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Manuell herunterladen</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Aktivieren</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>In den Windows-Einstellungen aktivieren</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Das Problem verstehen</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Eine Idee teilen</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Die Installation beenden</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Fehler beheben</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Ich habe kDrive aktiviert</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Konto behalten</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Abmelden</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Anmelden</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Verwalten</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Dateien einzeln verwalten</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Speicher verwalten</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Debug-Ordner öffnen</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Explorer öffnen</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Ordner öffnen</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Im Browser öffnen</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>In Explorer öffnen</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>In Finder öffnen</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>In kDrive Web öffnen</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>kDrive öffnen</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Ausschlüsse verwalten</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Synchronisierungseinstellungen öffnen</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pausieren</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Aktualisieren</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Versionshinweise</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Entfernen</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Entferne (%n Element)</numerusform> 
+                <numerusform>Entfernen (%n Elemente)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Synchronisierung entfernen</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>%1 umbenennen</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Anmeldung neu starten</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Synchronisierung fortsetzen</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Synchronisierung neu starten</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Erneut versuchen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Zum Standardordner zurückkehren</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Speichern</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Meine Auswahl speichern</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Suchen</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Aktivitäten anzeigen</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Auswählen</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Einen Ordner auswählen</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Ordner auswählen</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Einen Speicherort auswählen</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Ausgewählt</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Senden</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Debug-Ordner senden</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Einstellungen öffnen</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Angebote anzeigen</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Optionen anzeigen</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Abmelden</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Starten</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Versionsauswahl starten</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Kostenlos starten</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Offline synchronisieren</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Jetzt aktualisieren</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Abonnement aktualisieren</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Upgraden</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Bestätigen</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Bestätigen und weiter</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Aktivieren</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Eine Version auswählen</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Zwei verschiedene Versionen dieser Dateien wurden erkannt.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versionskonflikte</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Nach einer Datei suchen</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopieren von Link…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Freigabelink wird erstellt…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Sie können die von Infomaniak erfassten Nutzungs- und Betriebsdaten anpassen, um Fehler zu beheben und die Anwendung zu verbessern. Beide verwendeten Tools werden ausschliesslich von uns gehostet und verwaltet.
+
+Der Quellcode dieser Anwendung kann überprüft werden, die gesammelten Informationen sind anonym und Ihre persönlichen Daten bleiben streng vertraulich und werden niemals an Dritte weitergegeben.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Datenverwaltung</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respektiert Ihre Privatsphäre</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Wählen Sie die Menge der zu protokollierenden Informationen aus.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Ermöglicht dem Infomaniak-Support, die Ursache eines Vorfalls zu identifizieren.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Debug-Protokolle</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Diese Apps werden standardmässig ignoriert und können nicht geändert werden.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Diese Dateien sind standardmässig ausgeschlossen und können nicht geändert werden.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatischer Ausschluss</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>In diesen Situationen ist eine neue Synchronisierung erforderlich, um kDrive korrekt weiter zu verwenden.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Bitte wählen Sie einen leeren Ordner aus, der sich nicht im Stammverzeichnis eines Laufwerks befindet.
+
+Dieser Ordner darf nicht in einem anderen Synchronisierungsordner enthalten sein und darf keinen Synchronisierungsunterordner enthalten.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Dieser Ordner kann nicht ausgewählt werden</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Eine Regel hinzufügen</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Eine Ausschlussregel hinzufügen</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Sie sind dabei, %1 von der Anwendung zu trennen.
+Der Synchronisierungsordner verbleibt auf Ihrem Computer, wird jedoch nicht mehr mit kDrive synchronisiert.
+
+Alle Ihre Daten bleiben online auf kDrive zugänglich.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Von diesem Konto abmelden?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Der lokale Ordner verbleibt auf Ihrem Computer, wird jedoch nicht mehr mit kDrive synchronisiert.
+Diese Aktion ist dauerhaft.
+Um Ihr Laufwerk erneut zu synchronisieren, müssen Sie es später neu verbinden.
+
+Stellen Sie vor dem Fortfahren sicher, dass alle Ihre Dateien auf dem neuesten Stand und vollständig synchronisiert sind.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Synchronisierung entfernen?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Die Änderung des Synchronisierungsmodus wurde abgebrochen.
+
+Die aktuelle Synchronisierung bleibt unverändert. Wenn jedoch ein abnormales Verhalten auftritt, müssen Sie möglicherweise die Synchronisierung löschen und neu erstellen, um den ordnungsgemässen Betrieb wiederherzustellen.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Ein Fehler ist aufgetreten</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Dieser Vorgang kann je nach Grösse Ihrer Daten einige Zeit in Anspruch nehmen. Wenn er fehlschlägt, kann eine vollständige Neusynchronisierung des Laufwerks erforderlich sein.
+
+Stellen Sie vor dem Fortfahren sicher, dass alle Ihre Dateien auf dem neuesten Stand und synchronisiert sind.
+
+Schliessen Sie die Anwendung während des Vorgangs nicht.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Synchronisierungsmodus ändern?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>So stellen Sie die Synchronisierung wieder her:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Das Laufwerk, das Ihren Synchronisierungsordner enthält, ist nicht mehr verbunden</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Verbinden Sie es erneut, um die Synchronisierung fortzusetzen.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Benachrichtigungen deaktivieren</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Nicht beitreten</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/de/anwendungen/kdrive-herunterladen</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Sie haben keine Berechtigung, auf dieses kDrive zuzugreifen.
+Bitte überprüfen Sie Ihre Berechtigungen oder wenden Sie sich an Ihren Administrator.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Zugriff auf kDrive verweigert</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Ihr kDrive befindet sich im Ruhemodus</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Dieses kDrive wurde nicht verlängert. Sie können nicht mehr darauf zugreifen.
+Erneuern Sie Ihr Abonnement, um den Dienst zu reaktivieren.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Dieses kDrive wurde nicht verlängert. Sie können nicht mehr darauf zugreifen.
+Wenden Sie sich an Ihren Administrator, um den Dienst zu reaktivieren.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Ihr kDrive ist abgelaufen</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Melden Sie sich erneut an, um kDrive weiterhin zu verwenden.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Sie wurden abgemeldet</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Das für diese Verbindung verwendete Konto stimmt nicht mit dem Konto für dieses kDrive überein.
+Bitte melden Sie sich erneut mit der korrekten E-Mail-Adresse %1 an</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Dieses Konto stimmt nicht überein</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive wird aktiviert… dies kann einen Moment dauern.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive wird aktiviert</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Diagnoseinformationen auf meinem Computer aufzeichnen.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Debug-Protokollierung aktivieren</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Geben Sie Ihr Passwort ein</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Ein weiteres %1, dessen Name sich nur in der Gross-/Kleinschreibung unterscheidet, existiert bereits in diesem Ordner. Dieser Namenstyp wird von der kDrive Windows-Anwendung nicht unterstützt. Benennen Sie eines der %2 aus kDrive online um, damit Sie es auf Ihrem PC synchronisieren können.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Namenskonflikte in Gross- und Kleinschreibung</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Eine Änderung in Ihrer Konfiguration wurde erkannt</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>In diesen Situationen kann eine neue Synchronisierung erforderlich sein, um kDrive korrekt weiter zu verwenden.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Überprüfen Sie %1, um den Zugriff wiederherzustellen</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Letzter Speicherort von %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Externes Laufwerk getrennt</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Dieser Vorgang kann je nach Datenmenge einige Zeit in Anspruch nehmen.
+
+Schliessen Sie die Anwendung während des Vorgangs nicht.
+
+Wenn er fehlschlägt, können Sie einfach eine vollständige Neusynchronisierung des Laufwerks starten oder unseren Support kontaktieren.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Offline-Synchronisierung aktivieren</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Dieses kDrive ist vorübergehend aufgrund von Wartungsarbeiten nicht verfügbar.
+Bitte versuchen Sie es in einigen Minuten erneut.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Wartung in Bearbeitung</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Abschliessendes Leerzeichen im Namen von %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Von der Synchronisierung ausgeschlossen</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Datei gesperrt</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Datei gerettet</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Diese Datei überschreitet die maximal zulässige Grösse (50 GB).
+Wenden Sie sich an den Support, um das Limit aufzuheben.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Datei zu gross</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Zugriff verboten</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Der Name dieses %1 enthält ein oder mehrere Zeichen, die von der kDrive Windows-Anwendung nicht unterstützt werden. Benennen Sie %2 über kDrive online um.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Ungültiger Name</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Nicht unterstütztes Zeichen</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Sie haben nicht die erforderlichen Berechtigungen, um diese Aktion auszuführen.
+Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Zugriff verboten</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Nicht unterstützter Dateityp</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Dieser Ordner ist an seinem ursprünglichen Speicherort nicht mehr zugänglich.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synchronisierungsordner nicht gefunden</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Eines Ihrer kDrives wird innerhalb des Synchronisierungsordners eines anderen kDrive synchronisiert.
+Verschieben Sie einen der Ordner, damit sie nicht mehr verschachtelt sind, oder löschen Sie Ihre Synchronisierung, um sie neu zu erstellen.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Verschachtelte kDrives</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Auf %1 kann auf Ihrem Computer nicht zugegriffen werden. Überprüfen Sie, ob es noch vorhanden ist und ob Sie die Rechte haben, darauf zuzugreifen.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 nicht zugänglich</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Name von %1 zu lang</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Verbindung zu kDrive nicht möglich.
+Die Synchronisierung wird automatisch fortgesetzt, sobald die Verbindung wiederhergestellt ist.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Verbindung vorübergehend nicht verfügbar</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Unzureichender Speicherplatz</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Der Name dieser Datei enthält ein oder mehrere Zeichen, die von der kDrive-Anwendung noch nicht unterstützt werden. Benennen Sie die Datei über kDrive online um.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Nicht unterstütztes Zeichen</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Der Pfad zu diesem %1 ist zu lang, um synchronisiert zu werden. Benennen Sie einen oder mehrere Ordner, in denen es sich befindet, um den Pfad zu verkürzen.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Pfad zu %1 zu lang</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Ihr kDrive ist voll. Geben Sie Speicherplatz frei oder upgraden Sie Ihr Abonnement, um %1 zu synchronisieren.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Speicherlimit erreicht</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Dieser Name ist vom System Ihres Computers reserviert. Benennen Sie %1 über kDrive online um.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Name von %1 reserviert</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Überprüfen Sie den Speicherort oder die Zugriffsrechte des Ordners.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synchronisierungsordner nicht zugänglich</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync hat nicht die nötigen Berechtigungen, um zu funktionieren.
+öffnen Sie die macOS-Einstellungen, um sie zu aktivieren.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Genehmigung erforderlich</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Der Speicherplatz Ihres Geräts ist voll. Die Synchronisierung wurde pausiert. Geben Sie Speicherplatz frei, um die Synchronisierung fortzusetzen.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Unzureichender Speicherplatz</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Dieser Ordner ist an seinem ursprünglichen Speicherort nicht mehr zugänglich.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Dieser Ordner ist nicht mehr zugänglich. Eine Aktion ist erforderlich, um die Synchronisierung fortzusetzen.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synchronisierungsordner nicht gefunden</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync kann nicht gestartet werden. Sie können Ihre Dateien weiterhin synchronisieren, indem Sie die Offline-Synchronisierung in den Einstellungen aktivieren. Wenden Sie sich an den Support, wenn das Problem weiterhin besteht.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Lite Sync kann nicht gestartet werden</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Die Synchronisierung dieses Elements ist fehlgeschlagen. Es wird später automatisch erneut versucht.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synchronisierung vorübergehend fehlgeschlagen</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Der Upload konnte nicht abgeschlossen werden. Bitte versuchen Sie es später erneut.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Es scheint, dass wir die App nicht laden können…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Bei der Löschung Ihres Kontos ist ein Fehler aufgetreten.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Zu prüfende Dateien</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Sonstige</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System und Berechtigungen</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Die URL %1 konnte nicht geöffnet werden.</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Zu behebende Fehler</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Dieser Ordner kann nicht synchronisiert werden. Bitte wählen Sie einen anderen Ordner aus.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Fehler beim Versuch, das Installationsprogramm zu starten</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Fehler beim Ändern des Synchronisationsmodus</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blockieren Sie Apps, die Ihre Dateien herunterladen oder ändern könnten.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Dateien, die dieser Regel entsprechen, werden nicht synchronisiert.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Vermeiden Sie, dass bestimmte temporäre oder Systemdateien in kDrive kopiert werden.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Aktiviert die Erfassung zusätzlicher Informationen, die für den Support nützlich sind.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Erweitertes detailliertes Protokoll</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Wenn diese Option aktiviert ist, läuft kDrive langsamer.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Freigabelink konnte nicht erstellt werden</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/de/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Helfen Sie uns, kDrive zu verbessern</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/074f5c5a-372b-40a6-b82f-9157fdb3d2d7</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Eine Benachrichtigung informiert Sie, wenn eine Datei von dieser Regel ausgeschlossen wird.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Datei existiert bereits</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Dateisynchronisierungsmodus</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Legen Sie fest, wie Ihre Dateien gespeichert und abgerufen werden.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Auszuschliessende Dateien</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoriten</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Freigaben</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Papierkorb</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Für 1 Stunde</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Für eine Woche</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Für drei Tage</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hallo %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/de/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Support</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Geben Sie Speicherplatz frei oder upgraden Sie Ihren Plan, um Ihre Dateien weiterhin zu synchronisieren.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Ihr kDrive ist voll</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Einige Dateien konnten nicht synchronisiert werden.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Sie haben &lt;b&gt;einen Synchronisationsfehler&lt;/b&gt;</numerusform> 
+                <numerusform>Sie haben &lt;b&gt;%n Synchronisierungsfehler&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Wir können nicht auf Ihre Dateien zugreifen. Starten Sie die Anwendung neu, um die Synchronisierung fortzusetzen. Wenn das Problem weiterhin besteht, wenden Sie sich an den Support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Verbindung zu kDrive unterbrochen</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktivieren Sie kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Sie müssen kDrive.app aktivieren, bevor Sie fortfahren können</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktivieren Sie kDrive und kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Sie müssen die Berechtigungen aktivieren, bevor Sie fortfahren können</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Gehen Sie zu Privatsphäre und Sicherheit &gt; Vollzugriff auf das Laufwerk</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Vollzugriff auf das Laufwerk</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Privatsphäre und Sicherheit</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Wählen Sie Öffnen und Erweiterungen &gt; Sicherheitserweiterungen</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Sicherheitserweiterungen</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Öffnen und Erweiterungen</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Öffnen Sie die Systemeinstellungen &gt; Allgemein</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Systemeinstellungen</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Starten Sie die Anwendung auf Wunsch neu</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Dieses Element ist auf diesem Gerät nicht verfügbar.
+Es wird in Ihrem Browser geöffnet.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/de/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Zugriffsrechte geändert</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Aktiviert</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>Vor %1</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Alle Ordner</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Gesamtes kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Tracking erlauben</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>App-Kennung</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Anwendungsname</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Autor</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Standardmässig</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Wählen Sie aus, welche Version Ihrer Dateien Sie behalten möchten.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Wählen Sie für jede Datei die zu behaltende Version aus.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Welche Version möchten Sie behalten?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Zu behaltende Version auswählen</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Die Online-Versionen der folgenden %1 Dateien werden durch Ihre lokalen Versionen ersetzt.
+Achtung: Dies kann die Arbeit Ihrer Mitarbeiter überschreiben.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Nur lokale Versionen behalten</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Bei jedem Konflikt behalten wir automatisch die zuletzt geänderte Version (lokal oder online). Dies ist in den meisten Fällen die sicherste Wahl.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Die neuesten Versionen behalten</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Alle lokalen Änderungen für diese %1 Dateien werden verworfen.
+Nützlich, wenn Sie wissen, dass die wichtige Arbeit online auf kDrive ist.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Nur Online-Versionen behalten</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Melden Sie sich an, um zu beginnen.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Eine %1 erstellen.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Datum</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Deaktiviert</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>datei</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Ordner</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Ordner gelöscht</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Ordner verschoben oder geändert</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Der Ordner wurde möglicherweise auf ein anderes Laufwerk verschoben und dann an seinen ursprünglichen Speicherort zurückgebracht.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>ordner</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Ordner verschoben oder umbenannt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Ordner neu erstellt oder ersetzt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Der Ordner wurde gelöscht und neu erstellt oder durch einen anderen Ordner mit demselben Namen ersetzt.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Gerade eben</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokal</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 Dateien wurden sowohl auf Ihrem Computer als auch auf kDrive geändert.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Am neuesten</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Name</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Neues Gerät erkannt</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Sie verwenden kDrive auf einem neuen Computer nach der Wiederherstellung aus einer Sicherungskopie.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Neuer Ordner</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>neue Synchronisierung</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Keine Konflikte entsprechen Ihrer Suche</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Keine Fehler zu beheben</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Benachrichtigung</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Benachrichtigen, wenn Datei ausgeschlossen ist</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Deaktiviert</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Online-Ordner gelöscht</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Der synchronisierte Ordner wurde auf kDrive online gelöscht oder ist nicht mehr zugänglich.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Ursprünglicher Speicherort:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Empfohlen</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Der Ordner wurde möglicherweise auf ein anderes Laufwerk verschoben und dann an seinen ursprünglichen Speicherort zurückgebracht.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>An den ursprünglichen Speicherort wiederherstellen.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regeln</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Wie das System</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>T</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>Std</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>Min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>Sek</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Seit: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Grösse</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 frei</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 frei</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Wird berechnet…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 verwendet</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 verwendet</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Von kDrive Web synchronisiert</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Von Ihrem Computer synchronisiert</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Dieses kDrive enthält nur Dateien. Alle Dateien werden auf diesem Gerät synchronisiert.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Kein Ordner zum Auswählen</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synchronisierungsordner</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Speicherort</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synchronisieren Sie Ihre kDrives auf diesem Gerät</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synchronisierte Ordner</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synchronisierung</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Zeit</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Willkommen bei kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 von %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive-Verwaltung</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Sprache</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Starten Sie die Anwendung neu, um die neue Sprache vollständig zu übernehmen.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Mehr erfahren</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3 Lizenz – Git-Quellen</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link in die Zwischenablage kopiert</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Inkompatibles Laufwerk oder Ordner direkt im Stammverzeichnis des Laufwerks (z. B. wählen Sie einen Ordner wie /Mon drive statt /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Inkompatibles Laufwerk oder Ordner direkt im Stammverzeichnis des Laufwerks (z. B. wählen Sie einen Ordner wie D:/Mon drive statt D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Standort auf dem Computer</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Debug</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Fehler</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Erweitert</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Fatal</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Warnung</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Debug-Ordner an Infomaniak Support senden</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Einige Dateinamen enthalten möglicherweise Sonderzeichen, die nicht unterstützt werden (wie doppelte Anführungszeichen, Backslashes oder Zeilenumbrüche).
+
+Bitte überprüfen und benennen Sie Dateien mit ungewöhnlichen Zeichen um und versuchen Sie es erneut.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Ungültiger Dateiname</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Protokolle werden komprimiert…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Protokolle werden an den Support hochgeladen…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Der letzte Upload ist fehlgeschlagen. Bitte überprüfen Sie Ihre Internetverbindung und stellen Sie sicher, dass mindestens ein kDrive-Benutzer angemeldet ist. Uploads sind auf 10 pro Tag begrenzt.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Verschiedene Versionen dieser Dateien wurden erkannt.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 Versionskonflikte erkannt</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo ist ein Analysetool, das ausschliesslich von Infomaniak gehostet und verwaltet wird, um zu verstehen, wie die Anwendung verwendet wird.
+
+Die Analyse dieser Daten ermöglicht es unserem Team, die Benutzeroberfläche der Anwendung kontinuierlich zu verbessern.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Verschiebung abgebrochen</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Gelöschte Dateien in den Papierkorb des Computers verschieben</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Einige Elemente können möglicherweise nicht verschoben werden.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Mehr Speicherplatz, mehr Funktionen mit my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Hilfe benötigt?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Netzwerk</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Fügen Sie ein Konto hinzu, um zu beginnen</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Keine Ergebnisse gefunden</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Nicht synchronisiert</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Immer</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Nie</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Eine Benachrichtigung erhalten, wenn eine Datei ausgeschlossen wird</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Synchronisierung für dieses kDrive konfigurieren</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Passen Sie den Speicherort Ihres kDrive-Ordners auf Ihrem Computer an:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Der gewählte Ordner muss leer sein, damit die Synchronisierung korrekt funktioniert.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Wählen Sie die Ordner aus, die auf diesem Computer synchronisiert werden sollen:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synchronisierte Ordner</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Für jedes kDrive können Sie auswählen, wo es auf Ihrem Computer synchronisiert wird und welche Ordner synchronisiert werden sollen.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synchronisierter Inhalt:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synchronisierter Inhalt: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Speicherort:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Speicherort: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Ihre kDrives konfigurieren</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Wählen Sie die Ordner aus, die auf diesem Computer synchronisiert werden sollen</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Dateien werden nur beim Öffnen heruntergeladen, um Speicherplatz zu sparen.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Lite Sync aktivieren</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Dieses kDrive ist bereits konfiguriert.
+Gehen Sie zu Ihren Einstellungen, um es zu ändern.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Lassen Sie kDrive in den macOS-Einstellungen zu:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktivieren Sie kDrive auf Ihrem Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Um die Installation abzuschliessen, müssen Sie kDrive den Zugriff auf Ihre Ordner erlauben:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Erlauben Sie den Zugriff auf Ordner</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Starten Sie kostenlos mit my kSuite,
+oder wählen Sie einen Plan, der Ihren Bedürfnissen entspricht.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Sie haben noch kein kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Wählen Sie die kDrives aus, die auf diesem Computer synchronisiert werden sollen:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisierung läuft</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Schön, Sie zu sehen!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Alle kDrive-Ordner</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Benutzerdefinierte Auswahl</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Die private, schnelle und sichere Cloud, gehostet in der Schweiz.
+
+Melden Sie sich an und halten Sie Ihre Dokumente auf allen Ihren Geräten synchronisiert.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Ein Fehler ist aufgetreten. Bitte versuchen Sie es erneut.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Anmeldefehler</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Nur noch wenige Augenblicke, wir laden Ihr Konto…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Anmelden über Ihren Browser…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Ihre Informationen werden abgerufen…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Einen Moment…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Willkommen bei kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Ihre Dateien sind bereit, sicher auf Ihrem Computer synchronisiert zu werden.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Alles bereit!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Wir schliessen die Konfiguration Ihrer kDrives ab.
+
+Bitte warten Sie einen Moment.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synchronisierung läuft…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>kDrive beim Computerstart öffnen</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Anmeldeseite öffnen</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Pfad in die Zwischenablage kopiert</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Legen Sie fest, wie kDrive eine Verbindung zum Internet herstellt.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Authentifizierung erforderlich</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Passwort</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxy-Einstellungen</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxy-Typ</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manuelle Konfiguration</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Keiner</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Benutzername</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Intern</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Speicherort auf kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>In %1 suchen</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Suchen…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>Diese Datei ist nicht lokal verfügbar und wird in Ihrem Browser geöffnet</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Dateien durchsuchen</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Wählen Sie die Ordner aus, die auf diesem Computer synchronisiert werden sollen.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Nicht ausgewählte Ordner werden nicht auf Ihr Gerät heruntergeladen. Sie bleiben online verfügbar und werden nicht gelöscht.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Nicht ausgewählte Ordner werden nicht auf Ihr Gerät heruntergeladen. Sie bleiben online verfügbar.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry ist ein Tool, das ausschliesslich von Infomaniak gehostet und verwaltet wird, um die Stabilität der Anwendung in Echtzeit zu überwachen und technische Fehler automatisch an unsere Entwickler zu melden.
+
+Diese Daten ermöglichen es unserem Team, die Anwendung schnell zu beheben und zu optimieren, was zu einer besseren Benutzererfahrung für Sie führt.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Einstellungen</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Konten &amp; Synchronisierungen</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Erweitert</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Allgemein</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-Ordner</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>In Ihrem Browser anmelden</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>KDrive öffnen</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Verlassen</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Einstellungen</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Freier Speicherplatz auf dem Computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-Dateien auf dem Computer gespeichert</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Andere Dateien auf dem Computer</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Laderaumnutzung…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Freier Raum</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Sonstige Dateien</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Auf Ihrem Gerät gespeicherte kDrive-Dateien</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive kann nicht auf das Volumen zugreifen
+Vergewissern Sie sich, dass es angeschlossen ist,
+entsperrt ist und von Ihrem Computer aus darauf zugegriffen werden kann.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Auf das Volumen kann nicht zugegriffen werden</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Verwalten Sie synchronisierte Ordner, um Speicherplatz auf Ihrem Mac freizugeben.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synchronisierung</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Dieser PC – %1 – %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 auf %2 verwendet</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Online gespeichert</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Ihre Dateien bleiben in der Cloud und belegen keinen Speicherplatz auf Ihrem Computer.
+Für den Zugriff ist eine Internetverbindung erforderlich.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synchronisierungsfehler</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Benutzerdefinierter Ordner</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Standardordner</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synchronisierung</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Ihr neuer Synchronisierungsmodus wird angewendet…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synchronisierungsregeln</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Es ist ein Fehler aufgetreten</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Letzte Synchronisierung war erfolgreich</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Die Synchronisierung wird angehalten</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Die Synchronisierung läuft</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synchronisiert</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synchronisiert</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Von Ihrem Computer synchronisiert</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Von kDrive Web synchronisiert</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>Ihre Dateien werden synchronisiert</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>die Synchronisierung ist angehalten</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Ihre aktuellen Dateien werden aktualisiert.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisierung läuft</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Ihre heruntergeladenen Dateien bleiben weiterhin verfügbar.
+Die Synchronisierung wird automatisch fortgesetzt, sobald Sie wieder verbunden sind.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Die Synchronisierung wurde vorübergehend gestoppt.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synchronisierung während der Pause</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Ihre Dateien sind zugänglich und synchronisiert.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Keine laufenden Aktivitäten</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>Ihre Dateien sind auf dem neuesten Stand</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synchronisierung</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Eine Datei oder ein Ordner in Ihrem Synchronisierungsordner scheint beschädigt zu sein.
+Die Synchronisierung wurde pausiert. Bitte überprüfen Sie Ihre Dateien und versuchen Sie es erneut.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Beschädigte Datei erkannt</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Aktivität</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Startseite</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Speicher</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Der Ordner darf nicht das Stammverzeichnis eines Laufwerks sein und darf keinen bereits synchronisierten Ordner enthalten oder sich darin befinden.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Der Ordner muss leer sein, darf nicht das Stammverzeichnis eines Laufwerks sein und darf keinen bereits synchronisierten Ordner enthalten oder sich darin befinden.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Dieser Ordner kann nicht verwendet werden</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Individuelle Bearbeitung</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Synchronisierung verwalten</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Eine Benachrichtigung informiert Sie, wenn eine Datei durch diese Regel ausgeschlossen wird</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>kDrive schliessen</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>kDrive öffnen</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Einstellungen</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Versuchen Sie einen anderen Suchbegriff</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Tippen Sie, um die Suche zu starten</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Stellen Sie sicher, dass Ihre Internetverbindung aktiv ist, dass dieser Name nicht bereits verwendet wird und dass er keine ungültigen Zeichen enthält.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Dieser Ordner kann nicht erstellt werden</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Nicht autorisierter Zugriff</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Ihre Dateien sind zugänglich und synchronisiert.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Keine aktuellen Aktivitäten</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Bitte versuchen Sie es in einigen Momenten erneut.
+Wenn das Problem weiterhin besteht, wenden Sie sich bitte an den Support.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ein unerwarteter Fehler ist aufgetreten</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Bis morgen</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 verfügbar</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Die Installation dauert weniger als eine Minute.
+Ihre Synchronisierung wird am Ende automatisch fortgesetzt.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Diese Version ignorieren</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Jetzt installieren</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Später erinnern</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Neuigkeiten anzeigen</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Version %1 · Sie verwenden %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Update verfügbar</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Eine neue Version von kDrive ist erforderlich, um fortzufahren.
+Bitte aktualisieren Sie die Anwendung, um auf Ihre Dateien zuzugreifen und die Synchronisierung fortzusetzen.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Aktualisierung erforderlich</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Aktualisierung</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Unvollständiger Upload</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Bestimmte Apps von der Synchronisierung ausschliessen.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Fügen Sie Dateien hinzu, die von der Synchronisierung ausgeschlossen werden sollen.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Benutzerdefinierte Ausschlussregeln</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Schliessen Sie bestimmte Dateitypen von der Synchronisierung aus.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Quellcode anzeigen</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Sie haben einen Synchronisierungsfehler</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Sie haben {0} Synchronisierungsfehler</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive kann nicht auf Laufwerk %1 zugreifen.
+Stellen Sie sicher, dass es verbunden,
+entriegelt und von Ihrem Computer aus zugänglich ist.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Speicherlaufwerk %1 ist nicht zugänglich</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Entfernen</numerusform> 
+                <numerusform>Entfernen (%1 Regeln)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Änderung wird angewendet…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Speicherplatz verwalten</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Übergeordneten Ordner öffnen</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Aktualisieren</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Debug-Stufe</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Die Synchronisierung wird automatisch neu gestartet.
+Wenn das Problem weiterhin besteht, wenden Sie sich an unseren Support und fügen Sie die nachstehenden technischen Details bei.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Technische Details</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ein unerwarteter Fehler ist aufgetreten</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Löschvorgang abgebrochen</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Doppelte Namen</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Sie haben nicht die erforderlichen Berechtigungen, um %1 zu diesem Speicherort hinzuzufügen.
+Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Sie haben keine Berechtigung, %1 zu löschen. Es wurde an seinen ursprünglichen Speicherort wiederhergestellt. Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Die Zugriffsberechtigungen für %1 wurden geändert, was die Synchronisierung verhindert.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Eine Datei oder ein Ordner mit diesem Namen existiert bereits.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Sie haben keine Rechte, diese Datei zu bearbeiten.
+Die Originalversion wurde beibehalten und Ihre Bearbeitung wurde in einer separaten Datei mit „Konflikt“ im Namen gespeichert. Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Der Name dieses %1 endet mit einem Leerzeichen, was die Synchronisierung verhindert. Benennen Sie %2 über kDrive online um.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Eine Ausschlussregel verhindert die Synchronisierung dieses %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Eine Datei mit diesem Namen existiert bereits.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Diese Datei wird derzeit von einem anderen Benutzer verwendet.
+Ihre Änderungen werden später synchronisiert.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Diese Datei wurde auf kDrive online gelöscht, während Sie sie bearbeiteten. Eine Kopie wurde auf Ihrem Computer im Wiederherstellungsordner gespeichert.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Diese Datei überschreitet die maximal zulässige Grösse (50 GB).
+Wenden Sie sich an Ihren Administrator, um das Dateigrössenlimit zu erhöhen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Dieser Name enthält nur Leerzeichen und kann nicht verwendet werden. Benennen Sie %1 über kDrive online um.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Diese Datei ist ein Hardlink, der nicht synchronisiert werden kann.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Sie haben keine Rechte, %1 hierhin zu verschieben; es wird an seinen ursprünglichen Speicherort wiederhergestellt. Fordern Sie den Zugriff beim Eigentümer oder Administrator an.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Dieser Name überschreitet die zulässige Länge (250 Zeichen). Benennen Sie %1 um.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Auf Ihrem Computer ist nicht genügend Speicherplatz vorhanden, um diese Datei zu synchronisieren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Der gesamte Ordner ist gross.
+Um den Upload zu beschleunigen, empfehlen wir, nur die letzte kDrive-Sitzung zu senden.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Nur letzte Sitzung senden</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="el"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ unlocked and accessible from your computer.</source>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Εφαρμογή αλλαγής…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Διαχείριση χώρου δίσκου</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Άνοιγμα γονικού φακέλου</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Ενημέρωση</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Επίπεδο εντοπισμού σφαλμάτων</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ If the problem persists, contact our support and attach the technical details be
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Τεχνικές λεπτομέρειες</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Παρουσιάστηκε μη αναμενόμενο σφάλμα</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Η διαγραφή ακυρώθηκε</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Διπλά ονόματα</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Request access from the owner or administrator.</source>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Δεν έχετε άδεια να διαγράψετε αυτό το %1. Έχει αποκατασταθεί στην αρχική του τοποθεσία. Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Τα δικαιώματα πρόσβασης για το %1 άλλαξαν, εμποδίζοντας τον συγχρονισμό του.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Υπάρχει ήδη ένα αρχείο ή φάκελος με αυτό το όνομα.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ The original version has been kept and your edit has been saved in a separate fi
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Το όνομα αυτού του %1 τελειώνει με κενό, εμποδίζοντας τον συγχρονισμό του. Μετονομάστε το %2 από το kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Ένας κανόνας εξαίρεσης εμποδίζει τον συγχρονισμό αυτού του %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Υπάρχει ήδη ένα αρχείο με αυτό το όνομα.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Your changes will be synced later.</source>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Αυτό το αρχείο διαγράφηκε στο kDrive online ενώ το επεξεργαζόσασταν. Ένα αντίγραφο αποθηκεύτηκε στον υπολογιστή σας στον φάκελο ανάκτησης.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contact your administrator to increase the file size limit.</source>
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Αυτό το όνομα περιέχει μόνο κενά και δεν μπορεί να χρησιμοποιηθεί. Μετονομάστε το %1 από το kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Αυτό το αρχείο είναι σκληρός σύνδεσμος (hard link) που δεν μπορεί να συγχρονιστεί.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Δεν έχετε δικαιώματα για να μεταφέρετε αυτό το %1 εδώ· θα αποκατασταθεί στην αρχική του τοποθεσία. Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Αυτό το όνομα υπερβαίνει το επιτρεπτό μήκος (250 χαρακτήρες). Μετονομάστε το %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Δεν υπάρχει αρκετός χώρος στον υπολογιστή σας για τον συγχρονισμό αυτού του αρχείου.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: el, Greek
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="el"> 
     <context>
@@ -344,6 +344,16 @@ You can open them at any time, even without an internet connection.</source>
             <source>Manage storage</source> 
             <translation>Διαχείριση αποθηκευτικού χώρου</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Μεγιστοποίηση</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Ελαχιστοποίηση</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Άνοιγμα φακέλου εντοπισμού σφαλμάτων</translation> 
@@ -427,6 +437,11 @@ You can open them at any time, even without an internet connection.</source>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Επανεκκίνηση συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Επαναφορά</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: el, Greek
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="el"> 
     <context>
@@ -2077,7 +2077,7 @@ This data allows our team to quickly fix and optimize the application, resulting
             <translation>Φάκελος kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Συνδεθείτε από το πρόγραμμα περιήγησής σας</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_el.ts
+++ b/src/gui4/linux/translations/client_el.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: el, Greek
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="el"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Έκδοση %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Σχετικά</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Σχετικά με το kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Αναπτύχθηκε και φιλοξενείται αποκλειστικά στην Ελβετία, το kDrive διασφαλίζει την πλήρη προστασία των δεδομένων σας, χωρίς μεταπώληση ή παρακολούθηση, σε κέντρα δεδομένων πιστοποιημένα ISO, με κρυπτογράφηση και δημιουργία αντιγράφων ασφαλείας σε πολλαπλά μέσα.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Ορατές δραστηριότητες</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Επιλογή καναλιού διανομής</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Εμφάνιση περισσότερων πληροφοριών</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Επιλογή λειτουργίας συγχρονισμού</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Ο συγχρονισμός ολοκληρώθηκε</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Ο συγχρονισμός βρίσκεται σε εξέλιξη</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Καμία πρόσφατη δραστηριότητα</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Είστε εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Ο συγχρονισμός διακόπηκε</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Όλες οι δραστηριότητες</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Μόνο η δική μου δραστηριότητα</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Συγχρονισμός φακέλου με το kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Επιλέξτε τον φάκελο του υπολογιστή σας για συγχρονισμό με το kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Συγχρονισμένος φάκελος</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Προσαρμόστε τη θέση του φακέλου του υπολογιστή σας στο kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Επιλέξτε τη θέση του φακέλου στο kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Τοποθεσία kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Επιλέξτε έναν φάκελο στον υπολογιστή σας για συγχρονισμό με το kDrive.
+Μπορείτε να αποκτήσετε πρόσβαση στους προηγμένους συγχρονισμούς σας από τον επιλογέα μονάδας στην αρχική σελίδα.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Συγχρονισμός φακέλου με το kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Προηγμένος συγχρονισμός</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Εφαρμογή προς εξαίρεση</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Η εφαρμογή είναι ενημερωμένη</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Διαγράφει αρχεία καταγραφής παλαιότερα από 7 ημέρες για εξοικονόμηση χώρου στο δίσκο.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Αυτόματη εκκαθάριση</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Αυτόματες ενημερώσεις</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Διαθέσιμο εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Τα αρχεία σας αντιγράφονται στον υπολογιστή σας.
+Μπορείτε να τα ανοίξετε ανά πάσα στιγμή, ακόμα και χωρίς σύνδεση στο διαδίκτυο.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Μπορείτε να το αφυπνίσετε από τη διαδικτυακή διεπαφή.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Αποκτήστε πρόσβαση στις νέες εκδόσεις της εφαρμογής πριν κυκλοφορήσουν στο ευρύ κοινό και βοηθήστε στη βελτίωση της εφαρμογής μοιράζοντάς μας τις ιδέες σας.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Εγγραφή στο πρόγραμμα beta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Το πρόγραμμα περιήγησής σας θα ανοίξει αυτόματα για να ολοκληρώσετε τη σύνδεση. Μόλις συνδεθείτε, θα επιστρέψετε αυτόματα στο kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Ενεργοποίηση συγχρονισμού εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Συγχρονισμός φακέλου</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Προσθήκη κανόνα</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Προσθήκη αποθηκευτικού χώρου</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Προηγμένες ρυθμίσεις</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Εφαρμογή σε %1 αρχεία</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Αίτηση πρόσβασης</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Άκυρο</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Αλλαγή φακέλου</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Αποθήκευση εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Αποθήκευση online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Εναλλαγή χρήστη</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Κλείσιμο</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Κλείσιμο kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Διαμόρφωση</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Επιβεβαίωση</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Σύνδεση</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Σύνδεση λογαριασμού</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Επικοινωνία υποστήριξης</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Συνέχεια</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Αντιγραφή συνδέσμου κοινής χρήσης</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Δημιουργία λογαριασμού</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Δημιουργία νέου συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Προσαρμοσμένη τοποθεσία</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Αποσύνδεση αυτού του λογαριασμού</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Λήψη σε εξέλιξη…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Μη αυτόματη λήψη</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Ενεργοποίηση</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Ενεργοποίηση στις ρυθμίσεις των Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Κατανόηση του ζητήματος</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Κοινοποίηση ιδέας</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Ολοκλήρωση εγκατάστασης</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Διόρθωση σφαλμάτων</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Υποστήριξη</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Έχω ενεργοποιήσει το kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Διατήρηση λογαριασμού</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Αποσύνδεση</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Σύνδεση</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Διαχείριση</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Χειρισμός αρχείων μεμονωμένα</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Διαχείριση αποθηκευτικού χώρου</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Άνοιγμα φακέλου εντοπισμού σφαλμάτων</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Άνοιγμα Εξερευνητή</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Άνοιγμα φακέλου</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Άνοιγμα στο πρόγραμμα περιήγησης</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Άνοιγμα στον Εξερευνητή</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Άνοιγμα στο Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Άνοιγμα στο kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Άνοιγμα kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Διαχείριση εξαιρέσεων</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Άνοιγμα ρυθμίσεων συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Παύση</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Ανανέωση</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Σημειώσεις έκδοσης</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Κατάργηση</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Κατάργηση (%n στοιχείου)</numerusform> 
+                <numerusform>Κατάργηση (%n στοιχείων)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Κατάργηση συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Μετονομασία %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Επανεκκίνηση σύνδεσης</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Συνέχιση συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Επανεκκίνηση συγχρονισμού</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Επανάληψη</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Επιστροφή στον προεπιλεγμένο φάκελο</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Αποθήκευση</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Αποθήκευση των επιλογών μου</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Αναζήτηση</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Προβολή δραστηριοτήτων</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Επιλογή</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Επιλογή φακέλου</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Επιλογή φακέλων</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Επιλογή τοποθεσίας</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Επιλεγμένο</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Αποστολή</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Αποστολή φακέλου εντοπισμού σφαλμάτων</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Άνοιγμα ρυθμίσεων</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Προβολή προσφορών</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Εμφάνιση επιλογών</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Αποσύνδεση</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Έναρξη</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Έναρξη επιλογής εκδόσεων</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Ξεκινήστε δωρεάν</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Συγχρονισμός εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Ενημέρωση τώρα</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Ενημέρωση συνδρομής</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Αναβάθμιση</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Επιβεβαίωση</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Επιβεβαίωση και μετάβαση στο επόμενο</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Αφύπνιση</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Επιλογή έκδοσης</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Εντοπίστηκαν δύο διαφορετικές εκδόσεις αυτών των αρχείων.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Συγκρούσεις εκδόσεων</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Αναζήτηση αρχείου</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Αντιγραφή συνδέσμου…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Δημιουργία συνδέσμου κοινής χρήσης…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Μπορείτε να προσαρμόσετε τα δεδομένα χρήσης και λειτουργίας που συλλέγει η Infomaniak για τη διόρθωση σφαλμάτων και τη βελτίωση της εφαρμογής. Και τα δύο εργαλεία που χρησιμοποιούνται φιλοξενούνται και διαχειρίζονται αποκλειστικά από εμάς.
+
+Ο πηγαίος κώδικας αυτής της εφαρμογής μπορεί να επαληθευτεί, οι πληροφορίες που συλλέγονται είναι ανώνυμες και τα προσωπικά σας στοιχεία παραμένουν αυστηρά εμπιστευτικά και δεν μοιράζονται ποτέ με τρίτους.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Διαχείριση δεδομένων</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Η Infomaniak σέβεται την ιδιωτικότητά σας</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Επιλέξτε την ποσότητα πληροφοριών που θα καταγράφονται.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Επιτρέπουν στην υποστήριξη της Infomaniak να εντοπίσει την αιτία ενός συμβάντος.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Αρχεία καταγραφής εντοπισμού σφαλμάτων</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Αυτές οι εφαρμογές αγνοούνται από προεπιλογή και δεν μπορούν να τροποποιηθούν.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Αυτά τα αρχεία εξαιρούνται από προεπιλογή και δεν μπορούν να τροποποιηθούν.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Αυτόματη εξαίρεση</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>Σε αυτές τις περιπτώσεις, απαιτείται νέος συγχρονισμός για να συνεχίσετε να χρησιμοποιείτε σωστά το kDrive.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Επιλέξτε έναν κενό φάκελο που δεν βρίσκεται στη ρίζα μιας μονάδας δίσκου.
+
+Αυτός ο φάκελος δεν πρέπει να περιλαμβάνεται σε άλλον φάκελο συγχρονισμού και δεν πρέπει να περιέχει υποφάκελο συγχρονισμού.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Αυτός ο φάκελος δεν μπορεί να επιλεγεί</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Προσθήκη κανόνα</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Προσθήκη κανόνα εξαίρεσης</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Πρόκειται να αποσυνδέσετε τον λογαριασμό %1 από την εφαρμογή.
+Ο φάκελος συγχρονισμού θα παραμείνει στον υπολογιστή σας, αλλά δεν θα συγχρονίζεται πλέον με το kDrive.
+
+Όλα τα δεδομένα σας θα παραμένουν προσβάσιμα διαδικτυακά στο kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Αποσύνδεση από αυτόν τον λογαριασμό;</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Ο τοπικός φάκελος θα παραμείνει στον υπολογιστή σας, αλλά δεν θα συγχρονίζεται πλέον με το kDrive.
+Αυτή η ενέργεια είναι μόνιμη.
+Για να συγχρονίσετε ξανά τη μονάδα σας, θα χρειαστεί να τη συνδέσετε ξανά αργότερα.
+
+Πριν συνεχίσετε, βεβαιωθείτε ότι όλα τα αρχεία σας είναι ενημερωμένα και πλήρως συγχρονισμένα.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Κατάργηση συγχρονισμού;</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Η αλλαγή λειτουργίας συγχρονισμού ακυρώθηκε.
+
+Ο τρέχων συγχρονισμός παραμένει αμετάβλητος. Ωστόσο, εάν παρουσιαστεί ανώμαλη συμπεριφορά, ίσως χρειαστεί να διαγράψετε και να δημιουργήσετε ξανά τον συγχρονισμό για να αποκαταστήσετε τη σωστή λειτουργία.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Παρουσιάστηκε σφάλμα</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Αυτή η λειτουργία ενδέχεται να χρειαστεί κάποιο χρόνο ανάλογα με το μέγεθος των δεδομένων σας. Εάν αποτύχει, ίσως απαιτηθεί πλήρης επανασυγχρονισμός της μονάδας.
+
+Πριν συνεχίσετε, βεβαιωθείτε ότι όλα τα αρχεία σας είναι ενημερωμένα και συγχρονισμένα.
+
+Μην κλείσετε την εφαρμογή κατά τη διάρκεια της διαδικασίας.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Αλλαγή λειτουργίας συγχρονισμού;</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Δείτε πώς να αποκαταστήσετε τον συγχρονισμό:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Ο δίσκος που περιέχει τον φάκελο συγχρονισμού σας δεν είναι πλέον συνδεδεμένος</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Συνδέστε τον ξανά για να συνεχίσετε τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Απενεργοποίηση ειδοποιήσεων</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Χωρίς εγγραφή</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Δεν έχετε άδεια πρόσβασης σε αυτό το kDrive.
+Ελέγξτε τα δικαιώματά σας ή επικοινωνήστε με τον διαχειριστή σας.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Η πρόσβαση στο kDrive απορρίφθηκε</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Το kDrive σας βρίσκεται σε κατάσταση αδρανείας</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Αυτό το kDrive δεν ανανεώθηκε. Δεν μπορείτε πλέον να έχετε πρόσβαση σε αυτό.
+Ανανεώστε τη συνδρομή σας για να επανενεργοποιήσετε την υπηρεσία.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Αυτό το kDrive δεν ανανεώθηκε. Δεν μπορείτε πλέον να έχετε πρόσβαση σε αυτό.
+Επικοινωνήστε με τον διαχειριστή σας για να επανενεργοποιήσετε την υπηρεσία.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Το kDrive σας έχει λήξει</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Συνδεθείτε ξανά για να συνεχίσετε να χρησιμοποιείτε το kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Αποσυνδεθήκατε</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Ο λογαριασμός που χρησιμοποιήθηκε για αυτή τη σύνδεση δεν αντιστοιχεί στον λογαριασμό αυτού του kDrive.
+Συνδεθείτε ξανά με τη σωστή διεύθυνση email %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Αυτός ο λογαριασμός δεν αντιστοιχεί</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>Το kDrive αφυπνίζεται… αυτό μπορεί να χρειαστεί μερικές στιγμές.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>Το kDrive αφυπνίζεται</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Καταγραφή διαγνωστικών πληροφοριών στον υπολογιστή μου.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Ενεργοποίηση καταγραφής εντοπισμού σφαλμάτων</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Εισαγάγετε τον κωδικό πρόσβασής σας</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Ένα άλλο %1 του οποίου το όνομα διαφέρει μόνο στα κεφαλαία/μικρά γράμματα υπάρχει ήδη σε αυτόν το φάκελο. Αυτός ο τύπος ονόματος δεν υποστηρίζεται από την εφαρμογή kDrive Windows. Μετονομάστε έναν από τους φακέλους %2 από το kDrive online, ώστε να μπορείτε να τον συγχρονίσετε στον υπολογιστή σας.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Συγκρουόμενα ονόματα, ευαίσθητα στην πεζότητα</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Εντοπίστηκε αλλαγή στη διαμόρφωσή σας</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>Σε αυτές τις περιπτώσεις, ενδέχεται να απαιτείται νέος συγχρονισμός για να συνεχίσετε να χρησιμοποιείτε σωστά το kDrive.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Ελέγξτε το %1 για να αποκαταστήσετε την πρόσβαση</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Τελευταία τοποθεσία του %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Εξωτερικός δίσκος αποσυνδέθηκε</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Αυτή η λειτουργία μπορεί να χρειαστεί κάποιο χρόνο ανάλογα με την ποσότητα των δεδομένων που πρέπει να επεξεργαστούν.
+
+Μην κλείσετε την εφαρμογή κατά τη διάρκεια της διαδικασίας.
+
+Εάν αποτύχει, μπορείτε εύκολα να ξεκινήσετε έναν πλήρη επανασυγχρονισμό της μονάδας ή να επικοινωνήσετε με την υποστήριξή μας.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Ενεργοποίηση συγχρονισμού εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Αυτό το kDrive δεν είναι προσωρινά διαθέσιμο λόγω συντήρησης.
+Δοκιμάστε ξανά σε λίγα λεπτά.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Συντήρηση σε εξέλιξη</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Κενό στο τέλος του ονόματος %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Εξαιρείται από τον συγχρονισμό</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Αρχείο κλειδωμένο</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Αρχείο ανακτήθηκε</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Αυτό το αρχείο υπερβαίνει το μέγιστο επιτρεπτό μέγεθος (50 GB).
+Επικοινωνήστε με την υποστήριξη για να αρθεί το όριο.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Το αρχείο είναι πολύ μεγάλο</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Απαγορευμένη πρόσβαση</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Το όνομα αυτού του %1 περιέχει έναν ή περισσότερους χαρακτήρες που δεν υποστηρίζονται από την εφαρμογή kDrive Windows. Μετονομάστε το %2 από το kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Μη έγκυρο όνομα</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Μη υποστηριζόμενος χαρακτήρας</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Δεν έχετε τα απαραίτητα δικαιώματα για να εκτελέσετε αυτή την ενέργεια.
+Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Απαγορευμένη πρόσβαση</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Μη υποστηριζόμενος τύπος αρχείου</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Αυτός ο φάκελος δεν είναι πλέον προσβάσιμος στην αρχική του τοποθεσία.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Ο φάκελος συγχρονισμού δεν βρέθηκε</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Ένα από τα kDrive σας συγχρονίζεται μέσα στον φάκελο συγχρονισμού ενός άλλου kDrive.
+Μεταφέρετε έναν από τους φακέλους ώστε να μην είναι πλέον ένθετοι, ή διαγράψτε τον συγχρονισμό σας για να τον δημιουργήσετε ξανά.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Ένθετα kDrive</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Δεν είναι δυνατή η πρόσβαση σε αυτό το %1 στον υπολογιστή σας. Ελέγξτε ότι υπάρχει ακόμα και ότι έχετε δικαιώματα πρόσβασης σε αυτό.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 μη προσβάσιμο</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Το όνομα %1 είναι πολύ μακρύ</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Δεν είναι δυνατή η σύνδεση στο kDrive.
+Ο συγχρονισμός θα συνεχιστεί αυτόματα μόλις αποκατασταθεί η σύνδεση.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Η σύνδεση δεν είναι προσωρινά διαθέσιμη</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Ανεπαρκής χώρος δίσκου</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Το όνομα αυτού του αρχείου περιέχει έναν ή περισσότερους χαρακτήρες που δεν υποστηρίζονται ακόμα από την εφαρμογή kDrive. Μετονομάστε το αρχείο από το kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Μη υποστηριζόμενος χαρακτήρας</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Η διαδρομή προς αυτό το %1 είναι πολύ μακριά για συγχρονισμό. Μετονομάστε έναν ή περισσότερους φακέλους στους οποίους βρίσκεται για να μικρύνετε τη διαδρομή.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Η διαδρομή προς %1 είναι πολύ μακριά</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Το kDrive σας είναι γεμάτο. Ελευθερώστε χώρο ή αναβαθμίστε τη συνδρομή σας για να συγχρονίσετε αυτό το %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Το όριο αποθηκευτικού χώρου συμπληρώθηκε</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Αυτό το όνομα είναι δεσμευμένο από το σύστημα του υπολογιστή σας. Μετονομάστε το %1 από το kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Το όνομα %1 είναι δεσμευμένο</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Ελέγξτε την τοποθεσία ή τα δικαιώματα πρόσβασης του φακέλου.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Ο φάκελος συγχρονισμού δεν είναι προσβάσιμος</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>Το LiteSync δεν έχει τα απαραίτητα δικαιώματα για να λειτουργήσει.
+ανοίξτε τις Προτιμήσεις του macOS για να τις ενεργοποιήσετε.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Απαιτούμενη εξουσιοδότηση</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Ο χώρος δίσκου της συσκευής σας είναι γεμάτος. Ο συγχρονισμός διακόπηκε. Ελευθερώστε χώρο για να συνεχίσετε τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Ανεπαρκής χώρος δίσκου</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Αυτός ο φάκελος δεν είναι πλέον προσβάσιμος στην αρχική του τοποθεσία.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Αυτός ο φάκελος δεν είναι πλέον προσβάσιμος. Απαιτείται ενέργεια για να συνεχιστεί ο συγχρονισμός.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Ο φάκελος συγχρονισμού δεν βρέθηκε</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Το Lite Sync δεν μπορεί να εκκινήσει. Μπορείτε να συνεχίσετε να συγχρονίζετε τα αρχεία σας ενεργοποιώντας τον συγχρονισμό εκτός σύνδεσης στις ρυθμίσεις. Επικοινωνήστε με την υποστήριξη εάν το πρόβλημα παραμένει.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Αδύνατη εκκίνηση του Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Ο συγχρονισμός αυτού του στοιχείου απέτυχε. Θα επαναληφθεί αυτόματα αργότερα.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Ο συγχρονισμός απέτυχε προσωρινά</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Η μεταφόρτωση δεν μπόρεσε να ολοκληρωθεί. Δοκιμάστε ξανά αργότερα.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Φαίνεται ότι δεν μπορούμε να φορτώσουμε την εφαρμογή…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Παρουσιάστηκε σφάλμα κατά τη διαγραφή του λογαριασμού σας.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Αρχεία για έλεγχο</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Άλλα</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Σύστημα και δικαιώματα</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Δεν κατέστη δυνατό το άνοιγμα της διεύθυνσης URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Σφάλματα για διόρθωση</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Αυτός ο φάκελος δεν μπορεί να συγχρονιστεί. Παρακαλώ επιλέξτε έναν άλλο φάκελο.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Σφάλμα κατά την εκκίνηση του εγκαταστάτη</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Σφάλμα κατά την αλλαγή λειτουργίας συγχρονισμού</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Αποκλείστε τις εφαρμογές που ενδέχεται να κατεβάσουν ή να τροποποιήσουν τα αρχεία σας.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Τα αρχεία που ταιριάζουν με αυτόν τον κανόνα δεν θα συγχρονίζονται.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Αποφύγετε την αντιγραφή ορισμένων προσωρινών αρχείων ή αρχείων συστήματος στο kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Ενεργοποιεί τη συλλογή πρόσθετων πληροφοριών χρήσιμων για την υποστήριξη.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Εκτεταμένο λεπτομερές αρχείο καταγραφής</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Όταν αυτή η επιλογή είναι ενεργή, το kDrive λειτουργεί πιο αργά.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Αποτυχία δημιουργίας συνδέσμου κοινής χρήσης</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Βοηθήστε μας να βελτιώσουμε το kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Μια ειδοποίηση σας ενημερώνει όταν ένα αρχείο αποκλείεται από αυτόν τον κανόνα.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Το αρχείο υπάρχει ήδη</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Λειτουργία συγχρονισμού αρχείων</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Καθορίστε τον τρόπο αποθήκευσης και πρόσβασης στα αρχεία σας.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Αρχεία για εξαίρεση</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Αγαπημένα</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Κοινοποιήσεις</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Κάδος απορριμμάτων</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Για 1 ώρα</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Για μία εβδομάδα</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Για τρεις ημέρες</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Γεια σας %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Υποστήριξη Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Ελευθερώστε χώρο ή αναβαθμίστε το πλάνο σας για να συνεχίσετε να συγχρονίζετε τα αρχεία σας.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Το kDrive σας είναι γεμάτο</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Ορισμένα αρχεία δεν μπόρεσαν να συγχρονιστούν.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Έχετε &lt;b&gt;ένα σφάλμα συγχρονισμού&lt;/b&gt;</numerusform> 
+                <numerusform>Έχετε &lt;b&gt;%n σφάλματα συγχρονισμού&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Δεν μπορούμε να αποκτήσουμε πρόσβαση στα αρχεία σας. Επανεκκινήστε την εφαρμογή για να συνεχίσετε τον συγχρονισμό. Εάν το πρόβλημα συνεχίζεται, επικοινωνήστε με την υποστήριξη.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Διακόπηκε η σύνδεση με το kDrive</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Ενεργοποιήστε το kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Πρέπει να ενεργοποιήσετε το kDrive.app πριν συνεχίσετε</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Ενεργοποιήστε το kDrive και το kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Πρέπει να ενεργοποιήσετε τις εξουσιοδοτήσεις πριν συνεχίσετε</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Μεταβείτε στο Απόρρητο και ασφάλεια &gt; Πλήρης πρόσβαση στον δίσκο</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Πλήρης πρόσβαση στον δίσκο</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Απόρρητο και ασφάλεια</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Επιλέξτε Άνοιγμα και επεκτάσεις &gt; Επεκτάσεις ασφαλείας</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Επεκτάσεις ασφαλείας</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Άνοιγμα και επεκτάσεις</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Ανοίξτε τις Ρυθμίσεις συστήματος &gt; Γενικά</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Ρυθμίσεις συστήματος</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Επανεκκινήστε την εφαρμογή εάν απαιτείται</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Αυτό το στοιχείο δεν είναι διαθέσιμο σε αυτή τη συσκευή.
+Θα ανοίξει στο πρόγραμμα περιήγησής σας.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Τα δικαιώματα πρόσβασης τροποποιήθηκαν</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Ενεργοποιημένο</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>πριν από %1</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Όλοι οι φάκελοι</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Όλο το kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Να επιτρέπεται η παρακολούθηση</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Αναγνωριστικό εφαρμογής</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Όνομα εφαρμογής</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Συντάκτης</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Από προεπιλογή</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Επιλέξτε ποια έκδοση των αρχείων σας θέλετε να διατηρήσετε.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Για κάθε αρχείο, επιλέξτε την έκδοση που θέλετε να διατηρήσετε.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Ποια έκδοση θέλετε να διατηρήσετε;</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Επιλογή έκδοσης για διατήρηση</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Οι διαδικτυακές εκδόσεις αυτών των %1 αρχείων θα αντικατασταθούν από τις τοπικές σας εκδόσεις.
+Προσοχή, αυτό μπορεί να αντικαταστήσει τη δουλειά των συνεργατών σας.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Διατήρηση μόνο των τοπικών εκδόσεων</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Για κάθε σύγκρουση, θα διατηρούμε αυτόματα την έκδοση (τοπική ή διαδικτυακή) που τροποποιήθηκε πιο πρόσφατα. Αυτή είναι η πιο ασφαλής επιλογή στις περισσότερες περιπτώσεις.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Διατήρηση των πιο πρόσφατων εκδόσεων</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Όλες οι τοπικές αλλαγές για αυτά τα %1 αρχεία θα απορριφθούν.
+Χρήσιμο εάν γνωρίζετε ότι η σημαντική εργασία βρίσκεται διαδικτυακά στο kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Διατήρηση μόνο των διαδικτυακών εκδόσεων</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Συνδεθείτε για να ξεκινήσετε.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Δημιουργήστε έναν %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Ημερομηνία</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Απενεργοποιημένο</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>αρχείο</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Φάκελος</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Ο φάκελος διαγράφηκε</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Ο φάκελος μεταφέρθηκε ή τροποποιήθηκε</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Ο φάκελος μπορεί να έχει μεταφερθεί σε άλλον δίσκο και στη συνέχεια να επιστράφηκε στην αρχική του τοποθεσία.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>φάκελος</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Ο φάκελος μεταφέρθηκε ή μετονομάστηκε</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Ο φάκελος δημιουργήθηκε εκ νέου ή αντικαταστάθηκε</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Ο φάκελος διαγράφηκε και δημιουργήθηκε εκ νέου ή αντικαταστάθηκε από άλλον φάκελο με το ίδιο όνομα.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Μόλις τώρα</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Τοπικό</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 αρχεία τροποποιήθηκαν τόσο στον υπολογιστή σας όσο και στο kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Πιο πρόσφατο</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Όνομα</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Εντοπίστηκε νέα συσκευή</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Χρησιμοποιείτε το kDrive σε νέο υπολογιστή, μετά από επαναφορά από αντίγραφο ασφαλείας.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Νέος φάκελος</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>νέος συγχρονισμός</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Καμία σύγκρουση δεν αντιστοιχεί στην αναζήτησή σας</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Δεν υπάρχουν σφάλματα για διόρθωση</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Ειδοποίηση</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Ειδοποίηση εάν το αρχείο αποκλείστηκε</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Ανενεργό</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Ο φάκελος διαγράφηκε στο διαδίκτυο</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Ο συγχρονισμένος φάκελος διαγράφηκε στο kDrive online ή δεν είναι πλέον προσβάσιμος.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Αρχική τοποθεσία:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Συνιστάται</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Ο φάκελος μπορεί να έχει μεταφερθεί σε άλλον δίσκο και στη συνέχεια να επιστράφηκε στην αρχική του τοποθεσία.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Επαναφέρετε το στην αρχική του τοποθεσία.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Κανόνες</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Ίδιο με το σύστημα</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>μ</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>ω</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>λεπτ</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>δευτ</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Από: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Μέγεθος</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Κατάσταση</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 ελεύθερο</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 ελεύθερα</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Υπολογισμός…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 χρησιμοποιημένο</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 χρησιμοποιημένα</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Συγχρονισμένο από το kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Συγχρονισμένο από τον υπολογιστή σας</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Αυτό το kDrive περιέχει μόνο αρχεία. Όλα τα αρχεία θα συγχρονιστούν σε αυτή τη συσκευή.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Δεν υπάρχουν φάκελοι για επιλογή</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Φάκελοι συγχρονισμού</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Τοποθεσία</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Συγχρονίστε τα kDrive σας σε αυτή τη συσκευή</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Συγχρονισμένοι φάκελοι</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Συγχρονισμός</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Χρόνος</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Καλωσορίσατε στο kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 από %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Διαχείριση kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Γλώσσα</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Επανεκκινήστε την εφαρμογή για να ολοκληρωθεί η εφαρμογή της νέας γλώσσας.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Μάθετε περισσότερα</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Άδεια LGPL v3 - Πηγές Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Ο σύνδεσμος αντιγράφηκε στο πρόχειρο</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Μη συμβατή μονάδα δίσκου ή φάκελος απευθείας στη ρίζα της μονάδας (π.χ. επιλέξτε έναν φάκελο όπως /Η μονάδα μου αντί για /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Μη συμβατή μονάδα δίσκου ή φάκελος απευθείας στη ρίζα της μονάδας (π.χ. επιλέξτε έναν φάκελο όπως D:/Η μονάδα μου αντί για D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Τοποθεσία στον υπολογιστή</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Εντοπισμός σφαλμάτων</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Σφάλμα</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Εκτεταμένο</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Κρίσιμο</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Πληροφορίες</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Προειδοποίηση</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Αποστολή φακέλου εντοπισμού σφαλμάτων στην υποστήριξη Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Ορισμένα ονόματα αρχείων ενδέχεται να περιέχουν μη υποστηριζόμενους ειδικούς χαρακτήρες (όπως διπλά εισαγωγικά, ανάστροφες κάθετες ή αλλαγές γραμμής).
+
+Ελέγξτε και μετονομάστε τα αρχεία που περιέχουν ασυνήθιστους χαρακτήρες και δοκιμάστε ξανά.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Μη έγκυρο όνομα αρχείου</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Συμπίεση αρχείων καταγραφής…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Μεταφόρτωση αρχείων καταγραφής στην υποστήριξη…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Η τελευταία μεταφόρτωση απέτυχε. Ελέγξτε τη σύνδεσή σας στο διαδίκτυο και βεβαιωθείτε ότι τουλάχιστον ένας χρήστης kDrive είναι συνδεδεμένος. Οι μεταφορτώσεις περιορίζονται σε 10 ανά ημέρα.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Εντοπίστηκαν διαφορετικές εκδόσεις αυτών των αρχείων.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 συγκρούσεις εκδόσεων εντοπίστηκαν</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Το Matomo είναι ένα εργαλείο ανάλυσης που φιλοξενείται και διαχειρίζεται αποκλειστικά από την Infomaniak για να κατανοεί πώς χρησιμοποιείται η εφαρμογή.
+
+Η ανάλυση αυτών των δεδομένων επιτρέπει στην ομάδα μας να βελτιώνει συνεχώς τη διεπαφή της εφαρμογής.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Η μεταφορά ακυρώθηκε</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Μεταφορά διαγραμμένων αρχείων στον κάδο ανακύκλωσης του υπολογιστή</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Ορισμένα στοιχεία μπορεί να μην είναι δυνατό να μεταφερθούν.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Περισσότερος αποθηκευτικός χώρος, περισσότερες λειτουργίες με τη my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Χρειάζεστε βοήθεια;</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Δίκτυο</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Προσθέστε έναν λογαριασμό για να ξεκινήσετε</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Δεν βρέθηκαν αποτελέσματα</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Μη συγχρονισμένο</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Πάντα</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Ποτέ</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Λήψη ειδοποίησης όταν ένα αρχείο εξαιρείται</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Ρύθμιση παραμέτρων συγχρονισμού για αυτό το kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Προσαρμόστε τη θέση του φακέλου kDrive στον υπολογιστή σας:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Ο επιλεγμένος φάκελος πρέπει να είναι κενός για να λειτουργεί σωστά ο συγχρονισμός.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Επιλέξτε τους φακέλους για συγχρονισμό σε αυτόν τον υπολογιστή:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Συγχρονισμένοι φάκελοι</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Για κάθε kDrive, μπορείτε να επιλέξετε πού συγχρονίζεται στον υπολογιστή σας και ποιους φακέλους να συγχρονίσετε.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Συγχρονισμένο περιεχόμενο:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Συγχρονισμένο περιεχόμενο: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Τοποθεσία:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Τοποθεσία: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Ρύθμιση παραμέτρων των kDrive σας</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Επιλέξτε τους φακέλους για συγχρονισμό σε αυτόν τον υπολογιστή</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Τα αρχεία λαμβάνονται μόνο κατά το άνοιγμά τους, για εξοικονόμηση χώρου δίσκου.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Ενεργοποίηση Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Αυτό το kDrive είναι ήδη διαμορφωμένο.
+Μεταβείτε στις ρυθμίσεις σας για να το τροποποιήσετε.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Εξουσιοδοτήστε το kDrive στις ρυθμίσεις του macOS:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Ενεργοποιήστε το kDrive στο Mac σας</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Για να ολοκληρώσετε την εγκατάσταση, πρέπει να εξουσιοδοτήσετε το kDrive να έχει πρόσβαση στα εξής:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Εξουσιοδότηση πρόσβασης στα αρχεία</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Ξεκινήστε δωρεάν με τη my kSuite,
+ή επιλέξτε ένα πλάνο που ταιριάζει στις ανάγκες σας.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Δεν έχετε ακόμα kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Επιλέξτε τα kDrive για συγχρονισμό σε αυτόν τον υπολογιστή:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Συγχρονισμός σε εξέλιξη</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Χαιρόμαστε που σας βλέπουμε!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Όλοι οι φάκελοι kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Προσαρμοσμένη επιλογή</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Το ιδιωτικό, γρήγορο και ασφαλές cloud, φιλοξενούμενο στην Ελβετία.
+
+Συνδεθείτε και διατηρήστε τα έγγραφά σας συγχρονισμένα σε όλες τις συσκευές σας.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Παρουσιάστηκε σφάλμα, παρακαλούμε δοκιμάστε ξανά.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Σφάλμα σύνδεσης</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Ακόμα λίγες στιγμές και θα φορτώσουμε τον λογαριασμό σας…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Σύνδεση από το πρόγραμμα περιήγησής σας…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Ανάκτηση πληροφοριών σας…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Ένα λεπτό…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Καλωσορίσατε στο kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Τα αρχεία σας είναι έτοιμα να συγχρονιστούν
+με ασφάλεια στον υπολογιστή σας.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Όλα έτοιμα!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Οριστικοποιούμε τη διαμόρφωση των kDrive σας.
+
+Παρακαλούμε περιμένετε μερικές στιγμές.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Συγχρονισμός σε εξέλιξη…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Άνοιγμα kDrive κατά την εκκίνηση του υπολογιστή</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Άνοιγμα σελίδας σύνδεσης</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Η διαδρομή αντιγράφηκε στο πρόχειρο</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Καθορίστε τον τρόπο σύνδεσης του kDrive στο διαδίκτυο.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Διακομιστής</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Απαιτείται έλεγχος ταυτότητας</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Κωδικός πρόσβασης</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Θύρα</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Ρυθμίσεις διακομιστή μεσολάβησης</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Τύπος διακομιστή μεσολάβησης</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Μη αυτόματη διαμόρφωση</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Κανένας</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Όνομα χρήστη</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Εσωτερικό</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Δοκιμή</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Τοποθεσία στο kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Αναζήτηση στο %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Επιλέξτε τους φακέλους για συγχρονισμό σε αυτόν τον υπολογιστή.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Οι μη επιλεγμένοι φάκελοι δεν θα ληφθούν στη συσκευή σας. Θα παραμείνουν διαθέσιμοι online και δεν θα διαγραφούν.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Οι μη επιλεγμένοι φάκελοι δεν θα ληφθούν στη συσκευή σας. Θα παραμείνουν διαθέσιμοι online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Το Sentry είναι ένα εργαλείο που φιλοξενείται και διαχειρίζεται αποκλειστικά από την Infomaniak για την παρακολούθηση σε πραγματικό χρόνο της σταθερότητας της εφαρμογής και την αυτόματη αναφορά τυχόν τεχνικών σφαλμάτων στους προγραμματιστές μας.
+
+Αυτά τα δεδομένα επιτρέπουν στην ομάδα μας να διορθώνει και να βελτιστοποιεί γρήγορα την εφαρμογή, με αποτέλεσμα καλύτερη εμπειρία χρήστη για εσάς.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Ρυθμίσεις</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Λογαριασμοί &amp; Συγχρονισμοί</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Προηγμένα</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Γενικά</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Φάκελος kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Συνδεθείτε από το πρόγραμμα περιήγησής σας</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Άνοιγμα kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Έξοδος</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Ρυθμίσεις</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Ελεύθερος χώρος στον υπολογιστή</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>Αρχεία kDrive αποθηκευμένα στον υπολογιστή</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Άλλα αρχεία στον υπολογιστή</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Φόρτωση χρήσης χώρου…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Ελεύθερος χώρος</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Άλλα αρχεία</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Αρχεία kDrive που είναι αποθηκευμένα στη συσκευή σας</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>Το kDrive δεν μπορεί να αποκτήσει πρόσβαση στον τόμο
+Βεβαιωθείτε ότι είναι συνδεδεμένος,
+ξεκλειδωμένος και προσβάσιμος από τον υπολογιστή σας.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Ο τόμος δεν είναι προσβάσιμος</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Διαχειριστείτε τους συγχρονισμένους φακέλους για να ελευθερώσετε χώρο στο Mac σας.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Συγχρονισμός</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Αυτός ο υπολογιστής - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 από %2 χρησιμοποιημένο</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Αποθηκευμένο online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Τα αρχεία σας παραμένουν στο cloud και δεν χρησιμοποιούν χώρο στον υπολογιστή σας.
+Απαιτείται σύνδεση στο διαδίκτυο για πρόσβαση σε αυτά.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Σφάλμα συγχρονισμού</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Προσαρμοσμένος φάκελος</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Προεπιλεγμένος φάκελος</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Συγχρονισμός</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Η νέα λειτουργία συγχρονισμού σας εφαρμόζεται…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Κανόνες συγχρονισμού</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Παρουσιάστηκε σφάλμα</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Ο τελευταίος συγχρονισμός ήταν επιτυχής</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Ο συγχρονισμός είναι σε παύση</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Ο συγχρονισμός βρίσκεται σε εξέλιξη</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Συγχρονίστηκε</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Συγχρονισμένο</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Συγχρονισμένο από τον υπολογιστή σας</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Συγχρονισμένο από το kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>τα αρχεία σας συγχρονίζονται</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>ο συγχρονισμός έχει τεθεί σε παύση</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Τα πρόσφατα αρχεία σας ενημερώνονται.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Συγχρονισμός σε εξέλιξη</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Τα αρχεία που έχετε κατεβάσει παραμένουν προσβάσιμα.
+Ο συγχρονισμός θα ξαναρχίσει αυτόματα μόλις συνδεθείτε ξανά.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Εκτός σύνδεσης</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Ο συγχρονισμός έχει σταματήσει προσωρινά.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Συγχρονισμός κατά τη διακοπή</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Τα αρχεία σας είναι προσβάσιμα και συγχρονισμένα.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Καμία ενεργή δραστηριότητα</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>τα αρχεία σας είναι ενημερωμένα</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Συγχρονισμός</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Ένα αρχείο ή φάκελος στον φάκελο συγχρονισμού σας φαίνεται να έχει καταστραφεί.
+Ο συγχρονισμός διακόπηκε. Ελέγξτε τα αρχεία σας και δοκιμάστε ξανά.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Εντοπίστηκε κατεστραμμένο αρχείο</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Δραστηριότητα</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Αρχική</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Αποθηκευτικός χώρος</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Ο φάκελος δεν πρέπει να είναι η ρίζα μιας μονάδας δίσκου και δεν πρέπει να περιέχει ή να βρίσκεται μέσα σε φάκελο που συγχρονίζεται ήδη.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Ο φάκελος πρέπει να είναι κενός, δεν πρέπει να είναι η ρίζα μιας μονάδας δίσκου και δεν πρέπει να περιέχει ή να βρίσκεται μέσα σε φάκελο που συγχρονίζεται ήδη.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Αυτός ο φάκελος δεν μπορεί να χρησιμοποιηθεί</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Μεμονωμένος χειρισμός</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Διαχείριση συγχρονισμού</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Μια ειδοποίηση σας ενημερώνει όταν ένα αρχείο εξαιρείται από αυτόν τον κανόνα</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Κλείσιμο kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Άνοιγμα kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Ρυθμίσεις</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Ελέγξτε ότι η σύνδεσή σας στο διαδίκτυο είναι ενεργή, ότι αυτό το όνομα δεν χρησιμοποιείται ήδη και ότι δεν περιέχει μη έγκυρους χαρακτήρες.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Αδύνατη δημιουργία αυτού του φακέλου</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Μη εξουσιοδοτημένη πρόσβαση</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Τα αρχεία σας είναι προσβάσιμα και συγχρονισμένα.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Καμία πρόσφατη δραστηριότητα</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Παρακαλούμε δοκιμάστε ξανά σε λίγες στιγμές.
+Εάν το πρόβλημα παραμένει, παρακαλούμε επικοινωνήστε με την υποστήριξη.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Παρουσιάστηκε μη αναμενόμενο σφάλμα</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Μέχρι αύριο</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 διαθέσιμο</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Η εγκατάσταση διαρκεί λιγότερο από ένα λεπτό.
+Ο συγχρονισμός σας θα συνεχιστεί αυτόματα στο τέλος.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Αγνόηση αυτής της έκδοσης</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Εγκατάσταση τώρα</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Υπενθύμιση αργότερα</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Δείτε τι νέο υπάρχει</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Έκδοση %1 · Χρησιμοποιείτε την %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Διαθέσιμη ενημέρωση</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Απαιτείται νέα έκδοση του kDrive για να συνεχίσετε.
+Ενημερώστε την εφαρμογή για να αποκτήσετε πρόσβαση στα αρχεία σας και να συνεχίσετε τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Απαιτείται ενημέρωση</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Ενημέρωση</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Ημιτελής μεταφόρτωση</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Εξαιρέστε ορισμένες εφαρμογές από τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Προσθήκη αρχείων για εξαίρεση από τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Προσαρμοσμένοι κανόνες εξαίρεσης</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Εξαιρέστε ορισμένους τύπους αρχείων από τον συγχρονισμό.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Προβολή πηγαίου κώδικα</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Έχετε ένα σφάλμα συγχρονισμού</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Έχετε {0} σφάλματα συγχρονισμού</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Το kDrive δεν μπορεί να αποκτήσει πρόσβαση στη μονάδα %1
+Βεβαιωθείτε ότι είναι συνδεδεμένη,
+ξεκλειδωμένη και προσβάσιμη από τον υπολογιστή σας.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Η μονάδα αποθήκευσης %1 δεν είναι προσβάσιμη</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Κατάργηση</numerusform> 
+                <numerusform>Κατάργηση (%1 κανόνων)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Εφαρμογή αλλαγής…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Διαχείριση χώρου δίσκου</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Άνοιγμα γονικού φακέλου</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Ενημέρωση</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Επίπεδο εντοπισμού σφαλμάτων</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Ο συγχρονισμός θα επανεκκινήσει αυτόματα.
+Εάν το πρόβλημα παραμένει, επικοινωνήστε με την υποστήριξή μας επισυνάπτοντας τις τεχνικές λεπτομέρειες παρακάτω.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Τεχνικές λεπτομέρειες</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Παρουσιάστηκε μη αναμενόμενο σφάλμα</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Η διαγραφή ακυρώθηκε</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Διπλά ονόματα</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Δεν έχετε τα απαραίτητα δικαιώματα για να προσθέσετε ένα %1 σε αυτή την τοποθεσία.
+Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Δεν έχετε άδεια να διαγράψετε αυτό το %1. Έχει αποκατασταθεί στην αρχική του τοποθεσία. Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Τα δικαιώματα πρόσβασης για το %1 άλλαξαν, εμποδίζοντας τον συγχρονισμό του.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Υπάρχει ήδη ένα αρχείο ή φάκελος με αυτό το όνομα.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Δεν έχετε δικαιώματα για να επεξεργαστείτε αυτό το αρχείο.
+Διατηρήθηκε η αρχική έκδοση και η επεξεργασία σας αποθηκεύτηκε σε ξεχωριστό αρχείο με "conflict" στο όνομά του. Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Το όνομα αυτού του %1 τελειώνει με κενό, εμποδίζοντας τον συγχρονισμό του. Μετονομάστε το %2 από το kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Ένας κανόνας εξαίρεσης εμποδίζει τον συγχρονισμό αυτού του %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Υπάρχει ήδη ένα αρχείο με αυτό το όνομα.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Αυτό το αρχείο χρησιμοποιείται αυτή τη στιγμή από άλλον χρήστη.
+Οι αλλαγές σας θα συγχρονιστούν αργότερα.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Αυτό το αρχείο διαγράφηκε στο kDrive online ενώ το επεξεργαζόσασταν. Ένα αντίγραφο αποθηκεύτηκε στον υπολογιστή σας στον φάκελο ανάκτησης.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Αυτό το αρχείο υπερβαίνει το μέγιστο επιτρεπτό μέγεθος (50 GB).
+Επικοινωνήστε με τον διαχειριστή σας για να αυξήσετε το όριο μεγέθους αρχείου.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Αυτό το όνομα περιέχει μόνο κενά και δεν μπορεί να χρησιμοποιηθεί. Μετονομάστε το %1 από το kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Αυτό το αρχείο είναι σκληρός σύνδεσμος (hard link) που δεν μπορεί να συγχρονιστεί.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Δεν έχετε δικαιώματα για να μεταφέρετε αυτό το %1 εδώ· θα αποκατασταθεί στην αρχική του τοποθεσία. Ζητήστε πρόσβαση από τον κάτοχο ή τον διαχειριστή.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Αυτό το όνομα υπερβαίνει το επιτρεπτό μήκος (250 χαρακτήρες). Μετονομάστε το %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Δεν υπάρχει αρκετός χώρος στον υπολογιστή σας για τον συγχρονισμό αυτού του αρχείου.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Ο πλήρης φάκελος είναι μεγάλος.
+Για να επιταχύνετε την αποστολή, σας συνιστούμε να στείλετε μόνο την τελευταία περίοδο σύνδεσης kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Αποστολή μόνο της τελευταίας περιόδου σύνδεσης</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: en, English
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>About</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>About kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Visible activities</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Choosing a distribution channel</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Show more information</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Select a synchronization mode</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synchronization complete</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synchronization in progress</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>No recent activity</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>You are offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synchronization paused</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>All activities</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>My activity only</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sync a folder with kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Choose the folder on your computer to sync with kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synced folder</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Customize the location of your computer folder on kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Choose the folder location on kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive location</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sync a folder with kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Advanced sync</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>App to exclude</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>The application is up to date</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Deletes logs older than 7 days to save disk space.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatic cleanup</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatic updates</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Available offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>You can wake it up from the web interface.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Join the beta program</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Enable offline sync</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Sync a folder</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Add a rule</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Add storage</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Advanced settings</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Apply to %1 files</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Request access</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Cancel</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Change folder</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Store offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Store online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Switch user</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Close</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Close kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configure</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Confirm</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Sign in</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Connect an account</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contact support</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Continue</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Copy share link</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Create an account</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Create a new sync</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Custom location</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Disconnect this account</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Downloading…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Download manually</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Enable</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Enable in Windows settings</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Understand the issue</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Share an idea</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Finish installation</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Fix errors</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>I’ve activated kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Keep account</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Sign out</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Sign in</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Manage</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Handle files individually</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Manage storage</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Open debug folder</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Open Explorer</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Open folder</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Open in browser</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Open in Explorer</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Open in Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Open in kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Open kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Manage exclusions</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Open sync settings</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pause</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Refresh</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Release notes</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Remove</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Remove (%n element)</numerusform> 
+                <numerusform>Remove (%n elements)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Remove sync</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Rename %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Restart sign-in</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Resume sync</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Restart sync</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Retry</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Return to default folder</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Save</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Save my choices</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Search</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>View activities</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Select</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Select a folder</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Select folders</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Select a location</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Selected</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Send</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Send debug folder</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Open settings</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>View offers</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Show options</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Sign out</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Start</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Start version selection</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Get started for free</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Sync offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Update now</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Update subscription</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Upgrade</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Confirm</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Confirm and go to next</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Wake up</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Choose a version</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Two different versions of these files were detected.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Version conflicts</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Search for a file</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Copying Link…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Creating share link…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Data management</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respects your privacy</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Select the amount of information to log.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Allows Infomaniak support to identify the cause of an incident.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Debug logs</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>These apps are ignored by default and cannot be modified.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>These files are excluded by default and cannot be modified.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatic exclusion</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>In these situations, a new sync is required to continue using kDrive correctly.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>This folder cannot be selected</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Add a rule</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Add an exclusion rule</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Sign out of this account?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Remove sync?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>An error occurred</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Change sync mode?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Here is how to restore sync:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>The disk containing your sync folder is no longer connected</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Reconnect it to resume sync.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Disable notifications</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Don’t join</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Access denied to kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Your kDrive is in sleep mode</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Your kDrive has expired</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Sign in again to continue using kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>You have been signed out</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>This account does not match</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive is waking up… this may take a few moments.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive is waking up</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Record diagnostic information on my computer.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Enable debug logging</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Enter your password</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Case-sensitive name conflict</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>A change was detected in your configuration</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>In these situations, a new sync may be required to continue using kDrive correctly.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Check the %1 to restore access</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Last location of %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>External disk disconnected</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Enable offline sync</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Maintenance in progress</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Trailing space in %1 name</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Excluded from sync</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>File locked</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>File rescued</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>File too large</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Access forbidden</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Invalid name</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Unsupported character</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Access forbidden</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Unsupported file type</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>This folder is no longer accessible at its original location.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Sync folder not found</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Nested kDrives</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 inaccessible</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>%1 name too long</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Connection temporarily unavailable</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Insufficient disk space</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Unsupported character</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Path to %1 too long</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Storage limit reached</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>%1 name reserved</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Check the location or access rights of the folder.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Sync folder inaccessible</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Authorization required</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Insufficient disk space</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>This folder is no longer accessible at its original location.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>This folder is no longer accessible. Action is required to resume sync.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Sync folder not found</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Unable to start Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Syncing of this item failed. It will be retried automatically later.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Sync temporarily failed</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>The upload could not be completed. Please try again later.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Looks like we cannot load the app…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>An error occurred while deleting your account.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Files to verify</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Other</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System and permissions</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Failed to open URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Errors to fix</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>This folder cannot be synced. Please select a different folder.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Error while trying to start the installer</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Error while changing the mode of synchronization</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Block apps that might download or modify your files.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Files matching this rule will not be synced.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Prevent certain temporary or system files from being copied to kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Enables collection of additional information useful for support.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Extended detailed log</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>When this option is enabled, kDrive runs more slowly.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Failed to create a share link</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Help us improve kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>A notification informs you when a file is excluded by this rule.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>File already exists</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>File sync mode</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Define how your files are stored and accessed.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Files to exclude</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favorites</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Shares</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Trash</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>For 1 hour</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>For one week</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>For three days</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hello %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Support</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Free up space or upgrade your plan to continue syncing your files.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Your kDrive is full</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Some files could not be synced.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>You have &lt;b&gt;one synchronization error&lt;/b&gt;</numerusform> 
+                <numerusform>You have &lt;b&gt;%n synchronization errors&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Connection to kDrive interrupted</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Activate kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>You must activate kDrive.app before continuing</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Activate kDrive and kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>You must activate authorizations before continuing</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Go to Privacy &amp; Security &gt; Full disk access</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Full disk access</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Privacy &amp; Security</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Select Open &amp; Extensions &gt; Security extensions</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Security extensions</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Open &amp; Extensions</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Open System Settings &gt; General</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>System Settings</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Restart the application if required</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>This item is not available on this device.
+It will open in your browser.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Access rights modified</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Enabled</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>%1 ago</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>All folders</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>All kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Allow tracking</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Application Identifier</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Application Name</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Author</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>By default</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Choose which version of your files you want to keep.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>For each file, select the version to keep.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Which version do you want to keep?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Choose the version to keep</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Keep local versions only</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Keep the most recent versions</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Keep online versions only</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Sign in to get started.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Create a %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Date</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Disabled</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>file</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Folder</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Folder deleted</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Folder moved or modified</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>The folder may have been moved to another disk and then returned to its original location.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>folder</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Folder moved or renamed</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Folder recreated or replaced</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>The folder was deleted and recreated, or replaced by another folder with the same name.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Just now</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Local</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 files have been modified both on your computer and on kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Most recent</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Name</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>New device detected</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>You are using kDrive on a new computer, after restoring from a backup.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>New folder</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>new sync</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>No conflicts match your search</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>No errors to fix</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notification</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Notify if file excluded</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Off</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Online folder deleted</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>The synced folder was deleted on kDrive online or is no longer accessible.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Original location:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Recommended</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>The folder may have been moved to another disk and then returned to its original location.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Restore it to its original location.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Rules</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Same as system</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sec</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Since: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Size</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 free</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 free</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Calculating…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 used</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 used</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synced from kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synced from your computer</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>This kDrive contains only files. All files will be synced on this device.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>No folder to select</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Sync folders</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Location</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Sync your kDrives on this device</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synced folders</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synchronization</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Time</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Welcome to kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 of %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive management</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Language</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Restart the application to finish applying the new language.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Learn more</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3 License - Git Sources</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link copied to clipboard</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Location on computer</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Debug</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Error</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Extended</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Fatal</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Warning</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Send debug folder to Infomaniak support</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Invalid file name</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Compressing logs…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Uploading logs to support…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Different versions of these files were detected.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 version conflicts detected</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Move canceled</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Move deleted files to the computer’s recycle bin</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Some items may not be able to be moved.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>More storage, more features with my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Need help?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Network</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Add an account to get started</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>No results found</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Not synced</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Always</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Never</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Receive a notification when a file is excluded</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Configure sync for this kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Customize the location of your kDrive folder on your computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>The chosen folder must be empty for sync to work correctly.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Choose the folders to sync on this computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synced folders</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synced content:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synced content: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Location:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Location: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Configure your kDrives</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Choose the folders to sync on this computer</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Files are only downloaded when opened, to save disk space.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Enable Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>This kDrive is already configured.
+Go to your settings to modify it.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Authorize kDrive in macOS settings:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Activate kDrive on your Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>To complete the installation, you must authorize kDrive to access your:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Authorize access to files</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Get started for free with my kSuite,
+or choose a plan that suits your needs.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>You don’t have a kDrive yet.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Choose the kDrives to sync on this computer:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Sync in progress</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Good to see you!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>All kDrive folders</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Custom selection</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>An error occurred, please try again.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Sign-in error</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Just a few more moments, and we’ll load your account…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Login from your browser…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Retrieving your information…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>One moment…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Welcome to kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Your files are ready to be synced
+safely on your computer.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>All set!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Sync in progress…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Open kDrive when the computer starts</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Open the sign-in page</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Path copied to clipboard</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Define how kDrive connects to the internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Authentication required</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Password</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxy settings</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxy type</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manual configuration</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>None</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Username</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Internal</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Location on kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Search in %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Select the folders to sync on this computer.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Unselected folders will not be downloaded to your device. They will remain available online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Settings</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Accounts &amp; Sync</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Advanced</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>General</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive folder</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Sign in using your browse</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Open kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Quit</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Settings</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Free space on computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive files stored on computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Other files on computer</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Loading space usage…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Free space</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Other files</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>kDrive files stored on your device</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>The volume is not accessible</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Manage synchronized folders to free up space on your Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Sync</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>This PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 on %2 used</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Stored online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Sync error</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Custom folder</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Default folder</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Sync</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Your new sync mode is being applied…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Sync rules</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>An error occurred</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Last sync was successful</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Sync is paused</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Sync is running</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synced</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synced</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synced from your computer</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synced from kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>your files are syncing</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synchronization is paused</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Your recent files are being updated.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Sync in progress</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Sync has been temporarily stopped.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synchronization on pause</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Your files are accessible and synced.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>No activity in progress</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>your files are up to date</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Sync</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Corrupted file detected</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Activity</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Home</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Storage</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>This folder cannot be used</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Individual handling</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Manage synchronization</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>A notification informs you when a file is excluded by this rule</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Close kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Open kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Settings</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Unable to create this folder</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Unauthorized access</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Your files are accessible and synced.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>No recent activity</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Please try again in a few moments.
+If the problem persists, please contact support.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>An unexpected error occurred</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Until tomorrow</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 available</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignore this version</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Install now</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Remind me later</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>See what’s new</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Version %1 · You are using %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Update available</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Update required</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Update</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Incomplete upload</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Exclude certain apps from synchronization.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Add files to exclude from sync.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Custom exclusion rules</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Exclude certain file types from synchronization.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>View source code</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>You have a sync error</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>You have {0} sync errors</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Storage disk %1 is not accessible</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Remove</numerusform> 
+                <numerusform>Remove (%1 rules)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Applying change…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Manage disk space</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Open parent folder</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Update</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Debug level</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Technical details</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>An unexpected error occurred</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Deletion canceled</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Duplicate names</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>The access permissions for %1 were changed, preventing it from being synced.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>A file or folder with this name already exists.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>An exclusion rule is preventing this %1 from being synced.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>A file with this name already exists.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>This file is currently being used by another user.
+Your changes will be synced later.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>This file is a hard link that cannot be synced.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>This name exceeds the allowed length (250 characters). Rename the %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>There is not enough space on your computer to sync this file.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Send last session only</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: en, English
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en"> 
     <context>
@@ -2077,8 +2077,8 @@ This data allows our team to quickly fix and optimize the application, resulting
             <translation>kDrive folder</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
-            <translation>Sign in using your browse</translation> 
+            <source>Sign in using your browser</source> 
+            <translation>Sign in using your browser</translation> 
         </message> 
         <message id="statusBarOpenApp"> 
             <source>Open kDrive</source> 

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: en, English
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en"> 
     <context>
@@ -344,6 +344,16 @@ You can open them at any time, even without an internet connection.</translation
             <source>Manage storage</source> 
             <translation>Manage storage</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximize</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimize</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Open debug folder</translation> 
@@ -427,6 +437,11 @@ You can open them at any time, even without an internet connection.</translation
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Restart sync</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Restore</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_en.ts
+++ b/src/gui4/linux/translations/client_en.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ unlocked and accessible from your computer.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Applying change…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Manage disk space</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Open parent folder</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Update</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Debug level</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ If the problem persists, contact our support and attach the technical details be
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Technical details</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>An unexpected error occurred</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Deletion canceled</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Duplicate names</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Request access from the owner or administrator.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>The access permissions for %1 were changed, preventing it from being synced.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>A file or folder with this name already exists.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ The original version has been kept and your edit has been saved in a separate fi
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>An exclusion rule is preventing this %1 from being synced.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>A file with this name already exists.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Your changes will be synced later.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contact your administrator to increase the file size limit.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>This file is a hard link that cannot be synced.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>This name exceeds the allowed length (250 characters). Rename the %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>There is not enough space on your computer to sync this file.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: es, Spanish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="es"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versión %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versión %1 (compilación %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Acerca de</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Acerca de kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Desarrollado y alojado exclusivamente en Suiza, kDrive garantiza la protección total de sus datos, sin reventa ni espionaje, en centros de datos certificados ISO, con cifrado y copia de seguridad en varios soportes.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Actividades visibles</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Elegir el canal de distribución</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Ver más información</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Borrar búsqueda</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Buscar tus archivos</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Buscando…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Seleccionar un modo de sincronización</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Sincronización completada</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Sincronización en curso</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Sin actividad reciente</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Está sin conexión</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Sincronización en pausa</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Todas las actividades</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Solo mi actividad</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizar una carpeta con kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Elija la carpeta de su ordenador para sincronizar con kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Carpeta sincronizada</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Personalice la ubicación de la carpeta de su ordenador en kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Elegir la ubicación de la carpeta en kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Ubicación en kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Seleccione una carpeta en su ordenador para sincronizar con kDrive.
+Puede acceder a sus sincronizaciones avanzadas desde el selector de unidades en la página de inicio.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizar una carpeta con kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Sincronización avanzada</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Aplicación a excluir</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>La aplicación está actualizada</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Elimina los registros de más de 7 días para ahorrar espacio en disco.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Limpieza automática</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Actualizaciones automáticas</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Disponible sin conexión</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Sus archivos se copian en su ordenador.
+Puede abrirlos en cualquier momento, incluso sin conexión a Internet.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Puede activarlo desde la interfaz web.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Obtenga acceso anticipado a las nuevas versiones de la aplicación antes de que se publiquen para el público en general y ayude a mejorar la aplicación compartiendo sus ideas de mejora con nosotros.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Unirse al programa beta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Su navegador debería abrirse automáticamente para completar el inicio de sesión. Una vez que haya iniciado sesión, volverá automáticamente a kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Activar sincronización sin conexión</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Sincronizar una carpeta</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Agregar una regla</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Agregar almacenamiento</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Ajustes avanzados</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Aplicar a %1 archivos</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Solicitar acceso</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Cancelar</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Cambiar carpeta</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Guardar sin conexión</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Guardar en línea</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Cambiar usuario</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Cerrar</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Cerrar kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configurar</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Confirmar</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Iniciar sesión</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Conectar una cuenta</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contactar con el servicio de asistencia</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Continúe en</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Copiar enlace compartido</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Crear una cuenta</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Crear una nueva sincronización</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Ubicación personalizada</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Desconectar esta cuenta</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Descargando…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Descargar manualmente</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Activar</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Activar en los ajustes de Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Entender el problema</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Compartir una idea</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Terminar la instalación</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Corregir errores</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Soporte</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>He activado kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive en línea</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Mantener cuenta</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Cerrar sesión</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Iniciar sesión</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Administrar</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Gestionar archivos individualmente</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Administrar almacenamiento</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Abrir carpeta de depuración</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Abrir Explorer</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Abrir carpeta</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Abrir en el navegador</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Abrir en Explorer</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Abrir en el Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Abrir en kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Abrir kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Administrar exclusiones</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Abrir ajustes de sincronización</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pausar</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Actualizar</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Notas de la versión</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Eliminar</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Eliminar (%n elemento)</numerusform> 
+                <numerusform>Eliminar (%n elementos)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Eliminar sincronización</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Renombrar %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Reiniciar inicio de sesión</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Reanudar sincronización</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Reiniciar sincronización</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Reintentar</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Volver a la carpeta predeterminada</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Guardar</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Guardar mis elecciones</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Buscar</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Ver actividades</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Seleccionar</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Seleccionar una carpeta</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Seleccionar carpetas</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Seleccionar una ubicación</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Seleccionado</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Enviar</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Enviar carpeta de depuración</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Abrir ajustes</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Ver ofertas</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Mostrar opciones</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Cerrar sesión</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Inicio</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Iniciar selección de versiones</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Comenzar gratis</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Sincronizar sin conexión</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Actualizar ahora</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Actualizar suscripción</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Actualizar</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Confirmar</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Confirmar e ir al siguiente</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Activar</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Elegir una versión</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Se detectaron dos versiones diferentes de estos archivos.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Conflictos de versiones</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Buscar un archivo</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Copiando enlace…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Creando enlace compartido…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Puede personalizar los datos de uso y operativos recopilados por Infomaniak para corregir errores y mejorar la aplicación. Ambas herramientas utilizadas están alojadas y gestionadas exclusivamente por nosotros.
+
+El código fuente de esta aplicación puede verificarse, la información recopilada es anónima y su información personal permanece estrictamente confidencial y nunca se comparte con terceros.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Gestión de datos</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respeta su privacidad</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Seleccione la cantidad de información a registrar.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Permite al soporte de Infomaniak identificar la causa de un incidente.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Registros de depuración</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Estas aplicaciones se ignoran de forma predeterminada y no se pueden modificar.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Estos archivos se excluyen de forma predeterminada y no se pueden modificar.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Exclusión automática</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>En estas situaciones, se requiere una nueva sincronización para continuar usando kDrive correctamente.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Seleccione una carpeta vacía que no esté en la raíz de una unidad.
+
+Esta carpeta no debe estar incluida en otra carpeta de sincronización y no debe contener una subcarpeta de sincronización.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Esta carpeta no se puede seleccionar</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Agregar una regla</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Agregar una regla de exclusión</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Está a punto de desconectar %1 de la aplicación.
+La carpeta de sincronización permanecerá en su ordenador, pero ya no se sincronizará con kDrive.
+
+Todos sus datos seguirán siendo accesibles en línea en kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>¿Cerrar sesión en esta cuenta?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>La carpeta local permanecerá en su ordenador, pero ya no se sincronizará con kDrive.
+Esta acción es permanente.
+Para sincronizar su unidad nuevamente, deberá volver a conectarla más tarde.
+
+Antes de continuar, asegúrese de que todos sus archivos están actualizados y completamente sincronizados.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>¿Eliminar sincronización?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>El cambio de modo de sincronización fue cancelado.
+
+La sincronización actual permanece sin cambios. Sin embargo, si se produce un comportamiento anormal, es posible que deba eliminar y recrear la sincronización para restaurar el funcionamiento correcto.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Se produjo un error</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Esta operación puede tardar algún tiempo dependiendo del tamaño de sus datos. Si falla, puede ser necesaria una resincronización completa de la unidad.
+
+Antes de continuar, asegúrese de que todos sus archivos estén actualizados y sincronizados.
+
+No cierre la aplicación durante el proceso.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>¿Cambiar el modo de sincronización?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Aquí se explica cómo restaurar la sincronización:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>El disco que contiene su carpeta de sincronización ya no está conectado</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Vuelva a conectarlo para reanudar la sincronización.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Desactivar notificaciones</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>No unirse</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/es/aplicaciones/descargar-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>No tiene permiso para acceder a este kDrive.
+Verifique sus permisos o contacte con su administrador.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Acceso denegado a kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Su kDrive está en modo de suspensión</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Este kDrive no ha sido renovado. Ya no puede acceder a él.
+Renueve su suscripción para reactivar el servicio.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Este kDrive no ha sido renovado. Ya no puede acceder a él.
+Contacte con su administrador para reactivar el servicio.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Su kDrive ha expirado</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Inicie sesión nuevamente para continuar usando kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Se ha cerrado su sesión</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>La cuenta utilizada para esta conexión no coincide con la de este kDrive.
+Inicie sesión nuevamente con la dirección de correo electrónico correcta %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Esta cuenta no coincide</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive se está activando… esto puede tardar unos instantes.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive se está activando</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Registrar información de diagnóstico en mi ordenador.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Activar registro de depuración</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Introduzca su contraseña</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>En esta carpeta ya existe otro %1 cuyo nombre sólo difiere en mayúsculas/minúsculas. Este tipo de nombre no es compatible con la aplicación kDrive Windows. Cambie el nombre de una de las carpetas %2 desde kDrive online para poder sincronizarla en su PC.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Nombres contradictorios, distingue mayúsculas de minúsculas</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Se detectó un cambio en su configuración</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>En estas situaciones, puede ser necesaria una nueva sincronización para continuar usando kDrive correctamente.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Consulte %1 para restaurar el acceso</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Última ubicación de %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Disco externo desconectado</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Esta operación puede tardar algún tiempo dependiendo de la cantidad de datos a procesar.
+
+No cierre la aplicación durante el proceso.
+
+Si falla, puede iniciar fácilmente una resincronización completa de la unidad o contactar con nuestro soporte.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Activar sincronización sin conexión</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Este kDrive no está disponible temporalmente por mantenimiento.
+Vuelva a intentarlo en unos minutos.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Mantenimiento en curso</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Espacio al final del nombre de %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Excluido de la sincronización</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Archivo bloqueado</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Archivo recuperado</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Este archivo supera el tamaño máximo permitido (50 GB).
+Contacte con el soporte para desbloquear el límite.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Archivo demasiado grande</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Acceso prohibido</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>El nombre de este %1 contiene uno o más caracteres no admitidos por la aplicación kDrive Windows. Cambie el nombre del %2 desde kDrive en línea.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Nombre no válido</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carácter no admitido</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>No tiene los permisos necesarios para realizar esta acción.
+Solicite acceso al propietario o al administrador.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Acceso prohibido</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Tipo de archivo no admitido</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Esta carpeta ya no es accesible en su ubicación original.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Carpeta de sincronización no encontrada</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Uno de sus kDrives está sincronizado dentro de la carpeta de sincronización de otro kDrive.
+Mueva una de las carpetas para que ya no estén anidadas, o elimine su sincronización para recrearla.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>kDrives anidados</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>No se puede acceder a este %1 en su ordenador. Verifique que aún existe y que tiene los derechos para acceder a él.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 inaccesible</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Nombre de %1 demasiado largo</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>No se puede conectar a kDrive.
+La sincronización se reanudará automáticamente una vez que se restablezca la conexión.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Conexión temporalmente no disponible</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espacio en disco insuficiente</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>El nombre de este archivo contiene uno o más caracteres aún no admitidos por la aplicación kDrive. Cambie el nombre del archivo desde kDrive en línea.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carácter no admitido</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>La ruta de acceso a este %1 es demasiado larga para sincronizarse. Cambie el nombre de una o más carpetas en las que se encuentra para acortar la ruta.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Ruta de acceso a %1 demasiado larga</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Su kDrive está lleno. Libere espacio o actualice su suscripción para sincronizar este %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Límite de almacenamiento alcanzado</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Este nombre está reservado por el sistema de su ordenador. Cambie el nombre del %1 desde kDrive en línea.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Nombre de %1 reservado</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Verifique la ubicación o los derechos de acceso de la carpeta.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Carpeta de sincronización inaccesible</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync no tiene los permisos necesarios para funcionar.
+abre las Preferencias de macOS para habilitarlos.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorización necesaria</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>El espacio en disco de su dispositivo está lleno. La sincronización está en pausa. Libere espacio para reanudar la sincronización.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espacio en disco insuficiente</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Esta carpeta ya no es accesible en su ubicación original.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Esta carpeta ya no es accesible. Se requiere una acción para reanudar la sincronización.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Carpeta de sincronización no encontrada</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync no puede iniciarse. Puede continuar sincronizando sus archivos activando la sincronización sin conexión en los ajustes. Contacte con el soporte si el problema persiste.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>No se puede iniciar Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>La sincronización de este elemento falló. Se reintentará automáticamente más tarde.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Sincronización temporalmente fallida</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>La subida no pudo completarse. Vuelva a intentarlo más tarde.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Parece que no podemos cargar la aplicación…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Se ha producido un error al eliminar tu cuenta.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Archivos por verificar</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Otros</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Sistema y permisos</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>No se ha podido abrir la URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Errores por corregir</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Esta carpeta no se puede sincronizar. Selecciona otra carpeta.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Error al intentar iniciar el instalador</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Error al cambiar el modo de sincronización</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Bloquee las aplicaciones que puedan descargar o modificar sus archivos.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Los archivos que coincidan con esta regla no se sincronizarán.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Evite que ciertos archivos temporales o del sistema se copien en kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Activa la recopilación de información adicional útil para el soporte.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Registro detallado extendido</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Cuando esta opción está activada, kDrive funciona más lentamente.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Error al crear un enlace compartido</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/es/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Ayúdenos a mejorar kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/e1304b1e-ebd0-4ffe-9234-a1a91730e651</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Una notificación le informa cuando un archivo es excluido por esta regla.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>El archivo ya existe</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Modo de sincronización de archivos</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Defina cómo se almacenan y se accede a sus archivos.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Archivos a excluir</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoritos</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Compartidos</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Papelera</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Durante 1 hora</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Durante una semana</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Durante tres días</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hola %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/es/soporte</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Soporte de Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Libere espacio o actualice su plan para continuar sincronizando sus archivos.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Su kDrive está lleno</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Algunos archivos no pudieron sincronizarse.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Tienes &lt;b&gt;un error&lt;/b&gt; de sincronización</numerusform> 
+                <numerusform>Tiene &lt;b&gt;%n errores de sincronización&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>No podemos acceder a sus archivos. Reinicie la aplicación para reanudar la sincronización. Si el problema continúa, contacte con el soporte.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Conexión a kDrive interrumpida</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Activar kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Debes activar kDrive.app antes de continuar</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Activar la extensión kDrive y kDrive LiteSync</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Debe activar las autorizaciones antes de continuar</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Vaya a Confidencialidad y seguridad &gt; Acceso total al disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Acceso total al disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Confidencialidad y seguridad</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Seleccione Abrir y Extensiones &gt; Extensiones de seguridad</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Extensiones de seguridad</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Abrir y Extensiones</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Abra Configuración del sistema &gt; General</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Configuración del sistema</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Reinicie la aplicación si es necesario</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Este elemento no está disponible en este dispositivo.
+Se abrirá en su navegador.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/es/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Derechos de acceso modificados</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Activado</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>hace %1</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Todas las carpetas</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Todo kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Permitir seguimiento</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Identificador de la app</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Nombre de la aplicación</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Autor</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Por defecto</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Elija la versión de sus archivos que desea conservar.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Para cada archivo, seleccione la versión que desea conservar.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>¿Qué versión desea conservar?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Elegir la versión a conservar</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Las versiones en línea de estos %1 archivos serán reemplazadas por sus versiones locales.
+Tenga cuidado, esto puede sobrescribir el trabajo de sus colaboradores.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Conservar solo las versiones locales</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Para cada conflicto, conservaremos automáticamente la versión (local o en línea) modificada más recientemente. Esta es la opción más segura en la mayoría de los casos.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Conservar las versiones más recientes</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Todos los cambios locales de estos %1 archivos serán descartados.
+Útil si sabe que el trabajo importante está en línea en kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Conservar solo las versiones en línea</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Inicie sesión para comenzar.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Cree una %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Fecha</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Desactivado</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>archivo</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Carpeta</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Carpeta eliminada</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Carpeta movida o modificada</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Es posible que la carpeta haya sido movida a otro disco y luego devuelta a su ubicación original.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>carpeta</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Carpeta movida o renombrada</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Carpeta recreada o reemplazada</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>La carpeta fue eliminada y recreada, o reemplazada por otra carpeta con el mismo nombre.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Ahora mismo</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Local</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 archivos han sido modificados tanto en su ordenador como en kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Más reciente</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nombre</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Nuevo dispositivo detectado</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Está usando kDrive en un nuevo ordenador, después de restaurar desde una copia de seguridad.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nueva carpeta</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nueva sincronización</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Ningún conflicto coincide con su búsqueda</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>No hay errores que corregir</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notificación</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Notificar si archivo excluido</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Desactivado</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>En línea</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Carpeta en línea eliminada</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>La carpeta sincronizada fue eliminada en kDrive en línea o ya no es accesible.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Ubicación original:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Recomendado</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Es posible que la carpeta haya sido movida a otro disco y luego devuelta a su ubicación original.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Restáurelo a su ubicación original.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Reglas</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Igual que el sistema</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>seg</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Desde: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Tamaño</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Estado</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 libre</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 libres</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Calculando…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 usado</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 usados</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizado desde kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizado desde su ordenador</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Este kDrive solo contiene archivos. Todos los archivos se sincronizarán en este dispositivo.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>No hay carpeta para seleccionar</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Carpetas de sincronización</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Ubicación</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Sincronice sus kDrives en este dispositivo</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Carpetas sincronizadas</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Sincronización</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tiempo</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bienvenido a kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 de %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Gestión de kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Idioma</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Reinicie la aplicación para terminar de aplicar el nuevo idioma.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Más información</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Licencia LGPL v3 - Fuentes Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Enlace copiado al portapapeles</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Disco incompatible o carpeta directamente en la raíz del disco (ej: elige una carpeta como /Mon drive en lugar de /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Disco incompatible o carpeta directamente en la raíz del disco (ej: elige una carpeta como D:/Mon drive en lugar de D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Ubicación en el ordenador</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Depuración</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Error</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Extendido</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Crítico</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Información</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Advertencia</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Enviar carpeta de depuración al soporte de Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Algunos nombres de archivos pueden contener caracteres especiales no admitidos (como comillas dobles, barras invertidas o saltos de línea).
+
+Por favor, verifique y cambie el nombre de los archivos que contengan caracteres inusuales y luego inténtelo de nuevo.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Nombre de archivo no válido</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Comprimiendo registros…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Transfiriendo registros al soporte…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>La última transferencia falló. Verifique su conexión a Internet y asegúrese de que al menos un usuario de kDrive haya iniciado sesión. Las transferencias están limitadas a 10 por día.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Se detectaron versiones diferentes de estos archivos.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 conflictos de versiones detectados</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo es una herramienta de análisis alojada y gestionada exclusivamente por Infomaniak para entender cómo se usa la aplicación.
+
+El análisis de estos datos permite a nuestro equipo mejorar continuamente la interfaz de la aplicación.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Movimiento cancelado</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Mover los archivos eliminados a la papelera del ordenador</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Es posible que algunos elementos no puedan moverse.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Más almacenamiento, más funciones con my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>¿Necesita ayuda?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Red</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Agregue una cuenta para comenzar</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>No se encontraron resultados</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>No sincronizado</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Siempre</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Nunca</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Recibir una notificación cuando se excluye un archivo</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Configurar la sincronización para este kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Personalice la ubicación de su carpeta kDrive en su ordenador:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>La carpeta elegida debe estar vacía para que la sincronización funcione correctamente.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Elija las carpetas a sincronizar en este ordenador:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Carpetas sincronizadas</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Para cada kDrive, puede elegir dónde se sincroniza en su ordenador y qué carpetas sincronizar.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Contenido sincronizado:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Contenido sincronizado: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Ubicación:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Ubicación: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Configurar sus kDrives</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Elija las carpetas a sincronizar en este ordenador</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Los archivos se descargan solo al abrirlos, para ahorrar espacio en disco.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Activar Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Este kDrive ya está configurado.
+Vaya a sus ajustes para modificarlo.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autorizar kDrive en los ajustes de macOS:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Activar kDrive en tu Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Para completar la instalación, debes autorizar a kDrive a acceder a tu:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autorizar el acceso a los expedientes</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Comience gratis con my kSuite,
+o elija un plan que se adapte a sus necesidades.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Aún no tiene un kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Elija los kDrives a sincronizar en este ordenador:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronización en curso</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>¡Qué bueno verte!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Todas las carpetas de kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Selección personalizada</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>La nube privada, rápida y segura, alojada en Suiza.
+
+Inicie sesión y mantenga sus documentos sincronizados en todos sus dispositivos.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Se produjo un error, vuelva a intentarlo.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Error de inicio de sesión</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Sólo unos momentos más y cargaremos su cuenta…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Conectarse desde el navegador…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Recuperando su información…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Un momento…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bienvenido a kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Sus archivos están listos para sincronizarse
+de forma segura en su ordenador.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>¡Todo listo!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Estamos finalizando la configuración de sus kDrives.
+
+Por favor, espere unos instantes.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Sincronización en curso…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Abrir kDrive cuando se inicie el ordenador</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Abrir la página de inicio de sesión</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Ruta copiada al portapapeles</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Defina cómo kDrive se conecta a Internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Servidor</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Autenticación requerida</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Contraseña</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Puerto</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Ajustes de proxy</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Tipo de proxy</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Configuración manual</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Ninguno</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Nombre de usuario</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Interno</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Ubicación en kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Buscar en %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Buscar…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>Este archivo no está disponible localmente y se abrirá en tu navegador</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Buscar tus archivos</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Seleccione las carpetas a sincronizar en este ordenador.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Las carpetas no seleccionadas no se descargarán en su dispositivo. Seguirán disponibles en línea y no se eliminarán.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Las carpetas no seleccionadas no se descargarán en su dispositivo. Seguirán disponibles en línea.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry es una herramienta alojada y gestionada exclusivamente por Infomaniak para monitorear la estabilidad de la aplicación en tiempo real e informar automáticamente de cualquier error técnico a nuestros desarrolladores.
+
+Estos datos permiten a nuestro equipo corregir y optimizar rápidamente la aplicación, lo que se traduce en una mejor experiencia de usuario para usted.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Ajustes</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Cuentas y sincronizaciones</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avanzado</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>General</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Carpeta kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Inicie sesión en su navegador</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Abrir kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Deja</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Ajustes</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Espacio libre en el ordenador</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>Archivos kDrive almacenados en el ordenador</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Otros archivos en el ordenador</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Uso del espacio de carga…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Espacio libre</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Otros archivos</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Archivos de kDrive almacenados en tu dispositivo</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive no puede acceder al volumen
+Asegúrese de que está conectado
+desbloqueado y accesible desde su ordenador.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>No se puede acceder al volumen</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Gestiona las carpetas sincronizadas para liberar espacio en tu Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Sincronización</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Este PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 en %2 utilizado</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Almacenados en línea</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Sus archivos permanecen en la nube y no utilizan espacio en su ordenador.
+Se requiere conexión a Internet para acceder a ellos.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Error de sincronización</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Carpeta personalizada</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Carpeta predeterminada</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Sincronización</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Se está aplicando su nuevo modo de sincronización…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Reglas de sincronización</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Se ha producido un error</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>La última sincronización se ha realizado correctamente</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Sincronización en pausa</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Sync está en marcha</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Sincronizado</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Sincronizado</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizado desde su ordenador</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizado desde kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>sus archivos se están sincronizando</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>la sincronización está en pausa</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Sus archivos recientes se están actualizando.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronización en curso</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Podrás seguir accediendo a tus archivos descargados.
+La sincronización se reanudará automáticamente en cuanto vuelvas a conectarte.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Sin conexión</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>La sincronización se ha detenido temporalmente.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Sincronización en pausa</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Sus archivos son accesibles y están sincronizados.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Sin actividad en curso</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>sus archivos están actualizados</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Sincronización</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Un archivo o carpeta en su carpeta de sincronización parece estar dañado.
+La sincronización ha sido pausada. Verifique sus archivos e inténtelo de nuevo.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Archivo dañado detectado</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Actividad</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Inicio</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Almacenamiento</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>La carpeta no debe ser la raíz de una unidad y no debe contener ni estar dentro de una carpeta ya sincronizada.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>La carpeta debe estar vacía, no debe ser la raíz de una unidad y no debe contener ni estar dentro de una carpeta ya sincronizada.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Esta carpeta no se puede usar</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Gestión individual</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Gestionar la sincronización</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Una notificación le informa cuando un archivo es excluido por esta regla</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Cerrar kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Abrir kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Ajustes</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Prueba con otro término de búsqueda</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Escribe para empezar a buscar</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Verifique que su conexión a Internet esté activa, que este nombre no esté ya en uso y que no contenga caracteres no válidos.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>No se puede crear esta carpeta</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Acceso no autorizado</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Sus archivos son accesibles y están sincronizados.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Sin actividad reciente</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Vuelva a intentarlo en unos instantes.
+Si el problema persiste, contacte con el soporte.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Se produjo un error inesperado</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Hasta mañana</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 disponible</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>La instalación tarda menos de un minuto.
+Su sincronización se reanudará automáticamente al finalizar.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorar esta versión</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Instalar ahora</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Recordar más tarde</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Ver novedades</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versión %1 · Está usando la %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Actualización disponible</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Se requiere una nueva versión de kDrive para continuar.
+Actualice la aplicación para acceder a sus archivos y reanudar la sincronización.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Actualización requerida</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Actualización</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Subida incompleta</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Excluir ciertas aplicaciones de la sincronización.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Agregue archivos para excluir de la sincronización.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Reglas de exclusión personalizadas</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Excluya ciertos tipos de archivos de la sincronización.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Ver código fuente</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Tiene un error de sincronización</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Tiene {0} errores de sincronización</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive no puede acceder al disco %1
+Asegúrese de que está conectado,
+desbloqueado y accesible desde su ordenador.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>El disco de almacenamiento %1 no es accesible</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Eliminar</numerusform> 
+                <numerusform>Eliminar (%1 reglas)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Aplicando cambio…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Administrar espacio en disco</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Abrir carpeta principal</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Actualizar</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Nivel de depuración</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>La sincronización se reiniciará automáticamente.
+Si el problema persiste, contacte con nuestro soporte adjuntando los detalles técnicos que aparecen a continuación.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Detalles técnicos</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Se produjo un error inesperado</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Eliminación cancelada</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Nombres duplicados</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>No tiene los permisos necesarios para agregar un %1 en esta ubicación.
+Solicite acceso al propietario o al administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>No tiene permiso para eliminar este %1. Se ha restaurado a su ubicación original. Solicite acceso al propietario o al administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Los permisos de acceso de %1 fueron modificados, lo que impide su sincronización.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Ya existe un archivo o carpeta con este nombre.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>No tiene los derechos para editar este archivo.
+Se ha conservado la versión original y su edición se ha guardado en un archivo separado con «conflicto» en su nombre. Solicite acceso al propietario o al administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>El nombre de este %1 termina con un espacio, lo que impide su sincronización. Cambie el nombre del %2 desde kDrive en línea.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Una regla de exclusión impide la sincronización de este %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Ya existe un archivo con este nombre.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Este archivo está siendo utilizado actualmente por otro usuario.
+Sus cambios se sincronizarán más tarde.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Este archivo fue eliminado en kDrive en línea mientras lo estaba editando. Se ha conservado una copia en su ordenador en la carpeta de recuperación.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Este archivo supera el tamaño máximo permitido (50 GB).
+Contacte con su administrador para aumentar el límite de tamaño de archivo.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Este nombre contiene solo espacios y no se puede usar. Cambie el nombre del %1 desde kDrive en línea.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Este archivo es un enlace físico que no puede sincronizarse.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>No tiene los derechos para mover este %1 aquí; se restaurará a su ubicación original. Solicite acceso al propietario o al administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Este nombre supera la longitud permitida (250 caracteres). Cambie el nombre del %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>No hay suficiente espacio en su ordenador para sincronizar este archivo.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>La carpeta completa es grande.
+Para acelerar el envío, recomendamos enviar solo la última sesión de kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Enviar solo la última sesión</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="es"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ desbloqueado y accesible desde su ordenador.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Aplicando cambio…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Administrar espacio en disco</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Abrir carpeta principal</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Actualizar</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Nivel de depuración</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Si el problema persiste, contacte con nuestro soporte adjuntando los detalles t�
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Detalles técnicos</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Se produjo un error inesperado</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Eliminación cancelada</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Nombres duplicados</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Solicite acceso al propietario o al administrador.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>No tiene permiso para eliminar este %1. Se ha restaurado a su ubicación original. Solicite acceso al propietario o al administrador.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Los permisos de acceso de %1 fueron modificados, lo que impide su sincronización.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Ya existe un archivo o carpeta con este nombre.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ Se ha conservado la versión original y su edición se ha guardado en un archivo
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>El nombre de este %1 termina con un espacio, lo que impide su sincronización. Cambie el nombre del %2 desde kDrive en línea.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Una regla de exclusión impide la sincronización de este %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Ya existe un archivo con este nombre.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Sus cambios se sincronizarán más tarde.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Este archivo fue eliminado en kDrive en línea mientras lo estaba editando. Se ha conservado una copia en su ordenador en la carpeta de recuperación.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contacte con su administrador para aumentar el límite de tamaño de archivo.</t
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Este nombre contiene solo espacios y no se puede usar. Cambie el nombre del %1 desde kDrive en línea.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Este archivo es un enlace físico que no puede sincronizarse.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>No tiene los derechos para mover este %1 aquí; se restaurará a su ubicación original. Solicite acceso al propietario o al administrador.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Este nombre supera la longitud permitida (250 caracteres). Cambie el nombre del %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>No hay suficiente espacio en su ordenador para sincronizar este archivo.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -254,7 +254,7 @@ Puede abrirlos en cualquier momento, incluso sin conexión a Internet.</translat
         </message> 
         <message id="buttonContinue"> 
             <source>Continue</source> 
-            <translation>Continúe en</translation> 
+            <translation>Continuar</translation> 
         </message> 
         <message id="buttonCopyShareLink"> 
             <source>Copy share link</source> 
@@ -2086,7 +2086,7 @@ Estos datos permiten a nuestro equipo corregir y optimizar rápidamente la aplic
         </message> 
         <message id="statusBarQuitApp"> 
             <source>Quit</source> 
-            <translation>Deja</translation> 
+            <translation>Salir</translation> 
         </message> 
         <message id="statusBarSettings"> 
             <source>Settings</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: es, Spanish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="es"> 
     <context>
@@ -344,6 +344,16 @@ Puede abrirlos en cualquier momento, incluso sin conexión a Internet.</translat
             <source>Manage storage</source> 
             <translation>Administrar almacenamiento</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximizar</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimizar</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Abrir carpeta de depuración</translation> 
@@ -427,6 +437,11 @@ Puede abrirlos en cualquier momento, incluso sin conexión a Internet.</translat
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Reiniciar sincronización</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Restaurar</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_es.ts
+++ b/src/gui4/linux/translations/client_es.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: es, Spanish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="es"> 
     <context>
@@ -2077,7 +2077,7 @@ Estos datos permiten a nuestro equipo corregir y optimizar rápidamente la aplic
             <translation>Carpeta kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Inicie sesión en su navegador</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fi, Finnish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fi"> 
     <context>
@@ -344,6 +344,16 @@ Voit avata ne milloin tahansa, jopa ilman internet-yhteyttä.</translation>
             <source>Manage storage</source> 
             <translation>Hallitse tallennustilaa</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Suurenna</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Pienennä</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Avaa virheenkorjauskansio</translation> 
@@ -427,6 +437,11 @@ Voit avata ne milloin tahansa, jopa ilman internet-yhteyttä.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Käynnistä synkronointi uudelleen</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Palauta</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fi, Finnish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fi"> 
     <context>
@@ -2077,7 +2077,7 @@ Näiden tietojen avulla tiimimme voi nopeasti korjata ja optimoida sovellusta, m
             <translation>kDrive-kansio</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Kirjaudu sisään selaimessasi</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: fi, Finnish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="fi"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versio %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versio %1 (rakennus %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Tietoja</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Tietoja kDrivesta</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>kDrive on kehitetty ja isännöity yksinomaan Sveitsissä. Se varmistaa tietojesi täydellisen suojan ilman myyntiä tai vakoilua, ISO-sertifioiduissa datakeskuksissa, salauksella ja varmuuskopioinnilla useille tallennusvälineille.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Näkyvät toiminnot</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Jakelukanavan valitseminen</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Näytä lisätiedot</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Valitse synkronointitila</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synkronointi valmis</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synkronointi käynnissä</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Ei viimeaikaista toimintaa</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Olet offline-tilassa</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synkronointi keskeytetty</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Kaikki toiminnot</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Vain oma toimintani</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkronoi kansio kDriven kanssa</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Valitse tietokoneeltasi kDriveen synkronoitava kansio:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synkronoitu kansio</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Muokkaa tietokoneen kansion sijaintia kDrivessa:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Valitse kansion sijainti kDrivessa</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-sijainti</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Valitse tietokoneeltasi kDriven kanssa synkronoitava kansio.
+Voit käyttää kehittyneitä synkronointejasi kotisivun asemavalikosta.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkronoi kansio kDriven kanssa</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Kehittynyt synkronointi</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Sovellus, joka jätetään pois</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Sovellus on ajan tasalla</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Poistaa yli 7 päivää vanhat lokit levytilan säästämiseksi.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automaattinen siivous</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automaattiset päivitykset</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Saatavilla offline-tilassa</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Tiedostosi kopioidaan tietokoneellesi.
+Voit avata ne milloin tahansa, jopa ilman internet-yhteyttä.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Voit herättää sen verkkokäyttöliittymästä.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Saa varhainen pääsy uusiin sovellusversioihin ennen niiden julkaisua suurelle yleisölle ja osallistu sovelluksen kehittämiseen jakamalla parannusideoitasi kanssamme.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Liity beta-ohjelmaan</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Selaimesi pitäisi avautua automaattisesti kirjautumisen viimeistelemiseksi. Kun olet kirjautunut sisään, sinut palautetaan automaattisesti kDriveen.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Ota offline-synkronointi käyttöön</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synkronoi kansio</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Lisää sääntö</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Lisää tallennustilaa</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Lisäasetukset</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Käytä %1 tiedostoon</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Pyydä käyttöoikeutta</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Peruuta</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Vaihda kansio</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Tallenna offline-tilaan</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Tallenna verkossa</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Vaihda käyttäjä</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Sulje</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Sulje kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Määritä</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Vahvista</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Kirjaudu sisään</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Yhdistä tili</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Ota yhteyttä tukeen</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Jatka</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Kopioi jakolinkki</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Luo tili</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Luo uusi synkronointi</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Mukautettu sijainti</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Katkaise yhteys tähän tiliin</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Ladataan…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Lataa manuaalisesti</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Ota käyttöön</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Ota käyttöön Windows-asetuksissa</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Ymmärrä ongelma</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Jaa idea</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Viimeistele asennus</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Korjaa virheet</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Tuki</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Olen aktivoinut kDriven</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive verkossa</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Säilytä tili</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Kirjaudu ulos</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Kirjaudu sisään</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Hallitse</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Käsittele tiedostot yksitellen</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Hallitse tallennustilaa</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Avaa virheenkorjauskansio</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Avaa Resurssienhallinta</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Avaa kansio</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Avaa selaimessa</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Avaa Resurssienhallinnassa</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Avaa Finderissa</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Avaa kDrive Web:ssä</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Avaa kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Hallitse poissulkemisia</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Avaa synkronointiasetukset</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Keskeytä</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Päivitä</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Julkaisutiedot</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Poista</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Poista (%n kohde)</numerusform> 
+                <numerusform>Poista (%n kohdetta)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Poista synkronointi</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Nimeä %1 uudelleen</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Käynnistä kirjautuminen uudelleen</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Jatka synkronointia</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Käynnistä synkronointi uudelleen</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Yritä uudelleen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Palaa oletuskansioon</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Tallenna</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Tallenna valinnat</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Hae</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Näytä toiminnot</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Valitse</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Valitse kansio</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Valitse kansiot</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Valitse sijainti</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Valittu</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Lähetä</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Lähetä virheenkorjauskansio</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Avaa asetukset</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Näytä tarjoukset</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Näytä vaihtoehdot</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Kirjaudu ulos</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Käynnistä</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Aloita versioiden valinta</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Aloita ilmaiseksi</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synkronoi offline-tilassa</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Päivitä nyt</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Päivitä tilaus</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Päivitä</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Vahvista</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Vahvista ja siirry seuraavaan</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Herätä</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Valitse versio</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Näistä tiedostoista havaittiin kaksi eri versiota.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versioristiriidat</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Hae tiedostoa</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopioidaan linkkiä…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Luodaan jakolinkkiä…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Voit muokata Infomaniakille sovellusten virheiden korjaamiseksi ja kehittämiseksi lähetettäviä käyttö- ja toimintatietoja. Molemmat käytetyt työkalut ovat Infomaniakilla isännöityjä ja hallittuja.
+
+Tämän sovelluksen lähdekoodi on tarkistettavissa, kerätyt tiedot ovat anonyymejä ja henkilötietosi pysyvät tiukasti luottamuksellisina eikä niitä koskaan jaeta kolmansille osapuolille.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Tietojen hallinta</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak kunnioittaa yksityisyyttäsi</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Valitse kirjattavien tietojen määrä.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Antaa Infomaniakin tuelle mahdollisuuden tunnistaa vian syy.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Virheenkorjauslokit</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Nämä sovellukset ohitetaan oletusarvoisesti, eikä niitä voi muokata.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Nämä tiedostot on oletuksena poissuljettu, eikä niitä voi muokata.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automaattinen poissulkeminen</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>Näissä tilanteissa tarvitaan uusi synkronointi kDriven oikean käytön jatkamiseksi.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Valitse tyhjä kansio, joka ei sijaitse aseman juuressa.
+
+Tämä kansio ei saa sisältyä toiseen synkronointikansioon eikä sisältää synkronoinnin alikansioita.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Tätä kansiota ei voi valita</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Lisää sääntö</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Lisää poissulkemissääntö</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Olet katkaisemassa yhteyden tiliin %1 sovelluksesta.
+Synkronointikansio pysyy tietokoneellasi, mutta sitä ei enää synkronoida kDriven kanssa.
+
+Kaikki tietosi pysyvät saatavilla verkossa kDrivessa.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Kirjaudutaanko ulos tältä tililtä?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Paikallinen kansio pysyy tietokoneellasi, mutta sitä ei enää synkronoida kDriven kanssa.
+Tämä toiminto on pysyvä.
+Aseman uudelleen synkronointia varten se on yhdistettävä myöhemmin uudelleen.
+
+Varmista ennen jatkamista, että kaikki tiedostosi ovat ajan tasalla ja täysin synkronoituina.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Poistetaanko synkronointi?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Synkronointitilan muutos peruutettiin.
+
+Nykyinen synkronointi pysyy muuttumattomana. Jos kuitenkin ilmenee poikkeavaa toimintaa, synkronointi on ehkä poistettava ja luotava uudelleen oikean toiminnan palauttamiseksi.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Virhe tapahtui</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Tämä toiminto voi kestää jonkin aikaa tietojesi koon mukaan. Jos se epäonnistuu, aseman täydellinen uudelleensynkronointi saattaa olla tarpeen.
+
+Varmista ennen jatkamista, että kaikki tiedostosi ovat ajan tasalla ja synkronoituina.
+
+Älä sulje sovellusta prosessin aikana.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Vaihdetaanko synkronointitila?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Näin synkronointi palautetaan:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Synkronointikansion sisältävä levy ei ole enää yhdistettynä</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Yhdistä se uudelleen synkronoinnin jatkamiseksi.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Poista ilmoitukset käytöstä</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Älä liity</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Sinulla ei ole lupaa käyttää tätä kDrivea.
+Tarkista käyttöoikeutesi tai ota yhteyttä järjestelmänvalvojaasi.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Pääsy kDriveen estetty</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>kDrivesi on lepotilassa</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Tätä kDrivea ei ole uusittu. Et enää pääse siihen.
+Uusi tilauksesi aktivoidaksesi palvelun uudelleen.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Tätä kDrivea ei ole uusittu. Et enää pääse siihen.
+Ota yhteyttä järjestelmänvalvojaasi aktivoidaksesi palvelun uudelleen.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>kDrivesi on vanhentunut</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Kirjaudu sisään uudelleen jatkaaksesi kDriven käyttöä.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Sinut on kirjattu ulos</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Tähän yhteyteen käytetty tili ei vastaa tämän kDriven tiliä.
+Kirjaudu uudelleen sisään oikealla sähköpostiosoitteella %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Tämä tili ei vastaa</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive herää… tämä voi kestää hetken.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive herää</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Tallenna diagnostiikkatiedot tietokoneelleni.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Ota virheenkorjauksen kirjaus käyttöön</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Syötä salasanasi</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Tässä kansiossa on jo toinen %1, jonka nimi eroaa vain isojen ja pienten kirjainten osalta. Tämäntyyppistä nimeä ei tueta kDrive Windows -sovelluksessa. Nimeä yksi %2-kansioista uudelleen kDrive online -ohjelmassa, jotta voit synkronoida sen tietokoneellasi.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Ristiriitaiset nimet, isojen ja pienten kirjainten huomioiminen</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Konfiguraatiossasi havaittiin muutos</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>Näissä tilanteissa uusi synkronointi saattaa olla tarpeen kDriven oikean toiminnan jatkamiseksi.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Katso %1 palauttaaksesi käyttöoikeuden</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Kohteen %1 viimeinen sijainti:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Ulkoinen levy irrotettu</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Tämä toiminto voi kestää jonkin aikaa käsiteltävän tietomäärän mukaan.
+
+Älä sulje sovellusta prosessin aikana.
+
+Jos se epäonnistuu, voit helposti käynnistää aseman täydellisen uudelleensynkronoinnin tai ottaa yhteyttä tukeemme.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Ota offline-synkronointi käyttöön</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Tämä kDrive on tilapäisesti poissa käytöstä huollon vuoksi.
+Yritä uudelleen muutaman minuutin kuluttua.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Huolto käynnissä</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Välilyönti %1 nimen lopussa</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Poissuljettu synkronoinnista</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Tiedosto lukittu</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Tiedosto pelastettu</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Tämä tiedosto ylittää sallitun enimmäiskoon (50 Gt).
+Ota yhteyttä tukeen rajan poistamiseksi.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Tiedosto liian suuri</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Pääsy kielletty</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Tämän %1 nimi sisältää yhden tai useamman merkin, joita kDriven Windows-sovellus ei tue. Nimeä %2 uudelleen kDrive-verkkopalvelusta.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Virheellinen nimi</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Ei-tuettu merkki</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Sinulla ei ole tarvittavia käyttöoikeuksia tämän toiminnon suorittamiseen.
+Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Pääsy kielletty</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Ei-tuettu tiedostotyyppi</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Tämä kansio ei ole enää käytettävissä alkuperäisessä sijainnissaan.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkronointikansiota ei löydy</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Yksi kDriveistasi on synkronoitu toisen kDriven synkronointikansion sisälle.
+Siirrä toinen kansioista niin, ettei niitä enää ole sisäkkäin, tai poista synkronointi luodaksesi sen uudelleen.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Sisäkkäiset kDrivert</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Ei voi käyttää tätä %1 tietokoneella. Tarkista, että se on edelleen olemassa ja että sinulla on oikeudet käyttää sitä.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 ei käytettävissä</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>%1 nimi liian pitkä</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Ei voida muodostaa yhteyttä kDriveen.
+Synkronointi jatkuu automaattisesti, kun yhteys on palautettu.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Yhteys tilapäisesti katkennut</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Levytila riittämätön</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Tämän tiedoston nimi sisältää yhden tai useamman merkin, joita kDrive-sovellus ei vielä tue. Nimeä tiedosto uudelleen kDrive-verkkopalvelusta.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Ei-tuettu merkki</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Polku tähän %1 on liian pitkä synkronoitavaksi. Nimeä yksi tai useampi kansio, jossa se sijaitsee, lyhentääksesi polkua.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Polku kohteeseen %1 liian pitkä</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>kDrivesi on täynnä. Vapauta tilaa tai päivitä tilauksesi synkronoidaksesi tämän %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Tallennusraja saavutettu</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Tämä nimi on tietokoneesi järjestelmän varausnimi. Nimeä %1 uudelleen kDrive-verkkopalvelusta.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>%1 nimi varattu</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Tarkista kansion sijainti tai käyttöoikeudet.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synkronointikansio ei ole käytettävissä</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSyncillä ei ole tarvittavia käyttöoikeuksia.
+avaa macOS-asetukset ottaaksesi ne käyttöön.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Tarvittava lupa</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Laitteesi levytila on täynnä. Synkronointi on keskeytetty. Vapauta tilaa jatkaaksesi synkronointia.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Levytila riittämätön</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Tämä kansio ei ole enää käytettävissä alkuperäisessä sijainnissaan.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Tämä kansio ei ole enää käytettävissä. Synkronoinnin jatkaminen vaatii toimia.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkronointikansiota ei löydy</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync ei voi käynnistyä. Voit jatkaa tiedostojen synkronointia ottamalla offline-synkronoinnin käyttöön asetuksissa. Ota yhteyttä tukeen, jos ongelma jatkuu.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Lite Sync ei käynnisty</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Tämän kohteen synkronointi epäonnistui. Se yritetään uudelleen automaattisesti myöhemmin.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synkronointi epäonnistui tilapäisesti</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Latausta ei voitu viimeistellä. Yritä myöhemmin uudelleen.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Sovellusta ei näytä voivan ladata…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Tilin poistamisen aikana tapahtui virhe.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Tarkistettavat tiedostot</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Muut</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Järjestelmä ja käyttöoikeudet</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>URL-osoitetta %1 ei voitu avata</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Korjattavat virheet</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Tätä kansiota ei voi synkronoida. Valitse toinen kansio.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Virhe asennusohjelman käynnistämisessä</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Virhe synkronointitilan vaihtamisen aikana</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Estä sovellukset, jotka voivat ladata tai muokata tiedostojasi.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Tätä sääntöä vastaavia tiedostoja ei synkronoida.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Varmista, ettei tietyjä väliaikaisia tai järjestelmätiedostoja kopioida kDriveen.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Ottaa käyttöön tukea hyödyttävien lisätietojen keräämisen.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Laajennettu yksityiskohtainen loki</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Kun tämä vaihtoehto on käytössä, kDrive toimii hitaammin.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Jakolinkin luominen epäonnistui</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Auta meitä parantamaan kDrivea</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Ilmoitus kertoo sinulle, kun tämä sääntö sulkee pois tiedoston.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Tiedosto on jo olemassa</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Tiedostojen synkronointitila</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Määritä, miten tiedostosi tallennetaan ja miten niihin pääsee.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Poissuljetavat tiedostot</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Suosikit</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Jaot</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Roskakori</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>1 tunniksi</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Viikoksi</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Kolmeksi päiväksi</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hei %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniakin tuki</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Vapauta tilaa tai päivitä pakettisi jatkaaksesi tiedostojen synkronointia.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>kDrivesi on täynnä</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Joitakin tiedostoja ei voitu synkronoida.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Sinulla on &lt;b&gt;yksi synkronointivirhe&lt;/b&gt;</numerusform> 
+                <numerusform>Sinulla on &lt;b&gt;%n synkronointivirhettä&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Emme pääse tiedostoihisi. Käynnistä sovellus uudelleen synkronoinnin jatkamiseksi. Jos ongelma jatkuu, ota yhteyttä tukeen.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Yhteys kDriveen keskeytyi</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktivoi kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>kDrive.app on aktivoitava ennen jatkamista</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktivoi kDrive ja kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Luvat on aktivoitava ennen jatkamista</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Siirry kohtaan Yksityisyys ja turvallisuus &gt; Täysi levykäyttö</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Täysi levykäyttö</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Yksityisyys ja turvallisuus</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Valitse Avaaminen ja laajennukset &gt; Suojauslaajennukset</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Suojauslaajennukset</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Avaaminen ja laajennukset</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Avaa Järjestelmäasetukset &gt; Yleiset</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Järjestelmäasetukset</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Käynnistä sovellus uudelleen tarvittaessa</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Tämä kohde ei ole käytettävissä tällä laitteella.
+Se avautuu selaimessasi.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Käyttöoikeuksia muutettu</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Käytössä</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>%1 sitten</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Kaikki kansiot</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Koko kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Salli seuranta</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Sovelluksen tunnus</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Sovelluksen nimi</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Tekijä</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Oletuksena</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Valitse, minkä version tiedostoistasi haluat säilyttää.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Valitse kullekin tiedostolle säilytettävä versio.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Minkä version haluat säilyttää?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Valitse säilytettävä versio</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Näiden %1 tiedoston verkkoversiot korvataan paikallisilla versioillasi.
+Huomaa, että tämä voi ylikirjoittaa yhteistyötekijöittesi työn.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Säilytä vain paikalliset versiot</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Kullekin ristiriidalle säilytetään automaattisesti viimeksi muokattu versio (paikallinen tai verkkoversio). Tämä on turvallisin valinta useimmissa tapauksissa.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Säilytä uusimmat versiot</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Kaikki näiden %1 tiedoston paikalliset muutokset hylätään.
+Hyödyllinen, jos tiedät tärkeän työn olevan verkossa kDrivessa.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Säilytä vain verkkoversiot</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Kirjaudu sisään aloittaaksesi.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Luo %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Päivämäärä</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Pois käytöstä</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>UKK</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>tiedosto</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Kansio</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Kansio poistettu</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Kansio siirretty tai muokattu</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Kansio on ehkä siirretty toiselle levylle ja palautettu sitten takaisin alkuperäiseen sijaintiinsa.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>kansio</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Kansio siirretty tai nimetty uudelleen</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Kansio luotu uudelleen tai korvattu</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Kansio poistettiin ja luotiin uudelleen tai se korvattiin toisella samannimisellä kansiolla.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>Gt</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Juuri nyt</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>kt</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Paikallinen</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 tiedostoa on muokattu sekä tietokoneellasi että kDrivessa.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>Mt</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Uusin</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nimi</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Uusi laite havaittu</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Käytät kDrivea uudella tietokoneella varmuuskopiosta palautuksen jälkeen.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Uusi kansio</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>uusi synkronointi</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Ei hakuasi vastaavia ristiriitoja</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Ei korjattavia virheitä</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Ilmoitus</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Ilmoita, jos tiedosto on suljettu pois</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Pois</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Verkossa</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Verkkokansio poistettu</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Synkronoitu kansio poistettiin kDrive-verkkopalvelusta tai se ei enää ole käytettävissä.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Alkuperäinen sijainti:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Suositeltu</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Kansio on ehkä siirretty toiselle levylle ja palautettu sitten takaisin alkuperäiseen sijaintiinsa.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Palauta se alkuperäiseen sijaintiinsa.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Säännöt</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Sama kuin järjestelmässä</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>pv</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>t</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>s</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Alkaen: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Koko</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Tila</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 vapaana</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 vapaana</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Lasketaan…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 käytössä</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 käytössä</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkronoitu kDrive-verkkopalvelusta</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkronoitu tietokoneeltasi</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Tässä kDrivessa on vain tiedostoja. Kaikki tiedostot synkronoidaan tälle laitteelle.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Ei valittavia kansioita</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synkronointikansiot</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Sijainti</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synkronoi kDrivesi tällä laitteella</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synkronoidut kansiot</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synkronointi</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>Tt</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Aika</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Tervetuloa kDriveen</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 / %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDriven hallinta</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Kieli</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Käynnistä sovellus uudelleen uuden kielen käyttöönoton viimeistelemiseksi.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Lue lisää</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3 -lisenssi - Git-lähteet</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Linkki kopioitu leikepöydälle</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Yhteensopimaton asema tai kansio suoraan aseman juuressa (esim.: valitse kansio kuten /Oma asema /n sijaan)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Yhteensopimaton asema tai kansio suoraan aseman juuressa (esim.: valitse kansio kuten D:/Oma asema D:/:n sijaan)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Sijainti tietokoneella</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Virheenkorjaus</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Virhe</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Laajennettu</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Kriittinen</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Tiedot</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Varoitus</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Lähetä virheenkorjauskansio Infomaniakin tukeen</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Joidenkin tiedostonimien saattaa sisältää erikoismerkkejä, joita ei tueta (kuten kaksoislainausmerkit, kenoviivat tai rivinvaihdot).
+
+Tarkista ja nimeä tiedostot, joissa on epätavallisia merkkejä, uudelleen ja yritä sitten uudelleen.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Virheellinen tiedostonimi</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Tiivistetään lokeja…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Ladataan lokeja tukeen…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Viimeisin lähetys epäonnistui. Tarkista internet-yhteys ja varmista, että vähintään yksi kDrive-käyttäjä on kirjautunut sisään. Lähetyksiä on rajoitettu 10:een päivässä.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Näistä tiedostoista havaittiin eri versioita.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 versioristiriitaa havaittu</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo on Infomaniakin yksinomaan isännöimä ja hallinnoima analytiikkatyökalu sovelluksen käytön ymmärtämiseksi.
+
+Näiden tietojen analysointi antaa tiimillemme mahdollisuuden jatkuvasti parantaa sovelluksen käyttöliittymää.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Siirto peruutettu</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Siirrä poistetut tiedostot tietokoneen roskakoriin</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Joitakin kohteita ei ehkä voi siirtää.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Enemmän tallennustilaa, enemmän ominaisuuksia my kSuite+:n avulla</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Tarvitsetko apua?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Verkko</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Lisää tili aloittaaksesi</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Ei tuloksia löydetty</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Ei synkronoitu</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Aina</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Ei koskaan</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Vastaanota ilmoitus, kun tiedosto suljetaan pois</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Määritä tämän kDriven synkronointi</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Muokkaa kDrive-kansiosi sijaintia tietokoneella:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Valitun kansion on oltava tyhjä, jotta synkronointi toimii oikein.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Valitse tällä tietokoneella synkronoitavat kansiot:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synkronoidut kansiot</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Jokaiselle kDrivelle voit valita, mihin se synkronoidaan tietokoneellesi ja mitkä kansiot synkronoidaan.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synkronoitu sisältö:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synkronoitu sisältö: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Sijainti:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Sijainti: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Määritä kDrivesi</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Valitse tällä tietokoneella synkronoitavat kansiot</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Tiedostot ladataan vain avaamisen yhteydessä levytilan säästämiseksi.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Ota Lite Sync käyttöön</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Tämä kDrive on jo määritetty.
+Siirry asetuksiin muokataksesi sitä.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Valtuuta kDrive macOS-asetuksissa:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktivoi kDrive Macissasi</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Asennuksen viimeistelemiseksi sinun on valtuutettava kDrive käyttämään seuraavia kansioita:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Valtuuta tiedostojen käyttö</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Aloita ilmaiseksi my kSuite -palvelulla,
+tai valitse tarpeisiisi sopiva paketti.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Sinulla ei vielä ole kDrivea.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Valitse tällä tietokoneella synkronoitavat kDrivert:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronointi käynnissä</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Mukava nähdä sinut!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Kaikki kDrive-kansiot</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Mukautettu valinta</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Yksityinen, nopea ja turvallinen pilvi, isännöity Sveitsissä.
+
+Kirjaudu sisään ja pidä asiakirjasi synkronoituina kaikilla laitteillasi.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Tapahtui virhe, yritä uudelleen.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Kirjautumisvirhe</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Vain hetki, ladataan tiliäsi…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Kirjautuminen selaimessa…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Haetaan tietojasi…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Hetki…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Tervetuloa kDriveen</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Tiedostosi ovat valmiita synkronoitavaksi
+turvallisesti tietokoneellesi.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Kaikki valmista!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Viimeistelemme kDrivejesi määritystä.
+
+Odota hetki.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synkronointi käynnissä…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Avaa kDrive tietokoneen käynnistyessä</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Avaa kirjautumissivu</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Polku kopioitu leikepöydälle</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Määritä, miten kDrive muodostaa yhteyden internetiin.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Palvelin</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Todennus vaaditaan</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Salasana</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Portti</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Välityspalvelimen asetukset</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Välityspalvelimen tyyppi</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manuaalinen määritys</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Ei mitään</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Käyttäjätunnus</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Sisäinen</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Testi</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Sijainti kDrivessa</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Hae kohteesta %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Valitse tällä tietokoneella synkronoitavat kansiot.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Valitsemattomia kansioita ei ladata laitteellesi. Ne pysyvät saatavilla verkossa eikä niitä poisteta.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Valitsemattomia kansioita ei ladata laitteellesi. Ne pysyvät saatavilla verkossa.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry on Infomaniakin yksinomaan isännöimä ja hallinnoima työkalu, joka seuraa sovelluksen vakautta reaaliajassa ja raportoi automaattisesti mahdolliset tekniset virheet kehittäjillemme.
+
+Näiden tietojen avulla tiimimme voi nopeasti korjata ja optimoida sovellusta, mikä tarkoittaa parempaa käyttökokemusta sinulle.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Asetukset</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Tilit ja synkronoinnit</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Lisäasetukset</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Yleiset</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-kansio</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Kirjaudu sisään selaimessasi</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Avaa kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Lopeta</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Asetukset</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Tietokoneen vapaa tila</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-tiedostot tallennettu tietokoneelle</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Muut tietokoneella olevat tiedostot</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Ladataan tilankäyttöä…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Vapaa tila</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Muut tiedostot</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Laitteellesi tallennetut kDrive-tiedostot</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive ei pääse asemalle
+Varmista, että se on kytketty,
+lukitsematon ja tietokoneeltasi käytettävissä.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Asema ei ole käytettävissä</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Hallitse synkronoituja kansioita vapauttaaksesi tilaa Maciltasi.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synkronointi</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Tämä tietokone - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 / %2 käytössä</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Tallennettu verkossa</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Tiedostosi pysyvät pilvipalvelussa eivätkä käytä tilaa tietokoneellasi.
+Internet-yhteys vaaditaan niiden käyttämiseen.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synkronointivirhe</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Mukautettu kansio</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Oletuskansio</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synkronointi</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Uutta synkronointitilaa sovelletaan…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synkronointisäännöt</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Virhe tapahtui</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Viimeisin synkronointi onnistui</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synkronointi on keskeytetty</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synkronointi on käynnissä</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synkronoitu</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synkronoitu</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkronoitu tietokoneeltasi</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkronoitu kDrive-verkkopalvelusta</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>tiedostosi synkronoidaan</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synkronointi on keskeytetty</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Viimeisimmät tiedostosi päivitetään.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronointi käynnissä</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Lataamasi tiedostot ovat edelleen käytettävissä.
+Synkronointi jatkuu automaattisesti, kun olet jälleen yhteydessä verkkoon.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline-tila</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Synkronointi on tilapäisesti pysäytetty.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synkronointi tauon aikana</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Tiedostosi ovat käytettävissä ja synkronoitu.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Ei toimintaa käynnissä</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>tiedostosi ovat ajan tasalla</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synkronointi</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Synkronointikansiossasi oleva tiedosto tai kansio näyttää olevan vioittunut.
+Synkronointi on keskeytetty. Tarkista tiedostosi ja yritä uudelleen.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Vioittunut tiedosto havaittu</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Toiminta</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Aloitus</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Tallennus</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Kansio ei saa olla aseman juuri eikä se saa sisältää tai olla jo synkronoidun kansion sisällä.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Kansion on oltava tyhjä, se ei saa olla aseman juuri, eikä se saa sisältää tai olla jo synkronoidun kansion sisällä.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Tätä kansiota ei voi käyttää</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Yksittäinen käsittely</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Synkronoinnin hallinta</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Ilmoitus kertoo sinulle, kun tiedosto suljetaan pois tällä säännöllä</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Sulje kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Avaa kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Asetukset</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Tarkista, että internet-yhteysi on aktiivinen, että tätä nimeä ei ole jo käytössä ja ettei se sisällä virheellisiä merkkejä.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Tätä kansiota ei voi luoda</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Luvaton käyttö</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Tiedostosi ovat käytettävissä ja synkronoitu.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Ei viimeaikaista toimintaa</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Yritä uudelleen hetken kuluttua.
+Jos ongelma jatkuu, ota yhteyttä tukeen.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Odottamaton virhe tapahtui</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Huomiseen saakka</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 saatavilla</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Asennus kestää alle minuutin.
+Synkronointi jatkuu automaattisesti lopuksi.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ohita tämä versio</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Asenna nyt</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Muistuta myöhemmin</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Katso uutuudet</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versio %1 · Käytät versiota %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Päivitys saatavilla</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Uusi kDrive-versio on tarpeen jatkamiseksi.
+Päivitä sovellus päästäksesi tiedostoihisi ja jatkaaksesi synkronointia.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Päivitys vaaditaan</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Päivitys</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Keskeytynyt lataus</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Sulje tietyt sovellukset synkronoinnin ulkopuolelle.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Lisää synkronoinnista poissuljetavat tiedostot.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Mukautetut poissulkemissäännöt</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Sulje tietyt tiedostotyypit synkronoinnin ulkopuolelle.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Näytä lähdekoodi</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Sinulla on synkronointivirhe</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Sinulla on {0} synkronointivirhettä</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive ei pääse levylle %1
+Varmista, että se on kytketty,
+lukitsematon ja tietokoneeltasi käytettävissä.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Tallennuslevy %1 ei ole käytettävissä</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Poista</numerusform> 
+                <numerusform>Poista (%1 sääntöä)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Muutosta sovelletaan…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Hallitse levytilaa</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Avaa yläkansio</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Päivitä</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Virheenkorjaustaso</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synkronointi käynnistyy automaattisesti uudelleen.
+Jos ongelma jatkuu, ota yhteyttä tukeen ja liitä alla olevat tekniset tiedot.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Tekniset tiedot</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Odottamaton virhe tapahtui</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Poisto peruutettu</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Nimien kaksoiskappale</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Sinulla ei ole tarvittavia käyttöoikeuksia lisätäksesi %1 tähän sijaintiin.
+Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Sinulla ei ole lupaa poistaa tätä %1. Se on palautettu alkuperäiseen sijaintiinsa. Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Kohteen %1 käyttöoikeuksia muutettiin, mikä estää sen synkronoinnin.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Tällä nimellä on jo olemassa tiedosto tai kansio.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Sinulla ei ole oikeuksia muokata tätä tiedostoa.
+Alkuperäinen versio on säilytetty ja muokkauksesi on tallennettu erilliseen tiedostoon, jonka nimessä on "konflikti". Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Tämän %1 nimi päättyy välilyöntiin, mikä estää sen synkronoinnin. Nimeä %2 uudelleen kDrive-verkkopalvelusta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Poissulkemissääntö estää tämän %1 synkronoinnin.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Tällä nimellä on jo olemassa tiedosto.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Toinen käyttäjä käyttää tätä tiedostoa parhaillaan.
+Muutoksesi synkronoidaan myöhemmin.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Tämä tiedosto poistettiin kDrive-verkkopalvelusta muokkauksen aikana. Kopio on säilytetty tietokoneellasi palautuskansiossa.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Tämä tiedosto ylittää sallitun enimmäiskoon (50 Gt).
+Ota yhteyttä järjestelmänvalvojaasi tiedostokokorajan kasvattamiseksi.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Tämä nimi sisältää vain välilyöntejä eikä sitä voi käyttää. Nimeä %1 uudelleen kDrive-verkkopalvelusta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Tämä tiedosto on kiintolinkkitiedosto, jota ei voi synkronoida.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Sinulla ei ole oikeuksia siirtää tätä %1 tähän; se palautetaan alkuperäiseen sijaintiinsa. Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Tämä nimi ylittää sallitun pituuden (250 merkkiä). Nimeä %1 uudelleen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Tietokoneellasi ei ole tarpeeksi tilaa tämän tiedoston synkronointiin.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Koko kansio on suuri.
+Lähetyksen nopeuttamiseksi suosittelemme lähettämään vain viimeisen kDrive-istunnon.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Lähetä vain viimeisin istunto</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_fi.ts
+++ b/src/gui4/linux/translations/client_fi.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="fi"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ lukitsematon ja tietokoneeltasi käytettävissä.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Muutosta sovelletaan…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Hallitse levytilaa</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Avaa yläkansio</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Päivitä</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Virheenkorjaustaso</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Jos ongelma jatkuu, ota yhteyttä tukeen ja liitä alla olevat tekniset tiedot.<
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Tekniset tiedot</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Odottamaton virhe tapahtui</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Poisto peruutettu</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Nimien kaksoiskappale</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Sinulla ei ole lupaa poistaa tätä %1. Se on palautettu alkuperäiseen sijaintiinsa. Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Kohteen %1 käyttöoikeuksia muutettiin, mikä estää sen synkronoinnin.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Tällä nimellä on jo olemassa tiedosto tai kansio.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ Alkuperäinen versio on säilytetty ja muokkauksesi on tallennettu erilliseen ti
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Tämän %1 nimi päättyy välilyöntiin, mikä estää sen synkronoinnin. Nimeä %2 uudelleen kDrive-verkkopalvelusta.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Poissulkemissääntö estää tämän %1 synkronoinnin.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Tällä nimellä on jo olemassa tiedosto.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Muutoksesi synkronoidaan myöhemmin.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Tämä tiedosto poistettiin kDrive-verkkopalvelusta muokkauksen aikana. Kopio on säilytetty tietokoneellasi palautuskansiossa.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Ota yhteyttä järjestelmänvalvojaasi tiedostokokorajan kasvattamiseksi.</trans
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Tämä nimi sisältää vain välilyöntejä eikä sitä voi käyttää. Nimeä %1 uudelleen kDrive-verkkopalvelusta.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Tämä tiedosto on kiintolinkkitiedosto, jota ei voi synkronoida.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Sinulla ei ole oikeuksia siirtää tätä %1 tähän; se palautetaan alkuperäiseen sijaintiinsa. Pyydä käyttöoikeutta omistajalta tai järjestelmänvalvojalta.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Tämä nimi ylittää sallitun pituuden (250 merkkiä). Nimeä %1 uudelleen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Tietokoneellasi ei ole tarpeeksi tilaa tämän tiedoston synkronointiin.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="fr"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ déverrouillé et accessible depuis votre ordinateur.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Appliquer le changement…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Gérer l’espace disque</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Ouvrir le dossier parent</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Mettre à jour</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Niveau de débogage</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Si le problème persiste, contactez notre support en joignant les détails techn
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Détails techniques</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Une erreur inattendue s’est produite</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Suppression annulée</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Dédoublement de noms</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Demandez l’accès au propriétaire ou à l’administrateur.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Vous n’avez pas l’autorisation de supprimer ce %1. Il a été restauré à son emplacement d’origine. Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Les droits d’accès du %1 ont été modifiés, ce qui empêche sa synchronisation.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Un fichier ou un dossier portant ce nom existe déjà.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ La version originale a été conservée et votre modification a été enregistr�
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Le nom de ce %1 se termine par un espace, ce qui empêche sa synchronisation. Renommez le %2 depuis kDrive en ligne.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Une règle d’exclusion empêche la synchronisation de ce %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Un fichier portant ce nom existe déjà.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Vos modifications seront synchronisées ultérieurement.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Ce fichier a été supprimé sur kDrive en ligne pendant que vous le modifiiez. Une copie a été conservée sur votre ordinateur dans le dossier de récupération.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contactez votre administrateur pour augmenter la limite de taille des fichiers.<
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Ce nom contient uniquement des espaces et ne peut pas être utilisé. Renommez le %1 depuis kDrive en ligne.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Ce fichier est un lien système (hard link) qui ne peut pas être synchronisé.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Vous ne disposez pas des droits pour déplacer ce %1 ici, il sera restauré à son emplacement d’origine. Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Ce nom dépasse la longueur autorisée (250 caractères). Renommez le %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Il n’y a plus assez d’espace sur votre ordinateur pour synchroniser ce fichier.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: fr, French
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="fr"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Version %1 (compilation %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>À propos</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>À propos de kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Développé et hébergé exclusivement en Suisse, kDrive assure une protection totale de vos données, sans revente ni espionnage, dans des centres certifiés ISO, avec chiffrement et sauvegarde sur plusieurs supports.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Activités visibles</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Choisir le canal de distribution</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Voir plus d’informations</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Effacer la recherche</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Rechercher vos fichiers</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Recherche en cours…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Sélectionner un mode de synchronisation</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synchronisation terminée</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synchronisation en cours</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Aucune activité récente</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Vous êtes hors ligne</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synchronisation interrompue</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Toutes les activités</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Mon activité uniquement</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synchroniser un dossier avec kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Choisissez le dossier de votre ordinateur à synchroniser sur kDrive :</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Dossier synchronisé</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Personnalisez l’emplacement du dossier de votre ordinateur sur kDrive :</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Choisissez l’emplacement du dossier sur kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Emplacement kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Sélectionnez un dossier sur votre ordinateur à synchroniser avec kDrive.
+Vous pouvez accéder à vos synchronisations avancées à partir du sélecteur de lecteur de la page d’accueil.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synchroniser un dossier avec kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Synchronisation avancée</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Application à exclure</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>L’application est à jour</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Supprime les journaux datant de plus de 7 jours pour économiser de l’espace.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Nettoyage automatique</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Mises à jour automatiques</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Disponibles hors ligne</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Vos fichiers sont copiés sur votre ordinateur.
+Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Vous pouvez le réveiller à partir de l’interface web.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Bénéficiez d’un accès anticipé aux nouvelles versions de l’application avant qu’elles ne soient diffusées au grand public et participez à l’amélioration de l’application en nous partageant vos idées d’améliorations.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Rejoindre le programme bêta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Votre navigateur devrait s’ouvrir automatiquement pour finaliser la connexion. Une fois connecté, vous reviendrez automatiquement dans kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Activer la synchronisation hors ligne</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synchroniser un dossier</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Ajouter une règle</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Ajouter du stockage</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Paramètres avancés</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Appliquer aux %1 fichiers</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Demander l’accès</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Annuler</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Modifier le dossier</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Stocker hors ligne</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Stocker en ligne</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Changer d’utilisateur</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Fermer</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Fermer kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configurer</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Confirmer</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Se connecter</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Connecter un compte</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contacter le support</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Continuer</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Copier le lien de partage</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Créer un compte</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Créer une nouvelle synchronisation</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Emplacement personnalisé</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Déconnecter ce compte</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Téléchargement en cours…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Télécharger manuellement</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Activer</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Activer dans les paramètres Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Comprendre le problème</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Partager une idée</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Terminer l’installation</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Corriger les erreurs</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>J’ai activé kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive en ligne</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Garder le compte</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Déconnecter</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Se connecter</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Gérer</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Traiter les fichiers individuellement</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Gérer le stockage</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Ouvrir le dossier de débogage</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Ouvrir l’explorateur</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Ouvrir le dossier</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Ouvrir dans le navigateur</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Ouvrir dans l’explorateur</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Ouvrir dans Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Ouvrir dans kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Ouvrir kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Gérer les exclusions</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Ouvrir les paramètres de synchronisation</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pause</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Rafraîchir</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Notes de mise à jour</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Supprimer</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Supprimer (%n élément)</numerusform> 
+                <numerusform>Supprimer (%n éléments)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Supprimer la synchronisation</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Renommer le %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Relancer la connexion</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Reprendre la synchronisation</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Redémarrer la synchronisation</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Réessayer</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Revenir au dossier par défaut</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Enregistrer</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Sauvegarder mes choix</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Recherche</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Voir les activités</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Sélectionner</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Sélectionner un dossier</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Sélectionner les dossiers</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Sélectionner un emplacement</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Sélectionné</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Envoyer</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Envoyer le dossier de débogage</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Ouvrir les paramètres</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Voir les offres</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Afficher les options</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Se déconnecter</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Démarrage</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Commencer le choix des versions</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Commencer gratuitement</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synchroniser hors ligne</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Mettre à jour maintenant</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Mettre à jour l’abonnement</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Mise à niveau</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Valider</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Valider et passer au suivant</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Réveil</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Choisir une version</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Deux versions différentes de ces fichiers ont été détectées.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Conflits de versions</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Rechercher un fichier</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Copie du lien…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Création du lien de partage…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Vous pouvez personnaliser les données d’utilisation et opérationnelles qui sont récupérées par Infomaniak pour corriger des bugs et faire évoluer l’application. Les deux outils utilisés sont hébergés et gérés exclusivement chez nous.
+
+Le code source de cette application peut être vérifié, les informations récoltées sont anonymes et vos informations personnelles restent strictement confidentielles et ne sont jamais partagées avec des tiers.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Gestion des données</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respecte votre vie privée</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Sélectionner la quantité d’informations enregistrées.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Permettent au support Infomaniak d’identifier l’origine d’un incident.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Journaux de débogage</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Ces applications sont ignorées par défaut et ne peuvent pas être modifiées.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Ces fichiers sont ignorés par défaut et ne peuvent pas être modifiés.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Exclusion automatique</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>Dans ces situations, une nouvelle synchronisation est nécessaire pour continuer à utiliser kDrive correctement.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Veuillez sélectionner un dossier vide qui ne se trouve pas à la racine d’un lecteur.
+
+Ce dossier ne doit pas être inclus dans un autre dossier de synchronisation et ne doit pas contenir de sous-dossier de synchronisation.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Ce dossier ne peut pas être sélectionné</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Ajouter une règle</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Ajouter une règle d’exclusion</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Vous allez déconnecter %1 de l’application.
+Le dossier de synchronisation restera sur votre ordinateur, mais ne sera plus synchronisé avec kDrive.
+
+Toutes vos données resteront accessibles en ligne sur kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Se déconnecter de ce compte ?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Le dossier local restera sur votre ordinateur, mais il ne sera plus synchronisé avec kDrive.
+Cette action est permanente.
+Pour synchroniser à nouveau votre lecteur, vous devrez le reconnecter plus tard.
+
+Avant de continuer, assurez-vous que tous vos fichiers sont à jour et entièrement synchronisés.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Supprimer la synchronisation ?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Le changement de mode de synchronisation a été annulé.
+
+La synchronisation actuelle reste inchangée. Toutefois, si un comportement anormal se produit, vous devrez peut-être supprimer et recréer la synchronisation pour rétablir le bon fonctionnement.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Une erreur s’est produite</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Cette opération peut prendre un certain temps, selon la taille de vos données. En cas d’échec, une nouvelle synchronisation complète du drive pourra être nécessaire.
+
+Avant de continuer, assurez-vous que tous vos fichiers sont bien à jour et synchronisés.
+
+Ne fermez pas l’application pendant le processus.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Changer le mode de synchronisation ?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Voici comment rétablir la synchronisation :</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Le disque contenant votre dossier de synchronisation n’est plus connecté</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Reconnectez-le pour reprendre la synchronisation.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Désactiver les notifications</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Ne pas rejoindre</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/fr/applications/telecharger-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Vous n’avez pas la permission d’accéder à ce kDrive.
+Veuillez vérifier vos autorisations ou contacter votre administrateur.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Accès refusé au kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Votre kDrive est en veille</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Ce kDrive n’a pas été renouvelé. Vous ne pouvez plus y accéder.
+Renouvelez votre abonnement pour réactiver le service.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Ce kDrive n’a pas été renouvelé. Vous ne pouvez plus y accéder.
+Contactez votre administrateur pour réactiver le service.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Votre kDrive a expiré</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Reconnectez-vous pour continuer à utiliser kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Vous avez été déconnecté</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Le compte utilisé pour cette connexion ne correspond pas à celui de ce kDrive.
+Veuillez vous connecter à nouveau avec l’adresse électronique correcte %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Ce compte ne correspond pas</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>Le kDrive est en cours de réveil… cela peut prendre quelques instants.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>Réveil du kDrive en cours</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Enregistrer les informations de diagnostic sur mon ordinateur.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Activer l’enregistrement des informations de débogage</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Entrez votre mot de passe</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Un autre %1 dont le nom diffère uniquement par les majuscules/minuscules existe déjà dans ce dossier. Ce type de nom n’est pas pris en charge par l’application kDrive Windows. Renommez l’un des %2 depuis kDrive en ligne pour pouvoir le synchroniser sur votre PC.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Conflit de noms à la casse près</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Un changement a été détecté dans votre configuration</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>Dans ces situations, une nouvelle synchronisation peut être nécessaire pour continuer à utiliser kDrive correctement.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Consultez la %1 pour rétablir l’accès</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Dernier emplacement du %1 :</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Disque externe déconnecté</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Cette opération peut prendre un certain temps, selon la quantité de données à traiter.
+
+Ne fermez pas l’application pendant le processus.
+
+En cas d’échec, vous pourrez lancer facilement une nouvelle synchronisation complète du drive ou contacter notre support.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Activer la synchronisation hors ligne</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Ce kDrive est temporairement indisponible pour cause de maintenance.
+Veuillez réessayer dans quelques minutes.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Maintenance en cours</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Espace à la fin du nom du %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Exclu de la synchronisation</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Fichier verrouillé</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Fichier récupéré</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Ce fichier dépasse la taille maximale autorisée (50 Go).
+Contactez le support pour débloquer la limite.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Fichier trop volumineux</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Accès interdit</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Le nom de ce %1 contient un ou plusieurs caractères non pris en charge par l’application kDrive. Renommez le %2 depuis kDrive en ligne.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Nom invalide</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Caractère non pris en charge</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Vous n’avez pas les droits nécessaires pour effectuer cette action.
+Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Accès interdit</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Type de fichier non pris en charge</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Ce dossier n’est plus accessible à son emplacement d’origine.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Dossier de synchronisation introuvable</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Un de vos kDrive est synchronisé à l’intérieur du dossier de synchronisation d’un autre kDrive.
+Déplacez l’un des dossiers pour qu’ils ne soient plus imbriqués ou supprimez votre synchronisation pour la recréer.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>kDrive imbriqués</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Impossible d’accéder à ce %1 sur votre ordinateur. Vérifiez qu’il existe toujours et que vous disposez des droits pour y accéder.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 inaccessible</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Nom de %1 trop long</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Impossible de se connecter à kDrive.
+La synchronisation reprendra automatiquement dès que la connexion sera rétablie.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Connexion temporairement indisponible</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espace disque insuffisant</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Le nom de ce fichier contient un ou plusieurs caractères non pris en charge par l’application kDrive. Renommez le fichier depuis kDrive en ligne.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Caractère non pris en charge</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Le chemin d’accès à ce %1 est trop long pour être synchronisé. Renommez un ou plusieurs dossiers dans lesquels il se trouve pour raccourcir le chemin.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Chemin d’accès au %1 trop long</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Votre kDrive est plein. Libérez de l’espace ou mettez à niveau votre abonnement pour synchroniser ce %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Limite de stockage atteinte</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Ce nom est réservé par le système de votre ordinateur. Renommez le %1 depuis kDrive en ligne.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Nom de %1 réservé</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Vérifiez l’emplacement ou les droits d’accès du dossier.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Dossier de synchronisation inaccessible</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync n’a pas les autorisations nécessaires pour fonctionner.
+ Ouvrez les Préférences macOS pour les activer.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorisation requise</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>L’espace disque de votre appareil est plein. La synchronisation est interrompue. Libérez de l’espace pour reprendre la synchronisation.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espace disque insuffisant</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Ce dossier n’est plus accessible à son emplacement d’origine.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Ce dossier n’est plus accessible. Une action est nécessaire pour reprendre la synchronisation.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Dossier de synchronisation introuvable</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync n’arrive pas à démarrer. Vous pouvez continuer à synchroniser vos fichiers en activant la synchronisation hors-ligne dans les paramètres. Contactez le support si le problème persiste.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Impossible de démarrer Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>La synchronisation de cet élément n’a pas réussi. Elle sera relancée automatiquement plus tard.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synchronisation temporairement échouée</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Le téléversement n’a pas pu être terminé. Veuillez réessayer plus tard.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Il semble que nous ne pouvons pas charger l’application…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Une erreur s’est produite lors de la suppression de votre compte.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Fichiers à vérifier</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Autres</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Système et autorisations</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Impossible d’ouvrir l’URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Erreurs à corriger</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Ce dossier ne peut pas être synchronisé. Veuillez sélectionner un autre dossier.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Erreur lors du démarrage du programme d’installation</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Erreur lors du changement de mode de synchronisation</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Bloquez les applications susceptibles de télécharger ou modifier vos fichiers.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Les fichiers correspondant à cette règle ne seront pas synchronisés.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Évitez que certains fichiers temporaires ou système ne soient copiés dans kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Active la collecte d’informations supplémentaires utiles au support.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Journal détaillé étendu</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Lorsque cette option est activée, kDrive fonctionne plus lentement.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Échec de la création d’un lien de partage</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/fr/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Aidez-nous à améliorer kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/fe6ca4b6-5812-4f39-8ca6-5f2300aecda6</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Une notification vous informe lorsqu’un fichier est exclu par cette règle.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Le fichier existe déjà</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Mode de synchronisation des fichiers</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Définissez comment vos fichiers sont stockés et accessibles.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Fichiers à exclure</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoris</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Partages</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Corbeille</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Pendant 1 heure</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Pendant une semaine</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Pendant trois jours</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Bonjour %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/fr/aide</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Support Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Libérez de l’espace ou mettez votre forfait à niveau pour continuer à synchroniser vos fichiers.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Votre kDrive est plein</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Certains fichiers n’ont pas pu être synchronisés.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Vous avez &lt;b&gt;une erreur&lt;/b&gt; de synchronisation</numerusform> 
+                <numerusform>Vous avez &lt;b&gt;%n erreurs&lt;/b&gt; de synchronisation</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Nous n’arrivons pas à accéder à vos fichiers. Redémarrez l’application pour relancer la synchronisation. Si le problème continue, contactez le support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Connexion à kDrive interrompue</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Activez kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Vous devez activer kDrive.app avant de continuer</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Activez kDrive et kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Vous devez activer les autorisations avant de continuer</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Allez dans Confidentialité et sécurité &gt; Accès complet au disque</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Accès complet au disque</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Confidentialité et sécurité</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Sélectionnez Ouverture et extensions &gt; Extensions de sécurité</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Extensions de sécurité</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Ouverture et extensions</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Ouvrez les Réglages système &gt; Général</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Réglages système</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Redémarrez l’application si demandé</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Cet élément n’est pas disponible sur cet appareil.
+Il s’ouvrira dans votre navigateur.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/fr/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Droits d’accès modifiés</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Activé</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>il y a %1</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Tous les dossiers</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Tout le kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Autoriser le suivi</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Identifiant de l’application</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Nom de l’application</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Auteur</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Par défaut</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>o</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Choisissez la version de vos fichiers que vous souhaitez conserver.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Pour chaque fichier, sélectionnez la version à conserver.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Quelle version souhaitez-vous garder ?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Choisir la version à conserver</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Les versions en ligne de ces %1 fichiers seront remplacées par vos versions locales.
+Attention, cela peut écraser le travail de vos collaborateurs.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Conserver uniquement les versions locales</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Pour chaque conflit, nous conserverons automatiquement la version (locale ou en ligne) modifiée le plus récemment. C’est le choix le plus sûr dans la plupart des cas.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Conserver les versions les plus récentes</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Toutes les modifications locales pour ces %1 fichiers seront annulées.
+Utile si vous savez que le travail important est en ligne sur kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Conserver uniquement les versions en ligne</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Connectez-vous pour commencer.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Créez une %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Date</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Desactivé</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>fichier</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Dossier</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Dossier supprimé</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Dossier déplacé ou modifié</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Le dossier a peut-être été déplacé vers un autre disque puis remis à son emplacement initial.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>dossier</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Dossier déplacé ou renommé</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Dossier recréé ou remplacé</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Le dossier a été supprimé puis recréé, ou remplacé par un autre dossier portant le même nom.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>Go</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>À l’instant</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>Ko</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Locale</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 fichiers ont été modifiés à la fois sur votre ordinateur et sur kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>Mo</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Plus récente</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nom</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Nouvel appareil détecté</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Vous utilisez kDrive sur un nouvel ordinateur, après une restauration depuis une sauvegarde.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nouveau dossier</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nouvelle synchronisation</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Aucun conflit ne correspond à votre recherche</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Aucune erreur à corriger</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notification</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Notifier si fichier exclu</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Désactivé</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>En ligne</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Dossier supprimé en ligne</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Le dossier synchronisé a été supprimé sur kDrive en ligne ou n’est plus accessible.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Emplacement d’origine :</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Recommandé</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Le dossier a peut-être été déplacé vers un autre disque puis remis à son emplacement initial.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Remettez-le à son emplacement d’origine.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Règles</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Identique au système</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sec</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Depuis : %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Taille</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Statut</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 libre</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 libres</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Calcul…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 utilisé</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 utilisés</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synchronisé à partir de kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synchronisé à partir de votre ordinateur</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Ce kDrive contient uniquement des fichiers. Tous les fichiers seront synchronisés sur cet appareil.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Aucun dossier à sélectionner</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Dossiers de synchronisation</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Emplacement</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synchronisez vos kDrive sur cet appareil</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Dossiers synchronisés</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synchronisation</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>To</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Temps</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bienvenue sur kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 sur %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Gestion de kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Langue</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Redémarrez l’application pour finir d’appliquer la nouvelle langue.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>En savoir plus</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Licence LGPL v3 - Sources Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Lien copié dans le presse-papiers</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Disque incompatible ou dossier directement à la racine du disque (ex : choisissez un dossier comme /Mon drive au lieu de /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Disque incompatible ou dossier directement à la racine du disque (ex : choisissez un dossier comme D:/Mon drive au lieu de D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Emplacement sur l’ordinateur</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Débogage</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Erreur</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Étendu</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Critique</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Avertissement</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Envoyer le dossier de débogage au support Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Certains noms de fichiers peuvent contenir des caractères spéciaux non pris en charge (tels que des guillemets doubles, des barres obliques inversées ou des sauts de ligne).
+
+Veuillez vérifier et renommer les fichiers contenant des caractères inhabituels, puis réessayez.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Nom de fichier invalide</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Compression des journaux…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Transfert des journaux vers le support…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Le dernier transfert a échoué. Veuillez vérifier votre connexion Internet et vous assurer qu’au moins un utilisateur de kDrive est connecté. Les transferts sont limités à 10 par jour.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Des versions différentes de ces fichiers ont été détectées.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 conflits de versions détectés</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo est un outil d’analyse hébergé et géré exclusivement par Infomaniak pour comprendre comment l’application est utilisée.
+
+L’étude de ces données permet à notre équipe d’améliorer en continu l’interface de l’application.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Déplacement annulé</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Déplacer les fichiers supprimés dans la corbeille de l’ordinateur</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Certains éléments ne pourront pas être déplacés.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Plus d’espace de stockage, plus de fonctionnalités avec ma kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Besoin d’aide ?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Réseau</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Ajoutez un compte pour commencer</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Aucun résultat trouvé</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Non synchronisé</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Toujours</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Jamais</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Recevoir une notification lorsqu’un fichier est exclu</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Configurer la synchronisation pour ce kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Personnalisez l’emplacement de votre dossier kDrive sur votre ordinateur :</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Le dossier choisi doit être vide pour que la synchronisation fonctionne correctement.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Choisissez les dossiers à synchroniser sur cet ordinateur :</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Dossiers synchronisés</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Pour chaque kDrive, vous pourrez choisir où il est synchronisé sur votre ordinateur et quels dossiers synchroniser.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Contenu synchronisé :</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Contenu synchronisé : %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Emplacement :</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Emplacement : %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Configurer vos kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Choisissez les dossiers à synchroniser sur cet ordinateur</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Les fichiers sont téléchargés uniquement à l’ouverture, pour économiser de l’espace disque.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Activer la Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Ce kDrive est déjà configuré.
+Allez dans vos paramètres pour le modifier.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autorisez kDrive dans les réglages macOS :</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Activez kDrive sur votre Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Pour terminer l’installation, vous devez autoriser kDrive à accéder à vos dossiers :</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autorisez l’accès aux dossiers</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Commencez gratuitement avec my kSuite,
+ou choisissez une offre adaptée à vos besoins.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Vous n’avez pas encore de kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Choisissez les kDrive à synchroniser sur cet ordinateur :</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisation en cours</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Content de vous retrouver !</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Tous les dossiers kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Sélection personnalisée</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Le cloud privé, rapide et sécurisé, hébergé en Suisse.
+
+Connectez-vous et gardez vos documents synchronisés sur tous vos appareils.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Une erreur est survenue, veuillez réessayer.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Erreur de connexion</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Encore quelques instants, nous chargeons votre compte…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Connexion depuis votre navigateur…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Récupération de vos informations…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Un instant…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bienvenue dans kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Vos fichiers sont prêts à être synchronisés
+en toute sécurité sur votre ordinateur.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Tout est prêt !</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Nous finalisons la configuration de vos kDrive.
+
+Nous vous invitons à patienter quelques instants.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synchronisation en cours…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Ouvrir kDrive au démarrage de l’ordinateur</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Ouvrir la page de connexion</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Chemin copié dans le presse-papiers</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Définissez comment kDrive se connecte à Internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Serveur</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Authentification requise</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Mot de passe</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Paramètres Proxy</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Type de proxy</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Configuration manuelle</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Aucun</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Nom d’utilisateur</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Bêta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Interne</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Emplacement sur kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Recherche dans %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Rechercher…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>Ce fichier n’est pas disponible localement et sera ouvert dans votre navigateur</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Rechercher vos fichiers</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Sélectionnez les dossiers à synchroniser sur cet ordinateur.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Les dossiers non sélectionnés ne seront pas téléchargés sur votre appareil. Ils resteront disponibles en ligne et ne seront pas supprimés.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Les dossiers non sélectionnés ne seront pas téléchargés sur votre appareil. Ils resteront disponibles en ligne.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry est un outil hébergé et géré exclusivement par Infomaniak pour surveiller en temps réel la stabilité de l’application et signaler automatiquement d’éventuelles erreurs techniques à nos développeurs.
+
+Ces données permettent à notre équipe de rapidement corriger et optimiser l’application, ce qui se traduit par une meilleure expérience d’utilisation pour vous.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Paramètres</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Comptes &amp; Synchronisations</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avancés</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Général</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Dossier kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Connectez-vous dans votre navigateur</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Ouvrir kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Quitter</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Paramètres</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Espace libre de l’ordinateur</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>Fichiers kDrive stockés sur l’ordinateur</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Autres fichiers de l’ordinateur</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Utilisation de l’espace de chargement…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Espace libre</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Autres fichiers</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Fichiers kDrive stockés sur votre appareil</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive ne peut pas accéder au volume
+Assurez-vous qu’il est bien connecté,
+déverrouillé et accessible depuis votre ordinateur.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Le volume n’est pas accessible</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Gérez les dossiers synchronisés pour libérer de l’espace sur votre Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synchronisation</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Ce PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 sur %2 utilisés</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Stockés en ligne</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Vos fichiers restent dans le cloud et n’utilisent pas de place sur votre ordinateur.
+Connexion internet requise pour y accéder.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Erreur de synchronisation</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Dossier personnalisé</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Dossier par défaut</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synchronisation</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Votre nouveau mode de synchronisation est en cours d’application…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Règles de synchronisation</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Une erreur s’est produite</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>La dernière synchronisation a réussi</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>La synchronisation est en pause</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>La synchronisation est en cours</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synchronisé</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synchronisé</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synchronisé à partir de votre ordinateur</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synchronisé depuis kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>vos fichiers se synchronisent</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>la synchronisation est en pause</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Vos fichiers récents sont en train d’être mis à jour.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisation en cours</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Vos fichiers téléchargés restent accessibles.
+La synchronisation reprendra automatiquement dès que vous serez reconnecté.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Hors ligne</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>La synchronisation est temporairement arrêtée.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synchronisation en pause</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Vos fichiers sont accessibles et synchronisés.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Aucune activité en cours</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>vos fichiers sont à jour</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synchronisation</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Un fichier ou un dossier dans votre dossier de synchronisation semble être corrompu.
+La synchronisation a été interrompue. Veuillez vérifier vos fichiers et réessayer.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Fichier corrompu détecté</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Activité</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Accueil</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Stockage</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Le dossier ne pas doit pas être la racine d’un lecteur et ne pas contenir ni être dans un dossier déjà synchronisé.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Le dossier doit être vide, ne pas être la racine d’un lecteur et ne pas contenir ni être dans un dossier déjà synchronisé.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Ce dossier ne peut pas être utilisé</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Traitement individuel</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Gérer la synchronisation</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Une notification vous informe lorsqu’un fichier est exclu par cette règle</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Fermer kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Ouvrir kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Paramètres</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Essayez un terme de recherche différent</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Tapez pour commencer la recherche</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Vérifiez que votre connexion internet est active, que ce nom n’est pas déjà utilisé et qu’il ne contient pas de caractères invalides.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Impossible de créer ce dossier</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Accès non autorisé</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Vos fichiers sont accessibles et synchronisés.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Aucune activité récente</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Veuillez réessayer dans quelques instants.
+Si le problème persiste, veuillez contacter le service d’assistance.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Une erreur inattendue s’est produite</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Jusqu’à demain</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 disponible</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>L’installation prend moins d’une minute.
+Votre synchronisation reprendra automatiquement à la fin.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorer cette version</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Installer maintenant</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Me rappeler plus tard</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Voir les nouveautés</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Version %1 · Vous utilisez la %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Mise à jour disponible</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Une nouvelle version de kDrive est nécessaire pour continuer.
+Mettez à jour l’application pour accéder à vos fichiers et relancer la synchronisation.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Mise à jour requise</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Mise à jour</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Téléversement incomplet</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Excluez certaines applications de la synchronisation.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Ajouter des fichiers à exclure de la synchronisation.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Règles d’exclusion personnalisées</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Excluez certains types de fichiers de la synchronisation.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Voir le code source</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Vous avez une erreur de synchronisation</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Vous avez {0} erreurs de synchronisation</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive ne peut pas accéder au disque %1
+Assurez-vous qu’il est bien connecté,
+déverrouillé et accessible depuis votre ordinateur.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Le disque de stockage %1 n’est pas accessible</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Supprimer</numerusform> 
+                <numerusform>Supprimer (%1 règles)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Appliquer le changement…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Gérer l’espace disque</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Ouvrir le dossier parent</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Mettre à jour</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Niveau de débogage</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>La synchronisation va redémarrer automatiquement.
+Si le problème persiste, contactez notre support en joignant les détails techniques ci-dessous.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Détails techniques</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Une erreur inattendue s’est produite</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Suppression annulée</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Dédoublement de noms</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Vous n’avez pas les droits nécessaires pour ajouter un %1 à cet emplacement.
+Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Vous n’avez pas l’autorisation de supprimer ce %1. Il a été restauré à son emplacement d’origine. Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Les droits d’accès du %1 ont été modifiés, ce qui empêche sa synchronisation.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Un fichier ou un dossier portant ce nom existe déjà.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Vous n’avez pas les droits pour modifier ce fichier.
+La version originale a été conservée et votre modification a été enregistrée dans un fichier séparé avec “conflit” dans son nom. Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Le nom de ce %1 se termine par un espace, ce qui empêche sa synchronisation. Renommez le %2 depuis kDrive en ligne.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Une règle d’exclusion empêche la synchronisation de ce %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Un fichier portant ce nom existe déjà.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Ce fichier est actuellement utilisé par un autre utilisateur.
+Vos modifications seront synchronisées ultérieurement.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Ce fichier a été supprimé sur kDrive en ligne pendant que vous le modifiiez. Une copie a été conservée sur votre ordinateur dans le dossier de récupération.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Ce fichier dépasse la taille maximale autorisée (50 Go).
+Contactez votre administrateur pour augmenter la limite de taille des fichiers.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Ce nom contient uniquement des espaces et ne peut pas être utilisé. Renommez le %1 depuis kDrive en ligne.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Ce fichier est un lien système (hard link) qui ne peut pas être synchronisé.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Vous ne disposez pas des droits pour déplacer ce %1 ici, il sera restauré à son emplacement d’origine. Demandez l’accès au propriétaire ou à l’administrateur.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Ce nom dépasse la longueur autorisée (250 caractères). Renommez le %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Il n’y a plus assez d’espace sur votre ordinateur pour synchroniser ce fichier.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Le dossier complet est volumineux.
+Pour accélérer l’envoi, nous vous recommandons de n’envoyer que la dernière session kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Envoyer uniquement la dernière session</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fr, French
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fr"> 
     <context>
@@ -344,6 +344,16 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</translati
             <source>Manage storage</source> 
             <translation>Gérer le stockage</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximiser</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Réduire</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Ouvrir le dossier de débogage</translation> 
@@ -427,6 +437,11 @@ Vous pouvez les ouvrir à tout moment, même sans accès à Internet.</translati
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Redémarrer la synchronisation</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Restaurer</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_fr.ts
+++ b/src/gui4/linux/translations/client_fr.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: fr, French
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="fr"> 
     <context>
@@ -2077,7 +2077,7 @@ Ces données permettent à notre équipe de rapidement corriger et optimiser l�
             <translation>Dossier kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Connectez-vous dans votre navigateur</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: it, Italian
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="it"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versione %1.%2
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versione %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Informazioni</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Informazioni su kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Sviluppato e ospitato esclusivamente in Svizzera, kDrive garantisce la totale protezione dei tuoi dati, senza rivendita né sorveglianza, in data center certificati ISO, con crittografia e backup su più supporti.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Attività visibili</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Scelta del canale di distribuzione</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Vedi altre informazioni</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Cancella ricerca</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Cerca i tuoi file</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Ricerca in corso…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Selezionare una modalità di sincronizzazione</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Sincronizzazione completata</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Sincronizzazione in corso</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Nessuna attività recente</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Sei offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Sincronizzazione sospesa</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Tutte le attività</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Solo la mia attività</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizza una cartella con kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Scegli la cartella del tuo computer da sincronizzare con kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Cartella sincronizzata</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Personalizza la posizione della cartella del tuo computer su kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Scegli la posizione della cartella su kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Posizione su kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Seleziona una cartella sul tuo computer da sincronizzare con kDrive.
+Puoi accedere alle sincronizzazioni avanzate dal selettore di unità nella pagina principale.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizza una cartella con kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Sincronizzazione avanzata</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>App da escludere</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>L’applicazione è aggiornata</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Elimina i log più vecchi di 7 giorni per risparmiare spazio su disco.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Pulizia automatica</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Aggiornamenti automatici</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Disponibile offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>I tuoi file vengono copiati sul tuo computer.
+Puoi aprirli in qualsiasi momento, anche senza connessione a internet.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Puoi riattivarlo dall’interfaccia web.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Ottieni accesso anticipato alle nuove versioni dell’applicazione prima che vengano rilasciate al pubblico e contribuisci a migliorare l’app condividendo con noi le tue idee di miglioramento.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Partecipa al programma beta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Il tuo browser dovrebbe aprirsi automaticamente per completare l’accesso. Una volta effettuato l’accesso, verrai automaticamente reindirizzato a kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Abilita sincronizzazione offline</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Sincronizza una cartella</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Aggiungi una regola</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Aggiungi spazio</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Impostazioni avanzate</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Applica a %1 file</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Richiedi accesso</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Annulla</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Cambia cartella</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Salva offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Salva online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Cambia utente</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Chiudi</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Chiudi kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configura</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Conferma</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Accedi</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Connetti un account</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contatta l’assistenza</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Continua</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Copia link di condivisione</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Crea un account</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Crea una nuova sincronizzazione</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Posizione personalizzata</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Disconnetti questo account</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Download in corso…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Scarica manualmente</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Abilita</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Abilita nelle impostazioni di Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Scopri il problema</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Condividi un’idea</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Installazione finale</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Correggi gli errori</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Supporto</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Ho attivato kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Mantieni account</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Esci</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Accedi</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Gestisci</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Gestisci i file singolarmente</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Gestisci spazio</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Apri cartella debug</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Apri Explorer</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Apri cartella</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Apri nel browser</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Apri in Explorer</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Aprire nel Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Apri in kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Apri kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Gestisci esclusioni</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Apri impostazioni di sincronizzazione</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Sospendi</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Aggiorna</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Note di rilascio</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Rimuovi</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Rimuovi (%n elemento)</numerusform> 
+                <numerusform>Rimuovi (%n elementi)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Rimuovi sincronizzazione</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Rinomina %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Riavvia accesso</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Riprendi sincronizzazione</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Riavvia sincronizzazione</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Riprova</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Torna alla cartella predefinita</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Salva</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Salva le mie scelte</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Cerca</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Visualizza attività</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Seleziona</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Seleziona una cartella</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Seleziona cartelle</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Seleziona una posizione</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Selezionato</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Invia</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Invia cartella debug</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Apri impostazioni</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Visualizza offerte</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Mostra le opzioni</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Esci</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Avvia</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Avvia selezione versione</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Inizia gratuitamente</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Sincronizza offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Aggiorna ora</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Aggiorna abbonamento</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Passa a un’offerta superiore</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Conferma</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Conferma e vai al successivo</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Riattiva</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Scegli una versione</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Sono state rilevate due versioni diverse di questi file.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Conflitti di versione</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Cerca un file</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Copia del link…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Creazione del link di condivisione…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Puoi personalizzare i dati di utilizzo e operativi raccolti da Infomaniak per correggere bug e migliorare l’applicazione. Entrambi gli strumenti utilizzati sono ospitati e gestiti esclusivamente da noi.
+
+Il codice sorgente di questa applicazione è verificabile, le informazioni raccolte sono anonime e i tuoi dati personali rimangono strettamente riservati e non vengono mai condivisi con terze parti.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Gestione dei dati</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak rispetta la tua privacy</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Seleziona la quantità di informazioni da registrare.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Consente al supporto Infomaniak di identificare la causa di un incidente.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Log di debug</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Queste app vengono ignorate per impostazione predefinita e non possono essere modificate.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Questi file sono esclusi per impostazione predefinita e non possono essere modificati.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Esclusione automatica</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>In questi casi, è necessaria una nuova sincronizzazione per continuare a utilizzare kDrive correttamente.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Seleziona una cartella vuota che non si trovi alla radice di un’unità.
+
+Questa cartella non deve essere inclusa in un’altra cartella di sincronizzazione e non deve contenere una sottocartella di sincronizzazione.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Questa cartella non può essere selezionata</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Aggiungi una regola</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Aggiungi una regola di esclusione</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Stai per disconnettere %1 dall’applicazione.
+La cartella di sincronizzazione rimarrà sul tuo computer, ma non sarà più sincronizzata con kDrive.
+
+Tutti i tuoi dati resteranno accessibili online su kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Esci da questo account?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>La cartella locale rimarrà sul tuo computer, ma non sarà più sincronizzata con kDrive.
+Questa azione è definitiva.
+Per sincronizzare nuovamente la tua unità, dovrai riconnetterla in seguito.
+
+Prima di continuare, assicurati che tutti i tuoi file siano aggiornati e completamente sincronizzati.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Rimuovere la sincronizzazione?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>La modifica della modalità di sincronizzazione è stata annullata.
+
+La sincronizzazione attuale rimane invariata. Tuttavia, in caso di comportamenti anomali, potrebbe essere necessario eliminare e ricreare la sincronizzazione per ripristinare il corretto funzionamento.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Si è verificato un errore</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Questa operazione potrebbe richiedere del tempo a seconda delle dimensioni dei tuoi dati. Se fallisce, potrebbe essere necessaria una risincronizzazione completa dell’unità.
+
+Prima di continuare, assicurati che tutti i tuoi file siano aggiornati e sincronizzati.
+
+Non chiudere l’applicazione durante il processo.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Cambiare la modalità di sincronizzazione?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Ecco come ripristinare la sincronizzazione:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Il disco contenente la tua cartella di sincronizzazione non è più connesso</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Riconnettilo per riprendere la sincronizzazione.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Disabilita notifiche</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Non partecipare</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/it/applicazioni/scarica-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Non hai il permesso di accedere a questo kDrive.
+Verifica le tue autorizzazioni o contatta il tuo amministratore.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Accesso negato a kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Il tuo kDrive è in modalità sospensione</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Questo kDrive non è stato rinnovato. Non puoi più accedervi.
+Rinnova il tuo abbonamento per riattivare il servizio.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Questo kDrive non è stato rinnovato. Non puoi più accedervi.
+Contatta il tuo amministratore per riattivare il servizio.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Il tuo kDrive è scaduto</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Accedi di nuovo per continuare a utilizzare kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Sei stato disconnesso</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>L’account utilizzato per questa connessione non corrisponde a quello di questo kDrive.
+Accedi di nuovo con l’indirizzo email corretto %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Questo account non corrisponde</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive si sta riattivando… potrebbe richiedere qualche istante.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive si sta riattivando</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Registra informazioni diagnostiche sul mio computer.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Abilita log di debug</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Inserisci la tua password</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>In questa cartella esiste già un altro %1 il cui nome differisce solo per le lettere maiuscole/minuscole. Questo tipo di nome non è supportato dall'applicazione kDrive per Windows. Rinominare una delle cartelle %2 da kDrive online per poterla sincronizzare sul PC.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Nomi contrastanti, sensibili alle maiuscole e alle minuscole</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>È stata rilevata una modifica alla tua configurazione</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>In questi casi, potrebbe essere necessaria una nuova sincronizzazione per continuare a utilizzare kDrive correttamente.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Consulta %1 per ripristinare l’accesso</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Ultima posizione di %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Disco esterno disconnesso</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Questa operazione potrebbe richiedere del tempo a seconda della quantità di dati da elaborare.
+
+Non chiudere l’applicazione durante il processo.
+
+In caso di errore, puoi avviare facilmente una risincronizzazione completa dell’unità o contattare il supporto.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Abilita sincronizzazione offline</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Questo kDrive è temporaneamente non disponibile a causa di manutenzione.
+Riprova tra qualche minuto.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Manutenzione in corso</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Spazio finale nel nome del %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Escluso dalla sincronizzazione</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>File bloccato</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>File recuperato</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Questo file supera la dimensione massima consentita (50 GB).
+Contatta il supporto per sbloccare il limite.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>File troppo grande</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Accesso vietato</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Il nome di questo %1 contiene uno o più caratteri non supportati dall’applicazione kDrive per Windows. Rinomina il %2 da kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Nome non valido</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carattere non supportato</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Non hai le autorizzazioni necessarie per eseguire questa azione.
+Richiedi l’accesso al proprietario o all’amministratore.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Accesso vietato</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Tipo di file non supportato</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Questa cartella non è più accessibile nella sua posizione originale.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Cartella di sincronizzazione non trovata</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Uno dei tuoi kDrive è sincronizzato all’interno della cartella di sincronizzazione di un altro kDrive.
+Sposta una delle cartelle in modo che non siano più annidate, o elimina la sincronizzazione per ricrearla.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>kDrive annidati</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Impossibile accedere a questo %1 sul tuo computer. Verifica che esista ancora e che tu abbia i diritti per accedervi.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 non accessibile</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Nome del %1 troppo lungo</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Impossibile connettersi a kDrive.
+La sincronizzazione riprenderà automaticamente una volta ripristinata la connessione.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Connessione temporaneamente non disponibile</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Spazio su disco insufficiente</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Il nome di questo file contiene uno o più caratteri non ancora supportati dall’applicazione kDrive. Rinomina il file da kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carattere non supportato</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Il percorso di questo %1 è troppo lungo per essere sincronizzato. Rinomina una o più cartelle al suo interno per accorciare il percorso.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Percorso verso %1 troppo lungo</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Il tuo kDrive è pieno. Libera spazio o aggiorna il tuo abbonamento per sincronizzare questo %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Limite di archiviazione raggiunto</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Questo nome è riservato dal sistema del tuo computer. Rinomina il %1 da kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Nome del %1 riservato</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Verifica la posizione o i diritti di accesso della cartella.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Cartella di sincronizzazione non accessibile</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync non dispone delle autorizzazioni necessarie per funzionare.
+aprite le Preferenze di macOS per abilitarli.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorizzazione necessaria</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Lo spazio su disco del tuo dispositivo è esaurito. La sincronizzazione è stata sospesa. Libera spazio per riprendere la sincronizzazione.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Spazio su disco insufficiente</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Questa cartella non è più accessibile nella sua posizione originale.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Questa cartella non è più accessibile. È necessario intervenire per riprendere la sincronizzazione.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Cartella di sincronizzazione non trovata</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync non può avviarsi. Puoi continuare a sincronizzare i tuoi file abilitando la sincronizzazione offline nelle impostazioni. Contatta il supporto se il problema persiste.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Impossibile avviare Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>La sincronizzazione di questo elemento ha avuto esito negativo. Verrà riprovata automaticamente in seguito.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Sincronizzazione temporaneamente fallita</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Il caricamento non ha potuto essere completato. Riprova più tardi.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Sembra che non riusciamo a caricare l’applicazione…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Si è verificato un errore durante la cancellazione dell’account.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>File da verificare</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Altro</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Sistema e autorizzazioni</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Impossibile aprire l’URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Errori da correggere</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Questa cartella non può essere sincronizzata. Seleziona un’altra cartella.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Errore durante il tentativo di avviare il programma di installazione</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Errore durante la modifica della modalità di sincronizzazione</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blocca le app che potrebbero scaricare o modificare i tuoi file.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>I file corrispondenti a questa regola non verranno sincronizzati.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Evitare che alcuni file temporanei o di sistema vengano copiati in kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Abilita la raccolta di informazioni aggiuntive utili per il supporto.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Log dettagliato esteso</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Quando questa opzione è abilitata, kDrive funziona più lentamente.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Impossibile creare un link di condivisione</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/it/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Aiutaci a migliorare kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/191a0beb-797d-4ec1-b1ff-31889a0012ee</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Una notifica ti informa quando un file viene escluso da questa regola.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Il file esiste già</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Modalità di sincronizzazione file</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Definisci come i tuoi file vengono archiviati e accessibili.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>File da escludere</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Preferiti</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Condivisioni</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Cestino</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Per 1 ora</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Per una settimana</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Per tre giorni</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Ciao %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/it/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Supporto Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Libera spazio o aggiorna il tuo piano per continuare a sincronizzare i tuoi file.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Il tuo kDrive è pieno</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Alcuni file non hanno potuto essere sincronizzati.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Si è verificato &lt;b&gt;un errore&lt;/b&gt; di sincronizzazione</numerusform> 
+                <numerusform>Si sono verificati &lt;b&gt;%n errori di sincronizzazione&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Non riusciamo ad accedere ai tuoi file. Riavvia l’applicazione per riprendere la sincronizzazione. Se il problema continua, contatta il supporto.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Connessione a kDrive interrotta</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Attivare kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>È necessario attivare kDrive.app prima di continuare</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Attivare l’estensione kDrive e kDrive LiteSync</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>È necessario attivare le autorizzazioni prima di proseguire</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Andare in Riservatezza e sicurezza &gt; Accesso all’intero disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Accesso all’intero disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Riservatezza e sicurezza</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Selezionare Apri ed Estensioni &gt; Estensioni di sicurezza</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Estensioni di sicurezza</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Apri ed Estensioni</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Aprire Impostazioni di sistema &gt; Generale</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Impostazioni di sistema</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Riavviare l’applicazione, se necessario</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Questo elemento non è disponibile su questo dispositivo.
+Si aprirà nel tuo browser.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/it/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Diritti di accesso modificati</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Attivato</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>%1 fa</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Tutte le cartelle</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Tutti i kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Consenti tracciamento</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>ID applicazione</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Nome dell’applicazione</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Autore</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Per impostazione predefinita</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Scegli quale versione dei tuoi file desideri conservare.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Per ogni file, seleziona la versione da conservare.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Quale versione desideri conservare?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Scegli la versione da conservare</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Le versioni online di questi %1 file verranno sostituite dalle tue versioni locali.
+Attenzione, questa operazione potrebbe sovrascrivere il lavoro dei tuoi collaboratori.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Mantieni solo le versioni locali</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Per ogni conflitto, manterremo automaticamente la versione (locale o online) modificata più di recente. Questa è la scelta più sicura nella maggior parte dei casi.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Mantieni le versioni più recenti</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Tutte le modifiche locali per questi %1 file verranno scartate.
+È utile se sai che il lavoro importante è online su kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Mantieni solo le versioni online</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Accedi per iniziare.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Crea un %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Data</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Disattivato</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>file</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Cartella</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Cartella eliminata</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Cartella spostata o modificata</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>La cartella potrebbe essere stata spostata su un altro disco e poi riportata nella posizione originale.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>cartella</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Cartella spostata o rinominata</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Cartella ricreata o sostituita</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>La cartella è stata eliminata e ricreata, oppure sostituita da un’altra cartella con lo stesso nome.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Proprio adesso</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Locale</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 file sono stati modificati sia sul tuo computer che su kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Più recente</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nome</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Nuovo dispositivo rilevato</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Stai utilizzando kDrive su un nuovo computer, dopo il ripristino da un backup.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nuova cartella</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nuova sincronizzazione</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Nessun conflitto corrisponde alla tua ricerca</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Nessun errore da correggere</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notifica</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Notifica se file escluso</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Spento</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Cartella online eliminata</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>La cartella sincronizzata è stata eliminata su kDrive online o non è più accessibile.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Posizione originale:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Consigliato</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>La cartella potrebbe essere stata spostata su un altro disco e poi riportata nella posizione originale.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Ripristinala nella posizione originale.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regole</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Come il sistema</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>g</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sec</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Dal: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Dimensione</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Stato</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 libero</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 libero</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Calcolo…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 utilizzato</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 utilizzato</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizzato da kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizzato dal tuo computer</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Questo kDrive contiene solo file. Tutti i file verranno sincronizzati su questo dispositivo.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Nessuna cartella da selezionare</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Cartelle di sincronizzazione</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Posizione</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Sincronizza i tuoi kDrive su questo dispositivo</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Cartelle sincronizzate</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Sincronizzazione</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tempo</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Benvenuto su kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 di %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Gestione kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Lingua</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Riavvia l’applicazione per completare l’applicazione della nuova lingua.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Scopri di più</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Licenza LGPL v3 - Sorgenti Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link copiato negli appunti</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Disco incompatibile o cartella direttamente nella radice del disco (es: scegli una cartella come /Mon drive invece di /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Disco incompatibile o cartella direttamente nella radice del disco (es: scegli una cartella come D:/Mon drive invece di D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Posizione sul computer</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Debug</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Errore</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Esteso</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Fatale</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Avviso</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Invia cartella debug al supporto Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Alcuni nomi di file potrebbero contenere caratteri speciali non supportati (come virgolette doppie, barre rovesciate o interruzioni di riga).
+
+Verifica e rinomina i file contenenti caratteri insoliti, quindi riprova.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Nome file non valido</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Compressione dei log…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Caricamento dei log al supporto…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>L’ultimo caricamento è fallito. Verifica la tua connessione internet e assicurati che almeno un utente kDrive sia connesso. I caricamenti sono limitati a 10 al giorno.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Sono state rilevate versioni diverse di questi file.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 conflitti di versione rilevati</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo è uno strumento di analisi ospitato e gestito esclusivamente da Infomaniak per comprendere come viene utilizzata l’applicazione.
+
+L’analisi di questi dati consente al nostro team di migliorare continuamente l’interfaccia dell’applicazione.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Spostamento annullato</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Sposta i file eliminati nel cestino del computer</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Alcuni elementi potrebbero non poter essere spostati.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Più spazio, più funzionalità con my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Hai bisogno di aiuto?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Rete</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Aggiungi un account per iniziare</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Nessun risultato trovato</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Non sincronizzato</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Sempre</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Mai</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Ricevi una notifica quando un file viene escluso</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Configura la sincronizzazione per questo kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Personalizza la posizione della tua cartella kDrive sul tuo computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>La cartella scelta deve essere vuota per il corretto funzionamento della sincronizzazione.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Scegli le cartelle da sincronizzare su questo computer:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Cartelle sincronizzate</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Per ogni kDrive, puoi scegliere dove viene sincronizzato sul tuo computer e quali cartelle sincronizzare.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Contenuto sincronizzato:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Contenuto sincronizzato: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Posizione:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Posizione: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Configura i tuoi kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Scegli le cartelle da sincronizzare su questo computer</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>I file vengono scaricati solo all’apertura, per risparmiare spazio su disco.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Attivare Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Questo kDrive è già configurato.
+Vai alle impostazioni per modificarlo.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autorizzare kDrive nelle impostazioni di macOS:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Attivare kDrive sul Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Per completare l’installazione, è necessario autorizzare kDrive ad accedere al proprio computer:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autorizzare l’accesso ai file</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Inizia gratuitamente con my kSuite,
+o scegli un piano adatto alle tue esigenze.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Non hai ancora un kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Scegli i kDrive da sincronizzare su questo computer:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronizzazione in corso</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Bentornato!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Tutte le cartelle kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Selezione personalizzata</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Il cloud privato, veloce e sicuro, ospitato in Svizzera.
+
+Accedi e mantieni i tuoi documenti sincronizzati su tutti i tuoi dispositivi.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Si è verificato un errore, riprova.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Errore di accesso</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Ancora qualche istante e caricheremo il suo conto…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Connessione dal browser…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Recupero delle tue informazioni…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Un momento…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Benvenuto su kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>I tuoi file sono pronti per essere sincronizzati
+in modo sicuro sul tuo computer.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Tutto pronto!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Stiamo finalizzando la configurazione dei tuoi kDrive.
+
+Attendi qualche istante.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Sincronizzazione in corso…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Apri kDrive all’avvio del computer</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Apri la pagina di accesso</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Percorso copiato negli appunti</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Definisci come kDrive si connette a internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Autenticazione richiesta</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Password</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Porta</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Impostazioni proxy</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Tipo di proxy</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Configurazione manuale</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Nessuno</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Nome utente</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Interno</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Posizione su kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Cerca in %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Cerca…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>Questo file non è disponibile localmente e verrà aperto nel browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Cerca i tuoi file</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Seleziona le cartelle da sincronizzare su questo computer.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Le cartelle non selezionate non verranno scaricate sul tuo dispositivo. Resteranno disponibili online e non verranno eliminate.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Le cartelle non selezionate non verranno scaricate sul tuo dispositivo. Resteranno disponibili online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry è uno strumento ospitato e gestito esclusivamente da Infomaniak per monitorare la stabilità dell’applicazione in tempo reale e segnalare automaticamente eventuali errori tecnici ai nostri sviluppatori.
+
+Questi dati consentono al nostro team di correggere e ottimizzare rapidamente l’applicazione, garantendoti un’esperienza utente migliore.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Impostazioni</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Account e sincronizzazioni</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avanzate</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Generale</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Cartella kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Accedi nel tuo browser</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Apri kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Lascia</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Impostazioni</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Spazio libero sul computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>File kDrive archiviati sul computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Altri file sul computer</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Utilizzo dello spazio di carico…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Spazio libero</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Altri file</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>File kDrive memorizzati sul tuo dispositivo</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive non può accedere al volume
+Assicurarsi che sia collegato,
+sbloccato e accessibile dal computer.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Il volume non è accessibile</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Gestite le cartelle sincronizzate per liberare spazio sul vostro Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Sincronizzazione</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Questo PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 su %2 utilizzato</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Archiviato online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>I tuoi file rimangono nel cloud e non occupano spazio sul tuo computer.
+È necessaria una connessione internet per accedervi.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Errore di sincronizzazione</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Cartella personalizzata</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Cartella predefinita</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Sincronizzazione</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>La nuova modalità di sincronizzazione è in fase di applicazione…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Regole di sincronizzazione</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Si è verificato un errore</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>L’ultima sincronizzazione è avvenuta con successo</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>La sincronizzazione è in pausa</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>La sincronizzazione è in corso</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Sincronizzato</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Sincronizzato</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizzato dal tuo computer</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizzato da kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>i tuoi file sono in sincronizzazione</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>la sincronizzazione è in pausa</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>I tuoi file recenti sono in fase di aggiornamento.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronizzazione in corso</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>I file scaricati rimangono accessibili.
+La sincronizzazione riprenderà automaticamente non appena ti ricollegherai.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>La sincronizzazione è stata temporaneamente interrotta.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Sincronizzazione in pausa</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>I tuoi file sono accessibili e sincronizzati.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Nessuna attività in corso</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>i tuoi file sono aggiornati</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Sincronizzazione</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Un file o una cartella nella tua cartella di sincronizzazione sembra essere danneggiato/a.
+La sincronizzazione è stata sospesa. Verifica i tuoi file e riprova.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>File danneggiato rilevato</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Attività</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Home</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Spazio</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>La cartella non deve essere la radice di un’unità e non deve contenere né trovarsi all’interno di una cartella già sincronizzata.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>La cartella deve essere vuota, non deve essere la radice di un’unità e non deve contenere né trovarsi all’interno di una cartella già sincronizzata.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Questa cartella non può essere utilizzata</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Gestione individuale</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Gestire la sincronizzazione</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Una notifica ti informa quando un file viene escluso da questa regola</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Chiudi kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Apri kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Impostazioni</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Prova un termine di ricerca diverso</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Digita per iniziare la ricerca</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Verifica che la tua connessione internet sia attiva, che questo nome non sia già in uso e che non contenga caratteri non validi.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Impossibile creare questa cartella</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Accesso non autorizzato</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>I tuoi file sono accessibili e sincronizzati.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Nessuna attività recente</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Riprova tra qualche istante.
+Se il problema persiste, contatta il supporto.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Si è verificato un errore imprevisto</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Fino a domani</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 disponibile</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>L’installazione richiede meno di un minuto.
+La sincronizzazione riprenderà automaticamente al termine.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignora questa versione</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Installa ora</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Ricordamelo più tardi</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Scopri le novità</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versione %1 · Stai usando la %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Aggiornamento disponibile</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>È necessaria una nuova versione di kDrive per continuare.
+Aggiorna l’applicazione per accedere ai tuoi file e riprendere la sincronizzazione.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Aggiornamento richiesto</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Aggiornamento</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Caricamento incompleto</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Escludi alcune applicazioni dalla sincronizzazione.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Aggiungi file da escludere dalla sincronizzazione.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Regole di esclusione personalizzate</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Escludi alcuni tipi di file dalla sincronizzazione.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Visualizza codice sorgente</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Hai un errore di sincronizzazione</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Hai {0} errori di sincronizzazione</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive non riesce ad accedere al disco %1
+Assicurati che sia connesso,
+sboccato e accessibile dal tuo computer.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Il disco di archiviazione %1 non è accessibile</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Rimuovi</numerusform> 
+                <numerusform>Rimuovi (%1 regole)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Applicazione della modifica…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Gestisci spazio su disco</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Apri cartella superiore</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Aggiorna</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Livello di debug</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>La sincronizzazione ripartirà automaticamente.
+Se il problema persiste, contatta il supporto e allega i dettagli tecnici qui sotto.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Dettagli tecnici</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Si è verificato un errore imprevisto</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Eliminazione annullata</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Nomi duplicati</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Non hai le autorizzazioni necessarie per aggiungere un %1 in questa posizione.
+Richiedi l’accesso al proprietario o all’amministratore.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Non hai il permesso di eliminare questo %1. È stato ripristinato nella posizione originale. Richiedi l’accesso al proprietario o all’amministratore.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Le autorizzazioni di accesso per %1 sono state modificate, impedendone la sincronizzazione.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Esiste già un file o una cartella con questo nome.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Non hai i diritti per modificare questo file.
+La versione originale è stata mantenuta e la tua modifica è stata salvata in un file separato con "conflict" nel nome. Richiedi l’accesso al proprietario o all’amministratore.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Il nome di questo %1 termina con uno spazio, impedendone la sincronizzazione. Rinomina il %2 da kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Una regola di esclusione impedisce la sincronizzazione di questo %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Esiste già un file con questo nome.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Questo file è attualmente in uso da un altro utente.
+Le tue modifiche verranno sincronizzate in seguito.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Questo file è stato eliminato da kDrive online mentre lo stavi modificando. Una copia è stata conservata sul tuo computer nella cartella di recupero.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Questo file supera la dimensione massima consentita (50 GB).
+Contatta il tuo amministratore per aumentare il limite di dimensione del file.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Questo nome contiene solo spazi e non può essere utilizzato. Rinomina il %1 da kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Questo file è un hard link e non può essere sincronizzato.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Non hai i diritti per spostare questo %1 qui; verrà ripristinato nella posizione originale. Richiedi l’accesso al proprietario o all’amministratore.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Questo nome supera la lunghezza consentita (250 caratteri). Rinomina il %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Non c’è spazio sufficiente sul tuo computer per sincronizzare questo file.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>La cartella completa è grande.
+Per velocizzare il caricamento, ti consigliamo di inviare solo l’ultima sessione kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Invia solo l’ultima sessione</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: it, Italian
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="it"> 
     <context>
@@ -344,6 +344,16 @@ Puoi aprirli in qualsiasi momento, anche senza connessione a internet.</translat
             <source>Manage storage</source> 
             <translation>Gestisci spazio</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Massimizza</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Riduci a icona</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Apri cartella debug</translation> 
@@ -427,6 +437,11 @@ Puoi aprirli in qualsiasi momento, anche senza connessione a internet.</translat
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Riavvia sincronizzazione</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Ripristina</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="it"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ sboccato e accessibile dal tuo computer.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Applicazione della modifica…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Gestisci spazio su disco</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Apri cartella superiore</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Aggiorna</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Livello di debug</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Se il problema persiste, contatta il supporto e allega i dettagli tecnici qui so
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Dettagli tecnici</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Si è verificato un errore imprevisto</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Eliminazione annullata</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Nomi duplicati</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Richiedi l’accesso al proprietario o all’amministratore.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Non hai il permesso di eliminare questo %1. È stato ripristinato nella posizione originale. Richiedi l’accesso al proprietario o all’amministratore.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Le autorizzazioni di accesso per %1 sono state modificate, impedendone la sincronizzazione.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Esiste già un file o una cartella con questo nome.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ La versione originale è stata mantenuta e la tua modifica è stata salvata in u
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Il nome di questo %1 termina con uno spazio, impedendone la sincronizzazione. Rinomina il %2 da kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Una regola di esclusione impedisce la sincronizzazione di questo %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Esiste già un file con questo nome.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Le tue modifiche verranno sincronizzate in seguito.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Questo file è stato eliminato da kDrive online mentre lo stavi modificando. Una copia è stata conservata sul tuo computer nella cartella di recupero.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contatta il tuo amministratore per aumentare il limite di dimensione del file.</
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Questo nome contiene solo spazi e non può essere utilizzato. Rinomina il %1 da kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Questo file è un hard link e non può essere sincronizzato.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Non hai i diritti per spostare questo %1 qui; verrà ripristinato nella posizione originale. Richiedi l’accesso al proprietario o all’amministratore.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Questo nome supera la lunghezza consentita (250 caratteri). Rinomina il %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Non c’è spazio sufficiente sul tuo computer per sincronizzare questo file.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_it.ts
+++ b/src/gui4/linux/translations/client_it.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: it, Italian
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="it"> 
     <context>
@@ -2077,7 +2077,7 @@ Questi dati consentono al nostro team di correggere e ottimizzare rapidamente lâ
             <translation>Cartella kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Accedi nel tuo browser</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nb, Norwegian Bokmål
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nb"> 
     <context>
@@ -344,6 +344,16 @@ Du kan åpne dem når som helst, selv uten internettforbindelse.</translation>
             <source>Manage storage</source> 
             <translation>Administrer lagring</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maksimer</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimer</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Åpne feilsøkingsmappe</translation> 
@@ -427,6 +437,11 @@ Du kan åpne dem når som helst, selv uten internettforbindelse.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Start synkronisering på nytt</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Gjenopprett</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: nb, Norwegian Bokmål
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="nb"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versjon %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versjon %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Om</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Om kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Utviklet og driftet utelukkende i Sveits, kDrive sikrer fullstendig beskyttelse av dine data, uten videresalg eller spionering, i ISO-sertifiserte datasentre, med kryptering og sikkerhetskopiering på flere medier.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Synlige aktiviteter</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Velge en distribusjonskanal</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Vis mer informasjon</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Velg en synkroniseringsmodus</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synkronisering fullført</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Ingen nylig aktivitet</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Du er frakoblet</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synkronisering pauset</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Alle aktiviteter</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Bare min aktivitet</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkroniser en mappe med kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Velg mappen på datamaskinen som skal synkroniseres med kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synkronisert mappe</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Tilpass plasseringen av datamaskinmappen på kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Velg mappeplasseringen på kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-plassering</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Velg en mappe på datamaskinen din for å synkronisere med kDrive.
+Du kan få tilgang til avanserte synkroniseringer fra stasjonvelgeren på startsiden.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkroniser en mappe med kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Avansert synkronisering</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>App som skal utelukkes</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Programmet er oppdatert</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Sletter logger eldre enn 7 dager for å spare diskplass.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatisk opprydding</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatiske oppdateringer</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Tilgjengelig frakoblet</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Filene dine er kopiert til datamaskinen.
+Du kan åpne dem når som helst, selv uten internettforbindelse.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Du kan vekke den fra nettgrensesnittet.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Få tidlig tilgang til nye versjoner av programmet før de slippes til allmennheten, og bidra til å forbedre appen ved å dele forbedringsidéene dine med oss.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Bli med i betaprogrammet</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Nettleseren din bør åpne seg automatisk for å fullføre innloggingen. Når du er logget inn, vil du automatisk bli sendt tilbake til kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktiver frakoblet synkronisering</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synkroniser en mappe</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Legg til en regel</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Legg til lagring</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Avanserte innstillinger</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Bruk på %1 filer</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Be om tilgang</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Avbryt</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Endre mappe</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Lagre frakoblet</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Lagre på nett</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Bytt bruker</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Lukk</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Lukk kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Konfigurer</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Bekreft</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Logg inn</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Koble til en konto</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Kontakt support</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Fortsett</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Kopier delingslenke</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Opprett en konto</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Opprett en ny synkronisering</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Tilpasset plassering</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Koble fra denne kontoen</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Laster ned…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Last ned manuelt</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Aktiver</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Aktiver i Windows-innstillinger</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Forstå problemet</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Del en idé</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Fullfør installasjonen</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Rett feil</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Jeg har aktivert kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive på nett</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Behold konto</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Logg ut</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Logg inn</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Administrer</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Behandle filer enkeltvis</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Administrer lagring</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Åpne feilsøkingsmappe</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Åpne Utforsker</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Åpne mappe</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Åpne i nettleser</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Åpne i Utforsker</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Åpne i Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Åpne i kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Åpne kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Administrer unntak</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Åpne synkroniseringsinnstillinger</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pause</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Oppdater</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Endringslogg</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Fjern</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Fjern (%n element)</numerusform> 
+                <numerusform>Fjern (%n elementer)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Fjern synkronisering</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Gi nytt navn til %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Start innlogging på nytt</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Gjenoppta synkronisering</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Start synkronisering på nytt</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Prøv igjen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Gå tilbake til standardmappen</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Lagre</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Lagre mine valg</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Søk</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Vis aktiviteter</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Velg</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Velg en mappe</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Velg mapper</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Velg en plassering</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Valgt</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Send</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Send feilsøkingsmappe</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Åpne innstillinger</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Vis tilbud</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Vis alternativer</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Logg ut</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Start</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Start versjonsvalg</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Kom i gang gratis</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synkroniser frakoblet</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Oppdater nå</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Oppdater abonnement</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Oppgrader</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Bekreft</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Bekreft og gå til neste</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Vekk opp</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Velg en versjon</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>To forskjellige versjoner av disse filene ble oppdaget.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versjonskonflikt</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Søk etter en fil</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopierer lenke…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Oppretter delingslenke…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Du kan tilpasse bruks- og driftsdata som samles inn av Infomaniak for å rette feil og forbedre programmet. Begge verktøyene som brukes, er driftet og administrert utelukkende av oss.
+
+Kildekoden til dette programmet kan verifiseres, informasjonen som samles inn er anonym, og din personlige informasjon forblir strengt konfidensiell og deles aldri med tredjeparter.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Dataadministrasjon</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respekterer ditt personvern</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Velg mengde informasjon som skal logges.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Lar Infomaniak-support identifisere årsaken til en hendelse.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Feilsøkingslogger</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Disse appene ignoreres som standard og kan ikke endres.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Disse filene er ekskludert som standard og kan ikke endres.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatisk ekskludering</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>I disse situasjonene kreves en ny synkronisering for å fortsette å bruke kDrive korrekt.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Velg en tom mappe som ikke befinner seg i roten av en stasjon.
+
+Denne mappen må ikke være inkludert i en annen synkroniseringsmappe og må ikke inneholde en synkroniseringsundermappe.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Denne mappen kan ikke velges</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Legg til en regel</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Legg til en ekskluderingsregel</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Du er i ferd med å koble fra %1 fra programmet.
+Synkroniseringsmappen forblir på datamaskinen, men vil ikke lenger synkroniseres med kDrive.
+
+Alle dine data forblir tilgjengelige på nett på kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Logg ut av denne kontoen?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Den lokale mappen forblir på datamaskinen, men vil ikke lenger synkroniseres med kDrive.
+Denne handlingen er permanent.
+For å synkronisere stasjonen på nytt må du koble den til igjen senere.
+
+Før du fortsetter, sørg for at alle filene dine er oppdaterte og fullstendig synkronisert.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Fjerne synkronisering?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Endringen av synkroniseringsmodus ble avbrutt.
+
+Gjeldende synkronisering er uendret. Hvis unormal atferd oppstår, kan det hende du må slette og gjenopprette synkroniseringen for å gjenopprette normal drift.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Det oppstod en feil</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Denne operasjonen kan ta tid avhengig av datastørrelsen. Hvis den mislykkes, kan en fullstendig ny synkronisering av stasjonen være nødvendig.
+
+Før du fortsetter, sørg for at alle filene dine er oppdaterte og synkronisert.
+
+Ikke lukk programmet under prosessen.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Endre synkroniseringsmodus?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Slik gjenoppretter du synkroniseringen:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Disken som inneholder synkroniseringsmappen er ikke lenger tilkoblet</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Koble den til igjen for å gjenoppta synkroniseringen.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Deaktiver varsler</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Ikke bli med</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Du har ikke tilgang til denne kDrive.
+Kontroller tillatelsene dine eller kontakt administratoren din.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Tilgang nektet til kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>kDrive er i hvilemodus</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Denne kDrive er ikke fornyet. Du har ikke lenger tilgang til den.
+Forny abonnementet ditt for å reaktivere tjenesten.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Denne kDrive er ikke fornyet. Du har ikke lenger tilgang til den.
+Kontakt administratoren din for å reaktivere tjenesten.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>kDrive har utløpt</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Logg inn igjen for å fortsette å bruke kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Du har blitt logget ut</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Kontoen som ble brukt for denne tilkoblingen samsvarer ikke med den for denne kDrive.
+Logg inn igjen med riktig e-postadresse %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Denne kontoen samsvarer ikke</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive våkner opp… dette kan ta et øyeblikk.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive våkner opp</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Registrer diagnostisk informasjon på datamaskinen min.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Aktiver feilsøkingslogging</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Skriv inn passordet ditt</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Det finnes allerede en annen %1 i denne mappen med et navn som bare skiller seg fra navnet med store og små bokstaver. Denne typen navn støttes ikke av kDrive Windows-applikasjonen. Gi nytt navn til en av %2-mappene fra kDrive online, slik at du kan synkronisere den på PC-en din.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Motstridende navn, små og store bokstaver</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>En endring ble oppdaget i konfigurasjonen din</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>I disse situasjonene kan en ny synkronisering være nødvendig for å fortsette å bruke kDrive korrekt.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Sjekk %1 for å gjenopprette tilgang</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Siste plassering av %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Ekstern disk frakoblet</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Denne operasjonen kan ta tid avhengig av datamengden som skal behandles.
+
+Ikke lukk programmet under prosessen.
+
+Hvis den mislykkes, kan du enkelt starte en fullstendig ny synkronisering av stasjonen eller kontakte vår support.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktiver frakoblet synkronisering</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Denne kDrive er midlertidig utilgjengelig på grunn av vedlikehold.
+Prøv igjen om noen minutter.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Vedlikehold pågår</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Mellomrom på slutten av %1-navn</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Ekskludert fra synkronisering</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Fil låst</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Fil reddet</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Denne filen overskrider maksimal tillatt størrelse (50 GB).
+Kontakt support for å låse opp grensen.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Fil for stor</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Tilgang forbudt</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Navnet på dette %1 inneholder ett eller flere tegn som ikke støttes av kDrive Windows-programmet. Gi nytt navn til %2 fra kDrive på nett.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Ugyldig navn</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Tegn som ikke støttes</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Du har ikke de nødvendige tillatelsene til å utføre denne handlingen.
+Be om tilgang fra eieren eller administratoren.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Tilgang forbudt</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Filtype støttes ikke</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Denne mappen er ikke lenger tilgjengelig på sin opprinnelige plassering.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmappe ikke funnet</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>En av kDrive-ene dine er synkronisert inne i synkroniseringsmappen til en annen kDrive.
+Flytt en av mappene slik at de ikke lenger er nøstet, eller slett synkroniseringen din for å opprette den på nytt.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Nestede kDrives</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Kan ikke få tilgang til dette %1 på datamaskinen din. Sjekk at det fortsatt finnes og at du har rettigheter til å åpne det.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 utilgjengelig</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>%1-navn for langt</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Kan ikke koble til kDrive.
+Synkroniseringen gjenopptas automatisk når tilkoblingen er gjenopprettet.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Tilkobling midlertidig utilgjengelig</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Utilstrekkelig diskplass</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Navnet på denne filen inneholder ett eller flere tegn som ennå ikke støttes av kDrive-programmet. Gi nytt navn til filen fra kDrive på nett.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Tegn som ikke støttes</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Banen til dette %1 er for lang til å synkroniseres. Gi nytt navn til én eller flere mapper den er i for å forkorte banen.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Bane til %1 for lang</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>kDrive-en din er full. Frigjør plass eller oppgrader abonnementet ditt for å synkronisere dette %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Lagringsgrense nådd</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Dette navnet er reservert av datamaskinsystemet ditt. Gi nytt navn til %1 fra kDrive på nett.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>%1-navn reservert</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Sjekk plasseringen eller tilgangsrettighetene for mappen.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synkroniseringsmappe utilgjengelig</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync har ikke de nødvendige tillatelsene for å fungere.
+åpne macOS Preferences for å aktivere dem.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorisasjon kreves</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Enhetens diskplass er full. Synkronisering er stoppet midlertidig. Frigjør plass for å gjenoppta synkronisering.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Utilstrekkelig diskplass</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Denne mappen er ikke lenger tilgjengelig på sin opprinnelige plassering.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Denne mappen er ikke lenger tilgjengelig. En handling er nødvendig for å gjenoppta synkronisering.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmappe ikke funnet</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync kan ikke starte. Du kan fortsette å synkronisere filene dine ved å aktivere frakoblet synkronisering i innstillingene. Kontakt support hvis problemet vedvarer.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Kan ikke starte Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Synkronisering av dette elementet mislyktes. Det vil prøves igjen automatisk senere.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synkronisering midlertidig mislyktes</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Opplastingen kunne ikke fullføres. Prøv igjen senere.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Det ser ut til at vi ikke kan laste programmet…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Det oppstod en feil ved sletting av kontoen din.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Filer som skal verifiseres</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Annet</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System og tillatelser</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Det gikk ikke an å åpne URL-adressen %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Feil som skal rettes</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Denne mappen kan ikke synkroniseres. Vennligst velg en annen mappe.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Feil ved forsøk på å starte installasjonsprogrammet</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Feil ved endring av synkroniseringsmodus</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blokker apper som kan laste ned eller endre filene dine.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Filer som samsvarer med denne regelen vil ikke bli synkronisert.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Unngå at visse midlertidige filer eller systemfiler kopieres til kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Aktiverer innsamling av tilleggsinformasjon som er nyttig for support.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Utvidet detaljert logg</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Når dette alternativet er aktivert, kjører kDrive langsommere.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Kunne ikke opprette en delingslenke</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Hjelp oss med å forbedre kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>En varsling informerer deg når en fil utelukkes av denne regelen.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Filen finnes allerede</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Filsynkroniseringsmodus</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Definer hvordan filene dine lagres og åpnes.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Filer som skal ekskluderes</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoritter</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Delinger</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Papirkurv</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>I 1 time</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>I én uke</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>I tre dager</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hei %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Support</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Frigjør plass eller oppgrader planen din for å fortsette å synkronisere filene dine.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>kDrive-en din er full</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Noen filer kunne ikke synkroniseres.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Du har &lt;b&gt;én synkroniseringsfeil&lt;/b&gt;</numerusform> 
+                <numerusform>Du har &lt;b&gt;%n synkroniseringsfeil&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Vi har ikke tilgang til filene dine. Start programmet på nytt for å gjenoppta synkronisering. Hvis problemet vedvarer, ta kontakt med support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Tilkobling til kDrive avbrutt</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktiver kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Du må aktivere kDrive.app før du fortsetter</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktiver kDrive og kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Du må aktivere tillatelser før du fortsetter</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Gå til Personvern og sikkerhet &gt; Full disktilgang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Full disktilgang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Personvern og sikkerhet</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Velg Åpne og utvidelser &gt; Sikkerhetsutvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Sikkerhetsutvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Åpne og utvidelser</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Åpne Systeminnstillinger &gt; Generelt</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Systeminnstillinger</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Start programmet på nytt hvis påkrevd</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Dette elementet er ikke tilgjengelig på denne enheten.
+Det vil åpnes i nettleseren din.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Tilgangsrettigheter endret</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Aktivert</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>for %1 siden</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Alle mapper</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Hele kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Tillat sporing</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Programidentifikator</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Programnavn</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Forfatter</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Som standard</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Velg hvilken versjon av filene du vil beholde.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>For hver fil, velg versjonen som skal beholdes.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Hvilken versjon vil du beholde?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Velg versjonen som skal beholdes</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Nettversjonene av disse %1 filene vil bli erstattet av dine lokale versjoner.
+Vær oppmerksom på at dette kan overskrive samarbeidspartnernes arbeid.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Behold bare lokale versjoner</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>For hver konflikt vil vi automatisk beholde versjonen (lokal eller på nett) som ble endret sist. Dette er det sikreste valget i de fleste tilfeller.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Behold de nyeste versjonene</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Alle lokale endringer for disse %1 filene vil bli forkastet.
+Nyttig hvis du vet at det viktige arbeidet er på nett på kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Behold bare nettversjoner</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Logg inn for å komme i gang.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Opprett en %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Dato</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Deaktivert</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>fil</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Mappe</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Mappe slettet</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Mappe flyttet eller endret</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen kan ha blitt flyttet til en annen disk og deretter returnert til sin opprinnelige plassering.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>mappe</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Mappe flyttet eller omdøpt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Mappe gjenopprettet eller erstattet</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Mappen ble slettet og gjenopprettet, eller erstattet av en annen mappe med samme navn.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Akkurat nå</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>kB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokal</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 filer har blitt endret både på datamaskinen din og på kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Nyeste</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Navn</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Ny enhet oppdaget</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Du bruker kDrive på en ny datamaskin, etter gjenoppretting fra en sikkerhetskopi.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Ny mappe</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>ny synkronisering</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Ingen konflikter samsvarer med søket ditt</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Ingen feil å rette</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Varsling</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Varsl hvis fil er ekskludert</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Av</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>På nett</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Nettmappe slettet</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Den synkroniserte mappen ble slettet på kDrive på nett eller er ikke lenger tilgjengelig.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Opprinnelig plassering:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Anbefalt</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen kan ha blitt flyttet til en annen disk og deretter returnert til sin opprinnelige plassering.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Gjenopprett den til den opprinnelige plasseringen.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regler</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Samme som system</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>t</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sek</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Siden: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Størrelse</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 ledig</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 ledig</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Beregner…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 brukt</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 brukt</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkronisert fra kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkronisert fra datamaskinen din</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Denne kDrive inneholder bare filer. Alle filer vil bli synkronisert på denne enheten.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Ingen mappe å velge</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synkroniseringsmapper</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Plassering</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synkroniser kDrive-ene dine på denne enheten</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserte mapper</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tid</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Velkommen til kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 av %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive-administrasjon</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Språk</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Start programmet på nytt for å fullføre anvendelsen av det nye språket.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Lær mer</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3-lisens – Git-kilder</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Lenke kopiert til utklippstavle</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Inkompatibel stasjon eller mappe direkte i roten av stasjonen (f.eks. velg en mappe som /Min stasjon i stedet for /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Inkompatibel stasjon eller mappe direkte i roten av stasjonen (f.eks. velg en mappe som D:/Min stasjon i stedet for D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Plassering på datamaskinen</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Feilsøking</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Feil</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Utvidet</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Kritisk</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Advarsel</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Send feilsøkingsmappe til Infomaniak support</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Noen filnavn kan inneholde spesialtegn som ikke støttes (som doble anførselstegn, omvendt skråstrek eller linjeskift).
+
+Kontroller og gi nytt navn til filer som inneholder uvanlige tegn, og prøv deretter på nytt.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Ugyldig filnavn</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Komprimerer logger…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Laster opp logger til support…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Den siste overføringen mislyktes. Kontroller internettforbindelsen din og sørg for at minst én kDrive-bruker er logget inn. Opplastinger er begrenset til 10 per dag.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Forskjellige versjoner av disse filene ble oppdaget.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 versjonskonflikt(er) oppdaget</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo er et analyseverktøy som er driftet og administrert utelukkende av Infomaniak for å forstå hvordan programmet brukes.
+
+Analyse av disse dataene lar teamet vårt kontinuerlig forbedre programmets grensesnitt.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Flytting avbrutt</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Flytt slettede filer til datamaskinens papirkurv</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Noen elementer kan ikke flyttes.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Mer lagringsplass, flere funksjoner med my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Trenger du hjelp?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Nettverk</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Legg til en konto for å komme i gang</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Ingen resultater funnet</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Ikke synkronisert</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Alltid</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Aldri</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Motta et varsel når en fil ekskluderes</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Konfigurer synkronisering for denne kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Tilpass plasseringen av kDrive-mappen din på datamaskinen:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Den valgte mappen må være tom for at synkroniseringen skal fungere korrekt.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Velg mappene som skal synkroniseres på denne datamaskinen:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserte mapper</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>For hver kDrive kan du velge hvor den synkroniseres på datamaskinen og hvilke mapper som skal synkroniseres.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synkronisert innhold:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synkronisert innhold: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Plassering:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Plassering: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Konfigurer kDrive-ene dine</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Velg mappene som skal synkroniseres på denne datamaskinen</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Filer lastes bare ned når de åpnes, for å spare diskplass.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Aktiver Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Denne kDrive er allerede konfigurert.
+Gå til innstillingene for å endre den.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autoriser kDrive i macOS-innstillinger:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktiver kDrive på din Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>For å fullføre installasjonen må du autorisere kDrive å få tilgang til:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autoriser tilgang til filer</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Kom i gang gratis med my kSuite,
+eller velg en plan som passer dine behov.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Du har ikke en kDrive ennå.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Velg kDrive-ene som skal synkroniseres på denne datamaskinen:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Hyggelig å se deg!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Alle kDrive-mapper</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Tilpasset utvalg</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Den private, raske og sikre skyen, driftet i Sveits.
+
+Logg inn og hold dokumentene dine synkronisert på alle enhetene dine.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Det oppstod en feil, vennligst prøv igjen.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Innloggingsfeil</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Bare noen øyeblikk til, vi laster inn kontoen din…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Innlogging fra nettleseren…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Henter informasjonen din…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Et øyeblikk…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Velkommen til kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Filene dine er klare til å bli synkronisert
+trygt på datamaskinen din.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Alt er klart!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Vi fullfører konfigurasjonen av kDrive-ene dine.
+
+Vennligst vent noen øyeblikk.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synkronisering pågår…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Åpne kDrive når datamaskinen starter</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Åpne innloggingssiden</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Bane kopiert til utklippstavle</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Definer hvordan kDrive kobler til internett.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Autentisering kreves</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Passord</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxy-innstillinger</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxy-type</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manuell konfigurasjon</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Ingen</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Brukernavn</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Intern</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Plassering på kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Søk i %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Velg mappene som skal synkroniseres på denne datamaskinen.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Mapper som ikke er valgt, vil ikke bli lastet ned til enheten din. De forblir tilgjengelige på nett og vil ikke bli slettet.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Mapper som ikke er valgt, vil ikke bli lastet ned til enheten din. De forblir tilgjengelige på nett.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry er et verktøy som er driftet og administrert utelukkende av Infomaniak for å overvåke stabiliteten til programmet i sanntid og automatisk rapportere eventuelle tekniske feil til utviklerne våre.
+
+Disse dataene lar teamet vårt raskt rette og optimalisere programmet, noe som gir en bedre brukeropplevelse for deg.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Innstillinger</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Kontoer og synkroniseringer</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avansert</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Generelt</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-mappe</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Logg inn i nettleseren din</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Åpne kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Avslutt</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Innstillinger</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Ledig plass på datamaskinen</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-filer lagret på datamaskinen</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Andre filer på datamaskinen</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Laster inn plassbruk…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Ledig plass</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Andre filer</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>kDrive-filer som er lagret på enheten din</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive kan ikke få tilgang til volumet
+Sørg for at det er tilkoblet,
+låst opp og tilgjengelig fra datamaskinen din.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Volumet er ikke tilgjengelig</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Administrer synkroniserte mapper for å frigjøre plass på din Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Denne PC-en – %1 – %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 av %2 brukt</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Lagret på nett</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Filene dine forblir i skyen og bruker ikke plass på datamaskinen din.
+Internettforbindelse kreves for å åpne dem.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synkroniseringsfeil</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Tilpasset mappe</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Standardmappe</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Den nye synkroniseringsmodusen din blir brukt…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synkroniseringsregler</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Det oppstod en feil</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Siste synkronisering var vellykket</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synkronisering er pauset</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synkronisert</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synkronisert</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkronisert fra datamaskinen din</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkronisert fra kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>filene dine synkroniseres</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synkroniseringen er satt på pause</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>De siste filene dine oppdateres.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>De nedlastede filene dine forblir tilgjengelige.
+Synkroniseringen starter automatisk igjen så snart du er tilkoblet igjen.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Frakoblet</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Synkronisering er midlertidig stoppet.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synkronisering i pause</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Filene dine er tilgjengelige og synkronisert.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Ingen aktivitet pågår</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>filene dine er oppdaterte</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>En fil eller mappe i synkroniseringsmappen din ser ut til å være korrupt.
+Synkronisering er stoppet midlertidig. Kontroller filene dine og prøv igjen.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Korrupt fil oppdaget</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Aktivitet</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Hjem</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Lagring</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen må ikke være roten av en stasjon og må ikke inneholde eller befinne seg inne i en allerede synkronisert mappe.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen må være tom, ikke være roten av en stasjon, og ikke inneholde eller befinne seg inne i en allerede synkronisert mappe.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Denne mappen kan ikke brukes</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Individuell behandling</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Administrer synkronisering</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Et varsel informerer deg når en fil ekskluderes av denne regelen</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Lukk kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Åpne kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Innstillinger</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Kontroller at internettforbindelsen er aktiv, at dette navnet ikke allerede er i bruk, og at det ikke inneholder ugyldige tegn.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Kan ikke opprette denne mappen</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Uautorisert tilgang</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Filene dine er tilgjengelige og synkronisert.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Ingen nylig aktivitet</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Vennligst prøv igjen om noen øyeblikk.
+Hvis problemet vedvarer, ta kontakt med support.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Det oppstod en uventet feil</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Til i morgen</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 tilgjengelig</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Installasjonen tar mindre enn et minutt.
+Synkroniseringen din gjenopptas automatisk til slutt.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorer denne versjonen</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Installer nå</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Påminn meg senere</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Se hva som er nytt</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versjon %1 · Du bruker %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Oppdatering tilgjengelig</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>En ny versjon av kDrive kreves for å fortsette.
+Oppdater programmet for å få tilgang til filene dine og gjenoppta synkroniseringen.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Oppdatering kreves</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Oppdatering</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Ufullstendig opplasting</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Utelukk visse apper fra synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Legg til filer som skal ekskluderes fra synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Tilpassede ekskluderingsregler</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Utelukk bestemte filtyper fra synkronisering.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Vis kildekode</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Du har en synkroniseringsfeil</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Du har {0} synkroniseringsfeil</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive kan ikke få tilgang til disk %1
+Sørg for at den er tilkoblet,
+låst opp og tilgjengelig fra datamaskinen din.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Lagringsdisk %1 er ikke tilgjengelig</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Fjern</numerusform> 
+                <numerusform>Fjern (%1 regler)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Bruker endring…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Administrer diskplass</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Åpne overordnet mappe</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Oppdater</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Feilsøkingsnivå</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synkroniseringen vil starte på nytt automatisk.
+Hvis problemet vedvarer, ta kontakt med vår support og legg ved de tekniske detaljene nedenfor.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Tekniske detaljer</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Det oppstod en uventet feil</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Sletting avbrutt</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Dupliserte navn</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Du har ikke de nødvendige tillatelsene til å legge til en %1 på dette stedet.
+Be om tilgang fra eieren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke tillatelse til å slette dette %1. Det er blitt gjenopprettet til sin opprinnelige plassering. Be om tilgang fra eieren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Tilgangsrettighetene for %1 ble endret, noe som hindrer synkronisering.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>En fil eller mappe med dette navnet finnes allerede.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke rettighetene til å redigere denne filen.
+Originalversjonen er beholdt og endringen din er lagret i en separat fil med "konflikt" i navnet. Be om tilgang fra eieren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Navnet på dette %1 avsluttes med et mellomrom, noe som hindrer synkronisering. Gi nytt navn til %2 fra kDrive på nett.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>En ekskluderingsregel forhindrer synkronisering av dette %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>En fil med dette navnet finnes allerede.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Denne filen brukes for øyeblikket av en annen bruker.
+Endringene dine vil bli synkronisert senere.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Denne filen ble slettet på kDrive på nett mens du redigerte den. En kopi er beholdt på datamaskinen din i gjenopprettingsmappen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Denne filen overskrider maksimal tillatt størrelse (50 GB).
+Kontakt administratoren din for å øke filstørrelsesgrensen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Dette navnet inneholder bare mellomrom og kan ikke brukes. Gi nytt navn til %1 fra kDrive på nett.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Denne filen er en hardlenke som ikke kan synkroniseres.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har ikke rettighetene til å flytte dette %1 hit; det vil bli gjenopprettet til sin opprinnelige plassering. Be om tilgang fra eieren eller administratoren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Dette navnet overskrider tillatt lengde (250 tegn). Gi nytt navn til %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Det er ikke nok plass på datamaskinen din til å synkronisere denne filen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Den fullstendige mappen er stor.
+For å fremskynde opplastingen anbefaler vi å sende bare den siste kDrive-sesjonen.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Send bare siste sesjon</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nb, Norwegian Bokmål
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nb"> 
     <context>
@@ -2077,7 +2077,7 @@ Disse dataene lar teamet vårt raskt rette og optimalisere programmet, noe som g
             <translation>kDrive-mappe</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Logg inn i nettleseren din</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_nb.ts
+++ b/src/gui4/linux/translations/client_nb.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="nb"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ låst opp og tilgjengelig fra datamaskinen din.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Bruker endring…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Administrer diskplass</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Åpne overordnet mappe</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Oppdater</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Feilsøkingsnivå</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Hvis problemet vedvarer, ta kontakt med vår support og legg ved de tekniske det
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Tekniske detaljer</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Det oppstod en uventet feil</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Sletting avbrutt</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Dupliserte navn</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Be om tilgang fra eieren eller administratoren.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har ikke tillatelse til å slette dette %1. Det er blitt gjenopprettet til sin opprinnelige plassering. Be om tilgang fra eieren eller administratoren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Tilgangsrettighetene for %1 ble endret, noe som hindrer synkronisering.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>En fil eller mappe med dette navnet finnes allerede.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ Originalversjonen er beholdt og endringen din er lagret i en separat fil med "ko
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Navnet på dette %1 avsluttes med et mellomrom, noe som hindrer synkronisering. Gi nytt navn til %2 fra kDrive på nett.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>En ekskluderingsregel forhindrer synkronisering av dette %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>En fil med dette navnet finnes allerede.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Endringene dine vil bli synkronisert senere.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Denne filen ble slettet på kDrive på nett mens du redigerte den. En kopi er beholdt på datamaskinen din i gjenopprettingsmappen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Kontakt administratoren din for å øke filstørrelsesgrensen.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Dette navnet inneholder bare mellomrom og kan ikke brukes. Gi nytt navn til %1 fra kDrive på nett.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Denne filen er en hardlenke som ikke kan synkroniseres.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har ikke rettighetene til å flytte dette %1 hit; det vil bli gjenopprettet til sin opprinnelige plassering. Be om tilgang fra eieren eller administratoren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Dette navnet overskrider tillatt lengde (250 tegn). Gi nytt navn til %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Det er ikke nok plass på datamaskinen din til å synkronisere denne filen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nl, Dutch; Flemish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nl"> 
     <context>
@@ -2077,7 +2077,7 @@ Deze gegevens stellen ons team in staat de applicatie snel te corrigeren en te o
             <translation>kDrive-map</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Inloggen via uw browser</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="nl"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ ontgrendeld en toegankelijk is vanaf uw computer.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Wijziging toepassen…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Schijfruimte beheren</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Bovenliggende map openen</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Bijwerken</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Debugniveau</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Als het probleem aanhoudt, neem dan contact op met onze ondersteuning en voeg de
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Technische details</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Er is een onverwachte fout opgetreden</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Verwijdering geannuleerd</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Dubbele namen</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Vraag toegang aan bij de eigenaar of beheerder.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>U heeft geen toestemming om deze %1 te verwijderen. Het is hersteld naar de oorspronkelijke locatie. Vraag toegang aan bij de eigenaar of beheerder.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>De toegangsrechten voor %1 zijn gewijzigd, waardoor het niet kan worden gesynchroniseerd.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Er bestaat al een bestand of map met deze naam.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ De originele versie is bewaard en uw bewerking is opgeslagen in een apart bestan
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>De naam van dit %1 eindigt met een spatie, waardoor het niet kan worden gesynchroniseerd. Hernoem de %2 vanuit kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Een uitsluitingsregel verhindert de synchronisatie van dit %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Er bestaat al een bestand met deze naam.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Uw wijzigingen worden later gesynchroniseerd.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Dit bestand is verwijderd op kDrive online terwijl u het aan het bewerken was. Een kopie is bewaard op uw computer in de herstelmap.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Neem contact op met uw beheerder om de bestandsgroottelimiet te verhogen.</trans
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Deze naam bevat alleen spaties en kan niet worden gebruikt. Hernoem de %1 vanuit kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Dit bestand is een harde koppeling (hard link) die niet kan worden gesynchroniseerd.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>U heeft niet de rechten om dit %1 hier te verplaatsen; het wordt hersteld naar de oorspronkelijke locatie. Vraag toegang aan bij de eigenaar of beheerder.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Deze naam overschrijdt de toegestane lengte (250 tekens). Hernoem de %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Er is onvoldoende ruimte op uw computer om dit bestand te synchroniseren.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: nl, Dutch; Flemish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="nl"> 
     <context>
@@ -344,6 +344,16 @@ U kunt ze op elk moment openen, zelfs zonder internetverbinding.</translation>
             <source>Manage storage</source> 
             <translation>Opslag beheren</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximaliseren</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimaliseren</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Debugmap openen</translation> 
@@ -427,6 +437,11 @@ U kunt ze op elk moment openen, zelfs zonder internetverbinding.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Synchronisatie opnieuw starten</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Herstellen</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_nl.ts
+++ b/src/gui4/linux/translations/client_nl.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: nl, Dutch; Flemish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="nl"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versie %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versie %1 (build %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Over</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Over kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Ontwikkeld en uitsluitend gehost in Zwitserland biedt kDrive totale bescherming van uw gegevens, zonder doorverkoop of bespionering, in ISO-gecertificeerde datacenters, met versleuteling en back-up op meerdere media.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Zichtbare activiteiten</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Een distributiekanaal kiezen</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Meer informatie weergeven</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Een synchronisatiemodus selecteren</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synchronisatie voltooid</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synchronisatie bezig</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Geen recente activiteit</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>U bent offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synchronisatie onderbroken</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Alle activiteiten</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Alleen mijn activiteit</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Een map synchroniseren met kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Kies de map op uw computer die u wilt synchroniseren met kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Gesynchroniseerde map</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Pas de locatie van uw computermap op kDrive aan:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Kies de maplocatie op kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-locatie</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Selecteer een map op uw computer om te synchroniseren met kDrive.
+U kunt uw geavanceerde synchronisaties openen via de schijfkiezer op de startpagina.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Een map synchroniseren met kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Geavanceerde synchronisatie</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Te negeren app</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>De applicatie is up-to-date</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Verwijdert logboeken ouder dan 7 dagen om schijfruimte te besparen.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatisch opruimen</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatische updates</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Beschikbaar offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Uw bestanden worden gekopieerd naar uw computer.
+U kunt ze op elk moment openen, zelfs zonder internetverbinding.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>U kunt het activeren vanuit de webinterface.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Krijg vroeg toegang tot nieuwe versies van de applicatie voordat ze worden vrijgegeven aan het grote publiek en help de app te verbeteren door uw verbeterideeën met ons te delen.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Deelnemen aan het bètaprogramma</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Uw browser zou automatisch moeten openen om het inloggen te voltooien. Zodra u bent ingelogd, keert u automatisch terug naar kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Offline synchronisatie inschakelen</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Een map synchroniseren</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Een regel toevoegen</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Opslag toevoegen</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Geavanceerde instellingen</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Toepassen op %1 bestanden</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Toegang aanvragen</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Annuleren</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Map wijzigen</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Offline opslaan</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Online opslaan</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Van gebruiker wisselen</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Sluiten</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>kDrive sluiten</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configureren</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Bevestigen</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Inloggen</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Een account verbinden</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contact opnemen met ondersteuning</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Doorgaan</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Deellink kopiëren</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Een account aanmaken</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Een nieuwe synchronisatie aanmaken</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Aangepaste locatie</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Dit account loskoppelen</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Downloaden…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Handmatig downloaden</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Inschakelen</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Inschakelen in Windows-instellingen</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Het probleem begrijpen</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Een idee delen</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Installatie voltooien</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Fouten corrigeren</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Ondersteuning</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Ik heb kDrive geactiveerd</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Account bewaren</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Uitloggen</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Inloggen</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Beheren</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Bestanden afzonderlijk behandelen</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Opslag beheren</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Debugmap openen</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Verkenner openen</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Map openen</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Openen in browser</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Openen in Verkenner</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Openen in Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Openen in kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>kDrive openen</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Uitsluitingen beheren</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Synchronisatie-instellingen openen</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pauzeren</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Vernieuwen</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Release-opmerkingen</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Verwijderen</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Verwijder (%n element)</numerusform> 
+                <numerusform>Verwijderen (%n elementen)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Synchronisatie verwijderen</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>%1 hernoemen</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Inloggen opnieuw starten</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Synchronisatie hervatten</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Synchronisatie opnieuw starten</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Opnieuw proberen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Terug naar standaardmap</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Opslaan</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Mijn keuzes opslaan</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Zoeken</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Activiteiten bekijken</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Selecteren</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Een map selecteren</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Mappen selecteren</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Een locatie selecteren</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Geselecteerd</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Verzenden</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Debugmap verzenden</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Instellingen openen</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Aanbiedingen bekijken</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Opties weergeven</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Uitloggen</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Starten</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Versieselectie starten</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Gratis aan de slag</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Offline synchroniseren</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Nu bijwerken</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Abonnement bijwerken</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Upgraden</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Bevestigen</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Bevestigen en naar volgende gaan</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Activeren</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Een versie kiezen</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Er zijn twee verschillende versies van deze bestanden gedetecteerd.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versieconflicten</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Zoek een bestand</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Link kopiëren…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Deellink aanmaken…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>U kunt de gebruiks- en operationele gegevens aanpassen die door Infomaniak worden verzameld om bugs op te lossen en de applicatie te verbeteren. Beide gebruikte tools worden uitsluitend door ons gehost en beheerd.
+
+De broncode van deze applicatie kan worden geverifieerd, de verzamelde informatie is anoniem en uw persoonlijke informatie blijft strikt vertrouwelijk en wordt nooit gedeeld met derden.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Gegevensbeheer</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respecteert uw privacy</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Selecteer de hoeveelheid te registreren informatie.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Stellen de Infomaniak-ondersteuning in staat de oorzaak van een incident te identificeren.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Debuglogboeken</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Deze apps worden standaard genegeerd en kunnen niet worden gewijzigd.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Deze bestanden worden standaard uitgesloten en kunnen niet worden gewijzigd.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatische uitsluiting</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>In deze situaties is een nieuwe synchronisatie vereist om kDrive correct te blijven gebruiken.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Selecteer een lege map die zich niet bevindt in de root van een schijf.
+
+Deze map mag niet zijn opgenomen in een andere synchronisatiemap en mag geen synchronisatiesubmap bevatten.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Deze map kan niet worden geselecteerd</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Een regel toevoegen</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Een uitsluitingsregel toevoegen</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>U staat op het punt %1 te verwijderen uit de applicatie.
+De synchronisatiemap blijft op uw computer, maar wordt niet meer gesynchroniseerd met kDrive.
+
+Al uw gegevens blijven online toegankelijk op kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Uitloggen bij dit account?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>De lokale map blijft op uw computer, maar wordt niet meer gesynchroniseerd met kDrive.
+Deze actie is permanent.
+Om uw schijf opnieuw te synchroniseren, moet u deze later opnieuw verbinden.
+
+Zorg er voor het doorgaan voor dat al uw bestanden up-to-date zijn en volledig gesynchroniseerd zijn.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Synchronisatie verwijderen?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>De wijziging van de synchronisatiemodus is geannuleerd.
+
+De huidige synchronisatie blijft ongewijzigd. Als er echter abnormaal gedrag optreedt, moet u mogelijk de synchronisatie verwijderen en opnieuw aanmaken om de goede werking te herstellen.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Er is een fout opgetreden</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Deze bewerking kan enige tijd in beslag nemen, afhankelijk van de grootte van uw gegevens. Als dit mislukt, kan een volledige hersynchronisatie van de schijf nodig zijn.
+
+Zorg er voor het doorgaan voor dat al uw bestanden up-to-date en gesynchroniseerd zijn.
+
+Sluit de applicatie niet tijdens het proces.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Synchronisatiemodus wijzigen?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Dit is hoe u de synchronisatie kunt herstellen:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>De schijf met uw synchronisatiemap is niet meer verbonden</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Sluit deze opnieuw aan om de synchronisatie te hervatten.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Meldingen uitschakelen</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Niet deelnemen</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>U heeft geen toestemming om toegang te krijgen tot dit kDrive.
+Controleer uw machtigingen of neem contact op met uw beheerder.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Toegang geweigerd tot kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Uw kDrive is in de slaapstand</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Dit kDrive is niet verlengd. U heeft er geen toegang meer toe.
+Vernieuw uw abonnement om de service opnieuw te activeren.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Dit kDrive is niet verlengd. U heeft er geen toegang meer toe.
+Neem contact op met uw beheerder om de service opnieuw te activeren.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Uw kDrive is verlopen</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Log opnieuw in om kDrive te blijven gebruiken.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>U bent uitgelogd</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Het account dat voor deze verbinding is gebruikt, komt niet overeen met dat van dit kDrive.
+Log opnieuw in met het juiste e-mailadres %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Dit account komt niet overeen</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive wordt geactiveerd… dit kan enkele ogenblikken duren.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive wordt geactiveerd</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Diagnostische informatie opnemen op mijn computer.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Foutopsporingsregistratie inschakelen</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Voer uw wachtwoord in</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Er bestaat al een andere %1 waarvan de naam alleen verschilt in hoofdletters/kleine letters in deze map. Dit type naam wordt niet ondersteund door de kDrive Windows applicatie. Hernoem een van de %2 mappen van kDrive online zodat u deze op uw pc kunt synchroniseren.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Conflicterende namen, hoofdlettergevoelig</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Er is een wijziging gedetecteerd in uw configuratie</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>In deze situaties kan een nieuwe synchronisatie nodig zijn om kDrive correct te blijven gebruiken.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Raadpleeg de %1 om de toegang te herstellen</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Laatste locatie van %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Externe schijf losgekoppeld</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Deze bewerking kan enige tijd in beslag nemen, afhankelijk van de hoeveelheid te verwerken gegevens.
+
+Sluit de applicatie niet tijdens het proces.
+
+Als het mislukt, kunt u eenvoudig een volledige hersynchronisatie van de schijf starten of contact opnemen met onze ondersteuning.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Offline synchronisatie inschakelen</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Dit kDrive is tijdelijk niet beschikbaar vanwege onderhoud.
+Probeer het over enkele minuten opnieuw.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Onderhoud bezig</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Spatie aan het einde van de naam van %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Uitgesloten van synchronisatie</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Bestand vergrendeld</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Bestand gered</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Dit bestand overschrijdt de maximaal toegestane grootte (50 GB).
+Neem contact op met ondersteuning om de limiet op te heffen.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Bestand te groot</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Toegang geweigerd</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>De naam van dit %1 bevat een of meer tekens die niet worden ondersteund door de kDrive Windows-applicatie. Hernoem de %2 vanuit kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Ongeldige naam</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Niet-ondersteund teken</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>U heeft niet de vereiste rechten om deze actie uit te voeren.
+Vraag toegang aan bij de eigenaar of beheerder.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Toegang geweigerd</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Niet-ondersteund bestandstype</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Deze map is niet meer toegankelijk op de oorspronkelijke locatie.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synchronisatiemap niet gevonden</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Een van uw kDrives is gesynchroniseerd in de synchronisatiemap van een ander kDrive.
+Verplaats een van de mappen zodat ze niet meer genest zijn, of verwijder uw synchronisatie om deze opnieuw aan te maken.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Geneste kDrives</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Kan geen toegang krijgen tot dit %1 op uw computer. Controleer of het nog bestaat en of u de rechten heeft om er toegang toe te krijgen.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 ontoegankelijk</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Naam van %1 te lang</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Kan geen verbinding maken met kDrive.
+De synchronisatie wordt automatisch hervat zodra de verbinding is hersteld.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Verbinding tijdelijk niet beschikbaar</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Onvoldoende schijfruimte</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>De naam van dit bestand bevat een of meer tekens die nog niet worden ondersteund door de kDrive-applicatie. Hernoem het bestand vanuit kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Niet-ondersteund teken</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Het pad naar dit %1 is te lang om te worden gesynchroniseerd. Hernoem een of meer mappen waarin het zich bevindt om het pad te verkorten.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Pad naar %1 te lang</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Uw kDrive is vol. Maak ruimte vrij of upgrade uw abonnement om dit %1 te synchroniseren.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Opslaglimiet bereikt</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Deze naam is gereserveerd door het systeem van uw computer. Hernoem de %1 vanuit kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Naam van %1 gereserveerd</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Controleer de locatie of de toegangsrechten van de map.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synchronisatiemap ontoegankelijk</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync heeft niet de benodigde machtigingen om te functioneren.
+open macOS Voorkeuren om ze in te schakelen.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Toestemming vereist</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>De schijfruimte van uw apparaat is vol. De synchronisatie is onderbroken. Maak ruimte vrij om de synchronisatie te hervatten.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Onvoldoende schijfruimte</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Deze map is niet meer toegankelijk op de oorspronkelijke locatie.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Deze map is niet meer toegankelijk. Er is actie vereist om de synchronisatie te hervatten.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synchronisatiemap niet gevonden</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync kan niet starten. U kunt uw bestanden blijven synchroniseren door offline synchronisatie in te schakelen in de instellingen. Neem contact op met ondersteuning als het probleem aanhoudt.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Kan Lite Sync niet starten</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>De synchronisatie van dit item is mislukt. Het wordt later automatisch opnieuw geprobeerd.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synchronisatie tijdelijk mislukt</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Het uploaden kon niet worden voltooid. Probeer het later opnieuw.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Het lijkt erop dat we de app niet kunnen laden…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Er is een fout opgetreden bij het verwijderen van uw account.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Te controleren bestanden</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Overige</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Systeem en machtigingen</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Kan URL %1 niet openen</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Te corrigeren fouten</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Dit dossier kan niet worden gesynchroniseerd. Kies een ander dossier.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Fout bij het starten van het installatieprogramma</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Fout bij het wijzigen van de synchronisatiemodus</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blokkeer apps die uw bestanden kunnen downloaden of wijzigen.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Bestanden die overeenkomen met deze regel worden niet gesynchroniseerd.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Voorkom dat bepaalde tijdelijke bestanden of systeembestanden naar kDrive worden gekopieerd.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Schakelt het verzamelen van aanvullende informatie in die nuttig is voor ondersteuning.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Uitgebreid gedetailleerd logboek</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Wanneer deze optie is ingeschakeld, werkt kDrive langzamer.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Aanmaken van deellink mislukt</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Help ons kDrive te verbeteren</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>En notifikation underretter dig, når en fil udelukkes af denne regel.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Bestand bestaat al</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Bestandssynchronisatiemodus</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Bepaal hoe uw bestanden worden opgeslagen en geopend.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Te uitsluiten bestanden</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favorieten</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Gedeeld</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Prullenbak</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Gedurende 1 uur</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Gedurende een week</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Gedurende drie dagen</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hallo %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Ondersteuning</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Maak ruimte vrij of upgrade uw abonnement om uw bestanden te blijven synchroniseren.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Uw kDrive is vol</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Sommige bestanden konden niet worden gesynchroniseerd.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>U heeft &lt;b&gt;één synchronisatiefout&lt;/b&gt;</numerusform> 
+                <numerusform>U heeft &lt;b&gt;%n synchronisatiefouten&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>We kunnen geen toegang krijgen tot uw bestanden. Start de applicatie opnieuw op om de synchronisatie te hervatten. Als het probleem aanhoudt, neem dan contact op met ondersteuning.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Verbinding met kDrive onderbroken</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Activeer kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>U moet kDrive.app activeren voor u kunt doorgaan</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Activeer kDrive en kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>U moet de machtigingen activeren voor u kunt doorgaan</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Ga naar Privacy &amp; Beveiliging &gt; Volledige schijftoegang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Volledige schijftoegang</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Privacy &amp; Beveiliging</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Selecteer Openen &amp; Extensies &gt; Beveiligingsextensies</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Beveiligingsextensies</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Openen &amp; Extensies</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Open Systeeminstellingen &gt; Algemeen</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Systeeminstellingen</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Start de applicatie opnieuw als dit wordt gevraagd</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Dit item is niet beschikbaar op dit apparaat.
+Het wordt geopend in uw browser.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Toegangsrechten gewijzigd</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Ingeschakeld</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>%1 geleden</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Alle mappen</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Geheel kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Tracking toestaan</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Toepassingsidentificatie</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Naam van de app</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Auteur</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Standaard</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Kies welke versie van uw bestanden u wilt bewaren.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Selecteer voor elk bestand de te bewaren versie.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Welke versie wilt u bewaren?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Kies de te bewaren versie</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>De online versies van deze %1 bestanden worden vervangen door uw lokale versies.
+Let op: dit kan het werk van uw medewerkers overschrijven.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Alleen lokale versies bewaren</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Voor elk conflict bewaren we automatisch de meest recentelijk gewijzigde versie (lokaal of online). Dit is in de meeste gevallen de veiligste keuze.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>De meest recente versies bewaren</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Alle lokale wijzigingen voor deze %1 bestanden worden verwijderd.
+Handig als u weet dat het belangrijke werk online staat op kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Alleen online versies bewaren</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Log in om te beginnen.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Maak een %1 aan.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Datum</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Uitgeschakeld</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>bestand</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Map</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Map verwijderd</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Map verplaatst of gewijzigd</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>De map is mogelijk verplaatst naar een andere schijf en daarna teruggezet naar de oorspronkelijke locatie.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>map</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Map verplaatst of hernoemd</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Map opnieuw aangemaakt of vervangen</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>De map is verwijderd en opnieuw aangemaakt, of vervangen door een andere map met dezelfde naam.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Zojuist</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokaal</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 bestanden zijn zowel op uw computer als op kDrive gewijzigd.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Meest recent</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Naam</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Nieuw apparaat gedetecteerd</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>U gebruikt kDrive op een nieuwe computer, na het herstellen vanuit een back-up.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nieuwe map</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nieuwe synchronisatie</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Geen conflicten gevonden voor uw zoekopdracht</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Geen fouten te corrigeren</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Melding</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Melding als bestand is uitgesloten</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Uit</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Online map verwijderd</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>De gesynchroniseerde map is verwijderd op kDrive online of is niet meer toegankelijk.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Oorspronkelijke locatie:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Aanbevolen</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>De map is mogelijk verplaatst naar een andere schijf en daarna teruggezet naar de oorspronkelijke locatie.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Zet het terug naar de oorspronkelijke locatie.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regels</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Hetzelfde als het systeem</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>u</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sec</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Sinds: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Grootte</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 vrij</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 vrij</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Berekenen…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 gebruikt</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 gebruikt</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Gesynchroniseerd vanuit kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Gesynchroniseerd vanuit uw computer</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Dit kDrive bevat alleen bestanden. Alle bestanden worden op dit apparaat gesynchroniseerd.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Geen map te selecteren</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synchronisatiemappen</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Locatie</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synchroniseer uw kDrives op dit apparaat</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Gesynchroniseerde mappen</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synchronisatie</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tijd</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Welkom bij kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 van %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive-beheer</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Taal</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Start de applicatie opnieuw op om de nieuwe taal volledig toe te passen.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Meer informatie</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3-licentie - Git-bronnen</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link gekopieerd naar klembord</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Incompatibele schijf of map direct in de root van de schijf (bijv.: kies een map zoals /Mijn drive in plaats van /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Incompatibele schijf of map direct in de root van de schijf (bijv.: kies een map zoals D:/Mijn drive in plaats van D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Locatie op computer</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Foutopsporing</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Fout</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Uitgebreid</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Kritiek</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Waarschuwing</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Debugmap naar Infomaniak-ondersteuning sturen</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Sommige bestandsnamen kunnen speciale tekens bevatten die niet worden ondersteund (zoals dubbele aanhalingstekens, backslashes of regeleinden).
+
+Controleer en hernoem de bestanden met ongebruikelijke tekens en probeer het opnieuw.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Ongeldige bestandsnaam</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Logboeken comprimeren…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Logboeken naar ondersteuning uploaden…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>De laatste upload is mislukt. Controleer uw internetverbinding en zorg ervoor dat er ten minste één kDrive-gebruiker is ingelogd. Uploads zijn beperkt tot 10 per dag.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Er zijn verschillende versies van deze bestanden gedetecteerd.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 versieconflicten gedetecteerd</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo is een analysetool die uitsluitend door Infomaniak wordt gehost en beheerd om te begrijpen hoe de applicatie wordt gebruikt.
+
+Het analyseren van deze gegevens stelt ons team in staat de interface van de applicatie voortdurend te verbeteren.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Verplaatsing geannuleerd</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Verwijderde bestanden naar de prullenbak van de computer verplaatsen</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Sommige items kunnen mogelijk niet worden verplaatst.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Meer opslag, meer functies met my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Hulp nodig?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Netwerk</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Voeg een account toe om te beginnen</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Geen resultaten gevonden</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Niet gesynchroniseerd</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Altijd</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Nooit</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Een melding ontvangen wanneer een bestand wordt uitgesloten</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Synchronisatie voor dit kDrive configureren</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Pas de locatie van uw kDrive-map op uw computer aan:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>De gekozen map moet leeg zijn voor de synchronisatie correct te werken.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Kies de mappen om op deze computer te synchroniseren:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Gesynchroniseerde mappen</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Voor elk kDrive kunt u kiezen waar het op uw computer wordt gesynchroniseerd en welke mappen worden gesynchroniseerd.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Gesynchroniseerde inhoud:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Gesynchroniseerde inhoud: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Locatie:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Locatie: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Uw kDrives configureren</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Kies de mappen om op deze computer te synchroniseren</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Bestanden worden alleen gedownload bij het openen, om schijfruimte te besparen.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Lite Sync inschakelen</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Dit kDrive is al geconfigureerd.
+Ga naar uw instellingen om het te wijzigen.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autoriseer kDrive in de macOS-instellingen:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Activeer kDrive op uw Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Om de installatie te voltooien, moet u kDrive toestemming geven om toegang te krijgen tot uw mappen:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Toegang tot mappen autoriseren</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Begin gratis met my kSuite,
+of kies een abonnement dat bij uw behoeften past.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>U heeft nog geen kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Kies de kDrives om op deze computer te synchroniseren:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisatie bezig</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Fijn u te zien!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Alle kDrive-mappen</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Aangepaste selectie</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>De privé, snelle en veilige cloud, gehost in Zwitserland.
+
+Log in en houd uw documenten gesynchroniseerd op al uw apparaten.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Er is een fout opgetreden, probeer het opnieuw.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Inlogfout</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Nog even geduld, we laden uw account…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Inloggen via uw browser…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Uw gegevens ophalen…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Een ogenblik…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Welkom bij kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Uw bestanden zijn klaar om veilig
+te worden gesynchroniseerd op uw computer.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Alles klaar!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>We voltooien de configuratie van uw kDrives.
+
+Even geduld alstublieft.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synchronisatie bezig…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>kDrive openen wanneer de computer start</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>De inlogpagina openen</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Pad gekopieerd naar klembord</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Bepaal hoe kDrive verbinding maakt met internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Authenticatie vereist</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Wachtwoord</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Poort</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxy-instellingen</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxytype</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Handmatige configuratie</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Geen</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Gebruikersnaam</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Bèta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Intern</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Locatie op kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Zoeken in %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Selecteer de mappen om op deze computer te synchroniseren.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Niet-geselecteerde mappen worden niet gedownload naar uw apparaat. Ze blijven online beschikbaar en worden niet verwijderd.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Niet-geselecteerde mappen worden niet gedownload naar uw apparaat. Ze blijven online beschikbaar.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry is een tool die uitsluitend door Infomaniak wordt gehost en beheerd om de stabiliteit van de applicatie in real time te bewaken en eventuele technische fouten automatisch aan onze ontwikkelaars te melden.
+
+Deze gegevens stellen ons team in staat de applicatie snel te corrigeren en te optimaliseren, wat resulteert in een betere gebruikerservaring voor u.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Instellingen</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Accounts &amp; synchronisatiess</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Geavanceerd</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Algemeen</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-map</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Inloggen via uw browser</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>kDrive openen</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Afsluiten</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Instellingen</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Vrije ruimte op computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-bestanden opgeslagen op computer</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Andere bestanden op computer</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Ruimtegebruik laden…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Vrije ruimte</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Overige bestanden</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>kDrive-bestanden die op je apparaat zijn opgeslagen</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive heeft geen toegang tot het volume
+Zorg ervoor dat het correct is aangesloten,
+ontgrendeld en toegankelijk is vanaf uw computer.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Het volume is niet toegankelijk</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Beheer gesynchroniseerde mappen om ruimte vrij te maken op uw Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synchronisatie</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Deze pc - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 van %2 gebruikt</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Online opgeslagen</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Uw bestanden blijven in de cloud en gebruiken geen ruimte op uw computer.
+Een internetverbinding is vereist om ze te openen.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synchronisatiefout</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Aangepaste map</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Standaardmap</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synchronisatie</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Uw nieuwe synchronisatiemodus wordt toegepast…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synchronisatieregels</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Er is een fout opgetreden</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Laatste synchronisatie geslaagd</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synchronisatie is gepauzeerd</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synchronisatie is bezig</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Gesynchroniseerd</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Gesynchroniseerd</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Gesynchroniseerd vanuit uw computer</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Gesynchroniseerd vanuit kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>uw bestanden worden gesynchroniseerd</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>de synchronisatie is onderbroken</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Uw recente bestanden worden bijgewerkt.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronisatie bezig</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Uw gedownloade bestanden blijven beschikbaar.
+De synchronisatie wordt automatisch hervat zodra u weer verbinding hebt.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>De synchronisatie is tijdelijk gestopt.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synchronisatie tijdens pauze</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Uw bestanden zijn toegankelijk en gesynchroniseerd.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Geen activiteit bezig</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>uw bestanden zijn up-to-date</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synchronisatie</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Een bestand of map in uw synchronisatiemap lijkt beschadigd te zijn.
+De synchronisatie is onderbroken. Controleer uw bestanden en probeer het opnieuw.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Beschadigd bestand gedetecteerd</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Activiteit</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Startpagina</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Opslag</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>De map mag niet de root van een schijf zijn en mag geen reeds gesynchroniseerde map bevatten of daarin opgenomen zijn.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>De map moet leeg zijn, mag niet de root van een schijf zijn en mag geen reeds gesynchroniseerde map bevatten of daarin opgenomen zijn.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Deze map kan niet worden gebruikt</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Afzonderlijke verwerking</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Synchronisatie beheren</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Een melding informeert u wanneer een bestand door deze regel wordt uitgesloten</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>kDrive sluiten</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>kDrive openen</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Instellingen</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Controleer of uw internetverbinding actief is, of deze naam nog niet in gebruik is en of het geen ongeldige tekens bevat.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Kan deze map niet aanmaken</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Ongeautoriseerde toegang</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Uw bestanden zijn toegankelijk en gesynchroniseerd.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Geen recente activiteit</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Probeer het over een paar ogenblikken opnieuw.
+Als het probleem aanhoudt, neem dan contact op met ondersteuning.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Er is een onverwachte fout opgetreden</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Tot morgen</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 beschikbaar</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>De installatie duurt minder dan een minuut.
+Uw synchronisatie wordt automatisch hervat na afloop.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Deze versie negeren</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Nu installeren</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Herinner me later</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Bekijk de nieuwigheden</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versie %1 · U gebruikt %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Update beschikbaar</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Een nieuwe versie van kDrive is vereist om door te gaan.
+Werk de applicatie bij om toegang te krijgen tot uw bestanden en de synchronisatie te hervatten.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Update vereist</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Update</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Onvolledig uploaden</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Bepaalde apps uitsluiten van synchronisatie.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Bestanden toevoegen om uit de synchronisatie uit te sluiten.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Aangepaste uitsluitingsregels</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Sluit bepaalde bestandstypen uit van synchronisatie.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Broncode bekijken</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>U heeft een synchronisatiefout</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>U heeft {0} synchronisatiefouten</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive heeft geen toegang tot schijf %1
+Zorg ervoor dat deze correct is aangesloten,
+ontgrendeld en toegankelijk is vanaf uw computer.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Opslagschijf %1 is niet toegankelijk</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Verwijderen</numerusform> 
+                <numerusform>Verwijderen (%1 regels)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Wijziging toepassen…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Schijfruimte beheren</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Bovenliggende map openen</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Bijwerken</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Debugniveau</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>De synchronisatie wordt automatisch opnieuw gestart.
+Als het probleem aanhoudt, neem dan contact op met onze ondersteuning en voeg de onderstaande technische details bij.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Technische details</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Er is een onverwachte fout opgetreden</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Verwijdering geannuleerd</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Dubbele namen</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>U heeft niet de vereiste rechten om een %1 toe te voegen aan deze locatie.
+Vraag toegang aan bij de eigenaar of beheerder.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>U heeft geen toestemming om deze %1 te verwijderen. Het is hersteld naar de oorspronkelijke locatie. Vraag toegang aan bij de eigenaar of beheerder.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>De toegangsrechten voor %1 zijn gewijzigd, waardoor het niet kan worden gesynchroniseerd.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Er bestaat al een bestand of map met deze naam.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>U heeft niet de rechten om dit bestand te bewerken.
+De originele versie is bewaard en uw bewerking is opgeslagen in een apart bestand met "conflict" in de naam. Vraag toegang aan bij de eigenaar of beheerder.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>De naam van dit %1 eindigt met een spatie, waardoor het niet kan worden gesynchroniseerd. Hernoem de %2 vanuit kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Een uitsluitingsregel verhindert de synchronisatie van dit %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Er bestaat al een bestand met deze naam.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Dit bestand wordt momenteel gebruikt door een andere gebruiker.
+Uw wijzigingen worden later gesynchroniseerd.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Dit bestand is verwijderd op kDrive online terwijl u het aan het bewerken was. Een kopie is bewaard op uw computer in de herstelmap.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Dit bestand overschrijdt de maximaal toegestane grootte (50 GB).
+Neem contact op met uw beheerder om de bestandsgroottelimiet te verhogen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Deze naam bevat alleen spaties en kan niet worden gebruikt. Hernoem de %1 vanuit kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Dit bestand is een harde koppeling (hard link) die niet kan worden gesynchroniseerd.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>U heeft niet de rechten om dit %1 hier te verplaatsen; het wordt hersteld naar de oorspronkelijke locatie. Vraag toegang aan bij de eigenaar of beheerder.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Deze naam overschrijdt de toegestane lengte (250 tekens). Hernoem de %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Er is onvoldoende ruimte op uw computer om dit bestand te synchroniseren.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>De volledige map is groot.
+Om het uploaden te versnellen, raden we aan alleen de laatste kDrive-sessie te verzenden.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Alleen de laatste sessie verzenden</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pl, Polish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pl"> 
     <context>
@@ -2081,7 +2081,7 @@ Dane te pozwalają naszemu zespołowi na szybkie naprawianie i optymalizację ap
             <translation>Folder kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Zaloguj się przez przeglądarkę</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -1,0 +1,2685 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: pl, Polish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="pl"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Wersja %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Wersja %1 (kompilacja %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>O aplikacji</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>O kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Opracowany i hostowany wyłącznie w Szwajcarii, kDrive zapewnia pełną ochronę Twoich danych, bez odsprzedaży ani szpiegowania, w centrach danych certyfikowanych przez ISO, z szyfrowaniem i kopią zapasową na wielu nośnikach.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Widoczne aktywności</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Wybór kanału dystrybucji</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Pokaż więcej informacji</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Wybierz tryb synchronizacji</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synchronizacja zakończona</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synchronizacja w toku</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Brak ostatniej aktywności</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Jesteś offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synchronizacja wstrzymana</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Wszystkie aktywności</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Tylko moja aktywność</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synchronizuj folder z kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Wybierz folder na swoim komputerze do synchronizacji z kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synchronizowany folder</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Dostosuj lokalizację folderu komputera w kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Wybierz lokalizację folderu w kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Lokalizacja w kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Wybierz folder na swoim komputerze do synchronizacji z kDrive.
+Dostęp do zaawansowanych synchronizacji można uzyskać za pomocą selektora dysków na stronie głównej.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synchronizuj folder z kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Zaawansowana synchronizacja</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Aplikacja do wykluczenia</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Aplikacja jest aktualna</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Usuwa dzienniki starsze niż 7 dni, aby zaoszczędzić miejsce na dysku.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatyczne czyszczenie</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatyczne aktualizacje</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Dostępne offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Twoje pliki są skopiowane na Twój komputer.
+Możesz je otwierać w dowolnym momencie, nawet bez połączenia z Internetem.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Możesz go wybudzić z poziomu interfejsu internetowego.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Uzyskaj wcześniejszy dostęp do nowych wersji aplikacji przed ich udostępnieniem ogółowi społeczeństwa i pomóż ulepszać aplikację, dzieląc się z nami swoimi pomysłami na ulepszenia.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Dołącz do programu beta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Twoja przeglądarka powinna otworzyć się automatycznie, aby dokończyć logowanie. Po zalogowaniu zostaniesz automatycznie przekierowany do kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Włącz synchronizację offline</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synchronizuj folder</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Dodaj regułę</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Dodaj pamięć</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Ustawienia zaawansowane</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Zastosuj do %1 plików</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Poproś o dostęp</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Anuluj</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Zmień folder</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Przechowuj offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Przechowuj online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Zmień użytkownika</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Zamknij</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Zamknij kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Skonfiguruj</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Potwierdź</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Zaloguj się</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Połącz konto</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Kontakt z pomocą techniczną</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Kontynuuj</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Kopiuj link udostępniania</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Utwórz konto</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Utwórz nową synchronizację</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Niestandardowa lokalizacja</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Odłącz to konto</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Pobieranie…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Pobierz ręcznie</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Włącz</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Włącz w ustawieniach Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Zrozum problem</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Podziel się pomysłem</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Zakończ instalację</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Napraw błędy</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Wsparcie</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Aktywowałem/am kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Zachowaj konto</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Wyloguj się</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Zaloguj się</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Zarządzaj</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Obsługuj pliki indywidualnie</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Zarządzaj pamięcią</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Otwórz folder debugowania</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Otwórz Eksplorator</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Otwórz folder</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Otwórz w przeglądarce</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Otwórz w Eksploratorze</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Otwórz w Finderze</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Otwórz w kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Otwórz kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Zarządzaj wykluczeniami</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Otwórz ustawienia synchronizacji</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Wstrzymaj</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Odśwież</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Informacje o wydaniu</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Usuń</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Usuń (%n element)</numerusform> 
+                <numerusform>Usuń (%n elementy)</numerusform> 
+                <numerusform>Usuń (%n elementów)</numerusform> 
+                <numerusform>Usuń (%n elementów)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Usuń synchronizację</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Zmień nazwę %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Uruchom ponownie logowanie</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Wznów synchronizację</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Uruchom ponownie synchronizację</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Spróbuj ponownie</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Wróć do domyślnego folderu</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Zapisz</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Zapisz moje wybory</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Szukaj</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Wyświetl aktywności</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Wybierz</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Wybierz folder</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Wybierz foldery</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Wybierz lokalizację</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Wybrane</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Wyślij</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Wyślij folder debugowania</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Otwórz ustawienia</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Wyświetl oferty</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Pokaż opcje</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Wyloguj się</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Start</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Rozpocznij wybór wersji</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Zacznij za darmo</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synchronizuj offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Zaktualizuj teraz</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Zaktualizuj subskrypcję</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Uaktualnij</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Zatwierdź</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Zatwierdź i przejdź do następnego</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Wybudź</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Wybierz wersję</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Wykryto dwie różne wersje tych plików.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Konflikty wersji</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Wyszukaj plik</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopiowanie łącza…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Tworzenie łącza udostępniania…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Możesz dostosować dane użytkowania i operacyjne zbierane przez Infomaniak w celu naprawy błędów i ulepszania aplikacji. Oba używane narzędzia są hostowane i zarządzane wyłącznie przez nas.
+
+Kod źródłowy tej aplikacji może być weryfikowany, zbierane informacje są anonimowe, a Twoje dane osobowe pozostają ściśle poufne i nigdy nie są udostępniane osobom trzecim.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Zarządzanie danymi</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak szanuje Twoją prywatność</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Wybierz ilość informacji do rejestrowania.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Umożliwia wsparciu Infomaniak identyfikację przyczyny incydentu.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Dzienniki debugowania</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Te aplikacje są domyślnie ignorowane i nie można ich modyfikować.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Te pliki są domyślnie wykluczone i nie mogą być modyfikowane.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatyczne wykluczenie</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>W takich sytuacjach wymagana jest nowa synchronizacja, aby nadal prawidłowo korzystać z kDrive.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Wybierz pusty folder, który nie znajduje się w katalogu głównym dysku.
+
+Ten folder nie może być zawarty w innym folderze synchronizacji i nie może zawierać podfolderu synchronizacji.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Nie można wybrać tego folderu</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Dodaj regułę</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Dodaj regułę wykluczenia</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Zamierzasz odłączyć %1 od aplikacji.
+Folder synchronizacji pozostanie na Twoim komputerze, ale nie będzie już synchronizowany z kDrive.
+
+Wszystkie Twoje dane pozostaną dostępne online w kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Wylogować się z tego konta?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Folder lokalny pozostanie na Twoim komputerze, ale nie będzie już synchronizowany z kDrive.
+Ta akcja jest nieodwracalna.
+Aby ponownie zsynchronizować dysk, będziesz musiał podłączyć go ponownie później.
+
+Przed kontynuowaniem upewnij się, że wszystkie Twoje pliki są aktualne i w pełni zsynchronizowane.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Usunąć synchronizację?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Zmiana trybu synchronizacji została anulowana.
+
+Bieżąca synchronizacja pozostaje niezmieniona. Jednak jeśli wystąpi nieprawidłowe zachowanie, może być konieczne usunięcie i ponowne utworzenie synchronizacji w celu przywrócenia prawidłowego działania.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Wystąpił błąd</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Ta operacja może potrwać pewien czas w zależności od rozmiaru danych. W przypadku niepowodzenia może być wymagana pełna ponowna synchronizacja dysku.
+
+Przed kontynuowaniem upewnij się, że wszystkie Twoje pliki są aktualne i zsynchronizowane.
+
+Nie zamykaj aplikacji podczas procesu.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Zmienić tryb synchronizacji?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Oto jak przywrócić synchronizację:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Dysk zawierający folder synchronizacji nie jest już połączony</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Podłącz go ponownie, aby wznowić synchronizację.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Wyłącz powiadomienia</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Nie dołączaj</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Nie masz uprawnień do dostępu do tego kDrive.
+Sprawdź swoje uprawnienia lub skontaktuj się z administratorem.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Odmowa dostępu do kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Twój kDrive jest w trybie uśpienia</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Ten kDrive nie został odnowiony. Nie możesz już uzyskać do niego dostępu.
+Odnów subskrypcję, aby reaktywować usługę.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Ten kDrive nie został odnowiony. Nie możesz już uzyskać do niego dostępu.
+Skontaktuj się z administratorem, aby reaktywować usługę.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Twój kDrive wygasł</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Zaloguj się ponownie, aby nadal korzystać z kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Zostałeś wylogowany</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Konto użyte do tego połączenia nie odpowiada kontu tego kDrive.
+Zaloguj się ponownie przy użyciu właściwego adresu e-mail %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>To konto nie pasuje</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive się wybudza… może to chwilę potrwać.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive się wybudza</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Zapisuj informacje diagnostyczne na moim komputerze.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Włącz rejestrowanie debugowania</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Wprowadź hasło</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>W tym folderze istnieje już inny %1, którego nazwa różni się tylko wielkimi/małymi literami. Ten typ nazwy nie jest obsługiwany przez aplikację kDrive Windows. Zmień nazwę jednego z folderów %2 z aplikacji kDrive online, aby móc go zsynchronizować na komputerze.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Sprzeczne nazwy, wielkość liter ma znaczenie</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Wykryto zmianę w konfiguracji</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>W takich sytuacjach może być wymagana nowa synchronizacja, aby nadal prawidłowo korzystać z kDrive.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Sprawdź %1, aby przywrócić dostęp</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Ostatnia lokalizacja %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Zewnętrzny dysk odłączony</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Ta operacja może potrwać pewien czas w zależności od ilości danych do przetworzenia.
+
+Nie zamykaj aplikacji podczas procesu.
+
+W przypadku niepowodzenia możesz łatwo uruchomić pełną ponowną synchronizację dysku lub skontaktować się z naszym wsparciem.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Włącz synchronizację offline</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Ten kDrive jest tymczasowo niedostępny z powodu konserwacji.
+Spróbuj ponownie za kilka minut.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Konserwacja w toku</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Spacja na końcu nazwy %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Wykluczone z synchronizacji</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Plik zablokowany</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Plik odzyskany</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Ten plik przekracza maksymalny dozwolony rozmiar (50 GB).
+Skontaktuj się ze wsparciem, aby odblokować limit.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Plik zbyt duży</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Dostęp zabroniony</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Nazwa tego %1 zawiera jeden lub więcej znaków nieobsługiwanych przez aplikację kDrive dla systemu Windows. Zmień nazwę %2 w kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Nieprawidłowa nazwa</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Nieobsługiwany znak</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Nie masz wymaganych uprawnień do wykonania tej czynności.
+Poproś właściciela lub administratora o dostęp.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Dostęp zabroniony</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Nieobsługiwany typ pliku</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Ten folder nie jest już dostępny w swojej pierwotnej lokalizacji.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Nie znaleziono folderu synchronizacji</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Jeden z Twoich kDrive jest synchronizowany wewnątrz folderu synchronizacji innego kDrive.
+Przenieś jeden z folderów, aby nie były już zagnieżdżone, lub usuń synchronizację, aby ją odtworzyć.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Zagnieżdżone kDrive</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Nie można uzyskać dostępu do tego %1 na Twoim komputerze. Sprawdź, czy nadal istnieje i czy masz uprawnienia do dostępu do niego.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 niedostępny</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Nazwa %1 zbyt długa</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Nie można połączyć się z kDrive.
+Synchronizacja zostanie wznowiona automatycznie po przywróceniu połączenia.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Połączenie tymczasowo niedostępne</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Niewystarczające miejsce na dysku</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Nazwa tego pliku zawiera jeden lub więcej znaków, które nie są jeszcze obsługiwane przez aplikację kDrive. Zmień nazwę pliku w kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Nieobsługiwany znak</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Ścieżka do tego %1 jest zbyt długa, aby mogła być synchronizowana. Zmień nazwę jednego lub więcej folderów, w których się znajduje, aby skrócić ścieżkę.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Ścieżka do %1 zbyt długa</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Twój kDrive jest pełny. Zwolnij miejsce lub uaktualnij subskrypcję, aby zsynchronizować ten %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Osiągnięto limit pamięci</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Ta nazwa jest zarezerwowana przez system operacyjny Twojego komputera. Zmień nazwę %1 w kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Nazwa %1 zarezerwowana</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Sprawdź lokalizację lub prawa dostępu do folderu.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Folder synchronizacji niedostępny</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>Program LiteSync nie ma niezbędnych uprawnień do działania.
+otwórz Preferencje macOS, aby je włączyć.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Wymagana autoryzacja</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Miejsce na dysku Twojego urządzenia jest pełne. Synchronizacja została wstrzymana. Zwolnij miejsce, aby wznowić synchronizację.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Niewystarczające miejsce na dysku</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Ten folder nie jest już dostępny w swojej pierwotnej lokalizacji.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Ten folder nie jest już dostępny. Wymagane jest działanie, aby wznowić synchronizację.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Nie znaleziono folderu synchronizacji</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync nie może się uruchomić. Możesz nadal synchronizować swoje pliki, włączając synchronizację offline w ustawieniach. Skontaktuj się ze wsparciem, jeśli problem będzie się powtarzać.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Nie można uruchomić Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Synchronizacja tego elementu nie powiodła się. Zostanie ponownie podjęta automatycznie później.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synchronizacja tymczasowo nieudana</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Przesyłanie nie mogło zostać zakończone. Spróbuj ponownie później.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Wygląda na to, że nie możemy załadować aplikacji…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Wystąpił błąd podczas usuwania Twojego konta.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Pliki do zweryfikowania</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Inne</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System i uprawnienia</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Nie udało się otworzyć adresu URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Błędy do naprawienia</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Nie można zsynchronizować tego folderu. Wybierz inny folder.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Błąd podczas próby uruchomienia instalatora</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Błąd podczas zmiany trybu synchronizacji</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Zablokuj aplikacje, które mogą pobierać lub modyfikować Twoje pliki.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Pliki pasujące do tej reguły nie będą synchronizowane.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Unikaj kopiowania pewnych plików tymczasowych lub systemowych do kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Włącza zbieranie dodatkowych informacji przydatnych dla wsparcia.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Rozszerzony szczegółowy dziennik</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Gdy ta opcja jest włączona, kDrive działa wolniej.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Nie udało się utworzyć łącza udostępniania</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Pomóż nam ulepszyć kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Powiadomienie informuje Cię, gdy plik zostanie wykluczony przez tę regułę.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Plik już istnieje</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Tryb synchronizacji plików</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Zdefiniuj sposób przechowywania i dostępu do plików.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Pliki do wykluczenia</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Ulubione</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Udostępnienia</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Kosz</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Na 1 godzinę</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Na jeden tydzień</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Na trzy dni</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Cześć %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Wsparcie Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Zwolnij miejsce lub uaktualnij plan, aby nadal synchronizować pliki.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Twój kDrive jest pełny</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Niektóre pliki nie mogły zostać zsynchronizowane.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Masz &lt;b&gt;jeden błąd synchronizacji&lt;/b&gt;</numerusform> 
+                <numerusform>Masz &lt;b&gt;%n błędy synchronizacji&lt;/b&gt;</numerusform> 
+                <numerusform>Masz &lt;b&gt;%n błędów synchronizacji&lt;/b&gt;</numerusform> 
+                <numerusform>Masz &lt;b&gt;%n błędu synchronizacji&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Nie możemy uzyskać dostępu do Twoich plików. Uruchom ponownie aplikację, aby wznowić synchronizację. Jeśli problem będzie się powtarzać, skontaktuj się ze wsparciem.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Połączenie z kDrive zostało przerwane</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktywuj kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Przed kontynuowaniem musisz aktywować kDrive.app</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktywuj kDrive i kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Przed kontynuowaniem musisz aktywować autoryzacje</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Przejdź do Prywatność i bezpieczeństwo &gt; Pełny dostęp do dysku</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Pełny dostęp do dysku</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Prywatność i bezpieczeństwo</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Wybierz Otwieranie i rozszerzenia &gt; Rozszerzenia bezpieczeństwa</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Rozszerzenia bezpieczeństwa</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Otwieranie i rozszerzenia</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Otwórz Ustawienia systemowe &gt; Ogólne</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Ustawienia systemowe</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Uruchom ponownie aplikację, jeśli wymagane</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Ten element nie jest dostępny na tym urządzeniu.
+Otworzy się w Twojej przeglądarce.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Prawa dostępu zmienione</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Włączono</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>%1 temu</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Wszystkie foldery</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Cały kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Zezwól na śledzenie</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Identyfikator aplikacji</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Nazwa aplikacji</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Autor</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Domyślnie</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Wybierz wersję plików, którą chcesz zachować.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Dla każdego pliku wybierz wersję do zachowania.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Którą wersję chcesz zachować?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Wybierz wersję do zachowania</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Wersje online tych %1 plików zostaną zastąpione Twoimi lokalnymi wersjami.
+Uwaga, może to nadpisać pracę Twoich współpracowników.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Zachowaj tylko wersje lokalne</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>W przypadku każdego konfliktu automatycznie zachowamy najnowszą wersję (lokalną lub online). To najbezpieczniejszy wybór w większości przypadków.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Zachowaj najnowsze wersje</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Wszystkie lokalne zmiany dla tych %1 plików zostaną odrzucone.
+Przydatne, gdy wiesz, że ważna praca jest online w kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Zachowaj tylko wersje online</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Zaloguj się, aby zacząć.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Utwórz %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Data</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Wyłączono</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>plik</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Folder</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Folder usunięty</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Folder przeniesiony lub zmodyfikowany</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Folder mógł zostać przeniesiony na inny dysk, a następnie zwrócony do pierwotnej lokalizacji.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>folder</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Folder przeniesiony lub zmieniono nazwę</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Folder odtworzony lub zastąpiony</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Folder został usunięty i odtworzony lub zastąpiony przez inny folder o tej samej nazwie.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Przed chwilą</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokalnie</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 plików zostało zmodyfikowanych zarówno na Twoim komputerze, jak i w kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Najnowsza</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nazwa</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Wykryto nowe urządzenie</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Używasz kDrive na nowym komputerze, po przywróceniu z kopii zapasowej.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nowy folder</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nowa synchronizacja</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Brak konfliktów pasujących do wyszukiwania</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Brak błędów do naprawienia</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Powiadomienie</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Powiadom, jeśli plik został wykluczony</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Wyłączono</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Folder online usunięty</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Synchronizowany folder został usunięty w kDrive online lub nie jest już dostępny.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Pierwotna lokalizacja:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Zalecane</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Folder mógł zostać przeniesiony na inny dysk, a następnie zwrócony do pierwotnej lokalizacji.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Przywróć go do pierwotnej lokalizacji.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Reguły</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Tak samo jak system</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>s</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Od: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Rozmiar</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 wolne</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 wolnych</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Obliczanie…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 używane</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 używanych</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Zsynchronizowano z kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Zsynchronizowano z Twojego komputera</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Ten kDrive zawiera tylko pliki. Wszystkie pliki zostaną zsynchronizowane na tym urządzeniu.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Brak folderu do wybrania</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Foldery synchronizacji</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Lokalizacja</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synchronizuj swoje kDrive na tym urządzeniu</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Zsynchronizowane foldery</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synchronizacja</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Czas</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Witaj w kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 z %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Zarządzanie kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Język</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Uruchom ponownie aplikację, aby zakończyć stosowanie nowego języka.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Dowiedz się więcej</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Licencja LGPL v3 - Źródła Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Łącze skopiowane do schowka</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Niezgodny dysk lub folder bezpośrednio w katalogu głównym dysku (np. wybierz folder taki jak /Mój dysk zamiast /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Niezgodny dysk lub folder bezpośrednio w katalogu głównym dysku (np. wybierz folder taki jak D:/Mój dysk zamiast D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Lokalizacja na komputerze</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Debugowanie</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Błąd</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Rozszerzony</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Krytyczny</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Ostrzeżenie</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Wyślij folder debugowania do wsparcia Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Niektóre nazwy plików mogą zawierać znaki specjalne, które nie są obsługiwane (takie jak cudzysłowy, ukośniki odwrotne lub podziały wiersza).
+
+Sprawdź i zmień nazwy plików zawierających nietypowe znaki, a następnie spróbuj ponownie.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Nieprawidłowa nazwa pliku</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Kompresowanie dzienników…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Przesyłanie dzienników do wsparcia…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Ostatnie przesyłanie nie powiodło się. Sprawdź połączenie z Internetem i upewnij się, że co najmniej jeden użytkownik kDrive jest zalogowany. Przesyłanie jest ograniczone do 10 razy dziennie.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Wykryto różne wersje tych plików.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>Wykryto %1 konfliktów wersji</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo to narzędzie analityczne hostowane i zarządzane wyłącznie przez Infomaniak, służące do zrozumienia, jak aplikacja jest używana.
+
+Analiza tych danych pozwala naszemu zespołowi na ciągłe ulepszanie interfejsu aplikacji.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Przenoszenie anulowane</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Przenieś usunięte pliki do Kosza komputera</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Niektóre elementy mogą nie być możliwe do przeniesienia.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Więcej miejsca na dane, więcej funkcji z my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Potrzebujesz pomocy?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Sieć</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Dodaj konto, aby zacząć</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Nie znaleziono wyników</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Nie zsynchronizowano</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Zawsze</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Nigdy</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Otrzymuj powiadomienie, gdy plik jest wykluczony</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Skonfiguruj synchronizację dla tego kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Dostosuj lokalizację folderu kDrive na swoim komputerze:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Wybrany folder musi być pusty, aby synchronizacja działała prawidłowo.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Wybierz foldery do synchronizacji na tym komputerze:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Zsynchronizowane foldery</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Dla każdego kDrive możesz wybrać, gdzie jest synchronizowany na Twoim komputerze i które foldery synchronizować.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Zsynchronizowana zawartość:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Zsynchronizowana zawartość: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Lokalizacja:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Lokalizacja: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Skonfiguruj swoje kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Wybierz foldery do synchronizacji na tym komputerze</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Pliki są pobierane tylko przy otwieraniu, aby zaoszczędzić miejsce na dysku.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Włącz Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Ten kDrive jest już skonfigurowany.
+Przejdź do ustawień, aby go zmodyfikować.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autoryzuj kDrive w ustawieniach macOS:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktywuj kDrive na swoim Macu</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Aby ukończyć instalację, musisz autoryzować kDrive do dostępu do:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autoryzuj dostęp do plików</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Zacznij za darmo z my kSuite,
+lub wybierz plan dopasowany do Twoich potrzeb.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Nie masz jeszcze kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Wybierz kDrive do synchronizacji na tym komputerze:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronizacja w toku</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Miło Cię znowu widzieć!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Wszystkie foldery kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Niestandardowy wybór</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Prywatna, szybka i bezpieczna chmura, hostowana w Szwajcarii.
+
+Zaloguj się i synchronizuj dokumenty na wszystkich swoich urządzeniach.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Wystąpił błąd, spróbuj ponownie.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Błąd logowania</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Jeszcze chwilę, ładujemy Twoje konto…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Logowanie przez przeglądarkę…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Pobieranie Twoich informacji…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Chwileczkę…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Witaj w kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Twoje pliki są gotowe do bezpiecznej
+synchronizacji na Twoim komputerze.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Wszystko gotowe!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Finalizujemy konfigurację Twoich kDrive.
+
+Prosimy o chwilę cierpliwości.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synchronizacja w toku…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Otwórz kDrive przy uruchomieniu komputera</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Otwórz stronę logowania</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Ścieżka skopiowana do schowka</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Zdefiniuj, jak kDrive łączy się z Internetem.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Serwer</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Wymagane uwierzytelnianie</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Hasło</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Ustawienia proxy</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Typ proxy</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Konfiguracja ręczna</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Brak</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Nazwa użytkownika</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Wewnętrzny</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Lokalizacja w kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Szukaj w %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Wybierz foldery do synchronizacji na tym komputerze.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Niezaznaczone foldery nie będą pobierane na Twoje urządzenie. Pozostaną dostępne online i nie zostaną usunięte.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Niezaznaczone foldery nie będą pobierane na Twoje urządzenie. Pozostaną dostępne online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry to narzędzie hostowane i zarządzane wyłącznie przez Infomaniak do monitorowania stabilności aplikacji w czasie rzeczywistym i automatycznego zgłaszania wszelkich błędów technicznych naszym deweloperom.
+
+Dane te pozwalają naszemu zespołowi na szybkie naprawianie i optymalizację aplikacji, co przekłada się na lepsze doświadczenie użytkownika dla Ciebie.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Ustawienia</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Konta i synchronizacje</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Zaawansowane</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Ogólne</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Folder kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Zaloguj się przez przeglądarkę</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Otwórz kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Zakończ</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Ustawienia</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Wolne miejsce na komputerze</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>Pliki kDrive przechowywane na komputerze</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Inne pliki na komputerze</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Ładowanie danych o zajętości…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Wolne miejsce</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Inne pliki</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Pliki kDrive zapisane na Twoim urządzeniu</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive nie może uzyskać dostępu do woluminu
+Upewnij się, że jest podłączony,
+odblokowany i dostępny z Twojego komputera.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Wolumin jest niedostępny</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Zarządzaj zsynchronizowanymi folderami, aby zwolnić miejsce na Macu.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synchronizacja</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Ten komputer - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 z %2 używanych</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Przechowywane online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Twoje pliki pozostają w chmurze i nie zajmują miejsca na Twoim komputerze.
+Do ich dostępu wymagane jest połączenie z Internetem.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Błąd synchronizacji</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Niestandardowy folder</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Domyślny folder</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synchronizacja</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Stosowanie nowego trybu synchronizacji…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Reguły synchronizacji</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Wystąpił błąd</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Ostatnia synchronizacja zakończona sukcesem</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synchronizacja jest wstrzymana</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synchronizacja jest w toku</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Zsynchronizowano</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Zsynchronizowano</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Zsynchronizowano z Twojego komputera</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Zsynchronizowano z kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>Twoje pliki są synchronizowane</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synchronizacja jest wstrzymana</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Twoje ostatnie pliki są aktualizowane.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synchronizacja w toku</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Pobrane pliki pozostają dostępne.
+Synchronizacja wznowi się automatycznie, gdy tylko ponownie nawiążesz połączenie.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Synchronizacja została tymczasowo zatrzymana.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synchronizacja podczas pauzy</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Twoje pliki są dostępne i zsynchronizowane.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Brak aktywności w toku</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>Twoje pliki są aktualne</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synchronizacja</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Plik lub folder w folderze synchronizacji wydaje się być uszkodzony.
+Synchronizacja została wstrzymana. Sprawdź pliki i spróbuj ponownie.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Wykryto uszkodzony plik</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Aktywność</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Strona główna</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Pamięć</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Folder nie może być katalogiem głównym dysku i nie może zawierać już zsynchronizowanego folderu ani znajdować się w jego obrębie.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Folder musi być pusty, nie może być katalogiem głównym dysku i nie może zawierać już zsynchronizowanego folderu ani znajdować się w jego obrębie.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Nie można użyć tego folderu</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Obsługa indywidualna</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Zarządzanie synchronizacją</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Powiadomienie informuje Cię, gdy plik jest wykluczony przez tę regułę</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Zamknij kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Otwórz kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Ustawienia</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Sprawdź, czy Twoje połączenie z Internetem jest aktywne, czy ta nazwa nie jest już używana i czy nie zawiera nieprawidłowych znaków.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Nie można utworzyć tego folderu</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Nieautoryzowany dostęp</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Twoje pliki są dostępne i zsynchronizowane.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Brak ostatniej aktywności</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Spróbuj ponownie za kilka chwil.
+Jeśli problem będzie się powtarzać, skontaktuj się ze wsparciem.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Wystąpił nieoczekiwany błąd</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Do jutra</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 dostępny</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Instalacja trwa mniej niż minutę.
+Synchronizacja zostanie automatycznie wznowiona po zakończeniu.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignoruj tę wersję</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Zainstaluj teraz</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Przypomnij później</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Zobacz co nowego</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Wersja %1 · Używasz %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Dostępna aktualizacja</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>Aby kontynuować, wymagana jest nowa wersja kDrive.
+Zaktualizuj aplikację, aby uzyskać dostęp do plików i wznowić synchronizację.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Wymagana aktualizacja</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Aktualizacja</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Niekompletne przesyłanie</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Wyklucz niektóre aplikacje z synchronizacji.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Dodaj pliki do wykluczenia z synchronizacji.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Niestandardowe reguły wykluczenia</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Wyklucz niektóre typy plików z synchronizacji.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Wyświetl kod źródłowy</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Masz błąd synchronizacji</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Masz {0} błędów synchronizacji</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive nie może uzyskać dostępu do dysku %1
+Upewnij się, że jest podłączony,
+odblokowany i dostępny z Twojego komputera.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Dysk pamięci %1 jest niedostępny</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Usuń</numerusform> 
+                <numerusform>Usuń (%1 reguły)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Stosowanie zmiany…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Zarządzaj miejscem na dysku</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Otwórz folder nadrzędny</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Zaktualizuj</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Poziom debugowania</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synchronizacja zostanie uruchomiona ponownie automatycznie.
+Jeśli problem będzie się powtarzać, skontaktuj się z naszym wsparciem, dołączając poniższe szczegóły techniczne.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Szczegóły techniczne</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Wystąpił nieoczekiwany błąd</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Usuwanie anulowane</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Zduplikowane nazwy</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Nie masz wymaganych uprawnień, aby dodać %1 do tej lokalizacji.
+Poproś właściciela lub administratora o dostęp.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Nie masz uprawnień do usunięcia tego %1. Został on przywrócony do pierwotnej lokalizacji. Poproś właściciela lub administratora o dostęp.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Uprawnienia dostępu do %1 zostały zmienione, co uniemożliwia jego synchronizację.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Plik lub folder o tej nazwie już istnieje.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Nie masz uprawnień do edycji tego pliku.
+Oryginalna wersja została zachowana, a Twoja edycja została zapisana w osobnym pliku z „konfliktem" w nazwie. Poproś właściciela lub administratora o dostęp.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Nazwa tego %1 kończy się spacją, co uniemożliwia jego synchronizację. Zmień nazwę %2 w kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Reguła wykluczenia uniemożliwia synchronizację tego %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Plik o tej nazwie już istnieje.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Ten plik jest aktualnie używany przez innego użytkownika.
+Twoje zmiany zostaną zsynchronizowane później.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Ten plik został usunięty w kDrive online podczas jego edycji. Kopia została zachowana na Twoim komputerze w folderze odzyskiwania.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Ten plik przekracza maksymalny dozwolony rozmiar (50 GB).
+Skontaktuj się z administratorem, aby zwiększyć limit rozmiaru pliku.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Ta nazwa zawiera tylko spacje i nie może być używana. Zmień nazwę %1 w kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Ten plik jest twardym dowiązaniem (hard link), które nie może być synchronizowane.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Nie masz uprawnień do przeniesienia tego %1 tutaj; zostanie on przywrócony do pierwotnej lokalizacji. Poproś właściciela lub administratora o dostęp.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Ta nazwa przekracza dozwoloną długość (250 znaków). Zmień nazwę %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Na Twoim komputerze nie ma wystarczająco dużo miejsca, aby zsynchronizować ten plik.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Pełny folder jest duży.
+Aby przyspieszyć przesyłanie, zalecamy wysłanie tylko ostatniej sesji kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Wyślij tylko ostatnią sesję</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="pl"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2471,42 +2471,42 @@ odblokowany i dostępny z Twojego komputera.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Stosowanie zmiany…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Zarządzaj miejscem na dysku</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Otwórz folder nadrzędny</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Zaktualizuj</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Poziom debugowania</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2515,35 +2515,35 @@ Jeśli problem będzie się powtarzać, skontaktuj się z naszym wsparciem, doł
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Szczegóły techniczne</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Wystąpił nieoczekiwany błąd</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Usuwanie anulowane</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Zduplikowane nazwy</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2552,28 +2552,28 @@ Poproś właściciela lub administratora o dostęp.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Nie masz uprawnień do usunięcia tego %1. Został on przywrócony do pierwotnej lokalizacji. Poproś właściciela lub administratora o dostęp.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Uprawnienia dostępu do %1 zostały zmienione, co uniemożliwia jego synchronizację.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Plik lub folder o tej nazwie już istnieje.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2582,28 +2582,28 @@ Oryginalna wersja została zachowana, a Twoja edycja została zapisana w osobnym
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Nazwa tego %1 kończy się spacją, co uniemożliwia jego synchronizację. Zmień nazwę %2 w kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Reguła wykluczenia uniemożliwia synchronizację tego %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Plik o tej nazwie już istnieje.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2612,14 +2612,14 @@ Twoje zmiany zostaną zsynchronizowane później.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Ten plik został usunięty w kDrive online podczas jego edycji. Kopia została zachowana na Twoim komputerze w folderze odzyskiwania.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2628,49 +2628,49 @@ Skontaktuj się z administratorem, aby zwiększyć limit rozmiaru pliku.</transl
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Ta nazwa zawiera tylko spacje i nie może być używana. Zmień nazwę %1 w kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Ten plik jest twardym dowiązaniem (hard link), które nie może być synchronizowane.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Nie masz uprawnień do przeniesienia tego %1 tutaj; zostanie on przywrócony do pierwotnej lokalizacji. Poproś właściciela lub administratora o dostęp.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Ta nazwa przekracza dozwoloną długość (250 znaków). Zmień nazwę %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Na Twoim komputerze nie ma wystarczająco dużo miejsca, aby zsynchronizować ten plik.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_pl.ts
+++ b/src/gui4/linux/translations/client_pl.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pl, Polish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:28 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pl"> 
     <context>
@@ -344,6 +344,16 @@ Możesz je otwierać w dowolnym momencie, nawet bez połączenia z Internetem.</
             <source>Manage storage</source> 
             <translation>Zarządzaj pamięcią</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maksymalizuj</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimalizuj</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Otwórz folder debugowania</translation> 
@@ -429,6 +439,11 @@ Możesz je otwierać w dowolnym momencie, nawet bez połączenia z Internetem.</
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Uruchom ponownie synchronizację</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Przywróć</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="pt"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ desbloqueado e acessível no seu computador.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>A aplicar alteração…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Gerir espaço em disco</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Abrir pasta principal</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Atualizar</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Nível de depuração</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Se o problema persistir, contacte o nosso suporte e anexe os detalhes técnicos 
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Detalhes técnicos</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Ocorreu um erro inesperado</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Eliminação cancelada</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Nomes duplicados</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Peça acesso ao proprietário ou administrador.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Não tem permissão para eliminar este %1. Foi restaurado para a sua localização original. Peça acesso ao proprietário ou administrador.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>As permissões de acesso ao %1 foram alteradas, impedindo a sua sincronização.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>Já existe um ficheiro ou pasta com este nome.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ A versão original foi mantida e a sua edição foi guardada num ficheiro separa
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>O nome deste %1 termina com um espaço, impedindo a sua sincronização. Renomeie o %2 a partir do kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>Uma regra de exclusão está a impedir a sincronização deste %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>Já existe um ficheiro com este nome.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ As suas alterações serão sincronizadas mais tarde.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Este ficheiro foi eliminado no kDrive online enquanto o estava a editar. Foi mantida uma cópia no seu computador na pasta de recuperação.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Contacte o seu administrador para aumentar o limite de tamanho dos ficheiros.</t
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Este nome contém apenas espaços e não pode ser utilizado. Renomeie o %1 a partir do kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Este ficheiro é uma ligação física (hard link) que não pode ser sincronizada.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Não tem os direitos para mover este %1 para aqui; será restaurado para a sua localização original. Peça acesso ao proprietário ou administrador.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Este nome excede o comprimento permitido (250 caracteres). Renomeie o %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Não há espaço suficiente no seu computador para sincronizar este ficheiro.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pt, Portuguese
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:29 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pt"> 
     <context>
@@ -2077,7 +2077,7 @@ Estes dados permitem à nossa equipa corrigir e otimizar rapidamente a aplicaç�
             <translation>Pasta kDrive</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Inicie sessão no seu navegador</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: pt, Portuguese
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="pt"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Versão %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Versão %1 (compilação %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Acerca de</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Acerca do kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Desenvolvido e alojado exclusivamente na Suíça, o kDrive garante a proteção total dos seus dados, sem revenda nem espionagem, em centros de dados certificados ISO, com encriptação e cópia de segurança em vários suportes.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Atividades visíveis</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Escolher um canal de distribuição</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Ver mais informações</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Selecionar um modo de sincronização</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Sincronização concluída</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Sincronização em curso</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Sem atividade recente</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Está offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Sincronização pausada</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Todas as atividades</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Apenas a minha atividade</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizar uma pasta com o kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Escolha a pasta do seu computador para sincronizar com o kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Pasta sincronizada</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Personalize a localização da pasta do seu computador no kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Escolha a localização da pasta no kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>Localização no kDrive</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Selecione uma pasta no seu computador para sincronizar com o kDrive.
+Pode aceder às suas sincronizações avançadas a partir do seletor de unidade na página inicial.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Sincronizar uma pasta com o kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Sincronização avançada</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>Aplicação a excluir</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>A aplicação está atualizada</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Elimina registos com mais de 7 dias para poupar espaço em disco.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Limpeza automática</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Atualizações automáticas</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Disponível offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Os seus ficheiros são copiados para o seu computador.
+Pode abri-los em qualquer momento, mesmo sem ligação à Internet.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Pode ativá-lo a partir da interface web.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Tenha acesso antecipado às novas versões da aplicação antes de serem disponibilizadas ao público em geral e ajude a melhorar a aplicação partilhando as suas ideias de melhoria connosco.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Aderir ao programa beta</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>O seu navegador deverá abrir automaticamente para concluir o início de sessão. Depois de iniciar sessão, será automaticamente redirecionado para o kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Ativar a sincronização offline</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Sincronizar uma pasta</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Adicionar uma regra</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Adicionar armazenamento</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Definições avançadas</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Aplicar a %1 ficheiros</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Pedir acesso</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Cancelar</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Alterar pasta</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Armazenar offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Armazenar online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Mudar de utilizador</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Fechar</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Fechar o kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Configurar</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Confirmar</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Iniciar sessão</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Ligar uma conta</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Contactar o apoio</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Continuar</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Copiar link de partilha</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Criar uma conta</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Criar uma nova sincronização</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Localização personalizada</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Desligar esta conta</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>A transferir…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Transferir manualmente</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Ativar</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Ativar nas definições do Windows</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Compreender o problema</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Partilhar uma ideia</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Concluir a instalação</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Corrigir erros</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Suporte</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Ativei o kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Manter a conta</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Terminar sessão</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Iniciar sessão</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Gerir</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Gerir ficheiros individualmente</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Gerir armazenamento</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Abrir pasta de depuração</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Abrir o Explorador</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Abrir pasta</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Abrir no navegador</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Abrir no Explorador</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Abrir no Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Abrir no kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Abrir o kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Gerir exclusões</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Abrir definições de sincronização</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Pausa</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Atualizar</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Notas de versão</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Remover</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Remover (%n elemento)</numerusform> 
+                <numerusform>Remover (%n elementos)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Remover sincronização</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Renomear %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Reiniciar o início de sessão</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Retomar a sincronização</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Reiniciar a sincronização</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Tentar novamente</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Regressar à pasta predefinida</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Guardar</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Guardar as minhas escolhas</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Pesquisar</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Ver atividades</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Selecionar</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Selecionar uma pasta</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Selecionar pastas</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Selecionar uma localização</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Selecionado</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Enviar</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Enviar pasta de depuração</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Abrir definições</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Ver ofertas</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Mostrar opções</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Terminar sessão</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Iniciar</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Iniciar seleção de versão</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Começar gratuitamente</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Sincronizar offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Atualizar agora</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Atualizar subscrição</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Atualizar</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Confirmar</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Confirmar e avançar</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Ativar</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Escolher uma versão</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Foram detetadas duas versões diferentes destes ficheiros.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Conflitos de versões</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Procurar um ficheiro</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>A copiar link…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>A criar link de partilha…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Pode personalizar os dados de utilização e operacionais recolhidos pela Infomaniak para corrigir erros e melhorar a aplicação. As duas ferramentas utilizadas são alojadas e geridas exclusivamente por nós.
+
+O código-fonte desta aplicação pode ser verificado, as informações recolhidas são anónimas e as suas informações pessoais permanecem estritamente confidenciais e nunca são partilhadas com terceiros.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Gestão de dados</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>A Infomaniak respeita a sua privacidade</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Selecione a quantidade de informações a registar.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Permitem ao suporte da Infomaniak identificar a causa de um incidente.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Registos de depuração</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Estas aplicações são ignoradas por predefinição e não podem ser modificadas.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Estes ficheiros são excluídos por predefinição e não podem ser modificados.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Exclusão automática</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>Nestas situações, é necessária uma nova sincronização para continuar a utilizar o kDrive corretamente.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Selecione uma pasta vazia que não esteja na raiz de uma unidade.
+
+Esta pasta não deve estar incluída noutra pasta de sincronização nem conter uma subpasta de sincronização.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Não é possível selecionar esta pasta</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Adicionar uma regra</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Adicionar uma regra de exclusão</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Está prestes a desligar %1 da aplicação.
+A pasta de sincronização permanecerá no seu computador, mas deixará de ser sincronizada com o kDrive.
+
+Todos os seus dados permanecerão acessíveis online no kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Terminar sessão nesta conta?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>A pasta local permanecerá no seu computador, mas deixará de ser sincronizada com o kDrive.
+Esta ação é permanente.
+Para sincronizar a sua unidade novamente, terá de a reconectar mais tarde.
+
+Antes de continuar, certifique-se de que todos os seus ficheiros estão atualizados e totalmente sincronizados.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Remover sincronização?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>A alteração do modo de sincronização foi cancelada.
+
+A sincronização atual permanece inalterada. No entanto, se ocorrer algum comportamento anormal, poderá ter de eliminar e recriar a sincronização para restaurar o funcionamento correto.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Ocorreu um erro</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Esta operação pode demorar algum tempo, dependendo do tamanho dos seus dados. Em caso de falha, poderá ser necessária uma ressincronização completa da unidade.
+
+Antes de continuar, certifique-se de que todos os seus ficheiros estão atualizados e sincronizados.
+
+Não feche a aplicação durante o processo.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Alterar modo de sincronização?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Aqui está como restaurar a sincronização:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>O disco que contém a sua pasta de sincronização já não está ligado</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Ligue-o novamente para retomar a sincronização.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Desativar notificações</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Não aderir</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Não tem permissão para aceder a este kDrive.
+Verifique as suas permissões ou contacte o seu administrador.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Acesso recusado ao kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>O seu kDrive está em modo de suspensão</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Este kDrive não foi renovado. Já não pode aceder ao mesmo.
+Renove a sua subscrição para reativar o serviço.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Este kDrive não foi renovado. Já não pode aceder ao mesmo.
+Contacte o seu administrador para reativar o serviço.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>O seu kDrive expirou</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Inicie sessão novamente para continuar a utilizar o kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>A sua sessão foi encerrada</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>A conta utilizada para esta ligação não corresponde à deste kDrive.
+Inicie sessão novamente com o endereço de e-mail correto %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Esta conta não corresponde</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>O kDrive está a ser ativado… pode demorar alguns instantes.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>O kDrive está a ser ativado</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Registar informações de diagnóstico no meu computador.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Ativar o registo de depuração</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Introduza a sua palavra-passe</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>Outro %1 cujo nome difere apenas em maiúsculas/minúsculas já existe nesta pasta. Este tipo de nome não é suportado pela aplicação kDrive para Windows. Renomeie uma das pastas %2 do kDrive online para que possa sincronizá-la no seu PC.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Nomes contraditórios, sensíveis a maiúsculas e minúsculas</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>Foi detetada uma alteração na sua configuração</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>Nestas situações, uma nova sincronização pode ser necessária para continuar a utilizar o kDrive corretamente.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Consulte o %1 para restaurar o acesso</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Última localização de %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Disco externo desligado</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Esta operação pode demorar algum tempo, dependendo da quantidade de dados a processar.
+
+Não feche a aplicação durante o processo.
+
+Em caso de falha, pode facilmente iniciar uma nova sincronização completa da unidade ou contactar o nosso suporte.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Ativar a sincronização offline</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Este kDrive está temporariamente indisponível devido a manutenção.
+Tente novamente dentro de alguns minutos.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Manutenção em curso</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Espaço no final do nome do %1</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Excluído da sincronização</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Ficheiro bloqueado</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Ficheiro recuperado</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Este ficheiro excede o tamanho máximo permitido (50 GB).
+Contacte o suporte para desbloquear o limite.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Ficheiro demasiado grande</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Acesso proibido</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>O nome deste %1 contém um ou mais caracteres não suportados pela aplicação kDrive do Windows. Renomeie o %2 a partir do kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Nome inválido</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carácter não suportado</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Não tem as permissões necessárias para realizar esta ação.
+Peça acesso ao proprietário ou administrador.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Acesso proibido</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Tipo de ficheiro não suportado</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Esta pasta já não está acessível na sua localização original.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Pasta de sincronização não encontrada</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>Um dos seus kDrives está sincronizado dentro da pasta de sincronização de outro kDrive.
+Mova uma das pastas para que não fiquem encadeadas, ou elimine a sua sincronização para a recriar.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>kDrives encadeados</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Não é possível aceder a este %1 no seu computador. Verifique se ainda existe e se tem direitos para aceder ao mesmo.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 inacessível</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>Nome do %1 demasiado longo</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Não é possível ligar ao kDrive.
+A sincronização será retomada automaticamente quando a ligação for restabelecida.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Ligação temporariamente indisponível</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espaço em disco insuficiente</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>O nome deste ficheiro contém um ou mais caracteres ainda não suportados pela aplicação kDrive. Renomeie o ficheiro a partir do kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Carácter não suportado</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>O caminho para este %1 é demasiado longo para ser sincronizado. Renomeie uma ou mais pastas nas quais se encontra para encurtar o caminho.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Caminho para %1 demasiado longo</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>O seu kDrive está cheio. Liberte espaço ou atualize a sua subscrição para sincronizar este %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Limite de armazenamento atingido</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Este nome está reservado pelo sistema do seu computador. Renomeie o %1 a partir do kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>Nome de %1 reservado</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Verifique a localização ou os direitos de acesso à pasta.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Pasta de sincronização inacessível</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>O LiteSync não tem as permissões necessárias para funcionar.
+abra as Preferências do macOS para as ativar.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Autorização necessária</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>O espaço em disco do seu dispositivo está cheio. A sincronização foi pausada. Liberte espaço para retomar a sincronização.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Espaço em disco insuficiente</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Esta pasta já não está acessível na sua localização original.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Esta pasta já não está acessível. É necessária uma ação para retomar a sincronização.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Pasta de sincronização não encontrada</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>O Lite Sync não consegue iniciar. Pode continuar a sincronizar os seus ficheiros ativando a sincronização offline nas definições. Contacte o suporte se o problema persistir.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Não é possível iniciar o Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>A sincronização deste item falhou. Será tentada novamente automaticamente mais tarde.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Sincronização temporariamente falhada</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Não foi possível concluir o carregamento. Por favor, tente novamente mais tarde.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Parece que não conseguimos carregar a aplicação…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Ocorreu um erro ao eliminar a sua conta.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Ficheiros a verificar</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Outros</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>Sistema e permissões</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Não foi possível abrir o URL %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Erros a corrigir</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Esta pasta não pode ser sincronizada. Selecione outra pasta.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Erro ao tentar iniciar o instalador</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Erro ao alterar o modo de sincronização</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Bloqueie as aplicações que podem descarregar ou modificar os seus ficheiros.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Os ficheiros que correspondam a esta regra não serão sincronizados.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Evite que certos ficheiros temporários ou de sistema sejam copiados para o kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Ativa a recolha de informações adicionais úteis para o suporte.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Registo detalhado alargado</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>Quando esta opção está ativada, o kDrive funciona mais lentamente.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Falha ao criar link de partilha</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Ajude-nos a melhorar o kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>Uma notificação informa-o quando um ficheiro é excluído por esta regra.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>O ficheiro já existe</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Modo de sincronização de ficheiros</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Defina como os seus ficheiros são armazenados e acedidos.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Ficheiros a ignorar</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoritos</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Partilhas</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Reciclagem</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>Durante 1 hora</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>Durante uma semana</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>Durante três dias</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Olá %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Suporte Infomaniak</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Liberte espaço ou atualize o seu plano para continuar a sincronizar os seus ficheiros.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>O seu kDrive está cheio</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Alguns ficheiros não puderam ser sincronizados.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Tem &lt;b&gt;um erro&lt;/b&gt; de sincronização</numerusform> 
+                <numerusform>Tem &lt;b&gt;%n erros&lt;/b&gt; de sincronização</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Não conseguimos aceder aos seus ficheiros. Reinicie a aplicação para retomar a sincronização. Se o problema continuar, contacte o suporte.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Ligação ao kDrive interrompida</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Ative o kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Tem de ativar o kDrive.app antes de continuar</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Ative o kDrive e o kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Tem de ativar as autorizações antes de continuar</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Aceda a Privacidade e Segurança &gt; Acesso total ao disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Acesso total ao disco</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Privacidade e Segurança</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Selecione Abertura e Extensões &gt; Extensões de segurança</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Extensões de segurança</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Abertura e Extensões</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Abra as Definições do Sistema &gt; Geral</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Definições do Sistema</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Reinicie a aplicação se necessário</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Este item não está disponível neste dispositivo.
+Será aberto no seu navegador.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Direitos de acesso modificados</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Ativado</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>há %1</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Todas as pastas</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Todo o kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Permitir rastreamento</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Identificador da app</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Nome da aplicação</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Autor</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Por predefinição</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Escolha a versão dos seus ficheiros que pretende manter.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Para cada ficheiro, selecione a versão a manter.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Qual versão pretende manter?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Escolher a versão a manter</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>As versões online destes %1 ficheiros serão substituídas pelas suas versões locais.
+Atenção, isto pode substituir o trabalho dos seus colaboradores.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Manter apenas as versões locais</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>Para cada conflito, manteremos automaticamente a versão (local ou online) modificada mais recentemente. Esta é a escolha mais segura na maioria dos casos.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Manter as versões mais recentes</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Todas as alterações locais destes %1 ficheiros serão descartadas.
+Útil se souber que o trabalho importante está online no kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Manter apenas as versões online</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Inicie sessão para começar.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Crie uma %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Data</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Desativado</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>ficheiro</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Pasta</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Pasta eliminada</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Pasta movida ou modificada</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>A pasta pode ter sido movida para outro disco e depois devolvida à sua localização inicial.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>pasta</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Pasta movida ou renomeada</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Pasta recriada ou substituída</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>A pasta foi eliminada e recriada, ou substituída por outra pasta com o mesmo nome.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Agora mesmo</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Local</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 ficheiros foram modificados tanto no seu computador como no kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Mais recente</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Nome</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Novo dispositivo detetado</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Está a utilizar o kDrive num novo computador, após uma restauração a partir de uma cópia de segurança.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Nova pasta</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>nova sincronização</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Nenhum conflito corresponde à sua pesquisa</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Sem erros a corrigir</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Notificação</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Notificar se ficheiro excluído</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Desativado</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Pasta online eliminada</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>A pasta sincronizada foi eliminada no kDrive online ou já não está acessível.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Localização original:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Recomendado</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>A pasta pode ter sido movida para outro disco e depois devolvida à sua localização inicial.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Restaure-o para a sua localização original.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regras</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Igual ao sistema</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>h</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>seg</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Desde: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Tamanho</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Estado</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 livre</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 livres</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>A calcular…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 utilizado</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 utilizados</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizado a partir do kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizado a partir do seu computador</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Este kDrive contém apenas ficheiros. Todos os ficheiros serão sincronizados neste dispositivo.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Nenhuma pasta para selecionar</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Pastas de sincronização</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Localização</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Sincronize os seus kDrives neste dispositivo</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Pastas sincronizadas</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Sincronização</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tempo</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bem-vindo ao kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 de %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>Gestão do kDrive</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Idioma</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Reinicie a aplicação para concluir a aplicação do novo idioma.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Saiba mais</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>Licença LGPL v3 - Fontes Git</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Link copiado para a área de transferência</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Disco incompatível ou pasta diretamente na raiz do disco (ex: escolha uma pasta como /O meu drive em vez de /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Disco incompatível ou pasta diretamente na raiz do disco (ex: escolha uma pasta como D:/O meu drive em vez de D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Localização no computador</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Depuração</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Erro</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Alargado</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Crítico</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Informação</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Aviso</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Enviar pasta de depuração para o suporte da Infomaniak</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Alguns nomes de ficheiros podem conter caracteres especiais não suportados (como aspas duplas, barras invertidas ou quebras de linha).
+
+Verifique e renomeie os ficheiros que contenham caracteres incomuns e tente novamente.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Nome de ficheiro inválido</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>A comprimir registos…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>A transferir registos para o suporte…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>A última transferência falhou. Verifique a sua ligação à Internet e certifique-se de que pelo menos um utilizador do kDrive está com sessão iniciada. As transferências estão limitadas a 10 por dia.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Foram detetadas versões diferentes destes ficheiros.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 conflitos de versões detetados</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>O Matomo é uma ferramenta de análise alojada e gerida exclusivamente pela Infomaniak para perceber como a aplicação é utilizada.
+
+A análise destes dados permite à nossa equipa melhorar continuamente a interface da aplicação.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Movimento cancelado</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Mover ficheiros eliminados para a reciclagem do computador</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Alguns itens podem não poder ser movidos.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Mais espaço de armazenamento, mais funcionalidades com a minha kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Precisa de ajuda?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Rede</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Adicione uma conta para começar</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Nenhum resultado encontrado</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Não sincronizado</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Sempre</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Nunca</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Receber uma notificação quando um ficheiro é excluído</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Configurar a sincronização para este kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Personalize a localização da sua pasta kDrive no seu computador:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>A pasta escolhida deve estar vazia para que a sincronização funcione corretamente.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Escolha as pastas a sincronizar neste computador:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Pastas sincronizadas</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>Para cada kDrive, pode escolher onde é sincronizado no seu computador e quais as pastas a sincronizar.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Conteúdo sincronizado:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Conteúdo sincronizado: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Localização:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Localização: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Configurar os seus kDrives</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Escolha as pastas a sincronizar neste computador</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Os ficheiros são transferidos apenas quando abertos, para poupar espaço em disco.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Ativar o Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Este kDrive já está configurado.
+Aceda às suas definições para o modificar.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Autorize o kDrive nas definições do macOS:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Ative o kDrive no seu Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>Para concluir a instalação, deve autorizar o kDrive a aceder às suas:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Autorize o acesso às pastas</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Comece gratuitamente com a minha kSuite,
+ou escolha um plano adequado às suas necessidades.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Ainda não tem um kDrive.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Escolha os kDrives a sincronizar neste computador:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronização em curso</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Que bom vê-lo!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Todas as pastas do kDrive</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Seleção personalizada</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>A cloud privada, rápida e segura, alojada na Suíça.
+
+Inicie sessão e mantenha os seus documentos sincronizados em todos os seus dispositivos.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Ocorreu um erro, por favor tente novamente.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Erro de início de sessão</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Mais alguns instantes, estamos a carregar a sua conta…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>A iniciar sessão no seu navegador…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>A obter as suas informações…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Um momento…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Bem-vindo ao kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Os seus ficheiros estão prontos para ser sincronizados
+em segurança no seu computador.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Está tudo pronto!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Estamos a finalizar a configuração dos seus kDrives.
+
+Aguarde alguns instantes.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Sincronização em curso…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Abrir o kDrive quando o computador inicia</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Abrir a página de início de sessão</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Caminho copiado para a área de transferência</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Defina como o kDrive se liga à Internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Servidor</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Autenticação necessária</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Palavra-passe</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Porta</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Definições de proxy</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Tipo de proxy</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Configuração manual</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Nenhum</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Nome de utilizador</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Interno</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Teste</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Localização no kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Pesquisar em %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Selecione as pastas a sincronizar neste computador.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>As pastas não selecionadas não serão transferidas para o seu dispositivo. Permanecerão disponíveis online e não serão eliminadas.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>As pastas não selecionadas não serão transferidas para o seu dispositivo. Permanecerão disponíveis online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>O Sentry é uma ferramenta alojada e gerida exclusivamente pela Infomaniak para monitorizar em tempo real a estabilidade da aplicação e reportar automaticamente erros técnicos aos nossos programadores.
+
+Estes dados permitem à nossa equipa corrigir e otimizar rapidamente a aplicação, resultando numa melhor experiência de utilização para si.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Definições</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Contas e sincronizações</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avançadas</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Geral</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>Pasta kDrive</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Inicie sessão no seu navegador</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Abrir o kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Sair</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Definições</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Espaço livre no computador</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>Ficheiros kDrive armazenados no computador</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Outros ficheiros no computador</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>A carregar a utilização do espaço…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Espaço livre</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Outros ficheiros</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>Ficheiros do kDrive armazenados no seu dispositivo</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>O kDrive não consegue aceder ao volume
+Certifique-se de que está ligado,
+desbloqueado e acessível no seu computador.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>O volume não está acessível</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Gira as pastas sincronizadas para libertar espaço no seu Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Sincronização</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Este PC - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 de %2 utilizados</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Armazenados online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Os seus ficheiros permanecem na cloud e não ocupam espaço no seu computador.
+É necessária uma ligação à Internet para os aceder.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Erro de sincronização</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Pasta personalizada</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Pasta predefinida</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Sincronização</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>O seu novo modo de sincronização está a ser aplicado…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Regras de sincronização</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Ocorreu um erro</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>A última sincronização foi bem-sucedida</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>A sincronização está pausada</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>A sincronização está em curso</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Sincronizado</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Sincronizado</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Sincronizado a partir do seu computador</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Sincronizado a partir do kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>os seus ficheiros estão a sincronizar</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>a sincronização está em pausa</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Os seus ficheiros recentes estão a ser atualizados.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Sincronização em curso</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Os seus ficheiros descarregados continuam acessíveis.
+A sincronização será retomada automaticamente assim que se voltar a ligar.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>A sincronização foi temporariamente parada.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Sincronização em pausa</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Os seus ficheiros estão acessíveis e sincronizados.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Nenhuma atividade em curso</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>os seus ficheiros estão atualizados</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Sincronização</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>Um ficheiro ou pasta na sua pasta de sincronização parece estar corrompido.
+A sincronização foi interrompida. Verifique os seus ficheiros e tente novamente.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Ficheiro corrompido detetado</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Atividade</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Início</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Armazenamento</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>A pasta não pode ser a raiz de uma unidade e não deve conter nem estar dentro de uma pasta já sincronizada.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>A pasta deve estar vazia, não pode ser a raiz de uma unidade e não deve conter nem estar dentro de uma pasta já sincronizada.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Esta pasta não pode ser utilizada</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Tratamento individual</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Gerir a sincronização</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Uma notificação informa-o quando um ficheiro é excluído por esta regra</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Fechar o kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Abrir o kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Definições</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Verifique se a sua ligação à Internet está ativa, se este nome ainda não está em uso e se não contém caracteres inválidos.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Não é possível criar esta pasta</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Acesso não autorizado</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Os seus ficheiros estão acessíveis e sincronizados.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Sem atividade recente</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Por favor, tente novamente dentro de alguns instantes.
+Se o problema persistir, contacte o serviço de assistência.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ocorreu um erro inesperado</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Até amanhã</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 disponível</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>A instalação demora menos de um minuto.
+A sua sincronização será retomada automaticamente no final.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorar esta versão</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Instalar agora</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Lembrar mais tarde</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Ver novidades</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Versão %1 · Está a usar a %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Atualização disponível</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>É necessária uma nova versão do kDrive para continuar.
+Atualize a aplicação para aceder aos seus ficheiros e retomar a sincronização.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Atualização necessária</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Atualização</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Carregamento incompleto</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Excluir determinadas aplicações da sincronização.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Adicionar ficheiros a ignorar na sincronização.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Regras de exclusão personalizadas</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Exclua determinados tipos de ficheiros da sincronização.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Ver código-fonte</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Tem um erro de sincronização</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Tem {0} erros de sincronização</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>O kDrive não consegue aceder ao disco %1
+Certifique-se de que está ligado,
+desbloqueado e acessível no seu computador.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>O disco de armazenamento %1 não está acessível</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Remover</numerusform> 
+                <numerusform>Remover (%1 regras)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>A aplicar alteração…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Gerir espaço em disco</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Abrir pasta principal</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Atualizar</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Nível de depuração</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>A sincronização será reiniciada automaticamente.
+Se o problema persistir, contacte o nosso suporte e anexe os detalhes técnicos abaixo.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Detalhes técnicos</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ocorreu um erro inesperado</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Eliminação cancelada</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Nomes duplicados</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Não tem as permissões necessárias para adicionar um %1 a esta localização.
+Peça acesso ao proprietário ou administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Não tem permissão para eliminar este %1. Foi restaurado para a sua localização original. Peça acesso ao proprietário ou administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>As permissões de acesso ao %1 foram alteradas, impedindo a sua sincronização.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>Já existe um ficheiro ou pasta com este nome.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Não tem os direitos para editar este ficheiro.
+A versão original foi mantida e a sua edição foi guardada num ficheiro separado com "conflito" no nome. Peça acesso ao proprietário ou administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>O nome deste %1 termina com um espaço, impedindo a sua sincronização. Renomeie o %2 a partir do kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>Uma regra de exclusão está a impedir a sincronização deste %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>Já existe um ficheiro com este nome.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Este ficheiro está atualmente a ser utilizado por outro utilizador.
+As suas alterações serão sincronizadas mais tarde.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Este ficheiro foi eliminado no kDrive online enquanto o estava a editar. Foi mantida uma cópia no seu computador na pasta de recuperação.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Este ficheiro excede o tamanho máximo permitido (50 GB).
+Contacte o seu administrador para aumentar o limite de tamanho dos ficheiros.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Este nome contém apenas espaços e não pode ser utilizado. Renomeie o %1 a partir do kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Este ficheiro é uma ligação física (hard link) que não pode ser sincronizada.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Não tem os direitos para mover este %1 para aqui; será restaurado para a sua localização original. Peça acesso ao proprietário ou administrador.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Este nome excede o comprimento permitido (250 caracteres). Renomeie o %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Não há espaço suficiente no seu computador para sincronizar este ficheiro.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>A pasta completa é grande.
+Para acelerar o envio, recomendamos enviar apenas a última sessão do kDrive.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Enviar apenas a última sessão</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/translations/client_pt.ts
+++ b/src/gui4/linux/translations/client_pt.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: pt, Portuguese
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:29 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="pt"> 
     <context>
@@ -344,6 +344,16 @@ Pode abri-los em qualquer momento, mesmo sem ligação à Internet.</translation
             <source>Manage storage</source> 
             <translation>Gerir armazenamento</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximizar</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimizar</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Abrir pasta de depuração</translation> 
@@ -427,6 +437,11 @@ Pode abri-los em qualquer momento, mesmo sem ligação à Internet.</translation
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Reiniciar a sincronização</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Restaurar</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: sv, Swedish
  Exported by: Romain Galland
- Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+ Exported at: Thu, 09 Jul 2026 13:21:29 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="sv"> 
     <context>
@@ -344,6 +344,16 @@ Du kan öppna dem när som helst, även utan internetanslutning.</translation>
             <source>Manage storage</source> 
             <translation>Hantera lagring</translation> 
         </message> 
+        <message id="buttonMaximize"> 
+            <source>Maximize</source> 
+            <extracomment>Accessibility label for the window maximize control (Linux window chrome).</extracomment> 
+            <translation>Maximera</translation> 
+        </message> 
+        <message id="buttonMinimize"> 
+            <source>Minimize</source> 
+            <extracomment>Accessibility label for the window minimize control (Linux window chrome).</extracomment> 
+            <translation>Minimera</translation> 
+        </message> 
         <message id="buttonOpenDebugFolder"> 
             <source>Open debug folder</source> 
             <translation>Öppna felsökningsmapp</translation> 
@@ -427,6 +437,11 @@ Du kan öppna dem när som helst, även utan internetanslutning.</translation>
         <message id="buttonRestartSynchro"> 
             <source>Restart sync</source> 
             <translation>Starta om synkronisering</translation> 
+        </message> 
+        <message id="buttonRestore"> 
+            <source>Restore</source> 
+            <extracomment>Accessibility label for the window restore (un-maximize) control (Linux window chrome).</extracomment> 
+            <translation>Återställ</translation> 
         </message> 
         <message id="buttonRetry"> 
             <source>Retry</source> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -9,7 +9,7 @@
 --> 
 <TS version="2.1" sourcelanguage="en" language="sv"> 
     <context>
-        <name>main</name> 
+        <name></name> 
         <message id="aboutAppVersionCopyright"> 
             <source>Version %1.%2
 © 2019-%3 Infomaniak Network SA -</source> 
@@ -2467,42 +2467,42 @@ olåst och tillgänglig från din dator.</translation>
         </message> 
     </context> 
     <context>
-        <name>sync convertion</name> 
+        <name></name> 
         <message id="applyingChange"> 
             <source>Applying change…</source> 
             <translation>Tillämpar ändring…</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to manage disk space when not enough space is available</name> 
+        <name></name> 
         <message id="buttonManageDiskSpace"> 
             <source>Manage disk space</source> 
             <translation>Hantera diskutrymme</translation> 
         </message> 
     </context> 
     <context>
-        <name>Button to open the parent directory of the inaccessible file</name> 
+        <name></name> 
         <message id="buttonOpenParentFolder"> 
             <source>Open parent folder</source> 
             <translation>Öppna överordnad mapp</translation> 
         </message> 
     </context> 
     <context>
-        <name>Action de mettre à jour</name> 
+        <name></name> 
         <message id="buttonUpdate"> 
             <source>Update</source> 
             <translation>Uppdatera</translation> 
         </message> 
     </context> 
     <context>
-        <name>Settings</name> 
+        <name></name> 
         <message id="debugLevelSetting"> 
             <source>Debug level</source> 
             <translation>Felsökningsnivå</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <name></name> 
         <message id="defaultErrorDescription"> 
             <source>Synchronization will restart automatically.
 If the problem persists, contact our support and attach the technical details below.</source> 
@@ -2511,35 +2511,35 @@ Om problemet kvarstår, kontakta vår support och bifoga de tekniska detaljerna 
         </message> 
     </context> 
     <context>
-        <name>Label for the technical details expander in the default error card</name> 
+        <name></name> 
         <message id="defaultErrorDetailsLabel"> 
             <source>Technical details</source> 
             <translation>Tekniska detaljer</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for the default error card when an unhandled error occurs</name> 
+        <name></name> 
         <message id="defaultErrorTitle"> 
             <source>An unexpected error occurred</source> 
             <translation>Ett oväntat fel inträffade</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when file/folder deletion is cancelled</name> 
+        <name></name> 
         <message id="deleteCancelErrorTitle"> 
             <source>Deletion canceled</source> 
             <translation>Radering avbruten</translation> 
         </message> 
     </context> 
     <context>
-        <name>Title for error when files/folders have duplicate names</name> 
+        <name></name> 
         <message id="duplicateNamesErrorTitle"> 
             <source>Duplicate names</source> 
             <translation>Duplicerade namn</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for create cancel error</name> 
+        <name></name> 
         <message id="errCreateCancelDescription"> 
             <source>You do not have the required permissions to add a %1 to this location.
 Request access from the owner or administrator.</source> 
@@ -2548,28 +2548,28 @@ Begär åtkomst från ägaren eller administratören.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for delete cancel error</name> 
+        <name></name> 
         <message id="errDeleteCancelDescription"> 
             <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har inte behörighet att ta bort denna %1. Den har återställts till sin ursprungliga plats. Begär åtkomst från ägaren eller administratören.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Main description in the dialog explaining the issue</name> 
+        <name></name> 
         <message id="errDialogLocalFileAccessDescription"> 
             <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
             <translation>Åtkomstbehörigheterna för %1 har ändrats, vilket förhindrar att den synkroniseras.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for duplicate names error</name> 
+        <name></name> 
         <message id="errDuplicateNamesDescription"> 
             <source>A file or folder with this name already exists.</source> 
             <translation>En fil eller mapp med det här namnet finns redan.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for edit cancel error</name> 
+        <name></name> 
         <message id="errEditCancelDescription"> 
             <source>You do not have the rights to edit this file.
 The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
@@ -2578,28 +2578,28 @@ Originalversionen har behållits och din redigering har sparats i en separat fil
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character end with space error</name> 
+        <name></name> 
         <message id="errEndWithSpaceDescription"> 
             <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
             <translation>Namnet på denna %1 slutar med ett mellanslag, vilket förhindrar att den synkroniseras. Byt namn på %2 från kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for excluded by template error</name> 
+        <name></name> 
         <message id="errExcludedByTemplateDescription"> 
             <source>An exclusion rule is preventing this %1 from being synced.</source> 
             <translation>En undantagsregel förhindrar att den här %1 synkroniseras.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file exists error</name> 
+        <name></name> 
         <message id="errFileExistsDescription"> 
             <source>A file with this name already exists.</source> 
             <translation>En fil med det här namnet finns redan.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file locked error</name> 
+        <name></name> 
         <message id="errFileLockedDescription"> 
             <source>This file is currently being used by another user.
 Your changes will be synced later.</source> 
@@ -2608,14 +2608,14 @@ Dina ändringar synkroniseras senare.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for file rescued error</name> 
+        <name></name> 
         <message id="errFileRescuedDescription"> 
             <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
             <translation>Den här filen raderades på kDrive online medan du redigerade den. En kopia har sparats på din dator i återställningsmappen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for file too big error</name> 
+        <name></name> 
         <message id="errFileTooBigDescription"> 
             <source>This file exceeds the maximum allowed size (50 GB).
 Contact your administrator to increase the file size limit.</source> 
@@ -2624,49 +2624,49 @@ Kontakta din administratör för att öka filstorleksgränsen.</translation>
         </message> 
     </context> 
     <context>
-        <name>Description for forbidden character only spaces error</name> 
+        <name></name> 
         <message id="errForbiddenCharOnlySpacesDescription"> 
             <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
             <translation>Det här namnet innehåller bara mellanslag och kan inte användas. Byt namn på %1 från kDrive online.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for hardlink error</name> 
+        <name></name> 
         <message id="errHardlinkDescription"> 
             <source>This file is a hard link that cannot be synced.</source> 
             <translation>Den här filen är en hård länk som inte kan synkroniseras.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for move cancel error</name> 
+        <name></name> 
         <message id="errMoveCancelDescription"> 
             <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
             <translation>Du har inte rätt att flytta den här %1 hit; den återställs till sin ursprungliga plats. Begär åtkomst från ägaren eller administratören.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for name length error</name> 
+        <name></name> 
         <message id="errNameLengthDescription"> 
             <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
             <translation>Det här namnet överskrider den tillåtna längden (250 tecken). Byt namn på %1.</translation> 
         </message> 
     </context> 
     <context>
-        <name>Description for not enough disk space error</name> 
+        <name></name> 
         <message id="errNotEnoughDiskSpaceDescription"> 
             <source>There is not enough space on your computer to sync this file.</source> 
             <translation>Det finns inte tillräckligt med utrymme på din dator för att synkronisera den här filen.</translation> 
         </message> 
     </context> 
     <context>
-        <name>kDrive 4.0.0</name> 
+        <name></name> 
         <message id="labelKDriveVersion"> 
             <source>kDrive %1</source> 
             <translation>kDrive %1</translation> 
         </message> 
     </context> 
     <context>
-        <name>log upload</name> 
+        <name></name> 
         <message id="largeFolderRecommendation"> 
             <source>The full folder is large.
 To speed up the upload, we recommend sending only the last kDrive session.</source> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -5,7 +5,7 @@
  Project: kDrive Desktop
  Locale: sv, Swedish
  Exported by: Romain Galland
- Exported at: Thu, 09 Jul 2026 13:21:29 +0200 
+ Exported at: Thu, 09 Jul 2026 14:09:03 +0200 
 --> 
 <TS version="2.1" sourcelanguage="en" language="sv"> 
     <context>
@@ -2077,7 +2077,7 @@ Dessa data gör det möjligt för vårt team att snabbt åtgärda och optimera p
             <translation>kDrive-mapp</translation> 
         </message> 
         <message id="signInBrowser"> 
-            <source>Sign in using your browse</source> 
+            <source>Sign in using your browser</source> 
             <translation>Logga in med din webbläsare</translation> 
         </message> 
         <message id="statusBarOpenApp"> 

--- a/src/gui4/linux/translations/client_sv.ts
+++ b/src/gui4/linux/translations/client_sv.ts
@@ -1,0 +1,2681 @@
+<?xml version="1.0" encoding="UTF-8"?> 
+<!DOCTYPE TS> 
+<!--
+ Loco xml export: Qt framework TS file (LEGACY)
+ Project: kDrive Desktop
+ Locale: sv, Swedish
+ Exported by: Romain Galland
+ Exported at: Wed, 08 Jul 2026 16:48:00 +0200 
+--> 
+<TS version="2.1" sourcelanguage="en" language="sv"> 
+    <context>
+        <name>main</name> 
+        <message id="aboutAppVersionCopyright"> 
+            <source>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</source> 
+            <translation>Version %1.%2
+© 2019-%3 Infomaniak Network SA -</translation> 
+        </message> 
+        <message id="aboutAppVersionCopyrightMac"> 
+            <source>Version %1 (build %2)
+© 2019-%3 Infomaniak Network SA</source> 
+            <translation>Version %1 (bygg %2)
+© 2019-%3 Infomaniak Network SA</translation> 
+        </message> 
+        <message id="aboutButton"> 
+            <source>About</source> 
+            <translation>Om</translation> 
+        </message> 
+        <message id="aboutKDrive"> 
+            <source>About kDrive</source> 
+            <translation>Om kDrive</translation> 
+        </message> 
+        <message id="aboutKDriveDescription"> 
+            <source>Developed and hosted exclusively in Switzerland, kDrive ensures total protection of your data, with no reselling or spying, in ISO-certified data centers, with encryption and backup on multiple media.</source> 
+            <translation>Utvecklad och uteslutande driftad i Schweiz säkerställer kDrive ett fullständigt skydd av dina data, utan vidaresäljning eller spionage, i ISO-certifierade datacenter, med kryptering och säkerhetskopiera på flera media.</translation> 
+        </message> 
+        <message id="accessibilityActivityTypePicker"> 
+            <source>Visible activities</source> 
+            <translation>Synliga aktiviteter</translation> 
+        </message> 
+        <message id="accessibilityBetaProgramPicker"> 
+            <source>Choosing a distribution channel</source> 
+            <translation>Välj distributionskanal</translation> 
+        </message> 
+        <message id="accessibilityMoreInformation"> 
+            <source>Show more information</source> 
+            <translation>Visa mer information</translation> 
+        </message> 
+        <message id="accessibilitySearchClear"> 
+            <source>Clear search</source> 
+            <translation>Clear search</translation> 
+        </message> 
+        <message id="accessibilitySearchSheetLabel"> 
+            <source>Search your files</source> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="accessibilitySearching"> 
+            <source>Searching…</source> 
+            <translation>Searching…</translation> 
+        </message> 
+        <message id="accessibilitySelectSynchroMode"> 
+            <source>Select a synchronization mode</source> 
+            <translation>Välj ett synkroniseringsläge</translation> 
+        </message> 
+        <message id="activitiesTitleIdle"> 
+            <source>Synchronization complete</source> 
+            <translation>Synkronisering slutförd</translation> 
+        </message> 
+        <message id="activitiesTitleInProgress"> 
+            <source>Synchronization in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="activitiesTitleNoActivity"> 
+            <source>No recent activity</source> 
+            <translation>Ingen ny aktivitet</translation> 
+        </message> 
+        <message id="activitiesTitleOffline"> 
+            <source>You are offline</source> 
+            <translation>Du är offline</translation> 
+        </message> 
+        <message id="activitiesTitlePause"> 
+            <source>Synchronization paused</source> 
+            <translation>Synkronisering pausad</translation> 
+        </message> 
+        <message id="activitiesTypeAllActivities"> 
+            <source>All activities</source> 
+            <translation>Alla aktiviteter</translation> 
+        </message> 
+        <message id="activitiesTypeMyActivity"> 
+            <source>My activity only</source> 
+            <translation>Endast min aktivitet</translation> 
+        </message> 
+        <message id="addAdvancedSyncDialogTitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkronisera en mapp med kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderDescription"> 
+            <source>Choose the folder on your computer to sync with kDrive:</source> 
+            <translation>Välj mappen på din dator som ska synkroniseras med kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncLocalFolderTitle"> 
+            <source>Synced folder</source> 
+            <translation>Synkroniserad mapp</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderDescription"> 
+            <source>Customize the location of your computer folder on kDrive:</source> 
+            <translation>Anpassa platsen för din datormapp på kDrive:</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderPageTitle"> 
+            <source>Choose the folder location on kDrive</source> 
+            <translation>Välj mappens plats på kDrive</translation> 
+        </message> 
+        <message id="addAdvancedSyncRemoteFolderTitle"> 
+            <source>kDrive location</source> 
+            <translation>kDrive-plats</translation> 
+        </message> 
+        <message id="advancedSyncDescription"> 
+            <source>Select a folder on your computer to sync with kDrive.
+You can access your advanced syncs from the drive picker on the home page.</source> 
+            <translation>Välj en mapp på din dator att synkronisera med kDrive.
+Du kan komma åt dina avancerade synkroniseringar från enhetsväljaren på startsidan.</translation> 
+        </message> 
+        <message id="advancedSyncSubtitle"> 
+            <source>Sync a folder with kDrive</source> 
+            <translation>Synkronisera en mapp med kDrive</translation> 
+        </message> 
+        <message id="advancedSyncTitle"> 
+            <source>Advanced sync</source> 
+            <translation>Avancerad synkronisering</translation> 
+        </message> 
+        <message id="appToExclude"> 
+            <source>App to exclude</source> 
+            <translation>App som ska undantas</translation> 
+        </message> 
+        <message id="appUpToDate"> 
+            <source>The application is up to date</source> 
+            <translation>Programmet är uppdaterat</translation> 
+        </message> 
+        <message id="autoCleanupLogsDescription"> 
+            <source>Deletes logs older than 7 days to save disk space.</source> 
+            <translation>Tar bort loggar äldre än 7 dagar för att spara diskutrymme.</translation> 
+        </message> 
+        <message id="autoCleanupLogsSetting"> 
+            <source>Automatic cleanup</source> 
+            <translation>Automatisk rensning</translation> 
+        </message> 
+        <message id="automaticUpdatesSetting"> 
+            <source>Automatic updates</source> 
+            <translation>Automatiska uppdateringar</translation> 
+        </message> 
+        <message id="availableOffline"> 
+            <source>Available offline</source> 
+            <translation>Tillgänglig offline</translation> 
+        </message> 
+        <message id="availableOfflineDescription"> 
+            <source>Your files are copied to your computer.
+You can open them at any time, even without an internet connection.</source> 
+            <translation>Dina filer kopieras till din dator.
+Du kan öppna dem när som helst, även utan internetanslutning.</translation> 
+        </message> 
+        <message id="backErrorDriveAsleepDescription"> 
+            <source>You can wake it up from the web interface.</source> 
+            <translation>Du kan väcka den från webbgränssnittet.</translation> 
+        </message> 
+        <message id="betaProgramDescription"> 
+            <source>Get early access to new versions of the application before they are released to the general public and help improve the app by sharing your improvement ideas with us.</source> 
+            <translation>Få tidig åtkomst till nya versioner av programmet innan de släpps till allmänheten och hjälp till att förbättra appen genom att dela dina förbättringsidéer med oss.</translation> 
+        </message> 
+        <message id="betaProgramTitle"> 
+            <source>Join the beta program</source> 
+            <translation>Gå med i betaprogrammet</translation> 
+        </message> 
+        <message id="browserSignInInstruction"> 
+            <source>Your browser should open automatically to complete the sign-in. Once signed in, you will be automatically returned to kDrive.</source> 
+            <extracomment>Instruction shown during sign-in when waiting for browser-based authentication to complete.</extracomment> 
+            <translation>Din webbläsare bör öppnas automatiskt för att slutföra inloggningen. När du är inloggad återgår du automatiskt till kDrive.</translation> 
+        </message> 
+        <message id="buttonActivateOfflineSync"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktivera offlinesynkronisering</translation> 
+        </message> 
+        <message id="buttonAddAdvancedSync"> 
+            <source>Sync a folder</source> 
+            <translation>Synkronisera en mapp</translation> 
+        </message> 
+        <message id="buttonAddFileExclusionRule"> 
+            <source>Add a rule</source> 
+            <translation>Lägg till en regel</translation> 
+        </message> 
+        <message id="buttonAddStorage"> 
+            <source>Add storage</source> 
+            <translation>Lägg till lagringsutrymme</translation> 
+        </message> 
+        <message id="buttonAdvancedParameters"> 
+            <source>Advanced settings</source> 
+            <translation>Avancerade inställningar</translation> 
+        </message> 
+        <message id="buttonApplyToXFiles"> 
+            <source>Apply to %1 files</source> 
+            <translation>Tillämpa på %1 filer</translation> 
+        </message> 
+        <message id="buttonAskForAccess"> 
+            <source>Request access</source> 
+            <translation>Begär åtkomst</translation> 
+        </message> 
+        <message id="buttonCancel"> 
+            <source>Cancel</source> 
+            <translation>Avbryt</translation> 
+        </message> 
+        <message id="buttonChangeFolder"> 
+            <source>Change folder</source> 
+            <translation>Ändra mapp</translation> 
+        </message> 
+        <message id="buttonChangeToOffline"> 
+            <source>Store offline</source> 
+            <translation>Lagra offline</translation> 
+        </message> 
+        <message id="buttonChangeToOnline"> 
+            <source>Store online</source> 
+            <translation>Lagra online</translation> 
+        </message> 
+        <message id="buttonChangeUser"> 
+            <source>Switch user</source> 
+            <translation>Byt användare</translation> 
+        </message> 
+        <message id="buttonClose"> 
+            <source>Close</source> 
+            <translation>Stäng</translation> 
+        </message> 
+        <message id="buttonCloseKDrive"> 
+            <source>Close kDrive</source> 
+            <extracomment>Button to quit the kDrive application entirely.</extracomment> 
+            <translation>Stäng kDrive</translation> 
+        </message> 
+        <message id="buttonConfigure"> 
+            <source>Configure</source> 
+            <translation>Konfigurera</translation> 
+        </message> 
+        <message id="buttonConfirm"> 
+            <source>Confirm</source> 
+            <translation>Bekräfta</translation> 
+        </message> 
+        <message id="buttonConnect"> 
+            <source>Sign in</source> 
+            <translation>Logga in</translation> 
+        </message> 
+        <message id="buttonConnectAccount"> 
+            <source>Connect an account</source> 
+            <translation>Anslut ett konto</translation> 
+        </message> 
+        <message id="buttonContactSupport"> 
+            <source>Contact support</source> 
+            <translation>Kontakta support</translation> 
+        </message> 
+        <message id="buttonContinue"> 
+            <source>Continue</source> 
+            <translation>Fortsätt</translation> 
+        </message> 
+        <message id="buttonCopyShareLink"> 
+            <source>Copy share link</source> 
+            <translation>Kopiera delningslänk</translation> 
+        </message> 
+        <message id="buttonCreateAccount"> 
+            <source>Create an account</source> 
+            <translation>Skapa ett konto</translation> 
+        </message> 
+        <message id="buttonCreateNewSync"> 
+            <source>Create a new sync</source> 
+            <translation>Skapa en ny synkronisering</translation> 
+        </message> 
+        <message id="buttonCustomLocation"> 
+            <source>Custom location</source> 
+            <translation>Anpassad plats</translation> 
+        </message> 
+        <message id="buttonDisconnectAccount"> 
+            <source>Disconnect this account</source> 
+            <translation>Koppla från det här kontot</translation> 
+        </message> 
+        <message id="buttonDownloadInProgress"> 
+            <source>Downloading…</source> 
+            <translation>Laddar ned…</translation> 
+        </message> 
+        <message id="buttonDownloadManually"> 
+            <source>Download manually</source> 
+            <translation>Ladda ned manuellt</translation> 
+        </message> 
+        <message id="buttonEnable"> 
+            <source>Enable</source> 
+            <translation>Aktivera</translation> 
+        </message> 
+        <message id="buttonEnableInSettings"> 
+            <source>Enable in Windows settings</source> 
+            <translation>Aktivera i Windows-inställningar</translation> 
+        </message> 
+        <message id="buttonErrorResolutionTip"> 
+            <source>Understand the issue</source> 
+            <translation>Förstå problemet</translation> 
+        </message> 
+        <message id="buttonFeedback"> 
+            <source>Share an idea</source> 
+            <translation>Dela en idé</translation> 
+        </message> 
+        <message id="buttonFinishInstallation"> 
+            <source>Finish installation</source> 
+            <translation>Slutför installation</translation> 
+        </message> 
+        <message id="buttonFixErrors"> 
+            <source>Fix errors</source> 
+            <translation>Åtgärda fel</translation> 
+        </message> 
+        <message id="buttonHelpdesk"> 
+            <source>Support</source> 
+            <translation>Support</translation> 
+        </message> 
+        <message id="buttonKDriveIsActivated"> 
+            <source>I’ve activated kDrive</source> 
+            <translation>Jag har aktiverat kDrive</translation> 
+        </message> 
+        <message id="buttonKDriveOnline"> 
+            <source>kDrive online</source> 
+            <translation>kDrive online</translation> 
+        </message> 
+        <message id="buttonKeepAccount"> 
+            <source>Keep account</source> 
+            <translation>Behåll konto</translation> 
+        </message> 
+        <message id="buttonLogOut"> 
+            <source>Sign out</source> 
+            <translation>Logga ut</translation> 
+        </message> 
+        <message id="buttonLogin"> 
+            <source>Sign in</source> 
+            <translation>Logga in</translation> 
+        </message> 
+        <message id="buttonManage"> 
+            <source>Manage</source> 
+            <translation>Hantera</translation> 
+        </message> 
+        <message id="buttonManageIndividually"> 
+            <source>Handle files individually</source> 
+            <translation>Hantera filer individuellt</translation> 
+        </message> 
+        <message id="buttonManageStorage"> 
+            <source>Manage storage</source> 
+            <translation>Hantera lagring</translation> 
+        </message> 
+        <message id="buttonOpenDebugFolder"> 
+            <source>Open debug folder</source> 
+            <translation>Öppna felsökningsmapp</translation> 
+        </message> 
+        <message id="buttonOpenExplorer"> 
+            <source>Open Explorer</source> 
+            <translation>Öppna Utforskaren</translation> 
+        </message> 
+        <message id="buttonOpenFolder"> 
+            <source>Open folder</source> 
+            <translation>Öppna mapp</translation> 
+        </message> 
+        <message id="buttonOpenInBrowser"> 
+            <source>Open in browser</source> 
+            <translation>Öppna i webbläsare</translation> 
+        </message> 
+        <message id="buttonOpenInExplorer"> 
+            <source>Open in Explorer</source> 
+            <extracomment>Button to reveal the selected item in Windows Explorer.</extracomment> 
+            <translation>Öppna i Utforskaren</translation> 
+        </message> 
+        <message id="buttonOpenInFinder"> 
+            <source>Open in Finder</source> 
+            <translation>Öppna i Finder</translation> 
+        </message> 
+        <message id="buttonOpenInKDrive"> 
+            <source>Open in kDrive Web</source> 
+            <translation>Öppna i kDrive Web</translation> 
+        </message> 
+        <message id="buttonOpenKDrive"> 
+            <source>Open kDrive</source> 
+            <translation>Öppna kDrive</translation> 
+        </message> 
+        <message id="buttonOpenSyncExclusionRules"> 
+            <source>Manage exclusions</source> 
+            <translation>Hantera undantag</translation> 
+        </message> 
+        <message id="buttonOpenSyncSettings"> 
+            <source>Open sync settings</source> 
+            <translation>Öppna synkroniseringsinstillningar</translation> 
+        </message> 
+        <message id="buttonPause"> 
+            <source>Pause</source> 
+            <translation>Paus</translation> 
+        </message> 
+        <message id="buttonRefresh"> 
+            <source>Refresh</source> 
+            <translation>Uppdatera</translation> 
+        </message> 
+        <message id="buttonReleaseNotes"> 
+            <source>Release notes</source> 
+            <translation>Versionsnoteringar</translation> 
+        </message> 
+        <message id="buttonRemove"> 
+            <source>Remove</source> 
+            <translation>Ta bort</translation> 
+        </message> 
+        <message numerus="yes" id="buttonRemoveFileExclusionRule"> 
+            <source>Remove (%n element)</source> 
+            <translation>
+                <numerusform>Ta bort (%n element)</numerusform> 
+                <numerusform>Ta bort (%n element)</numerusform> 
+            </translation>
+        </message> 
+        <message id="buttonRemoveSync"> 
+            <source>Remove sync</source> 
+            <translation>Ta bort synkronisering</translation> 
+        </message> 
+        <message id="buttonRenameItem"> 
+            <source>Rename %1</source> 
+            <translation>Byt namn på %1</translation> 
+        </message> 
+        <message id="buttonRestartSignIn"> 
+            <source>Restart sign-in</source> 
+            <translation>Starta om inloggning</translation> 
+        </message> 
+        <message id="buttonRestartSync"> 
+            <source>Resume sync</source> 
+            <translation>Återuppta synkronisering</translation> 
+        </message> 
+        <message id="buttonRestartSynchro"> 
+            <source>Restart sync</source> 
+            <translation>Starta om synkronisering</translation> 
+        </message> 
+        <message id="buttonRetry"> 
+            <source>Retry</source> 
+            <translation>Försök igen</translation> 
+        </message> 
+        <message id="buttonReturnToDefaultFolder"> 
+            <source>Return to default folder</source> 
+            <translation>Återgå till standardmapp</translation> 
+        </message> 
+        <message id="buttonSave"> 
+            <source>Save</source> 
+            <translation>Spara</translation> 
+        </message> 
+        <message id="buttonSaveMyChoices"> 
+            <source>Save my choices</source> 
+            <translation>Spara mina val</translation> 
+        </message> 
+        <message id="buttonSearch"> 
+            <source>Search</source> 
+            <translation>Sök</translation> 
+        </message> 
+        <message id="buttonSeeActivities"> 
+            <source>View activities</source> 
+            <translation>Visa aktiviteter</translation> 
+        </message> 
+        <message id="buttonSelect"> 
+            <source>Select</source> 
+            <translation>Välj</translation> 
+        </message> 
+        <message id="buttonSelectFolder"> 
+            <source>Select a folder</source> 
+            <translation>Välj en mapp</translation> 
+        </message> 
+        <message id="buttonSelectFolders"> 
+            <source>Select folders</source> 
+            <translation>Välj mappar</translation> 
+        </message> 
+        <message id="buttonSelectLocation"> 
+            <source>Select a location</source> 
+            <translation>Välj en plats</translation> 
+        </message> 
+        <message id="buttonSelected"> 
+            <source>Selected</source> 
+            <translation>Vald</translation> 
+        </message> 
+        <message id="buttonSend"> 
+            <source>Send</source> 
+            <translation>Skicka</translation> 
+        </message> 
+        <message id="buttonSendLog"> 
+            <source>Send debug folder</source> 
+            <translation>Skicka felsökningsmapp</translation> 
+        </message> 
+        <message id="buttonSettings"> 
+            <source>Open settings</source> 
+            <translation>Öppna inställningar</translation> 
+        </message> 
+        <message id="buttonShowOffers"> 
+            <source>View offers</source> 
+            <translation>Visa erbjudanden</translation> 
+        </message> 
+        <message id="buttonShowOption"> 
+            <source>Show options</source> 
+            <translation>Visa alternativ</translation> 
+        </message> 
+        <message id="buttonSignOut"> 
+            <source>Sign out</source> 
+            <translation>Logga ut</translation> 
+        </message> 
+        <message id="buttonStart"> 
+            <source>Start</source> 
+            <translation>Start</translation> 
+        </message> 
+        <message id="buttonStartConflictsResolution"> 
+            <source>Start version selection</source> 
+            <translation>Starta versionsval</translation> 
+        </message> 
+        <message id="buttonStartForFree"> 
+            <source>Get started for free</source> 
+            <translation>Kom igång gratis</translation> 
+        </message> 
+        <message id="buttonSynchronizeOffline"> 
+            <source>Sync offline</source> 
+            <translation>Synkronisera offline</translation> 
+        </message> 
+        <message id="buttonUpdateNow"> 
+            <source>Update now</source> 
+            <translation>Uppdatera nu</translation> 
+        </message> 
+        <message id="buttonUpdateSubscription"> 
+            <source>Update subscription</source> 
+            <translation>Uppdatera prenumeration</translation> 
+        </message> 
+        <message id="buttonUpgradeOffer"> 
+            <source>Upgrade</source> 
+            <translation>Uppgradera</translation> 
+        </message> 
+        <message id="buttonValidate"> 
+            <source>Confirm</source> 
+            <translation>Bekräfta</translation> 
+        </message> 
+        <message id="buttonValidateAndGoNext"> 
+            <source>Confirm and go to next</source> 
+            <translation>Bekräfta och gå till nästa</translation> 
+        </message> 
+        <message id="buttonWakeUp"> 
+            <source>Wake up</source> 
+            <translation>Väck</translation> 
+        </message> 
+        <message id="conflictErrorAction"> 
+            <source>Choose a version</source> 
+            <translation>Välj en version</translation> 
+        </message> 
+        <message id="conflictErrorDescription"> 
+            <source>Two different versions of these files were detected.</source> 
+            <translation>Två olika versioner av dessa filer hittades.</translation> 
+        </message> 
+        <message id="conflictErrorTitle"> 
+            <source>Version conflicts</source> 
+            <translation>Versionskonflikt</translation> 
+        </message> 
+        <message id="conflictsSearchBoxPlaceholder"> 
+            <source>Search for a file</source> 
+            <translation>Sök efter en fil</translation> 
+        </message> 
+        <message id="copyingLink"> 
+            <source>Copying Link…</source> 
+            <translation>Kopierar länk…</translation> 
+        </message> 
+        <message id="creatingShareLink"> 
+            <source>Creating share link…</source> 
+            <translation>Skapar delningslänk…</translation> 
+        </message> 
+        <message id="dataManagementDescription"> 
+            <source>You can customize the usage and operational data collected by Infomaniak to fix bugs and improve the application. Both tools used are hosted and managed exclusively by us.
+
+The source code of this application can be verified, the information collected is anonymous and your personal information remains strictly confidential and is never shared with third parties.</source> 
+            <translation>Du kan anpassa vilka användnings- och driftsdata som samlas in av Infomaniak för att åtgärda buggar och förbättra programmet. Båda verktygen som används driftas och hanteras exklusivt av oss.
+
+Källkoden för det här programmet kan verifieras, den insamlade informationen är anonym och din personliga information förblir strikt konfidentiell och delas aldrig med tredje part.</translation> 
+        </message> 
+        <message id="dataManagementSettings"> 
+            <source>Data management</source> 
+            <translation>Datahantering</translation> 
+        </message> 
+        <message id="dataManagementSubtitle"> 
+            <source>Infomaniak respects your privacy</source> 
+            <translation>Infomaniak respekterar din integritet</translation> 
+        </message> 
+        <message id="debugLevelDescription"> 
+            <source>Select the amount of information to log.</source> 
+            <translation>Välj mängden information som ska loggas.</translation> 
+        </message> 
+        <message id="debugLogsDescription"> 
+            <source>Allows Infomaniak support to identify the cause of an incident.</source> 
+            <translation>Gör det möjligt för Infomaniaks support att identifiera orsaken till en incident.</translation> 
+        </message> 
+        <message id="debugLogsSettings"> 
+            <source>Debug logs</source> 
+            <translation>Felsökningsloggar</translation> 
+        </message> 
+        <message id="defaultExclusionAppListDescription"> 
+            <source>These apps are ignored by default and cannot be modified.</source> 
+            <translation>Dessa appar ignoreras som standard och kan inte ändras.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListDescription"> 
+            <source>These files are excluded by default and cannot be modified.</source> 
+            <translation>Dessa filer är undantagna som standard och kan inte ändras.</translation> 
+        </message> 
+        <message id="defaultExclusionFileListHeader"> 
+            <source>Automatic exclusion</source> 
+            <translation>Automatiskt undantag</translation> 
+        </message> 
+        <message id="dialogDataErrorSyncDirChangeDescription"> 
+            <source>In these situations, a new sync is required to continue using kDrive correctly.</source> 
+            <translation>I dessa situationer krävs en ny synkronisering för att fortsätta använda kDrive korrekt.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderDescription"> 
+            <source>Please select an empty folder that is not at the root of a drive.
+
+This folder must not be included in another sync folder and must not contain a sync subfolder.</source> 
+            <translation>Välj en tom mapp som inte är roten av en enhet.
+
+Den här mappen får inte ingå i en annan synkroniseringsmapp och får inte innehålla en synkroniserad undermapp.</translation> 
+        </message> 
+        <message id="dialogDriveSetupInvalidFolderTitle"> 
+            <source>This folder cannot be selected</source> 
+            <translation>Den här mappen kan inte väljas</translation> 
+        </message> 
+        <message id="dialogNewExclusionRulePrimaryButton"> 
+            <source>Add a rule</source> 
+            <translation>Lägg till en regel</translation> 
+        </message> 
+        <message id="dialogNewExclusionRuleTitle"> 
+            <source>Add an exclusion rule</source> 
+            <translation>Lägg till en undantagsregel</translation> 
+        </message> 
+        <message id="dialogRemoveAccountContent"> 
+            <source>You are about to disconnect %1 from the application.
+The sync folder will remain on your computer, but will no longer be synced with kDrive.
+
+All your data will remain accessible online on kDrive.</source> 
+            <translation>Du håller på att koppla från %1 från programmet.
+Synkroniseringsmappen finns kvar på din dator men synkroniseras inte längre med kDrive.
+
+All din data förblir tillgänglig online på kDrive.</translation> 
+        </message> 
+        <message id="dialogRemoveAccountTitle"> 
+            <source>Sign out of this account?</source> 
+            <translation>Logga ut från det här kontot?</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningContent"> 
+            <source>The local folder will remain on your computer, but it will no longer be synced with kDrive.
+This action is permanent.
+To sync your drive again, you will need to reconnect it later.
+
+Before continuing, make sure all your files are up to date and fully synced.</source> 
+            <translation>Den lokala mappen finns kvar på din dator, men den synkroniseras inte längre med kDrive.
+Den här åtgärden är permanent.
+För att synkronisera enheten igen måste du ansluta den på nytt senare.
+
+Se till att alla dina filer är uppdaterade och helt synkroniserade innan du fortsätter.</translation> 
+        </message> 
+        <message id="dialogSyncDeletionWarningTitle"> 
+            <source>Remove sync?</source> 
+            <translation>Ta bort synkronisering?</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorContent"> 
+            <source>The sync mode change was canceled.
+
+The current sync remains unchanged. However, if abnormal behavior occurs, you may need to delete and recreate the sync to restore proper operation.</source> 
+            <translation>Ändringen av synkroniseringsläget avbröts.
+
+Den aktuella synkroniseringen är oförändrad. Om ett onormalt beteende uppstår kan du dock behöva ta bort och återskapa synkroniseringen för att återställa korrekt funktion.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeErrorTitle"> 
+            <source>An error occurred</source> 
+            <translation>Ett fel inträffade</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningContent"> 
+            <source>This operation may take some time depending on the size of your data. If it fails, a full re-sync of the drive may be required.
+
+Before continuing, make sure all your files are up to date and synced.
+
+Do not close the application during the process.</source> 
+            <translation>Den här åtgärden kan ta en stund beroende på storleken på dina data. Om det misslyckas kan en fullständig omsynkronisering av enheten krävas.
+
+Se till att alla dina filer är uppdaterade och synkroniserade innan du fortsätter.
+
+Stäng inte programmet under processen.</translation> 
+        </message> 
+        <message id="dialogSyncModeChangeWarningTitle"> 
+            <source>Change sync mode?</source> 
+            <translation>Ändra synkroniseringsläge?</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Here is how to restore sync:</source> 
+            <translation>Så här återställer du synkroniseringen:</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorDescription"> 
+            <source>The disk containing your sync folder is no longer connected</source> 
+            <translation>Disken som innehåller din synkroniseringsmapp är inte längre ansluten</translation> 
+        </message> 
+        <message id="dialogSystemErrorSyncDirDiskMissingErrorTip"> 
+            <source>Reconnect it to resume sync.</source> 
+            <translation>Anslut den igen för att återuppta synkroniseringen.</translation> 
+        </message> 
+        <message id="disableNotificationsSetting"> 
+            <source>Disable notifications</source> 
+            <translation>Inaktivera aviseringar</translation> 
+        </message> 
+        <message id="doNotJoin"> 
+            <source>Don’t join</source> 
+            <translation>Gå inte med</translation> 
+        </message> 
+        <message id="downloadAppUrl"> 
+            <source>https://www.infomaniak.com/en/apps/download-kdrive</source> 
+            <translation>https://www.infomaniak.com/en/apps/download-kdrive</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorDescription"> 
+            <source>You do not have permission to access this kDrive.
+Please check your permissions or contact your administrator.</source> 
+            <translation>Du har inte behörighet att komma åt den här kDrive.
+Kontrollera dina behörigheter eller kontakta din administratör.</translation> 
+        </message> 
+        <message id="driveAccessDeniedErrorTitle"> 
+            <source>Access denied to kDrive</source> 
+            <translation>Åtkomst nekad till kDrive</translation> 
+        </message> 
+        <message id="driveAsleepErrorTitle"> 
+            <source>Your kDrive is in sleep mode</source> 
+            <translation>Din kDrive är i vilöläge</translation> 
+        </message> 
+        <message id="driveLockedAdminErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Renew your subscription to reactivate the service.</source> 
+            <translation>Den här kDrive har inte förnyats. Du kan inte längre komma åt den.
+Förnya din prenumeration för att återaktivera tjänsten.</translation> 
+        </message> 
+        <message id="driveLockedErrorDescription"> 
+            <source>This kDrive has not been renewed. You can no longer access it.
+Contact your administrator to reactivate the service.</source> 
+            <translation>Den här kDrive har inte förnyats. Du kan inte längre komma åt den.
+Kontakta din administratör för att återaktivera tjänsten.</translation> 
+        </message> 
+        <message id="driveLockedErrorTitle"> 
+            <source>Your kDrive has expired</source> 
+            <translation>Din kDrive har upphört att gälla</translation> 
+        </message> 
+        <message id="driveLoggingErrorDescription"> 
+            <source>Sign in again to continue using kDrive.</source> 
+            <translation>Logga in igen för att fortsätta använda kDrive.</translation> 
+        </message> 
+        <message id="driveLoggingErrorTitle"> 
+            <source>You have been signed out</source> 
+            <translation>Du har loggats ut</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchDescription"> 
+            <source>The account used for this connection does not match the one for this kDrive.
+Please sign in again with the correct email address %1</source> 
+            <translation>Kontot som används för den här anslutningen matchar inte det för den här kDrive.
+Logga in igen med rätt e-postadress %1</translation> 
+        </message> 
+        <message id="driveLoggingErrorUserMismatchTitle"> 
+            <source>This account does not match</source> 
+            <translation>Det här kontot matchar inte</translation> 
+        </message> 
+        <message id="driveWakingUpErrorDescription"> 
+            <source>kDrive is waking up… this may take a few moments.</source> 
+            <translation>kDrive vaknar… det kan ta några ögonblick.</translation> 
+        </message> 
+        <message id="driveWakingUpErrorTitle"> 
+            <source>kDrive is waking up</source> 
+            <translation>kDrive vaknar</translation> 
+        </message> 
+        <message id="enableDebugLogDescription"> 
+            <source>Record diagnostic information on my computer.</source> 
+            <translation>Spela in diagnostisk information på min dator.</translation> 
+        </message> 
+        <message id="enableDebugLogsSetting"> 
+            <source>Enable debug logging</source> 
+            <translation>Aktivera felsökningsloggning</translation> 
+        </message> 
+        <message id="enterPasswordPlaceholder"> 
+            <source>Enter your password</source> 
+            <translation>Ange ditt lösenord</translation> 
+        </message> 
+        <message id="errCaseDescription"> 
+            <source>Another %1 with a name differing only in upper/lower case already exists in this folder. This type of name is not supported by the kDrive Windows application. Rename one of the %2 folders in kDrive online to synchronize it on your PC.
+</source> 
+            <translation>En annan %1 vars namn endast skiljer sig åt i versaler/ gemener finns redan i den här mappen. Denna typ av namn stöds inte av Windows-programmet kDrive. Byt namn på en av %2-mapparna från kDrive online så att du kan synkronisera den på din dator.
+</translation> 
+        </message> 
+        <message id="errCaseTitle"> 
+            <source>Case-sensitive name conflict</source> 
+            <translation>Motstridiga namn, skiftlägeskänsliga</translation> 
+        </message> 
+        <message id="errDialogConfigChangedTitle"> 
+            <source>A change was detected in your configuration</source> 
+            <translation>En ändring hittades i din konfiguration</translation> 
+        </message> 
+        <message id="errDialogInvalidSyncSyncDirAccessDescription"> 
+            <source>In these situations, a new sync may be required to continue using kDrive correctly.</source> 
+            <translation>I dessa situationer kan en ny synkronisering krävas för att fortsätta använda kDrive korrekt.</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessFaqLink"> 
+            <source>Check the %1 to restore access</source> 
+            <translation>Se %1 för att återställa åtkomst</translation> 
+        </message> 
+        <message id="errDialogLocalFileAccessLocationLabel"> 
+            <source>Last location of %1:</source> 
+            <translation>Senaste plats för %1:</translation> 
+        </message> 
+        <message id="errDialogSystemSyncDirDiskMissingTitle"> 
+            <source>External disk disconnected</source> 
+            <translation>Extern disk frånkopplad</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsDescription"> 
+            <source>This operation may take some time depending on the amount of data to process.
+
+Do not close the application during the process.
+
+If it fails, you can easily start a full re-sync of the drive or contact our support.</source> 
+            <translation>Den här åtgärden kan ta en stund beroende på mängden data som ska behandlas.
+
+Stäng inte programmet under processen.
+
+Om det misslyckas kan du enkelt starta en fullständig omsynkronisering av enheten eller kontakta vår support.</translation> 
+        </message> 
+        <message id="errDialogSystemUnableToStartVfsTitle"> 
+            <source>Enable offline sync</source> 
+            <translation>Aktivera offlinesynkronisering</translation> 
+        </message> 
+        <message id="errDriveMaintenanceDescription"> 
+            <source>This kDrive is temporarily unavailable due to maintenance.
+Please try again in a few minutes.</source> 
+            <translation>Den här kDrive är tillfälligt otillgänglig på grund av underhåll.
+Försök igen om några minuter.</translation> 
+        </message> 
+        <message id="errDriveMaintenanceTitle"> 
+            <source>Maintenance in progress</source> 
+            <translation>Underhåll pågår</translation> 
+        </message> 
+        <message id="errEndWithSpaceTitle"> 
+            <source>Trailing space in %1 name</source> 
+            <translation>Avslutande mellanslag i %1-namn</translation> 
+        </message> 
+        <message id="errExcludedByTemplateTitle"> 
+            <source>Excluded from sync</source> 
+            <translation>Undantagen från synkronisering</translation> 
+        </message> 
+        <message id="errFileLockedTitle"> 
+            <source>File locked</source> 
+            <translation>Fil låst</translation> 
+        </message> 
+        <message id="errFileRescuedTitle"> 
+            <source>File rescued</source> 
+            <translation>Fil räddad</translation> 
+        </message> 
+        <message id="errFileTooBigAdminDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact support to unlock the limit.</source> 
+            <translation>Den här filen överskrider den maximalt tillåtna storleken (50 GB).
+Kontakta support för att låsa upp gränsen.</translation> 
+        </message> 
+        <message id="errFileTooBigTitle"> 
+            <source>File too large</source> 
+            <translation>Filen är för stor</translation> 
+        </message> 
+        <message id="errForbiddenActionTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Åtkomst förbjuden</translation> 
+        </message> 
+        <message id="errForbiddenCharDescription"> 
+            <source>The name of this %1 contains one or more characters not supported by the kDrive Windows application. Rename the %2 from kDrive online.</source> 
+            <translation>Namnet på denna %1 innehåller ett eller flera tecken som inte stöds av kDrive Windows-programmet. Byt namn på %2 från kDrive online.</translation> 
+        </message> 
+        <message id="errForbiddenCharOnlySpacesTitle"> 
+            <source>Invalid name</source> 
+            <translation>Ogiltigt namn</translation> 
+        </message> 
+        <message id="errForbiddenCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Tecknet stöds inte</translation> 
+        </message> 
+        <message id="errGenericForbiddenDescription"> 
+            <source>You do not have the required permissions to perform this action.
+Request access from the owner or administrator.</source> 
+            <translation>Du har inte nödvändiga behörigheter för att utföra den här åtgärden.
+Begär åtkomst från ägaren eller administratören.</translation> 
+        </message> 
+        <message id="errGenericForbiddenTitle"> 
+            <source>Access forbidden</source> 
+            <translation>Åtkomst förbjuden</translation> 
+        </message> 
+        <message id="errHardlinkTitle"> 
+            <source>Unsupported file type</source> 
+            <translation>Filtypen stöds inte</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessDescription"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Den här mappen är inte längre tillgänglig på sin ursprungliga plats.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirAccessTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmapp hittades inte</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingDescription"> 
+            <source>One of your kDrives is synced inside the sync folder of another kDrive.
+Move one of the folders so they are no longer nested, or delete your sync to recreate it.</source> 
+            <translation>En av dina kDrives synkroniseras inuti synkroniseringsmappen för en annan kDrive.
+Flytta en av mapparna så att de inte längre är kapslade, eller ta bort din synkronisering för att återskapa den.</translation> 
+        </message> 
+        <message id="errInvalidSyncSyncDirNestingTitle"> 
+            <source>Nested kDrives</source> 
+            <translation>Kapslade kDrives</translation> 
+        </message> 
+        <message id="errLocalFileAccessDescription"> 
+            <source>Cannot access this %1 on your computer. Check that it still exists and that you have the rights to access it.</source> 
+            <translation>Det går inte att komma åt den här %1 på din dator. Kontrollera att den fortfarande finns och att du har behörighet att komma åt den.</translation> 
+        </message> 
+        <message id="errLocalFileAccessTitle"> 
+            <source>%1 inaccessible</source> 
+            <translation>%1 otillgänglig</translation> 
+        </message> 
+        <message id="errNameLengthTitle"> 
+            <source>%1 name too long</source> 
+            <translation>%1-namn för långt</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherDescription"> 
+            <source>Unable to connect to kDrive.
+Sync will resume automatically once the connection is restored.</source> 
+            <translation>Det går inte att ansluta till kDrive.
+Synkroniseringen återuptas automatiskt när anslutningen har återställts.</translation> 
+        </message> 
+        <message id="errNetworkErrorOtherTitle"> 
+            <source>Connection temporarily unavailable</source> 
+            <translation>Anslutning tillfälligt otillgänglig</translation> 
+        </message> 
+        <message id="errNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Otillräckligt diskutrymme</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharDescription"> 
+            <source>The name of this file contains one or more characters not yet supported by the kDrive application. Rename the file from kDrive online.</source> 
+            <translation>Namnet på den här filen innehåller ett eller flera tecken som ännu inte stöds av kDrive-programmet. Byt namn på filen från kDrive online.</translation> 
+        </message> 
+        <message id="errNotYetSupportedCharTitle"> 
+            <source>Unsupported character</source> 
+            <translation>Tecknet stöds inte</translation> 
+        </message> 
+        <message id="errPathLengthDescription"> 
+            <source>The path to this %1 is too long to be synced. Rename one or more folders it is in to shorten the path.</source> 
+            <translation>Sökvägen till denna %1 är för lång för att synkroniseras. Byt namn på en eller flera mappar den befinner sig i för att korta ned sökvägen.</translation> 
+        </message> 
+        <message id="errPathLengthTitle"> 
+            <source>Path to %1 too long</source> 
+            <translation>Sökväg till %1 för lång</translation> 
+        </message> 
+        <message id="errQuotaExceededDescription"> 
+            <source>Your kDrive is full. Free up space or upgrade your subscription to sync this %1.</source> 
+            <translation>Din kDrive är full. Frgör utrymme eller uppgradera din prenumeration för att synkronisera den här %1.</translation> 
+        </message> 
+        <message id="errQuotaExceededTitle"> 
+            <source>Storage limit reached</source> 
+            <translation>Lagringsgräns nådd</translation> 
+        </message> 
+        <message id="errReservedNameDescription"> 
+            <source>This name is reserved by your computer’s system. Rename the %1 from kDrive online.</source> 
+            <translation>Det här namnet är reserverat av datorns system. Byt namn på %1 från kDrive online.</translation> 
+        </message> 
+        <message id="errReservedNameTitle"> 
+            <source>%1 name reserved</source> 
+            <translation>%1-namn reserverat</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessErrorDescription"> 
+            <source>Check the location or access rights of the folder.</source> 
+            <translation>Kontrollera mappens plats eller åtkomsträttigheter.</translation> 
+        </message> 
+        <message id="errSystemErrorSyncDirAccessTitle"> 
+            <source>Sync folder inaccessible</source> 
+            <translation>Synkroniseringsmappen är otillgänglig</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedDescription"> 
+            <source>LiteSync does not have the necessary permissions to function.
+open macOS Preferences to enable them.</source> 
+            <translation>LiteSync har inte de nödvändiga behörigheterna för att fungera.
+öppna macOS-inställningarna för att aktivera dem.</translation> 
+        </message> 
+        <message id="errSystemLiteSyncNotAllowedTitle"> 
+            <source>Authorization required</source> 
+            <translation>Auktorisation krävs</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceDescription"> 
+            <source>Your device’s disk space is full. Sync has been paused. Free up space to resume sync.</source> 
+            <translation>Enhetens diskutrymme är fullt. Synkroniseringen har pausats. Frgör utrymme för att återuppta synkroniseringen.</translation> 
+        </message> 
+        <message id="errSystemNotEnoughDiskSpaceTitle"> 
+            <source>Insufficient disk space</source> 
+            <translation>Otillräckligt diskutrymme</translation> 
+        </message> 
+        <message id="errSystemSyncDirChanged"> 
+            <source>This folder is no longer accessible at its original location.</source> 
+            <translation>Den här mappen är inte längre tillgänglig på sin ursprungliga plats.</translation> 
+        </message> 
+        <message id="errSystemSyncDirDiskMissingDescription"> 
+            <source>This folder is no longer accessible. Action is required to resume sync.</source> 
+            <translation>Den här mappen är inte längre tillgänglig. En åtgärd krävs för att återuppta synkroniseringen.</translation> 
+        </message> 
+        <message id="errSystemSyncDirMissingTitle"> 
+            <source>Sync folder not found</source> 
+            <translation>Synkroniseringsmapp hittades inte</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsDescription"> 
+            <source>Lite Sync cannot start. You can continue syncing your files by enabling offline sync in the settings. Contact support if the problem persists.</source> 
+            <translation>Lite Sync kan inte starta. Du kan fortsätta synkronisera dina filer genom att aktivera offlinesynkronisering i inställningarna. Kontakta support om problemet kvarstår.</translation> 
+        </message> 
+        <message id="errSystemUnableToStartVfsTitle"> 
+            <source>Unable to start Lite Sync</source> 
+            <translation>Det går inte att starta Lite Sync</translation> 
+        </message> 
+        <message id="errTmpBlacklistedDescription"> 
+            <source>Syncing of this item failed. It will be retried automatically later.</source> 
+            <translation>Synkronisering av det här objektet misslyckades. Det försöks automatiskt igen senare.</translation> 
+        </message> 
+        <message id="errTmpBlacklistedTitle"> 
+            <source>Sync temporarily failed</source> 
+            <translation>Synkronisering tillfälligt misslyckad</translation> 
+        </message> 
+        <message id="errUploadNotTerminatedDescription"> 
+            <source>The upload could not be completed. Please try again later.</source> 
+            <translation>Uppladdningen kunde inte slutföras. Försök igen senare.</translation> 
+        </message> 
+        <message id="errorConnectingToXPCServer"> 
+            <source>Looks like we cannot load the app…</source> 
+            <translation>Det verkar som att vi inte kan läsa in appen…</translation> 
+        </message> 
+        <message id="errorDeletingAccount"> 
+            <source>An error occurred while deleting your account.</source> 
+            <translation>Ett fel uppstod när ditt konto togs bort.</translation> 
+        </message> 
+        <message id="errorListFilesToVerifyHeader"> 
+            <source>Files to verify</source> 
+            <translation>Filer att kontrollera</translation> 
+        </message> 
+        <message id="errorListOthersHeader"> 
+            <source>Other</source> 
+            <translation>Övrigt</translation> 
+        </message> 
+        <message id="errorListSystemHeader"> 
+            <source>System and permissions</source> 
+            <translation>System och behörigheter</translation> 
+        </message> 
+        <message id="errorOpeningLocalURL"> 
+            <source>Failed to open URL %1</source> 
+            <translation>Det gick inte att öppna URL:en %1</translation> 
+        </message> 
+        <message id="errorPageTitle"> 
+            <source>Errors to fix</source> 
+            <translation>Fel att åtgärda</translation> 
+        </message> 
+        <message id="errorSelectedFolderIncorrect"> 
+            <source>This folder cannot be synced. Please select a different folder.</source> 
+            <translation>Den här mappen kan inte synkroniseras. Välj en annan mapp.</translation> 
+        </message> 
+        <message id="errorStartingInstaller"> 
+            <source>Error while trying to start the installer</source> 
+            <translation>Fel vid start av installationsprogrammet</translation> 
+        </message> 
+        <message id="errorWhileChangingSynchroMode"> 
+            <source>Error while changing the mode of synchronization</source> 
+            <translation>Fel vid ändring av synkroniseringsläge</translation> 
+        </message> 
+        <message id="excludeRuleAppDescription"> 
+            <source>Block apps that might download or modify your files.</source> 
+            <translation>Blockera appar som kan ladda ner eller ändra dina filer.</translation> 
+        </message> 
+        <message id="excludeRuleDescription"> 
+            <source>Files matching this rule will not be synced.</source> 
+            <translation>Filer som matchar den här regeln synkroniseras inte.</translation> 
+        </message> 
+        <message id="excludeRuleFileDescription"> 
+            <source>Prevent certain temporary or system files from being copied to kDrive.</source> 
+            <translation>Undvik att vissa temporära filer eller systemfiler kopieras till kDrive.</translation> 
+        </message> 
+        <message id="extendedLogDescription"> 
+            <source>Enables collection of additional information useful for support.</source> 
+            <translation>Aktiverar insamling av ytterligare information som är användbar för support.</translation> 
+        </message> 
+        <message id="extendedLogSetting"> 
+            <source>Extended detailed log</source> 
+            <translation>Utökad detaljerad logg</translation> 
+        </message> 
+        <message id="extendedLogWarning"> 
+            <source>When this option is enabled, kDrive runs more slowly.</source> 
+            <translation>När det här alternativet är aktiverat körs kDrive långsammare.</translation> 
+        </message> 
+        <message id="failedToCreateShareLinkError"> 
+            <source>Failed to create a share link</source> 
+            <translation>Det gick inte att skapa en delningslänk</translation> 
+        </message> 
+        <message id="faqUrl"> 
+            <source>https://www.infomaniak.com/en/support/faq/admin2/kdrive</source> 
+            <translation>https://www.infomaniak.com/en/support/faq/admin2/kdrive</translation> 
+        </message> 
+        <message id="feedbackSetting"> 
+            <source>Help us improve kDrive</source> 
+            <translation>Hjälp oss förbättra kDrive</translation> 
+        </message> 
+        <message id="feedbackURL"> 
+            <source>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</source> 
+            <translation>https://feedback.userreport.com/652ad8f0-84c8-4a21-9e31-7a8bd7134f46</translation> 
+        </message> 
+        <message id="fileExclusionNotificationWarning"> 
+            <source>A notification informs you when a file is excluded by this rule.</source> 
+            <translation>En avisering informerar dig när en fil undantas av denna regel.</translation> 
+        </message> 
+        <message id="fileExistsErrorTitle"> 
+            <source>File already exists</source> 
+            <translation>Filen finns redan</translation> 
+        </message> 
+        <message id="fileSyncMode"> 
+            <source>File sync mode</source> 
+            <translation>Filsynkroniseringsläge</translation> 
+        </message> 
+        <message id="fileSyncModeDescription"> 
+            <source>Define how your files are stored and accessed.</source> 
+            <translation>Definiera hur dina filer lagras och används.</translation> 
+        </message> 
+        <message id="filesToExclude"> 
+            <source>Files to exclude</source> 
+            <translation>Filer att exkludera</translation> 
+        </message> 
+        <message id="folderFavorites"> 
+            <source>Favorites</source> 
+            <translation>Favoriter</translation> 
+        </message> 
+        <message id="folderShares"> 
+            <source>Shares</source> 
+            <translation>Delningar</translation> 
+        </message> 
+        <message id="folderTrash"> 
+            <source>Trash</source> 
+            <translation>Papperskorg</translation> 
+        </message> 
+        <message id="forOneHour"> 
+            <source>For 1 hour</source> 
+            <translation>I 1 timme</translation> 
+        </message> 
+        <message id="forOneWeek"> 
+            <source>For one week</source> 
+            <translation>I en vecka</translation> 
+        </message> 
+        <message id="forThreeDays"> 
+            <source>For three days</source> 
+            <translation>I tre dagar</translation> 
+        </message> 
+        <message id="greetingLabel"> 
+            <source>Hello %1, %2</source> 
+            <translation>Hej %1, %2</translation> 
+        </message> 
+        <message id="helpKDriveName"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+        <message id="helpUrl"> 
+            <source>https://www.infomaniak.com/en/support</source> 
+            <translation>https://www.infomaniak.com/en/support</translation> 
+        </message> 
+        <message id="infomaniakSupport"> 
+            <source>Infomaniak Support</source> 
+            <translation>Infomaniak Support</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullSubtitle"> 
+            <source>Free up space or upgrade your plan to continue syncing your files.</source> 
+            <translation>Frgör utrymme eller uppgradera ditt abonnemang för att fortsätta synkronisera dina filer.</translation> 
+        </message> 
+        <message id="informationBlockKDriveFullTitle"> 
+            <source>Your kDrive is full</source> 
+            <translation>Din kDrive är full</translation> 
+        </message> 
+        <message id="informationBlockSynchroErrorSubtitle"> 
+            <source>Some files could not be synced.</source> 
+            <translation>Vissa filer kunde inte synkroniseras.</translation> 
+        </message> 
+        <message numerus="yes" id="informationBlockSynchroErrorTitle"> 
+            <source>You have &lt;b&gt;one synchronization error&lt;/b&gt;</source> 
+            <translation>
+                <numerusform>Du har &lt;b&gt;ett synkroniseringsfel&lt;/b&gt;</numerusform> 
+                <numerusform>Du har &lt;b&gt;%n synkroniseringsfel&lt;/b&gt;</numerusform> 
+            </translation>
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorSubtitle"> 
+            <source>We cannot access your files. Restart the application to resume sync. If the problem continues, contact support.</source> 
+            <translation>Vi kan inte komma åt dina filer. Starta om programmet för att återuppta synkroniseringen. Om problemet fortsätter, kontakta support.</translation> 
+        </message> 
+        <message id="informationBlockTmpDirAccessErrorTitle"> 
+            <source>Connection to kDrive interrupted</source> 
+            <translation>Anslutning till kDrive avbruten</translation> 
+        </message> 
+        <message id="instructionEnableKDrive"> 
+            <source>Activate kDrive.app</source> 
+            <translation>Aktivera kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveArgument"> 
+            <source>kDrive.app</source> 
+            <translation>kDrive.app</translation> 
+        </message> 
+        <message id="instructionEnableKDriveHint"> 
+            <source>You must activate kDrive.app before continuing</source> 
+            <translation>Du måste aktivera kDrive.app innan du fortsätter</translation> 
+        </message> 
+        <message id="instructionFullDisk"> 
+            <source>Activate kDrive and kDrive LiteSync Extension</source> 
+            <translation>Aktivera kDrive och kDrive LiteSync Extension</translation> 
+        </message> 
+        <message id="instructionFullDiskHint"> 
+            <source>You must activate authorizations before continuing</source> 
+            <translation>Du måste aktivera behörigheter innan du fortsätter</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurity"> 
+            <source>Go to Privacy &amp; Security &gt; Full disk access</source> 
+            <translation>Gå till Integritet och säkerhet &gt; Fullständig diskåtkomst</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityArgument"> 
+            <source>Full disk access</source> 
+            <translation>Fullständig diskåtkomst</translation> 
+        </message> 
+        <message id="instructionOpenPrivacySecurityLink"> 
+            <source>Privacy &amp; Security</source> 
+            <translation>Integritet och säkerhet</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensions"> 
+            <source>Select Open &amp; Extensions &gt; Security extensions</source> 
+            <translation>Välj Öppna och tillägg &gt; Säkerhetstillägg</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsArgument"> 
+            <source>Security extensions</source> 
+            <translation>Säkerhetstillägg</translation> 
+        </message> 
+        <message id="instructionOpenSecurityExtensionsLink"> 
+            <source>Open &amp; Extensions</source> 
+            <translation>Öppna och tillägg</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettings"> 
+            <source>Open System Settings &gt; General</source> 
+            <translation>Öppna Systeminställningar &gt; Allmänt</translation> 
+        </message> 
+        <message id="instructionOpenSystemSettingsLink"> 
+            <source>System Settings</source> 
+            <translation>Systeminställningar</translation> 
+        </message> 
+        <message id="instructionRestartIfNecessary"> 
+            <source>Restart the application if required</source> 
+            <translation>Starta om programmet om det krävs</translation> 
+        </message> 
+        <message id="itemUnavailableBrowserFallback"> 
+            <source>This item is not available on this device.
+It will open in your browser.</source> 
+            <translation>Det här objektet är inte tillgängligt på den här enheten.
+Det öppnas i din webbläsare.</translation> 
+        </message> 
+        <message id="kSuiteOfferUrl"> 
+            <source>https://www.infomaniak.com/en/ksuite</source> 
+            <translation>https://www.infomaniak.com/en/ksuite</translation> 
+        </message> 
+        <message id="labelAccessRightsModified"> 
+            <source>Access rights modified</source> 
+            <translation>Åtkomsträttigheter ändrade</translation> 
+        </message> 
+        <message id="labelActivated"> 
+            <source>Enabled</source> 
+            <translation>Aktiverad</translation> 
+        </message> 
+        <message id="labelAgo"> 
+            <source>%1 ago</source> 
+            <extracomment>Suffix for relative timestamps in activity lists; %@ is the time period (e.g., 5 minutes).</extracomment> 
+            <translation>för %1 sedan</translation> 
+        </message> 
+        <message id="labelAllFolders"> 
+            <source>All folders</source> 
+            <translation>Alla mappar</translation> 
+        </message> 
+        <message id="labelAllkDrive"> 
+            <source>All kDrive</source> 
+            <translation>Hela kDrive</translation> 
+        </message> 
+        <message id="labelAllowTracking"> 
+            <source>Allow tracking</source> 
+            <translation>Tillåt spårning</translation> 
+        </message> 
+        <message id="labelAppID"> 
+            <source>Application Identifier</source> 
+            <translation>Programidentifierare</translation> 
+        </message> 
+        <message id="labelApplicationName"> 
+            <source>Application Name</source> 
+            <translation>Programnamn</translation> 
+        </message> 
+        <message id="labelAuthor"> 
+            <source>Author</source> 
+            <translation>Författare</translation> 
+        </message> 
+        <message id="labelByDefault"> 
+            <source>By default</source> 
+            <translation>Som standard</translation> 
+        </message> 
+        <message id="labelBytes"> 
+            <source>B</source> 
+            <translation>B</translation> 
+        </message> 
+        <message id="labelChooseConflictVersion"> 
+            <source>Choose which version of your files you want to keep.</source> 
+            <translation>Välj vilken version av dina filer du vill behålla.</translation> 
+        </message> 
+        <message id="labelChooseConflictVersionIndividual"> 
+            <source>For each file, select the version to keep.</source> 
+            <translation>Välj för varje fil vilken version som ska behållas.</translation> 
+        </message> 
+        <message id="labelConflictDialogQuestion"> 
+            <source>Which version do you want to keep?</source> 
+            <translation>Vilken version vill du behålla?</translation> 
+        </message> 
+        <message id="labelConflictDialogTitle"> 
+            <source>Choose the version to keep</source> 
+            <translation>Välj vilken version som ska behållas</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalDescription"> 
+            <source>The online versions of these %1 files will be replaced by your local versions.
+Beware, this may overwrite your collaborators’ work.</source> 
+            <translation>Onlineversionerna av dessa %1 filer ersätts av dina lokala versioner.
+Var uppmärksam, detta kan skriva över dina kollegors arbete.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepLocalTitle"> 
+            <source>Keep local versions only</source> 
+            <translation>Behåll bara lokala versioner</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentDescription"> 
+            <source>For each conflict, we will automatically keep the version (local or online) modified most recently. This is the safest choice in most cases.</source> 
+            <translation>För varje konflikt behåller vi automatiskt den version (lokal eller online) som senast ändrades. Det är det säkraste valet i de flesta fall.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepMostRecentTitle"> 
+            <source>Keep the most recent versions</source> 
+            <translation>Behåll de senaste versionerna</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteDescription"> 
+            <source>All local changes for these %1 files will be discarded.
+Useful if you know the important work is online on kDrive.</source> 
+            <translation>Alla lokala ändringar för dessa %1 filer tas bort.
+Användbart om du vet att det viktiga arbetet finns online på kDrive.</translation> 
+        </message> 
+        <message id="labelConflictStrategyKeepRemoteTitle"> 
+            <source>Keep online versions only</source> 
+            <translation>Behåll bara onlineversionerna</translation> 
+        </message> 
+        <message id="labelConnectToStart"> 
+            <source>Sign in to get started.</source> 
+            <translation>Logga in för att komma igång.</translation> 
+        </message> 
+        <message id="labelCreateNewSync"> 
+            <source>Create a %1.</source> 
+            <translation>Skapa en %1.</translation> 
+        </message> 
+        <message id="labelDate"> 
+            <source>Date</source> 
+            <translation>Datum</translation> 
+        </message> 
+        <message id="labelDeactivated"> 
+            <source>Disabled</source> 
+            <translation>Inaktiverad</translation> 
+        </message> 
+        <message id="labelFAQ"> 
+            <source>FAQ</source> 
+            <translation>FAQ</translation> 
+        </message> 
+        <message id="labelFileLowerCase"> 
+            <source>file</source> 
+            <translation>fil</translation> 
+        </message> 
+        <message id="labelFolder"> 
+            <source>Folder</source> 
+            <translation>Mapp</translation> 
+        </message> 
+        <message id="labelFolderDeleted"> 
+            <source>Folder deleted</source> 
+            <translation>Mapp raderad</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModified"> 
+            <source>Folder moved or modified</source> 
+            <translation>Mapp flyttad eller ändrad</translation> 
+        </message> 
+        <message id="labelFolderDisplacedOrModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen kanske har flyttats till en annan disk och sedan återställts till sin ursprungliga plats.</translation> 
+        </message> 
+        <message id="labelFolderLowerCase"> 
+            <source>folder</source> 
+            <translation>mapp</translation> 
+        </message> 
+        <message id="labelFolderMovedOrRenamed"> 
+            <source>Folder moved or renamed</source> 
+            <translation>Mapp flyttad eller omdöpt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplaced"> 
+            <source>Folder recreated or replaced</source> 
+            <translation>Mapp återskapad eller ersätt</translation> 
+        </message> 
+        <message id="labelFolderRecreatedOrReplacedTip"> 
+            <source>The folder was deleted and recreated, or replaced by another folder with the same name.</source> 
+            <translation>Mappen raderades och återskapades, eller ersättes av en annan mapp med samma namn.</translation> 
+        </message> 
+        <message id="labelGigaBytes"> 
+            <source>GB</source> 
+            <extracomment>Unit abbreviation for gigabytes, used in file size and storage displays.</extracomment> 
+            <translation>GB</translation> 
+        </message> 
+        <message id="labelJustNow"> 
+            <source>Just now</source> 
+            <translation>Just nu</translation> 
+        </message> 
+        <message id="labelKiloBytes"> 
+            <source>KB</source> 
+            <extracomment>Unit abbreviation for kilobytes, used in file size displays.</extracomment> 
+            <translation>KB</translation> 
+        </message> 
+        <message id="labelLocal"> 
+            <source>Local</source> 
+            <translation>Lokal</translation> 
+        </message> 
+        <message id="labelManyConflictTitle"> 
+            <source>%1 files have been modified both on your computer and on kDrive.</source> 
+            <translation>%1 filer har ändrats både på din dator och på kDrive.</translation> 
+        </message> 
+        <message id="labelMegaBytes"> 
+            <source>MB</source> 
+            <extracomment>Unit abbreviation for megabytes, used in file size displays.</extracomment> 
+            <translation>MB</translation> 
+        </message> 
+        <message id="labelMostRecent"> 
+            <source>Most recent</source> 
+            <translation>Senaste</translation> 
+        </message> 
+        <message id="labelName"> 
+            <source>Name</source> 
+            <translation>Namn</translation> 
+        </message> 
+        <message id="labelNewDeviceDetected"> 
+            <source>New device detected</source> 
+            <translation>Ny enhet hittades</translation> 
+        </message> 
+        <message id="labelNewDeviceDetectedTip"> 
+            <source>You are using kDrive on a new computer, after restoring from a backup.</source> 
+            <translation>Du använder kDrive på en ny dator, efter en återställning från en säkerhetskopia.</translation> 
+        </message> 
+        <message id="labelNewFolder"> 
+            <source>New folder</source> 
+            <translation>Ny mapp</translation> 
+        </message> 
+        <message id="labelNewSync"> 
+            <source>new sync</source> 
+            <translation>ny synkronisering</translation> 
+        </message> 
+        <message id="labelNoConflictsFound"> 
+            <source>No conflicts match your search</source> 
+            <translation>Inga konflikter matchar din sökning</translation> 
+        </message> 
+        <message id="labelNoErrorsToFix"> 
+            <source>No errors to fix</source> 
+            <translation>Inga fel att åtgärda</translation> 
+        </message> 
+        <message id="labelNotifications"> 
+            <source>Notification</source> 
+            <translation>Avisering</translation> 
+        </message> 
+        <message id="labelNotifyIfFileExcluded"> 
+            <source>Notify if file excluded</source> 
+            <translation>Avisera om fil exkluderats</translation> 
+        </message> 
+        <message id="labelOff"> 
+            <source>Off</source> 
+            <translation>Av</translation> 
+        </message> 
+        <message id="labelOnline"> 
+            <source>Online</source> 
+            <translation>Online</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamed"> 
+            <source>Online folder deleted</source> 
+            <translation>Onlinemapp raderad</translation> 
+        </message> 
+        <message id="labelOnlineFolderDeletedOrRenamedTip"> 
+            <source>The synced folder was deleted on kDrive online or is no longer accessible.</source> 
+            <translation>Den synkroniserade mappen raderades på kDrive online eller är inte längre tillgänglig.</translation> 
+        </message> 
+        <message id="labelOriginalLocation"> 
+            <source>Original location:</source> 
+            <translation>Ursprunglig plats:</translation> 
+        </message> 
+        <message id="labelRecommended"> 
+            <source>Recommended</source> 
+            <translation>Rekommenderas</translation> 
+        </message> 
+        <message id="labelRemoteAccessRightsModifiedTip"> 
+            <source>The folder may have been moved to another disk and then returned to its original location.</source> 
+            <translation>Mappen kanske har flyttats till en annan disk och sedan återställts till sin ursprungliga plats.</translation> 
+        </message> 
+        <message id="labelRestoreToOriginalLocation"> 
+            <source>Restore it to its original location.</source> 
+            <translation>Återställ den till sin ursprungliga plats.</translation> 
+        </message> 
+        <message id="labelRules"> 
+            <source>Rules</source> 
+            <translation>Regler</translation> 
+        </message> 
+        <message id="labelSameAsSystem"> 
+            <source>Same as system</source> 
+            <translation>Samma som systemet</translation> 
+        </message> 
+        <message id="labelShortDay"> 
+            <source>d</source> 
+            <extracomment>Abbreviated unit for day used in relative timestamps (e.g., 3d ago).</extracomment> 
+            <translation>d</translation> 
+        </message> 
+        <message id="labelShortHour"> 
+            <source>h</source> 
+            <extracomment>Abbreviated unit for hour used in relative timestamps.</extracomment> 
+            <translation>t</translation> 
+        </message> 
+        <message id="labelShortMinute"> 
+            <source>min</source> 
+            <extracomment>Abbreviated unit for minute used in relative timestamps.</extracomment> 
+            <translation>min</translation> 
+        </message> 
+        <message id="labelShortSecond"> 
+            <source>sec</source> 
+            <extracomment>Abbreviated unit for second used in relative timestamps.</extracomment> 
+            <translation>sek</translation> 
+        </message> 
+        <message id="labelSince"> 
+            <source>Since: %1</source> 
+            <extracomment>Label showing the start time of a synchronization pause or event; %@ is the formatted date/time.</extracomment> 
+            <translation>Sedan: %1</translation> 
+        </message> 
+        <message id="labelSize"> 
+            <source>Size</source> 
+            <translation>Storlek</translation> 
+        </message> 
+        <message id="labelStatus"> 
+            <source>Status</source> 
+            <translation>Status</translation> 
+        </message> 
+        <message id="labelStorageFree"> 
+            <source>%1 free</source> 
+            <extracomment>Label showing available free storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 ledigt</translation> 
+        </message> 
+        <message id="labelStorageFree-plural"> 
+            <source>%1 free</source> 
+            <translation>%1 lediga</translation> 
+        </message> 
+        <message id="labelStorageLoading"> 
+            <source>Calculating…</source> 
+            <extracomment>Loading indicator text shown while storage usage is being calculated.</extracomment> 
+            <translation>Beräknar…</translation> 
+        </message> 
+        <message id="labelStorageUsed"> 
+            <source>%1 used</source> 
+            <extracomment>Label showing used storage space; %@ is the formatted size (singular form).</extracomment> 
+            <translation>%1 använt</translation> 
+        </message> 
+        <message id="labelStorageUsed-plural"> 
+            <source>%1 used</source> 
+            <translation>%1 använda</translation> 
+        </message> 
+        <message id="labelSyncDirectionIncoming"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkroniserat från kDrive web</translation> 
+        </message> 
+        <message id="labelSyncDirectionOutgoing"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkroniserat från din dator</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyDescription"> 
+            <source>This kDrive contains only files. All files will be synced on this device.</source> 
+            <translation>Den här kDrive innehåller bara filer. Alla filer synkroniseras på den här enheten.</translation> 
+        </message> 
+        <message id="labelSyncExclusionEmptyTitle"> 
+            <source>No folder to select</source> 
+            <translation>Ingen mapp att välja</translation> 
+        </message> 
+        <message id="labelSyncFolder"> 
+            <source>Sync folders</source> 
+            <translation>Synkroniseringsmappar</translation> 
+        </message> 
+        <message id="labelSyncLocation"> 
+            <source>Location</source> 
+            <translation>Plats</translation> 
+        </message> 
+        <message id="labelSyncYourKDrive"> 
+            <source>Sync your kDrives on this device</source> 
+            <translation>Synkronisera dina kDrives på den här enheten</translation> 
+        </message> 
+        <message id="labelSyncedFolders"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserade mappar</translation> 
+        </message> 
+        <message id="labelSynchronisation"> 
+            <source>Synchronization</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="labelTeraBytes"> 
+            <source>TB</source> 
+            <extracomment>Unit abbreviation for terabytes, used in storage displays.</extracomment> 
+            <translation>TB</translation> 
+        </message> 
+        <message id="labelTime"> 
+            <source>Time</source> 
+            <translation>Tid</translation> 
+        </message> 
+        <message id="labelWelcomeToKDrive"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Välkommen till kDrive</translation> 
+        </message> 
+        <message id="labelXoverY"> 
+            <source>%1 of %2</source> 
+            <translation>%1 av %2</translation> 
+        </message> 
+        <message id="labelkDriveManagement"> 
+            <source>kDrive management</source> 
+            <translation>kDrive-hantering</translation> 
+        </message> 
+        <message id="languageSetting"> 
+            <source>Language</source> 
+            <translation>Språk</translation> 
+        </message> 
+        <message id="languageSettingWarning"> 
+            <source>Restart the application to finish applying the new language.</source> 
+            <translation>Starta om programmet för att slutföra tillämpningen av det nya språket.</translation> 
+        </message> 
+        <message id="learnMore"> 
+            <source>Learn more</source> 
+            <translation>Läs mer</translation> 
+        </message> 
+        <message id="licensesHyperLink"> 
+            <source>LGPL v3 License - Git Sources</source> 
+            <translation>LGPL v3-licens - Git-källor</translation> 
+        </message> 
+        <message id="linkCopiedToClipboardTitle"> 
+            <source>Link copied to clipboard</source> 
+            <translation>Länk kopierad till urklipp</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionMac"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like /My drive instead of /)</source> 
+            <translation>Inkompatibel enhet eller mapp direkt i roten av enheten (t.ex. välj en mapp som /Min enhet istället för /)</translation> 
+        </message> 
+        <message id="liteSyncUnavailableDescriptionWin"> 
+            <source>Incompatible drive or folder directly at the root of the drive (e.g., choose a folder like D:/My drive instead of D:/)</source> 
+            <translation>Inkompatibel enhet eller mapp direkt i roten av enheten (t.ex. välj en mapp som D:/Min enhet istället för D:/)</translation> 
+        </message> 
+        <message id="localLocation"> 
+            <source>Location on computer</source> 
+            <extracomment>Label for the local PC folder location field in sync settings.</extracomment> 
+            <translation>Plats på dator</translation> 
+        </message> 
+        <message id="logLevelDebug"> 
+            <source>Debug</source> 
+            <translation>Felsök</translation> 
+        </message> 
+        <message id="logLevelError"> 
+            <source>Error</source> 
+            <translation>Fel</translation> 
+        </message> 
+        <message id="logLevelExtended"> 
+            <source>Extended</source> 
+            <translation>Utökad</translation> 
+        </message> 
+        <message id="logLevelFatal"> 
+            <source>Fatal</source> 
+            <translation>Kritisk</translation> 
+        </message> 
+        <message id="logLevelInfo"> 
+            <source>Info</source> 
+            <translation>Info</translation> 
+        </message> 
+        <message id="logLevelWarning"> 
+            <source>Warning</source> 
+            <translation>Varning</translation> 
+        </message> 
+        <message id="logUploadPopupTitle"> 
+            <source>Send debug folder to Infomaniak support</source> 
+            <translation>Skicka felsökningsmapp till Infomaniaks support</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorDescription"> 
+            <source>Some file names may contain special characters that are not supported (such as double quotes, backslashes, or line breaks).
+
+Please check and rename files containing unusual characters, then try again.</source> 
+            <translation>Vissa filnamn kan innehålla specialtecken som inte stöds (t.ex. dubbla citattecken, omvända snedstreck eller radbrytningar).
+
+Kontrollera och byt namn på filer som innehåller ovanliga tecken och försök sedan igen.</translation> 
+        </message> 
+        <message id="logicErrorFullListParsingErrorTitle"> 
+            <source>Invalid file name</source> 
+            <translation>Ogiltigt filnamn</translation> 
+        </message> 
+        <message id="logsStatusCompression"> 
+            <source>Compressing logs…</source> 
+            <translation>Komprimerar loggar…</translation> 
+        </message> 
+        <message id="logsStatusUpload"> 
+            <source>Uploading logs to support…</source> 
+            <translation>Laddar upp loggar till support…</translation> 
+        </message> 
+        <message id="logsUploadErrorTooltip"> 
+            <source>The last upload failed. Please check your internet connection and make sure at least one kDrive user is signed in. Uploads are limited to 10 per day.</source> 
+            <translation>Den senaste uppladdningen misslyckades. Kontrollera din internetanslutning och se till att minst en kDrive-användare är inloggad. Uppladdningar är begränsade till 10 per dag.</translation> 
+        </message> 
+        <message id="manyConflictErrorDescription"> 
+            <source>Different versions of these files were detected.</source> 
+            <translation>Olika versioner av dessa filer hittades.</translation> 
+        </message> 
+        <message id="manyConflictErrorTitle"> 
+            <source>%1 version conflicts detected</source> 
+            <translation>%1 versionskonflikt(er) hittades</translation> 
+        </message> 
+        <message id="matomoDescription"> 
+            <source>Matomo is an analytics tool hosted and managed exclusively by Infomaniak to understand how the application is used.
+
+Analyzing this data allows our team to continuously improve the application’s interface.</source> 
+            <translation>Matomo är ett analysverktyg som driftas och hanteras exklusivt av Infomaniak för att förstå hur programmet används.
+
+Analys av dessa data gör det möjligt för vårt team att kontinuerligt förbättra programmets gränssnitt.</translation> 
+        </message> 
+        <message id="moveCancelErrorTitle"> 
+            <source>Move canceled</source> 
+            <translation>Flytt avbruten</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinSetting"> 
+            <source>Move deleted files to the computer’s recycle bin</source> 
+            <translation>Flytta raderade filer till datorns papperskorg</translation> 
+        </message> 
+        <message id="moveDeletedFilesToRecycleBinWarning"> 
+            <source>Some items may not be able to be moved.</source> 
+            <translation>Vissa objekt kanske inte kan flyttas.</translation> 
+        </message> 
+        <message id="myksuitePlusBannerDescription"> 
+            <source>More storage, more features with my kSuite+</source> 
+            <translation>Mer lagringsutrymme, fler funktioner med my kSuite+</translation> 
+        </message> 
+        <message id="needHelpSetting"> 
+            <source>Need help?</source> 
+            <translation>Behöver du hjälp?</translation> 
+        </message> 
+        <message id="networkSettings"> 
+            <source>Network</source> 
+            <translation>Nätverk</translation> 
+        </message> 
+        <message id="noAccountConnected"> 
+            <source>Add an account to get started</source> 
+            <translation>Lägg till ett konto för att komma igång</translation> 
+        </message> 
+        <message id="noResultsFound"> 
+            <source>No results found</source> 
+            <translation>Inga resultat hittades</translation> 
+        </message> 
+        <message id="notSyncedDrive"> 
+            <source>Not synced</source> 
+            <translation>Inte synkroniserad</translation> 
+        </message> 
+        <message id="notificationsDisabledAlways"> 
+            <source>Always</source> 
+            <translation>Alltid</translation> 
+        </message> 
+        <message id="notificationsDisabledNever"> 
+            <source>Never</source> 
+            <translation>Aldrig</translation> 
+        </message> 
+        <message id="notifyOnFileExcluded"> 
+            <source>Receive a notification when a file is excluded</source> 
+            <translation>Ta emot ett meddelande när en fil exkluderas</translation> 
+        </message> 
+        <message id="onBoardingAdvancedSettingsDriveTitle"> 
+            <source>Configure sync for this kDrive</source> 
+            <translation>Konfigurera synkronisering för den här kDrive</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocation"> 
+            <source>Customize the location of your kDrive folder on your computer:</source> 
+            <translation>Anpassa platsen för din kDrive-mapp på din dator:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveCustomizeLocationTip"> 
+            <source>The chosen folder must be empty for sync to work correctly.</source> 
+            <translation>Den valda mappen måste vara tom för att synkroniseringen ska fungera korrekt.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionDescription"> 
+            <source>Choose the folders to sync on this computer:</source> 
+            <translation>Välj mapparna att synkronisera på den här datorn:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveExclusionTitle"> 
+            <source>Synced folders</source> 
+            <translation>Synkroniserade mappar</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionDescription"> 
+            <source>For each kDrive, you can choose where it is synced on your computer and which folders to sync.</source> 
+            <translation>För varje kDrive kan du välja var den synkroniseras på din dator och vilka mappar som ska synkroniseras.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusion"> 
+            <source>Synced content:</source> 
+            <translation>Synkroniserat innehåll:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionExclusionMac"> 
+            <source>Synced content: %1</source> 
+            <translation>Synkroniserat innehåll: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocation"> 
+            <source>Location:</source> 
+            <translation>Plats:</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionLocationMac"> 
+            <source>Location: %1</source> 
+            <translation>Plats: %1</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsDriveSelectionTitle"> 
+            <source>Configure your kDrives</source> 
+            <translation>Konfigurera dina kDrives</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsExclusionTitle"> 
+            <source>Choose the folders to sync on this computer</source> 
+            <translation>Välj mapparna att synkronisera på den här datorn</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncDescription"> 
+            <source>Files are only downloaded when opened, to save disk space.</source> 
+            <translation>Filer laddas ned enbart när de öppnas, för att spara diskutrymme.</translation> 
+        </message> 
+        <message id="onboardingAdvancedSettingsLiteSyncTitle"> 
+            <source>Enable Lite Sync</source> 
+            <translation>Aktivera Lite Sync</translation> 
+        </message> 
+        <message id="onboardingAlreadySyncedDriveTooltip"> 
+            <source>This kDrive is already configured.
+Go to your settings to modify it.</source> 
+            <translation>Den här kDrive är redan konfigurerad.
+Gå till dina inställningar för att ändra den.</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionDescription"> 
+            <source>Authorize kDrive in macOS settings:</source> 
+            <translation>Tillåt kDrive i macOS-inställningar:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationExtensionTitle"> 
+            <source>Activate kDrive on your Mac</source> 
+            <translation>Aktivera kDrive på din Mac</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskDescription"> 
+            <source>To complete the installation, you must authorize kDrive to access your:</source> 
+            <translation>För att slutföra installationen måste du ge kDrive åtkomst till dina:</translation> 
+        </message> 
+        <message id="onboardingAuthorizationFullDiskTitle"> 
+            <source>Authorize access to files</source> 
+            <translation>Tillåt åtkomst till filer</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveDescription"> 
+            <source>Get started for free with my kSuite,
+or choose a plan that suits your needs.</source> 
+            <translation>Kom igång gratis med my kSuite,
+eller välj ett abonnemang som passar dina behov.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionNoDriveTitle"> 
+            <source>You don’t have a kDrive yet.</source> 
+            <translation>Du har inte en kDrive ännu.</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSelectTitle"> 
+            <source>Choose the kDrives to sync on this computer:</source> 
+            <translation>Välj kDrives att synkronisera på den här datorn:</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionSyncInProgress"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="onboardingDriveSelectionTitle"> 
+            <source>Good to see you!</source> 
+            <translation>Kul att se dig!</translation> 
+        </message> 
+        <message id="onboardingExclusionSummaryNone"> 
+            <source>All kDrive folders</source> 
+            <translation>Alla kDrive-mappar</translation> 
+        </message> 
+        <message id="onboardingExclusionSummarySome"> 
+            <source>Custom selection</source> 
+            <translation>Anpassat urval</translation> 
+        </message> 
+        <message id="onboardingLoginDescription"> 
+            <source>The private, fast and secure cloud, hosted in Switzerland.
+
+Sign in and keep your documents synced across all your devices.</source> 
+            <translation>Det privata, snabba och säkra molnet, drftat i Schweiz.
+
+Logga in och håll dina dokument synkroniserade på alla dina enheter.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorDescription"> 
+            <source>An error occurred, please try again.</source> 
+            <translation>Ett fel uppstod, försök igen.</translation> 
+        </message> 
+        <message id="onboardingLoginErrorTitle"> 
+            <source>Sign-in error</source> 
+            <translation>Inloggningsfel</translation> 
+        </message> 
+        <message id="onboardingLoginHintLoading"> 
+            <source>Just a few more moments, and we’ll load your account…</source> 
+            <translation>Bara några ögonblick till, vi laddar ditt konto…</translation> 
+        </message> 
+        <message id="onboardingLoginHintWebAuth"> 
+            <source>Login from your browser…</source> 
+            <translation>Loggar in från din webbläsare…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingDescription"> 
+            <source>Retrieving your information…</source> 
+            <translation>Hämtar din information…</translation> 
+        </message> 
+        <message id="onboardingLoginProcessingTitle"> 
+            <source>One moment…</source> 
+            <translation>Ett ögonblick…</translation> 
+        </message> 
+        <message id="onboardingLoginTitle"> 
+            <source>Welcome to kDrive</source> 
+            <translation>Välkommen till kDrive</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyDescription"> 
+            <source>Your files are ready to be synced
+safely on your computer.</source> 
+            <translation>Dina filer är redo att synkroniseras
+säkert på din dator.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationAppReadyTitle"> 
+            <source>All set!</source> 
+            <translation>Allt är klart!</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressDescription"> 
+            <source>We are finalizing the configuration of your kDrives.
+
+Please wait a few moments.</source> 
+            <translation>Vi slutför konfigurationen av dina kDrives.
+
+Vänta ett ögonblick.</translation> 
+        </message> 
+        <message id="onboardingSynchronizationInProgressTitle"> 
+            <source>Sync in progress…</source> 
+            <translation>Synkronisering pågår…</translation> 
+        </message> 
+        <message id="openKDriveAtStartupSetting"> 
+            <source>Open kDrive when the computer starts</source> 
+            <translation>Öppna kDrive när datorn startar</translation> 
+        </message> 
+        <message id="openLoginPage"> 
+            <source>Open the sign-in page</source> 
+            <translation>Öppna inloggningssidan</translation> 
+        </message> 
+        <message id="pathCopiedToClipboard"> 
+            <source>Path copied to clipboard</source> 
+            <translation>Sökväg kopierad till urklipp</translation> 
+        </message> 
+        <message id="proxyConnectionDescription"> 
+            <source>Define how kDrive connects to the internet.</source> 
+            <translation>Definiera hur kDrive ansluter till internet.</translation> 
+        </message> 
+        <message id="proxyHost"> 
+            <source>Server</source> 
+            <translation>Server</translation> 
+        </message> 
+        <message id="proxyNeedAuth"> 
+            <source>Authentication required</source> 
+            <translation>Autentisering krävs</translation> 
+        </message> 
+        <message id="proxyPassword"> 
+            <source>Password</source> 
+            <translation>Lösenord</translation> 
+        </message> 
+        <message id="proxyPort"> 
+            <source>Port</source> 
+            <translation>Port</translation> 
+        </message> 
+        <message id="proxySettings"> 
+            <source>Proxy settings</source> 
+            <extracomment>Title of the proxy settings section in advanced settings.</extracomment> 
+            <translation>Proxyinällningar</translation> 
+        </message> 
+        <message id="proxyType"> 
+            <source>Proxy type</source> 
+            <translation>Proxytyp</translation> 
+        </message> 
+        <message id="proxyTypeHTTP"> 
+            <source>Manual configuration</source> 
+            <translation>Manuell konfiguration</translation> 
+        </message> 
+        <message id="proxyTypeNone"> 
+            <source>None</source> 
+            <translation>Ingen</translation> 
+        </message> 
+        <message id="proxyUser"> 
+            <source>Username</source> 
+            <translation>Användarnamn</translation> 
+        </message> 
+        <message id="releaseChannelBeta"> 
+            <source>Beta</source> 
+            <translation>Beta</translation> 
+        </message> 
+        <message id="releaseChannelInternal"> 
+            <source>Internal</source> 
+            <translation>Intern</translation> 
+        </message> 
+        <message id="releaseChannelTest"> 
+            <source>Test</source> 
+            <translation>Test</translation> 
+        </message> 
+        <message id="remoteLocation"> 
+            <source>Location on kDrive</source> 
+            <translation>Plats på kDrive</translation> 
+        </message> 
+        <message id="searchBoxPlaceholder"> 
+            <source>Search in %1</source> 
+            <translation>Sök i %1</translation> 
+        </message> 
+        <message id="searchPlaceholder"> 
+            <source>Search…</source> 
+            <extracomment>Search field placeholder in SearchSheetView.</extracomment> 
+            <translation>Search…</translation> 
+        </message> 
+        <message id="searchResultOpenInBrowserTooltip"> 
+            <source>This file is not available locally and will be opened in your browser</source> 
+            <extracomment>Tooltip shown on search results when file is not available locally and will open in browser.</extracomment> 
+            <translation>This file is not available locally and will be opened in your browser</translation> 
+        </message> 
+        <message id="searchYourFiles"> 
+            <source>Search your files</source> 
+            <extracomment>Empty search state title in SearchSheetView before any query is entered.</extracomment> 
+            <translation>Search your files</translation> 
+        </message> 
+        <message id="selectFoldersToSync"> 
+            <source>Select the folders to sync on this computer.</source> 
+            <translation>Välj mapparna att synkronisera på den här datorn.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescription"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online and will not be deleted.</source> 
+            <translation>Icke valda mappar laddas inte ned till din enhet. De förblir tillgängliga online och tas inte bort.</translation> 
+        </message> 
+        <message id="selectFoldersToSyncDescriptionShort"> 
+            <source>Unselected folders will not be downloaded to your device. They will remain available online.</source> 
+            <translation>Icke valda mappar laddas inte ned till din enhet. De förblir tillgängliga online.</translation> 
+        </message> 
+        <message id="sentryDescription"> 
+            <source>Sentry is a tool hosted and managed exclusively by Infomaniak to monitor the stability of the application in real time and automatically report any technical errors to our developers.
+
+This data allows our team to quickly fix and optimize the application, resulting in a better user experience for you.</source> 
+            <translation>Sentry är ett verktyg som driftas och hanteras exklusivt av Infomaniak för att övervaka programmets stabilitet i realtid och automatiskt rapportera eventuella tekniska fel till våra utvecklare.
+
+Dessa data gör det möjligt för vårt team att snabbt åtgärda och optimera programmet, vilket ger en bättre användarupplevelse för dig.</translation> 
+        </message> 
+        <message id="settingsTitle"> 
+            <source>Settings</source> 
+            <translation>Inställningar</translation> 
+        </message> 
+        <message id="sidebarItemAccounts"> 
+            <source>Accounts &amp; Sync</source> 
+            <translation>Konton och synkroniseringar</translation> 
+        </message> 
+        <message id="sidebarItemAdvanced"> 
+            <source>Advanced</source> 
+            <translation>Avancerat</translation> 
+        </message> 
+        <message id="sidebarItemGeneral"> 
+            <source>General</source> 
+            <translation>Allmänt</translation> 
+        </message> 
+        <message id="sidebarItemKDriveTitle"> 
+            <source>kDrive folder</source> 
+            <translation>kDrive-mapp</translation> 
+        </message> 
+        <message id="signInBrowser"> 
+            <source>Sign in using your browse</source> 
+            <translation>Logga in med din webbläsare</translation> 
+        </message> 
+        <message id="statusBarOpenApp"> 
+            <source>Open kDrive</source> 
+            <translation>Öppna kDrive</translation> 
+        </message> 
+        <message id="statusBarQuitApp"> 
+            <source>Quit</source> 
+            <translation>Avsluta</translation> 
+        </message> 
+        <message id="statusBarSettings"> 
+            <source>Settings</source> 
+            <translation>Inställningar</translation> 
+        </message> 
+        <message id="storageComputerFreeSpace"> 
+            <source>Free space on computer</source> 
+            <extracomment>Label for the free disk space segment in the local storage usage chart.</extracomment> 
+            <translation>Ledigt utrymme på datorn</translation> 
+        </message> 
+        <message id="storageComputerUsedByKDrive"> 
+            <source>kDrive files stored on computer</source> 
+            <extracomment>Label for the kDrive files segment in the local storage usage chart.</extracomment> 
+            <translation>kDrive-filer lagrade på datorn</translation> 
+        </message> 
+        <message id="storageComputerUsedByOther"> 
+            <source>Other files on computer</source> 
+            <extracomment>Label for the other files segment in the local storage usage chart.</extracomment> 
+            <translation>Övriga filer på datorn</translation> 
+        </message> 
+        <message id="storageDeviceNameMac"> 
+            <source>Macintosh</source> 
+            <translation>Macintosh</translation> 
+        </message> 
+        <message id="storageLoadingHint"> 
+            <source>Loading space usage…</source> 
+            <translation>Laddar utrymmesanvändning…</translation> 
+        </message> 
+        <message id="storageMacFreeSpace"> 
+            <source>Free space</source> 
+            <translation>Ledigt utrymme</translation> 
+        </message> 
+        <message id="storageMacUsedByComputer"> 
+            <source>Other files</source> 
+            <translation>Övriga filer</translation> 
+        </message> 
+        <message id="storageMacUsedByKDrive"> 
+            <source>kDrive files stored on your device</source> 
+            <translation>kDrive-filer som är lagrade på din enhet</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSDescription"> 
+            <source>kDrive can’t access the volume
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <translation>kDrive kan inte komma åt volymen
+Se till att den är ansluten,
+olåst och tillgänglig från din dator.</translation> 
+        </message> 
+        <message id="storageMissingDiskMacOSTitle"> 
+            <source>The volume is not accessible</source> 
+            <translation>Volymen är inte tillgänglig</translation> 
+        </message> 
+        <message id="storageSyncBlockMacDescription"> 
+            <source>Manage synchronized folders to free up space on your Mac.</source> 
+            <translation>Hantera synkroniserade mappar för att frgöra utrymme på din Mac.</translation> 
+        </message> 
+        <message id="storageSyncBlockTitle"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="storageThisComputerTitle"> 
+            <source>This PC - %1 - %2</source> 
+            <extracomment>Label for the local computer entry in the storage view; first %@ is computer name, second %@ is disk identifier.</extracomment> 
+            <translation>Den här datorn - %1 - %2</translation> 
+        </message> 
+        <message id="storageUsageLabel"> 
+            <source>%1 on %2 used</source> 
+            <translation>%1 av %2 använt</translation> 
+        </message> 
+        <message id="storedOnline"> 
+            <source>Stored online</source> 
+            <translation>Lagrade online</translation> 
+        </message> 
+        <message id="storedOnlineDescription"> 
+            <source>Your files remain in the cloud and do not use space on your computer.
+An internet connection is required to access them.</source> 
+            <translation>Dina filer finns kvar i molnet och tar inte upp utrymme på din dator.
+Internetanslutning krävs för att komma åt dem.</translation> 
+        </message> 
+        <message id="syncErrorTooltip"> 
+            <source>Sync error</source> 
+            <translation>Synkroniseringsfel</translation> 
+        </message> 
+        <message id="syncFolderCustomLocation"> 
+            <source>Custom folder</source> 
+            <translation>Anpassad mapp</translation> 
+        </message> 
+        <message id="syncFolderDefaultLocation"> 
+            <source>Default folder</source> 
+            <translation>Standardmapp</translation> 
+        </message> 
+        <message id="syncInProgressTooltip"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="syncModeApplying"> 
+            <source>Your new sync mode is being applied…</source> 
+            <translation>Ditt nya synkroniseringsläge tillämpas…</translation> 
+        </message> 
+        <message id="syncRules"> 
+            <source>Sync rules</source> 
+            <translation>Synkroniseringsregler</translation> 
+        </message> 
+        <message id="syncShortStatusError"> 
+            <source>An error occurred</source> 
+            <translation>Ett fel inträffade</translation> 
+        </message> 
+        <message id="syncShortStatusIdle"> 
+            <source>Last sync was successful</source> 
+            <translation>Senaste synkronisering lyckades</translation> 
+        </message> 
+        <message id="syncShortStatusPaused"> 
+            <source>Sync is paused</source> 
+            <translation>Synkronisering är pausad</translation> 
+        </message> 
+        <message id="syncShortStatusRunning"> 
+            <source>Sync is running</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="syncSuccessTooltip"> 
+            <source>Synced</source> 
+            <translation>Synkroniserad</translation> 
+        </message> 
+        <message id="syncedDrive"> 
+            <source>Synced</source> 
+            <translation>Synkroniserad</translation> 
+        </message> 
+        <message id="syncedFromComputer"> 
+            <source>Synced from your computer</source> 
+            <translation>Synkroniserat från din dator</translation> 
+        </message> 
+        <message id="syncedFromKDriveWeb"> 
+            <source>Synced from kDrive web</source> 
+            <translation>Synkroniserat från kDrive web</translation> 
+        </message> 
+        <message id="synchroInProgress"> 
+            <source>your files are syncing</source> 
+            <translation>dina filer synkroniseras</translation> 
+        </message> 
+        <message id="synchroPaused"> 
+            <source>synchronization is paused</source> 
+            <translation>synkroniseringen är pausad</translation> 
+        </message> 
+        <message id="synchroStatusInProgressDescription"> 
+            <source>Your recent files are being updated.</source> 
+            <translation>Dina senaste filer uppdateras.</translation> 
+        </message> 
+        <message id="synchroStatusInProgressTitle"> 
+            <source>Sync in progress</source> 
+            <translation>Synkronisering pågår</translation> 
+        </message> 
+        <message id="synchroStatusOfflineDescription"> 
+            <source>Your downloaded files will remain accessible.
+Syncing will resume automatically as soon as you reconnect.</source> 
+            <translation>Dina nedladdade filer förblir tillgängliga.
+Synkroniseringen återupptas automatiskt så snart du är uppkopplad igen.</translation> 
+        </message> 
+        <message id="synchroStatusOfflineTitle"> 
+            <source>Offline</source> 
+            <translation>Offline</translation> 
+        </message> 
+        <message id="synchroStatusPausedDescription"> 
+            <source>Sync has been temporarily stopped.</source> 
+            <translation>Synkroniseringen har tillfälligt stoppats.</translation> 
+        </message> 
+        <message id="synchroStatusPausedTitle"> 
+            <source>Synchronization on pause</source> 
+            <translation>Synkronisering vid paus</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Dina filer är tillgängliga och synkroniserade.</translation> 
+        </message> 
+        <message id="synchroStatusUpToDateTitle"> 
+            <source>No activity in progress</source> 
+            <translation>Ingen pågående aktivitet</translation> 
+        </message> 
+        <message id="synchroUpToDate"> 
+            <source>your files are up to date</source> 
+            <translation>dina filer är uppdaterade</translation> 
+        </message> 
+        <message id="synchronizationSettings"> 
+            <source>Sync</source> 
+            <translation>Synkronisering</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedDescription"> 
+            <source>A file or folder in your sync folder appears to be corrupted.
+Sync has been paused. Please check your files and try again.</source> 
+            <translation>En fil eller mapp i din synkroniseringsmapp verkar vara skadad.
+Synkroniseringen har pausats. Kontrollera dina filer och försök igen.</translation> 
+        </message> 
+        <message id="systemErrorFileOrDirectoryCorruptedTitle"> 
+            <source>Corrupted file detected</source> 
+            <translation>Skadad fil hittades</translation> 
+        </message> 
+        <message id="tabTitleActivities"> 
+            <source>Activity</source> 
+            <translation>Aktivitet</translation> 
+        </message> 
+        <message id="tabTitleHome"> 
+            <source>Home</source> 
+            <translation>Hem</translation> 
+        </message> 
+        <message id="tabTitleStorage"> 
+            <source>Storage</source> 
+            <translation>Lagring</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderAdvancedContent"> 
+            <source>The folder must not be the root of a drive and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen får inte vara roten till en enhet och får inte innehålla eller befinna sig i en redan synkroniserad mapp.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderContent"> 
+            <source>The folder must be empty, must not be the root of a drive, and must not contain or be inside an already synced folder.</source> 
+            <translation>Mappen måste vara tom, får inte vara roten till en enhet och får inte innehålla eller befinna sig i en redan synkroniserad mapp.</translation> 
+        </message> 
+        <message id="teachingTipInvalidFolderTitle"> 
+            <source>This folder cannot be used</source> 
+            <translation>Den här mappen kan inte användas</translation> 
+        </message> 
+        <message id="titleConflictIndividualResolution"> 
+            <source>Individual handling</source> 
+            <translation>Individuell hantering</translation> 
+        </message> 
+        <message id="titleManageSynchronization"> 
+            <source>Manage synchronization</source> 
+            <translation>Hantera synkroniseringen</translation> 
+        </message> 
+        <message id="tooltipExclusionRuleNotifications"> 
+            <source>A notification informs you when a file is excluded by this rule</source> 
+            <translation>Ett meddelande informerar dig när en fil exkluderas av den här regeln</translation> 
+        </message> 
+        <message id="trayIconButtonCloseKDrive.Label"> 
+            <source>Close kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Stäng kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenKDrive.Label"> 
+            <source>Open kDrive</source> 
+            <extracomment>This translation is used for the taskbar icon menu, which requires the x:Uid format (i.e., suffixed with .Label).</extracomment> 
+            <translation>Öppna kDrive</translation> 
+        </message> 
+        <message id="trayIconButtonOpenSettings.Label"> 
+            <source>Settings</source> 
+            <translation>Inställningar</translation> 
+        </message> 
+        <message id="tryDifferentSearchTerm"> 
+            <source>Try a different search term</source> 
+            <extracomment>Empty search state subtitle when no result matches the user query in SearchSheetView.</extracomment> 
+            <translation>Try a different search term</translation> 
+        </message> 
+        <message id="typeToStartSearching"> 
+            <source>Type to start searching</source> 
+            <extracomment>Empty search state subtitle in SearchSheetView before the user enters a query.</extracomment> 
+            <translation>Type to start searching</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipContent"> 
+            <source>Check that your internet connection is active, that this name is not already in use, and that it does not contain invalid characters.</source> 
+            <translation>Kontrollera att din internetanslutning är aktiv, att det här namnet inte redan används och att det inte innehåller ogiltiga tecken.</translation> 
+        </message> 
+        <message id="unableToCreateRemoteFolderTeachingTipTitle"> 
+            <source>Unable to create this folder</source> 
+            <translation>Det går inte att skapa den här mappen</translation> 
+        </message> 
+        <message id="unauthorizedAccess"> 
+            <source>Unauthorized access</source> 
+            <translation>Obehörig åtkomst</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityDescription"> 
+            <source>Your files are accessible and synced.</source> 
+            <translation>Dina filer är tillgängliga och synkroniserade.</translation> 
+        </message> 
+        <message id="unavailableContentNoActivityTitle"> 
+            <source>No recent activity</source> 
+            <translation>Ingen ny aktivitet</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipContent"> 
+            <source>Please try again in a few moments.
+If the problem persists, please contact support.</source> 
+            <translation>Försök igen om några ögonblick.
+Om problemet kvarstår, kontakta support.</translation> 
+        </message> 
+        <message id="unexpectedErrorTeachingTipTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ett oväntat fel inträffade</translation> 
+        </message> 
+        <message id="untilTomorrow"> 
+            <source>Until tomorrow</source> 
+            <translation>Till imorgon</translation> 
+        </message> 
+        <message id="updateAvailable"> 
+            <source>kDrive %1 available</source> 
+            <translation>kDrive %1 tillgänglig</translation> 
+        </message> 
+        <message id="updateDialogDescription"> 
+            <source>Installation takes less than a minute.
+Your synchronization will resume automatically at the end.</source> 
+            <translation>Installationen tar mindre än en minut.
+Din synkronisering återupptas automatiskt efteråt.</translation> 
+        </message> 
+        <message id="updateDialogIgnoreVersion"> 
+            <source>Ignore this version</source> 
+            <translation>Ignorera denna version</translation> 
+        </message> 
+        <message id="updateDialogInstallNow"> 
+            <source>Install now</source> 
+            <translation>Installera nu</translation> 
+        </message> 
+        <message id="updateDialogRemindLater"> 
+            <source>Remind me later</source> 
+            <translation>Påminn mig senare</translation> 
+        </message> 
+        <message id="updateDialogSeeWhatsNew"> 
+            <source>See what’s new</source> 
+            <translation>Se nyheter</translation> 
+        </message> 
+        <message id="updateDialogSubtitle"> 
+            <source>Version %1 · You are using %2</source> 
+            <translation>Version %1 · Du använder %2</translation> 
+        </message> 
+        <message id="updateDialogTitle"> 
+            <source>Update available</source> 
+            <translation>Uppdatering tillgänglig</translation> 
+        </message> 
+        <message id="updateRequiredDescription"> 
+            <source>A new version of kDrive is required to continue.
+Please update the application to access your files and resume synchronization.</source> 
+            <translation>En ny version av kDrive krävs för att fortsätta.
+Uppdatera programmet för att komma åt dina filer och återuppta synkroniseringen.</translation> 
+        </message> 
+        <message id="updateRequiredTitle"> 
+            <source>Update required</source> 
+            <translation>Uppdatering krävs</translation> 
+        </message> 
+        <message id="updateSettings"> 
+            <source>Update</source> 
+            <translation>Uppdatera</translation> 
+        </message> 
+        <message id="uploadNotTerminatedErrorTitle"> 
+            <source>Incomplete upload</source> 
+            <translation>Ofullständig uppladdning</translation> 
+        </message> 
+        <message id="userExclusionAppListHeaderDescription"> 
+            <source>Exclude certain apps from synchronization.</source> 
+            <translation>Undanta vissa appar från synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListDescription"> 
+            <source>Add files to exclude from sync.</source> 
+            <translation>Lägg till filer att exkludera från synkronisering.</translation> 
+        </message> 
+        <message id="userExclusionFileListHeader"> 
+            <source>Custom exclusion rules</source> 
+            <translation>Anpassade undantagsregler</translation> 
+        </message> 
+        <message id="userExclusionFileListHeaderDescription"> 
+            <source>Exclude certain file types from synchronization.</source> 
+            <translation>Undanta vissa filtyper från synkronisering.</translation> 
+        </message> 
+        <message id="viewSourceCode"> 
+            <source>View source code</source> 
+            <translation>Visa källkod</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle"> 
+            <source>You have a sync error</source> 
+            <extracomment>Title in the Windows information banner when there is exactly one synchronization error.</extracomment> 
+            <translation>Du har ett synkroniseringsfel</translation> 
+        </message> 
+        <message id="winInformationBlockSynchroErrorTitle-plural"> 
+            <source>You have {0} sync errors</source> 
+            <extracomment>Title in the Windows information banner when there are multiple sync errors; {0} is the error count.</extracomment> 
+            <translation>Du har {0} synkroniseringsfel</translation> 
+        </message> 
+        <message id="winStorageMissingDiskDescription"> 
+            <source>kDrive cannot access disk %1
+Make sure it is connected,
+unlocked and accessible from your computer.</source> 
+            <extracomment>Description shown when a storage disk is missing or inaccessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>kDrive kan inte komma åt disk %1
+Se till att den är ansluten,
+olåst och tillgänglig från din dator.</translation> 
+        </message> 
+        <message id="winStorageMissingDiskTitle"> 
+            <source>Storage disk %1 is not accessible</source> 
+            <extracomment>Title shown when a storage disk is not accessible; %@ is the disk name or drive letter.</extracomment> 
+            <translation>Lagringsdisk %1 är inte tillgänglig</translation> 
+        </message> 
+        <message numerus="yes" id="winbuttonRemoveFileExclusionRule"> 
+            <source>Remove</source> 
+            <extracomment>Button to remove a single selected file exclusion rule from the exclusion list.</extracomment> 
+            <translation>
+                <numerusform>Ta bort</numerusform> 
+                <numerusform>Ta bort (%1 regler)</numerusform> 
+            </translation>
+        </message> 
+    </context> 
+    <context>
+        <name>sync convertion</name> 
+        <message id="applyingChange"> 
+            <source>Applying change…</source> 
+            <translation>Tillämpar ändring…</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to manage disk space when not enough space is available</name> 
+        <message id="buttonManageDiskSpace"> 
+            <source>Manage disk space</source> 
+            <translation>Hantera diskutrymme</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Button to open the parent directory of the inaccessible file</name> 
+        <message id="buttonOpenParentFolder"> 
+            <source>Open parent folder</source> 
+            <translation>Öppna överordnad mapp</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Action de mettre à jour</name> 
+        <message id="buttonUpdate"> 
+            <source>Update</source> 
+            <translation>Uppdatera</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Settings</name> 
+        <message id="debugLevelSetting"> 
+            <source>Debug level</source> 
+            <translation>Felsökningsnivå</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for the default error card explaining an unexpected error occurred</name> 
+        <message id="defaultErrorDescription"> 
+            <source>Synchronization will restart automatically.
+If the problem persists, contact our support and attach the technical details below.</source> 
+            <translation>Synkronisering startas om automatiskt.
+Om problemet kvarstår, kontakta vår support och bifoga de tekniska detaljerna nedan.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Label for the technical details expander in the default error card</name> 
+        <message id="defaultErrorDetailsLabel"> 
+            <source>Technical details</source> 
+            <translation>Tekniska detaljer</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for the default error card when an unhandled error occurs</name> 
+        <message id="defaultErrorTitle"> 
+            <source>An unexpected error occurred</source> 
+            <translation>Ett oväntat fel inträffade</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when file/folder deletion is cancelled</name> 
+        <message id="deleteCancelErrorTitle"> 
+            <source>Deletion canceled</source> 
+            <translation>Radering avbruten</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Title for error when files/folders have duplicate names</name> 
+        <message id="duplicateNamesErrorTitle"> 
+            <source>Duplicate names</source> 
+            <translation>Duplicerade namn</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for create cancel error</name> 
+        <message id="errCreateCancelDescription"> 
+            <source>You do not have the required permissions to add a %1 to this location.
+Request access from the owner or administrator.</source> 
+            <translation>Du har inte nödvändiga behörigheter för att lägga till en %1 på den här platsen.
+Begär åtkomst från ägaren eller administratören.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for delete cancel error</name> 
+        <message id="errDeleteCancelDescription"> 
+            <source>You do not have permission to delete this %1. It has been restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har inte behörighet att ta bort denna %1. Den har återställts till sin ursprungliga plats. Begär åtkomst från ägaren eller administratören.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Main description in the dialog explaining the issue</name> 
+        <message id="errDialogLocalFileAccessDescription"> 
+            <source>The access permissions for %1 were changed, preventing it from being synced.</source> 
+            <translation>Åtkomstbehörigheterna för %1 har ändrats, vilket förhindrar att den synkroniseras.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for duplicate names error</name> 
+        <message id="errDuplicateNamesDescription"> 
+            <source>A file or folder with this name already exists.</source> 
+            <translation>En fil eller mapp med det här namnet finns redan.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for edit cancel error</name> 
+        <message id="errEditCancelDescription"> 
+            <source>You do not have the rights to edit this file.
+The original version has been kept and your edit has been saved in a separate file with “conflict” in its name. Request access from the owner or administrator.</source> 
+            <translation>Du har inte rätt att redigera den här filen.
+Originalversionen har behållits och din redigering har sparats i en separat fil med “konflikts” i namnet. Begär åtkomst från ägaren eller administratören.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character end with space error</name> 
+        <message id="errEndWithSpaceDescription"> 
+            <source>The name of this %1 ends with a space, preventing it from being synced. Rename the %2 from kDrive online.</source> 
+            <translation>Namnet på denna %1 slutar med ett mellanslag, vilket förhindrar att den synkroniseras. Byt namn på %2 från kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for excluded by template error</name> 
+        <message id="errExcludedByTemplateDescription"> 
+            <source>An exclusion rule is preventing this %1 from being synced.</source> 
+            <translation>En undantagsregel förhindrar att den här %1 synkroniseras.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file exists error</name> 
+        <message id="errFileExistsDescription"> 
+            <source>A file with this name already exists.</source> 
+            <translation>En fil med det här namnet finns redan.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file locked error</name> 
+        <message id="errFileLockedDescription"> 
+            <source>This file is currently being used by another user.
+Your changes will be synced later.</source> 
+            <translation>Den här filen används för tillfället av en annan användare.
+Dina ändringar synkroniseras senare.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file rescued error</name> 
+        <message id="errFileRescuedDescription"> 
+            <source>This file was deleted on kDrive online while you were editing it. A copy has been kept on your computer in the recovery folder.</source> 
+            <translation>Den här filen raderades på kDrive online medan du redigerade den. En kopia har sparats på din dator i återställningsmappen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for file too big error</name> 
+        <message id="errFileTooBigDescription"> 
+            <source>This file exceeds the maximum allowed size (50 GB).
+Contact your administrator to increase the file size limit.</source> 
+            <translation>Den här filen överskrider den maximalt tillåtna storleken (50 GB).
+Kontakta din administratör för att öka filstorleksgränsen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for forbidden character only spaces error</name> 
+        <message id="errForbiddenCharOnlySpacesDescription"> 
+            <source>This name contains only spaces and cannot be used. Rename the %1 from kDrive online.</source> 
+            <translation>Det här namnet innehåller bara mellanslag och kan inte användas. Byt namn på %1 från kDrive online.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for hardlink error</name> 
+        <message id="errHardlinkDescription"> 
+            <source>This file is a hard link that cannot be synced.</source> 
+            <translation>Den här filen är en hård länk som inte kan synkroniseras.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for move cancel error</name> 
+        <message id="errMoveCancelDescription"> 
+            <source>You do not have the rights to move this %1 here; it will be restored to its original location. Request access from the owner or administrator.</source> 
+            <translation>Du har inte rätt att flytta den här %1 hit; den återställs till sin ursprungliga plats. Begär åtkomst från ägaren eller administratören.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for name length error</name> 
+        <message id="errNameLengthDescription"> 
+            <source>This name exceeds the allowed length (250 characters). Rename the %1.</source> 
+            <translation>Det här namnet överskrider den tillåtna längden (250 tecken). Byt namn på %1.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>Description for not enough disk space error</name> 
+        <message id="errNotEnoughDiskSpaceDescription"> 
+            <source>There is not enough space on your computer to sync this file.</source> 
+            <translation>Det finns inte tillräckligt med utrymme på din dator för att synkronisera den här filen.</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>kDrive 4.0.0</name> 
+        <message id="labelKDriveVersion"> 
+            <source>kDrive %1</source> 
+            <translation>kDrive %1</translation> 
+        </message> 
+    </context> 
+    <context>
+        <name>log upload</name> 
+        <message id="largeFolderRecommendation"> 
+            <source>The full folder is large.
+To speed up the upload, we recommend sending only the last kDrive session.</source> 
+            <translation>Den fullständiga mappen är stor.
+För att påskynda uppladdningen rekommenderar vi att du bara skickar den senaste kDrive-sessionen.</translation> 
+        </message> 
+        <message id="sendLastSessionOnly"> 
+            <source>Send last session only</source> 
+            <translation>Skicka bara senaste sessionen</translation> 
+        </message> 
+    </context> 
+</TS>

--- a/src/gui4/linux/ui/onboarding/DriveSelectionView.qml
+++ b/src/gui4/linux/ui/onboarding/DriveSelectionView.qml
@@ -37,7 +37,7 @@ Item {
 
         Text {
             width: parent.width
-            text: qsTr("Welcome back!")
+            text: qsTrId("onboardingDriveSelectionTitle")
             color: IKColors.textPrimary
             font.pixelSize: IKFonts.largeTitleSize
             font.weight: Font.Bold
@@ -105,7 +105,7 @@ Item {
                 id: retryButton
 
                 height: IKOnboarding.driveSelectionButtonHeight
-                text: qsTr("Retry")
+                text: qsTrId("buttonRetry")
                 onClicked: root.selectionController.reload()
 
                 contentItem: Text {
@@ -139,7 +139,7 @@ Item {
 
             Text {
                 width: IKOnboarding.driveSelectionListWidth
-                text: qsTr("Select the kDrive to be synchronized on this computer:")
+                text: qsTrId("onboardingDriveSelectionSelectTitle")
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.subheadlineSize
                 font.weight: IKFonts.emphasized
@@ -165,7 +165,7 @@ Item {
 
                         anchors.fill: parent
                         enabled: false
-                        text: qsTr("Advanced settings")
+                        text: qsTrId("buttonAdvancedParameters")
                         onClicked: root.selectionController.requestAdvancedSettings()
 
                         contentItem: Text {
@@ -226,7 +226,7 @@ Item {
 
                     enabled: root.selectionController.canContinue
                     height: IKOnboarding.driveSelectionButtonHeight
-                    text: qsTr("Continue")
+                    text: qsTrId("buttonContinue")
                     onClicked: root.selectionController.continueOnboarding()
 
                     contentItem: Text {

--- a/src/gui4/linux/ui/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/onboarding/LoginView.qml
@@ -32,16 +32,23 @@ Item {
 
     function loginTitleText() {
         if (root.loginFailed) {
-            return qsTr("Connection error")
+            return qsTrId("onboardingLoginErrorTitle")
         }
-        return qsTr("Welcome to kDrive")
+        return qsTrId("onboardingLoginTitle")
     }
 
+    // onboardingLoginDescription is a single composed catalog string; its two paragraphs
+    // (separated by a blank line) map to the subtitle and the body texts below.
     function loginSubtitleText() {
         if (root.loginFailed) {
-            return qsTr("An error has occurred, please try again.")
+            return qsTrId("onboardingLoginErrorDescription")
         }
-        return qsTr("The fast, secure private cloud, hosted in Switzerland.")
+        return qsTrId("onboardingLoginDescription").split("\n\n")[0]
+    }
+
+    function loginBodyText() {
+        const parts = qsTrId("onboardingLoginDescription").split("\n\n")
+        return parts.length > 1 ? parts[1] : ""
     }
 
     Column {
@@ -80,7 +87,7 @@ Item {
             Text {
                 width: parent.width
                 visible: !root.loginFailed
-                text: qsTr("Log in and keep your documents synchronized on all your devices.")
+                text: root.loginBodyText()
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.bodySize
                 lineHeightMode: Text.FixedHeight
@@ -97,7 +104,7 @@ Item {
 
                 enabled: !root.onboardingFlowController.loginInProgress
                 height: IKOnboarding.loginButtonHeight
-                text: qsTr("Create an account")
+                text: qsTrId("buttonCreateAccount")
                 onClicked: root.onboardingFlowController.requestAccountCreation()
 
                 contentItem: Text {
@@ -128,7 +135,7 @@ Item {
 
                 enabled: !root.onboardingFlowController.loginInProgress
                 height: IKOnboarding.loginButtonHeight
-                text: qsTr("Login")
+                text: qsTrId("buttonLogin")
                 onClicked: root.onboardingFlowController.requestLogin()
 
                 contentItem: Text {
@@ -168,8 +175,8 @@ Item {
         Text {
             width: parent.width
             text: root.waitingForWebAuthentication
-                  ? qsTr("Login from your browser…")
-                  : qsTr("Just a few more moments, and we’ll load your account…")
+                  ? qsTrId("onboardingLoginHintWebAuth")
+                  : qsTrId("onboardingLoginHintLoading")
             color: IKColors.textPrimary
             font.pixelSize: IKOnboarding.loginBrowserTitleSize
             font.weight: IKFonts.emphasized

--- a/src/gui4/linux/ui/onboarding/LoginView.qml
+++ b/src/gui4/linux/ui/onboarding/LoginView.qml
@@ -37,18 +37,11 @@ Item {
         return qsTrId("onboardingLoginTitle")
     }
 
-    // onboardingLoginDescription is a single composed catalog string; its two paragraphs
-    // (separated by a blank line) map to the subtitle and the body texts below.
-    function loginSubtitleText() {
+    function loginDescriptionText() {
         if (root.loginFailed) {
             return qsTrId("onboardingLoginErrorDescription")
         }
-        return qsTrId("onboardingLoginDescription").split("\n\n")[0]
-    }
-
-    function loginBodyText() {
-        const parts = qsTrId("onboardingLoginDescription").split("\n\n")
-        return parts.length > 1 ? parts[1] : ""
+        return qsTrId("onboardingLoginDescription")
     }
 
     Column {
@@ -76,18 +69,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: root.loginSubtitleText()
-                color: IKColors.textSecondary
-                font.pixelSize: IKFonts.bodySize
-                lineHeightMode: Text.FixedHeight
-                lineHeight: IKOnboarding.loginBodyLineHeight
-                wrapMode: Text.WordWrap
-            }
-
-            Text {
-                width: parent.width
-                visible: !root.loginFailed
-                text: root.loginBodyText()
+                text: root.loginDescriptionText()
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.bodySize
                 lineHeightMode: Text.FixedHeight

--- a/src/gui4/linux/ui/onboarding/NoDriveAvailableView.qml
+++ b/src/gui4/linux/ui/onboarding/NoDriveAvailableView.qml
@@ -34,7 +34,7 @@ Column {
 
         Text {
             width: parent.width
-            text: qsTr("You don’t have a kDrive yet.")
+            text: qsTrId("onboardingDriveSelectionNoDriveTitle")
             color: IKColors.textPrimary
             font.pixelSize: IKFonts.title3Size
             font.weight: IKFonts.emphasized
@@ -45,7 +45,7 @@ Column {
 
         Text {
             width: parent.width
-            text: qsTr("Get started for free with my kSuite,\nor choose a package tailored to your needs.")
+            text: qsTrId("onboardingDriveSelectionNoDriveDescription")
             color: IKColors.textSecondary
             font.pixelSize: IKFonts.bodySize
             lineHeightMode: Text.FixedHeight
@@ -61,7 +61,7 @@ Column {
             id: showOffersButton
 
             height: IKOnboarding.driveSelectionButtonHeight
-            text: qsTr("Show offers")
+            text: qsTrId("buttonShowOffers")
             onClicked: root.selectionController.openDriveOffers()
 
             contentItem: Text {
@@ -91,7 +91,7 @@ Column {
             id: startForFreeButton
 
             height: IKOnboarding.driveSelectionButtonHeight
-            text: qsTr("Get started for free")
+            text: qsTrId("buttonStartForFree")
             onClicked: root.selectionController.startForFree()
 
             contentItem: Text {

--- a/src/gui4/linux/ui/onboarding/OnboardingAnimationsView.qml
+++ b/src/gui4/linux/ui/onboarding/OnboardingAnimationsView.qml
@@ -23,37 +23,30 @@ import "animations"
 Item {
     id: root
 
+    readonly property real contentHeightRatio: sourceHeight / sourceWidth
     required property var onboardingFlowController
-
-    readonly property bool showSyncFile: root.onboardingFlowController.driveSelectionActive
-                                         || root.onboardingFlowController.synchronizationActive
+    readonly property bool showSyncFile: root.onboardingFlowController.driveSelectionActive || root.onboardingFlowController.synchronizationActive
+    readonly property real sourceHeight: showSyncFile ? IKOnboarding.syncFileVectorSourceHeight : IKOnboarding.loaderStrokeVectorSourceHeight
 
     // Native source dimensions of the currently displayed animation. Exposed so the
     // illustration panel can preserve the animation aspect ratio across steps.
-    readonly property real sourceWidth: showSyncFile ? IKOnboarding.syncFileVectorSourceWidth
-                                                     : IKOnboarding.loaderStrokeVectorSourceWidth
-    readonly property real sourceHeight: showSyncFile ? IKOnboarding.syncFileVectorSourceHeight
-                                                      : IKOnboarding.loaderStrokeVectorSourceHeight
-    readonly property real contentHeightRatio: sourceHeight / sourceWidth
+    readonly property real sourceWidth: showSyncFile ? IKOnboarding.syncFileVectorSourceWidth : IKOnboarding.loaderStrokeVectorSourceWidth
 
     Item {
         id: animationFrame
 
         anchors.centerIn: parent
-        // Render the vector animation oversized for crispness, then scale it to fit the view.
-        width: root.sourceWidth * IKOnboarding.loaderStrokeRenderScale
         height: root.sourceHeight * IKOnboarding.loaderStrokeRenderScale
         scale: Math.min(root.width / width, root.height / height)
         transformOrigin: Item.Center
+        // Render the vector animation oversized for crispness, then scale it to fit the view.
+        width: root.sourceWidth * IKOnboarding.loaderStrokeRenderScale
 
         Loader {
             anchors.fill: parent
-            sourceComponent: root.showSyncFile
-                             ? (ThemeMode.isDark ? syncFileDarkComponent : syncFileLightComponent)
-                             : loaderStrokeComponent
+            sourceComponent: root.showSyncFile ? (ThemeMode.isDark ? syncFileDarkComponent : syncFileLightComponent) : loaderStrokeComponent
         }
     }
-
     Component {
         id: loaderStrokeComponent
 
@@ -62,7 +55,6 @@ Item {
             animations.loops: Animation.Infinite
         }
     }
-
     Component {
         id: syncFileLightComponent
 
@@ -71,7 +63,6 @@ Item {
             animations.loops: Animation.Infinite
         }
     }
-
     Component {
         id: syncFileDarkComponent
 

--- a/src/gui4/linux/ui/onboarding/OnboardingAnimationsView.qml
+++ b/src/gui4/linux/ui/onboarding/OnboardingAnimationsView.qml
@@ -25,9 +25,8 @@ Item {
 
     required property var onboardingFlowController
 
-    // Mirrors the macOS onboarding: the login step shows the loader-stroke animation
-    // while the drive-selection step shows the themed sync-file animation.
     readonly property bool showSyncFile: root.onboardingFlowController.driveSelectionActive
+                                         || root.onboardingFlowController.synchronizationActive
 
     // Native source dimensions of the currently displayed animation. Exposed so the
     // illustration panel can preserve the animation aspect ratio across steps.

--- a/src/gui4/linux/ui/onboarding/OnboardingWindow.qml
+++ b/src/gui4/linux/ui/onboarding/OnboardingWindow.qml
@@ -28,6 +28,12 @@ Item {
     readonly property var onboardingFlowController: session.flowController
     readonly property var driveSelectionController: session.driveSelectionController
     readonly property var drivesModel: session.availableDrivesModel
+    readonly property var onboardingStepComponents: [
+        loginComponent,
+        driveSelectionComponent,
+        synchronizationComponent,
+        readyComponent
+    ]
 
     Rectangle {
         anchors.fill: parent
@@ -46,13 +52,7 @@ Item {
 
             width: parent.width * IKOnboarding.contentPanelWidthRatio
             height: parent.height
-            sourceComponent: root.onboardingFlowController.readyActive
-                             ? readyComponent
-                             : (root.onboardingFlowController.synchronizationActive
-                                ? synchronizationComponent
-                                : (root.onboardingFlowController.driveSelectionActive
-                                   ? driveSelectionComponent
-                                   : loginComponent))
+            sourceComponent: root.onboardingStepComponents[root.onboardingFlowController.currentStep] || loginComponent
         }
 
         Rectangle {

--- a/src/gui4/linux/ui/onboarding/OnboardingWindow.qml
+++ b/src/gui4/linux/ui/onboarding/OnboardingWindow.qml
@@ -46,7 +46,13 @@ Item {
 
             width: parent.width * IKOnboarding.contentPanelWidthRatio
             height: parent.height
-            sourceComponent: root.onboardingFlowController.driveSelectionActive ? driveSelectionComponent : loginComponent
+            sourceComponent: root.onboardingFlowController.readyActive
+                             ? readyComponent
+                             : (root.onboardingFlowController.synchronizationActive
+                                ? synchronizationComponent
+                                : (root.onboardingFlowController.driveSelectionActive
+                                   ? driveSelectionComponent
+                                   : loginComponent))
         }
 
         Rectangle {
@@ -80,6 +86,22 @@ Item {
         DriveSelectionView {
             selectionController: root.driveSelectionController
             drivesModel: root.drivesModel
+        }
+    }
+
+    Component {
+        id: synchronizationComponent
+
+        SynchronizationView {
+            onboardingFlowController: root.onboardingFlowController
+        }
+    }
+
+    Component {
+        id: readyComponent
+
+        ReadyView {
+            onboardingFlowController: root.onboardingFlowController
         }
     }
 }

--- a/src/gui4/linux/ui/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/onboarding/ReadyView.qml
@@ -1,0 +1,93 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+Item {
+    id: root
+
+    required property var onboardingFlowController
+
+    readonly property bool compact: width < IKOnboarding.completionCompactBreakpointWidth
+
+    Column {
+        width: Math.min(IKOnboarding.completionContentMaxWidth, root.width - IKSpacing.s64)
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        anchors.leftMargin: root.compact ? IKSpacing.s32 : IKOnboarding.completionContentExpandedLeftMargin
+        spacing: IKOnboarding.completionReadySpacing
+
+        Column {
+            width: parent.width
+            spacing: IKOnboarding.completionTextSpacing
+
+            Text {
+                width: parent.width
+                text: qsTr("All set!")
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.largeTitleSize
+                font.weight: Font.Bold
+                lineHeightMode: Text.FixedHeight
+                lineHeight: IKOnboarding.completionTitleLineHeight
+                wrapMode: Text.WordWrap
+            }
+
+            Text {
+                width: parent.width
+                text: qsTr("Your files are ready to be securely synchronized on your computer.")
+                color: IKColors.textSecondary
+                font.pixelSize: IKFonts.bodySize
+                lineHeightMode: Text.FixedHeight
+                lineHeight: IKOnboarding.completionBodyLineHeight
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        Button {
+            id: openButton
+
+            height: IKOnboarding.completionButtonHeight
+            text: qsTr("Open kDrive")
+            onClicked: root.onboardingFlowController.openSynchronizedFolders()
+
+            contentItem: Text {
+                text: openButton.text
+                color: IKColors.actionOnPrimary
+                font.pixelSize: IKFonts.bodySize
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+
+            background: Rectangle {
+                implicitWidth: IKOnboarding.completionButtonMinWidth
+                implicitHeight: IKOnboarding.completionButtonHeight
+                radius: IKOnboarding.buttonCornerRadius
+                color: IKColors.actionPrimary
+            }
+
+            padding: 0
+            leftPadding: IKSpacing.s16
+            rightPadding: IKSpacing.s16
+            topPadding: 0
+            bottomPadding: 0
+        }
+    }
+}

--- a/src/gui4/linux/ui/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/onboarding/ReadyView.qml
@@ -40,7 +40,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: qsTr("All set!")
+                text: root.onboardingFlowController.title
                 color: IKColors.textPrimary
                 font.pixelSize: IKFonts.largeTitleSize
                 font.weight: Font.Bold
@@ -63,6 +63,7 @@ Item {
         Button {
             id: openButton
 
+            enabled: root.onboardingFlowController.readyActionEnabled
             height: IKOnboarding.completionButtonHeight
             text: qsTr("Open kDrive")
             onClicked: root.onboardingFlowController.openSynchronizedFolders()
@@ -80,7 +81,7 @@ Item {
                 implicitWidth: IKOnboarding.completionButtonMinWidth
                 implicitHeight: IKOnboarding.completionButtonHeight
                 radius: IKOnboarding.buttonCornerRadius
-                color: IKColors.actionPrimary
+                color: openButton.enabled ? IKColors.actionPrimary : IKColors.actionDisabled
             }
 
             padding: 0

--- a/src/gui4/linux/ui/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/onboarding/ReadyView.qml
@@ -51,7 +51,7 @@ Item {
 
             Text {
                 width: parent.width
-                text: qsTr("Your files are ready to be securely synchronized on your computer.")
+                text: qsTrId("onboardingSynchronizationAppReadyDescription")
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.bodySize
                 lineHeightMode: Text.FixedHeight
@@ -65,7 +65,7 @@ Item {
 
             enabled: root.onboardingFlowController.readyActionEnabled
             height: IKOnboarding.completionButtonHeight
-            text: qsTr("Open kDrive")
+            text: qsTrId("buttonOpenKDrive")
             onClicked: root.onboardingFlowController.openSynchronizedFolders()
 
             contentItem: Text {

--- a/src/gui4/linux/ui/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/onboarding/ReadyView.qml
@@ -70,7 +70,7 @@ Item {
 
             contentItem: Text {
                 text: openButton.text
-                color: IKColors.actionOnPrimary
+                color: openButton.enabled ? IKColors.actionOnPrimary : IKColors.actionDisabled
                 font.pixelSize: IKFonts.bodySize
                 horizontalAlignment: Text.AlignHCenter
                 verticalAlignment: Text.AlignVCenter

--- a/src/gui4/linux/ui/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/onboarding/SynchronizationView.qml
@@ -1,0 +1,100 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Controls
+import kDrive.UI
+
+Item {
+    id: root
+
+    required property var onboardingFlowController
+
+    readonly property bool compact: width < IKOnboarding.completionCompactBreakpointWidth
+
+    Column {
+        width: Math.min(IKOnboarding.completionContentMaxWidth, root.width - IKSpacing.s64)
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.left: parent.left
+        anchors.leftMargin: root.compact ? IKSpacing.s32 : IKOnboarding.completionContentExpandedLeftMargin
+        spacing: root.onboardingFlowController.synchronizationFailed
+                 ? IKOnboarding.completionErrorSpacing
+                 : IKOnboarding.completionTextSpacing
+
+        Column {
+            width: parent.width
+            spacing: IKOnboarding.completionTextSpacing
+
+            Text {
+                width: parent.width
+                text: root.onboardingFlowController.synchronizationFailed
+                      ? qsTr("An unexpected error occurred")
+                      : qsTr("Synchronization in progress..")
+                color: IKColors.textPrimary
+                font.pixelSize: IKFonts.largeTitleSize
+                font.weight: Font.Bold
+                lineHeightMode: Text.FixedHeight
+                lineHeight: IKOnboarding.completionTitleLineHeight
+                wrapMode: Text.WordWrap
+            }
+
+            Text {
+                width: parent.width
+                text: root.onboardingFlowController.synchronizationFailed
+                      ? qsTr("Please try again in a few moments.\nIf the problem persists, please contact support.")
+                      : qsTr("Your kDrive files are being synchronized.\nPlease wait a few moments.")
+                color: IKColors.textSecondary
+                font.pixelSize: IKFonts.bodySize
+                lineHeightMode: Text.FixedHeight
+                lineHeight: IKOnboarding.completionBodyLineHeight
+                wrapMode: Text.WordWrap
+            }
+        }
+
+        Button {
+            id: retryButton
+
+            visible: root.onboardingFlowController.synchronizationFailed
+            height: IKOnboarding.completionButtonHeight
+            text: qsTr("Retry")
+            onClicked: root.onboardingFlowController.retrySynchronization()
+
+            contentItem: Text {
+                text: retryButton.text
+                color: IKColors.actionOnPrimary
+                font.pixelSize: IKFonts.bodySize
+                horizontalAlignment: Text.AlignHCenter
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
+            }
+
+            background: Rectangle {
+                implicitWidth: IKOnboarding.completionButtonMinWidth
+                implicitHeight: IKOnboarding.completionButtonHeight
+                radius: IKOnboarding.buttonCornerRadius
+                color: IKColors.actionPrimary
+            }
+
+            padding: 0
+            leftPadding: IKSpacing.s16
+            rightPadding: IKSpacing.s16
+            topPadding: 0
+            bottomPadding: 0
+        }
+    }
+}

--- a/src/gui4/linux/ui/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/onboarding/SynchronizationView.qml
@@ -43,7 +43,7 @@ Item {
             Text {
                 width: parent.width
                 text: root.onboardingFlowController.synchronizationFailed
-                      ? qsTr("An unexpected error occurred")
+                      ? qsTrId("defaultErrorTitle")
                       : root.onboardingFlowController.title
                 color: IKColors.textPrimary
                 font.pixelSize: IKFonts.largeTitleSize
@@ -56,8 +56,8 @@ Item {
             Text {
                 width: parent.width
                 text: root.onboardingFlowController.synchronizationFailed
-                      ? qsTr("Please try again in a few moments.\nIf the problem persists, please contact support.")
-                      : qsTr("Your kDrive files are being synchronized.\nPlease wait a few moments.")
+                      ? qsTrId("unexpectedErrorTeachingTipContent")
+                      : qsTrId("onboardingSynchronizationInProgressDescription")
                 color: IKColors.textSecondary
                 font.pixelSize: IKFonts.bodySize
                 lineHeightMode: Text.FixedHeight
@@ -71,7 +71,7 @@ Item {
 
             visible: root.onboardingFlowController.synchronizationFailed
             height: IKOnboarding.completionButtonHeight
-            text: qsTr("Retry")
+            text: qsTrId("buttonRetry")
             onClicked: root.onboardingFlowController.retrySynchronization()
 
             contentItem: Text {

--- a/src/gui4/linux/ui/onboarding/SynchronizationView.qml
+++ b/src/gui4/linux/ui/onboarding/SynchronizationView.qml
@@ -44,7 +44,7 @@ Item {
                 width: parent.width
                 text: root.onboardingFlowController.synchronizationFailed
                       ? qsTr("An unexpected error occurred")
-                      : qsTr("Synchronization in progress..")
+                      : root.onboardingFlowController.title
                 color: IKColors.textPrimary
                 font.pixelSize: IKFonts.largeTitleSize
                 font.weight: Font.Bold

--- a/src/gui4/linux/ui/tokens/IKOnboarding.qml
+++ b/src/gui4/linux/ui/tokens/IKOnboarding.qml
@@ -105,6 +105,18 @@ QtObject {
     readonly property real driveSelectionTooltipRadius: IKRadius.r8
     readonly property int driveSelectionTooltipDelay: 250
 
+    // Synchronization and ready screen layout.
+    readonly property real completionCompactBreakpointWidth: compactBreakpointWidth
+    readonly property real completionContentMaxWidth: contentMaxWidth
+    readonly property real completionContentExpandedLeftMargin: expandedContentLeftMargin
+    readonly property real completionTextSpacing: IKSpacing.s8
+    readonly property real completionErrorSpacing: IKSpacing.s24
+    readonly property real completionReadySpacing: IKSpacing.s32
+    readonly property real completionTitleLineHeight: titleLineHeight
+    readonly property real completionBodyLineHeight: bodyLineHeight
+    readonly property real completionButtonHeight: compactButtonHeight
+    readonly property real completionButtonMinWidth: primaryButtonMinWidth
+
     // Source dimensions of the loader-stroke animation (login step).
     readonly property real loaderStrokeVectorSourceWidth: 163
     readonly property real loaderStrokeVectorSourceHeight: 134

--- a/src/gui4/linux/ui/window/IKWindowControlButton.qml
+++ b/src/gui4/linux/ui/window/IKWindowControlButton.qml
@@ -46,13 +46,13 @@ ToolButton {
     text: {
         switch (controlType) {
         case IKWindowControlButton.Minimize:
-            return qsTr("Minimize")
+            return qsTrId("buttonMinimize");
         case IKWindowControlButton.Maximize:
-            return qsTr("Maximize")
+            return qsTrId("buttonMaximize");
         case IKWindowControlButton.Restore:
-            return qsTr("Restore")
+            return qsTrId("buttonRestore");
         case IKWindowControlButton.Close:
-            return qsTr("Close")
+            return qsTrId("buttonClose");
         }
         return ""
     }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -240,6 +240,12 @@ void AppServer::init() {
         return;
     }
 #endif
+    // OAuth callback launches are only forwarders. If no running server was detected, stop here instead of letting the
+    // callback process initialize itself as a second full server instance.
+    if (!_authorizationCodeStr.isEmpty()) {
+        LOG_WARN(_logger, "Login authorization callback received but no running server was detected");
+        return;
+    }
 
     // Cleanup at quit
     connect(this, &QCoreApplication::aboutToQuit, this, &AppServer::onCleanup);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -218,17 +218,12 @@ void AppServer::init() {
     setWindowIcon(_theme->applicationIcon());
     setApplicationVersion(QString::fromStdString(_theme->version()));
 
-    parseOptions(_arguments);
-    if (!_authorizationCodeStr.isEmpty()) {
-        std::cout << "Authorization code received";
-        return;
-    }
-
     // Setup logging with default parameters
     if (!initLogging()) {
         throw std::runtime_error("Unable to init logging.");
     }
 
+    parseOptions(_arguments);
     if (_helpAsked || _versionAsked || _clearSyncNodesAsked || _clearKeychainKeysAsked) {
         LOG_INFO(_logger, "Command line options processed");
         return;

--- a/src/server/mainserver.cpp
+++ b/src/server/mainserver.cpp
@@ -204,6 +204,13 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
         return 0;
     }
 
+    // AppServer::init() stops before full server initialization for orphan OAuth callbacks; do not enter the event loop
+    // afterwards with that partially initialized process.
+    if (appPtr->authorizationCodeReceived()) {
+        std::cout << "No running server found for authorization callback" << std::endl;
+        return 0;
+    }
+
     return appPtr->exec();
 }
 


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR finalise le parcours d'onboarding Linux v4 en ajoutant les étapes de création automatique des synchronisations puis de complétion (écran "Ready"). Après la sélection des kDrive, chaque drive sélectionné est synchronisé automatiquement à sa racine distante, puis l'utilisateur atteint un écran final qui ouvre les dossiers synchronisés. La PR introduit également la localisation basée sur des identifiants, alimentée par des catalogues Qt exportés depuis Loco.

## Changements
- Ajout de `OnboardingSyncCreationCoordinator` qui crée séquentiellement une synchronisation pour chaque drive sélectionné : dérivation d'un dossier local sans collision via `requestFindGoodPathForNewSync`, puis `requestSyncAdd` à la racine kDrive distante.
- Extension de `OnboardingFlowController` avec les étapes Synchronization et Ready : nouvelles propriétés (`synchronizationActive`, `synchronizationFailed`, `readyActive`, `readyActionEnabled`), invocables (`retrySynchronization`, `openSynchronizedFolders`), transitions (`beginSynchronization`, `failSynchronization`, `completeSynchronization`, `completeOnboarding`) et signaux associés.
- Nouvelles vues QML `SynchronizationView.qml` (progression + état d'erreur avec bouton Réessayer) et `ReadyView.qml` (écran final avec bouton "Ouvrir kDrive") ; `OnboardingWindow.qml` route désormais vers ces vues selon l'étape courante.
- Nouveaux jetons de style `IKOnboarding` pour la mise en page des écrans de synchronisation et de complétion.
- Localisation : ajout de `AppClientLinux::setupTranslations()`, de la configuration `.import_loco.yml` (13 langues), des catalogues `client_*.ts` exportés par Loco, et compilation/embarquement des `.qm` sous `:/i18n` via `qt_add_translations` (CMake). Conversion des chaînes QML de `qsTr()` vers `qsTrId()` (`DriveSelectionView`, `LoginView`, `NoDriveAvailableView`, `IKWindowControlButton`).
- Câblage : `OnboardingSession` et `OnboardingSessionManager` reçoivent désormais `CachePopulator` (non const) et `ServiceEventBus`, transmis depuis `AppClientLinux`.
- Serveur : dans `AppServer::init()`, `parseOptions` est appelé après l'initialisation du logging et la vérification redondante du code d'autorisation est supprimée.

## Détails techniques
- Un lot de créations de synchronisation n'est pas transactionnel côté serveur. Le coordinateur s'arrête à la première erreur, conserve la clé en échec ainsi que toutes les clés non tentées dans `_pendingDriveKeys`, et préserve la config de la clé en échec pour que Réessayer réutilise exactement le même chemin local. Après un `SYNC_ADD` en échec, il demande à `CachePopulator` de reconstruire le graphe en ordre parent-first (`bootstrap()`) avant d'exposer Réessayer, afin qu'un retry ne puisse pas émettre `DRIVE_ADDED`/`SYNC_ADDED` dans un cache dépourvu du compte parent.
- Les catalogues sont basés sur des identifiants : `client_en` est installé comme base pour que chaque id se résolve toujours (repli en anglais), puis la locale système est superposée. Qt interroge les traducteurs du dernier installé au premier, donc la locale l'emporte là où elle traduit et retombe sur la base anglaise sinon.

## Notes
- PR de branche empilée : la cible est `linux-v4/improve-global-window-look`, pas `develop`.
- Les fichiers `.ts` sont détenus par Loco : les mettre à jour via `import_loco`, pas via la cible générée `update_translations` (lupdate).

</details>

---

## Summary
This PR completes the Linux v4 onboarding flow by adding the automatic synchronization creation and completion ("Ready") steps. After drive selection, every selected drive is synced automatically at its remote root, then the user reaches a final screen that opens the synchronized folders. The PR also introduces id-based localization backed by Loco-exported Qt catalogs.

## Changes
- Add `OnboardingSyncCreationCoordinator`, which creates a sync for each selected drive sequentially: it derives a collision-free local folder via `requestFindGoodPathForNewSync`, then calls `requestSyncAdd` at the remote kDrive root.
- Extend `OnboardingFlowController` with Synchronization and Ready steps: new properties (`synchronizationActive`, `synchronizationFailed`, `readyActive`, `readyActionEnabled`), invokables (`retrySynchronization`, `openSynchronizedFolders`), transition methods (`beginSynchronization`, `failSynchronization`, `completeSynchronization`, `completeOnboarding`), and matching signals.
- New QML views `SynchronizationView.qml` (in-progress plus error state with a Retry button) and `ReadyView.qml` (completion screen with an "Open kDrive" button); `OnboardingWindow.qml` now routes to these views based on the current step.
- New `IKOnboarding` style tokens for the synchronization and completion screen layout.
- Localization: add `AppClientLinux::setupTranslations()`, the `.import_loco.yml` config (13 languages), the Loco-exported `client_*.ts` catalogs, and CMake wiring (`qt_add_translations`) to compile and embed `.qm` files under `:/i18n`. Convert QML strings from `qsTr()` to `qsTrId()` (`DriveSelectionView`, `LoginView`, `NoDriveAvailableView`, `IKWindowControlButton`).
- Wiring: `OnboardingSession` and `OnboardingSessionManager` now receive `CachePopulator` (non-const) and `ServiceEventBus`, forwarded from `AppClientLinux`.
- Server: in `AppServer::init()`, call `parseOptions` after logging initialization and drop the redundant authorization-code early return.

## Technical Details
- A batch of onboarding sync creations is not transactional on the server. The coordinator stops at the first failure, keeps the failed key plus every not-yet-attempted key in `_pendingDriveKeys`, and preserves the failed key's pending config so Retry reuses the exact same local path. After a failed `SYNC_ADD`, it asks `CachePopulator` to rebuild the graph parent-first (`bootstrap()`) before exposing Retry, so a successful retry cannot emit `DRIVE_ADDED`/`SYNC_ADDED` into a cache that still lacks the account parent.
- Catalogs are id-based: `client_en` is installed as a base so every id always resolves (untranslated keys degrade to English), then the system locale is overlaid on top. Qt queries translators last-installed-first, so the locale wins where it has a translation and falls back to the English base otherwise.

## Notes
- Stacked-branch PR: the target is `linux-v4/improve-global-window-look`, not `develop`.
- The `.ts` files are owned by Loco: update them via `import_loco`, not via the generated `update_translations` (lupdate) target.