### PR TITLE
feat(server): open a local file from a kdrive://open URL

### DIFF
--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -11,6 +11,12 @@ Long-running background daemon that owns all sync state. Communicates with the G
 - Auto-updater (Windows): `src/server/updater/windowsupdater.h`
 - Auto-updater (Linux): `src/server/updater/linuxupdater.h`
 - Migration from legacy config: `src/server/migration/`
+- `kdrive://open/...` URL handler (open a synced file from a browser link, hydrating/downloading it first if needed): `src/server/openfileurlhandler.{h,cpp}`
+
+## kdrive:// URL scheme
+The `kdrive` scheme is registered at server startup by `Utility::registerLoginRedirection()` (registry keys on Windows, `lsregister` on macOS, `.desktop` + `xdg-mime` on Linux). Incoming URLs reach the server as a command-line argument (Windows/Linux, forwarded to the running instance through the `QtSingleApplication` message channel) or as a `QEvent::FileOpen` caught by `UrlSchemeEventFilter` (macOS). Two hosts are handled:
+- `kdrive://auth-desktop?...` — OAuth login redirect (see `AppServer::onAuthorizationCodeReceived`).
+- `kdrive://open/<relative path>[?driveId=<server drive id>]` — open a file of a sync (see `OpenFileUrlHandler`).
 
 ## IPC Architecture
 The GUI sends typed **job requests** to the server over the IPC channel. Each capability is a separate job class.

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 set(server_SRCS
     appserver.h appserver.cpp
+    openfileurlhandler.h openfileurlhandler.cpp
     comm/oldcommserver.h comm/oldcommserver.cpp
     comm/abstractcommchannel.h comm/abstractcommchannel.cpp
     comm/abstractcommserver.h

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -121,13 +121,15 @@ static const char optionsC[] =
         "  -h --help            : show this help screen.\n"
         "  -v --version         : show the application version.\n"
         "  --settings           : show the Settings window (if the application is running).\n"
-        "  --synthesis          : show the Synthesis window (if the application is running).\n";
+        "  --synthesis          : show the Synthesis window (if the application is running).\n"
+        "  kdrive://open/<path> : open a file of your kDrive (downloading or synchronizing it first if needed).\n";
 }
 
 static const QString showSynthesisMsg("showSynthesis");
 static const QString showSettingsMsg("showSettings");
 static const QString restartClientMsg("restartClient");
 static const QString authorizationCodeMsg("redirectLogin");
+static const QString openFileMsg("openFile");
 static const QString separatorMsg("$$$");
 
 static const QString crashMsg = SharedTools::QtSingleApplication::tr("kDrive application will close due to a fatal error.");
@@ -159,8 +161,9 @@ AppServer::AppServer(int &argc, char **argv) :
     _arguments = arguments();
     _theme = Theme::instance();
     installEventFilter(&_eventFilter);
-    (void) connect(&_eventFilter, &AuthorizationCodeEventFilter::authorizationCodeReceived, this,
+    (void) connect(&_eventFilter, &UrlSchemeEventFilter::authorizationCodeReceived, this,
                    &AppServer::onAuthorizationCodeReceived);
+    (void) connect(&_eventFilter, &UrlSchemeEventFilter::openFileUrlReceived, this, &AppServer::onOpenFileUrlReceived);
 }
 
 AppServer::~AppServer() {
@@ -530,6 +533,11 @@ void AppServer::init() {
     // Restart paused syncs
     connect(&_restartSyncsTimer, &QTimer::timeout, this, &AppServer::onRestartSyncs);
     _restartSyncsTimer.start(RESTART_SYNCS_INTERVAL);
+
+    // Process a file opening URL received at startup, once the syncs have been started.
+    if (!_openFileUrlStr.isEmpty()) {
+        QTimer::singleShot(delayedActionMs, this, [this]() { onOpenFileUrlReceived(_openFileUrlStr); });
+    }
 }
 
 void AppServer::cleanup() {
@@ -2669,6 +2677,8 @@ void AppServer::onMessageReceivedFromAnotherProcess(const QString &message, QObj
         const QString code = query.queryItemValue("code");
         const QString state = query.queryItemValue("state");
         onAuthorizationCodeReceived(code, state);
+    } else if (message.startsWith(openFileMsg)) {
+        onOpenFileUrlReceived(message.split(separatorMsg).back());
     } else if (message == showSynthesisMsg) {
         showSynthesis();
     } else if (message == showSettingsMsg) {
@@ -2694,6 +2704,14 @@ void AppServer::onMessageReceivedFromAnotherProcess(const QString &message, QObj
 
 void AppServer::onSendNotifAsked(const QString &title, const QString &message) {
     sendShowNotification(title, message);
+}
+
+void AppServer::onOpenFileUrlReceived(const QString &urlStr) {
+    LOG_INFO(_logger, "File opening URL received: '" << urlStr.toStdString() << "'");
+
+    auto *handler = new OpenFileUrlHandler(this, QUrl(urlStr), this);
+    (void) connect(handler, &OpenFileUrlHandler::finished, handler, &QObject::deleteLater);
+    handler->start();
 }
 
 void AppServer::onAuthorizationCodeReceived(const QString &code, const QString &state) {
@@ -3677,6 +3695,9 @@ void AppServer::parseOptions(const QStringList &options) {
                 _authorizationCodeStr = option;
                 break;
             }
+        } else if (OpenFileUrlHandler::isOpenFileUrl(QUrl(option))) {
+            _openFileUrlStr = option;
+            break;
         } else if (option == QLatin1String("--help") || option == QLatin1String("-h")) {
             _helpAsked = true;
             break;
@@ -3767,6 +3788,10 @@ void AppServer::sendRestartClientMsg() {
 
 void AppServer::sendAuthorizationCode() {
     sendMessage(authorizationCodeMsg + separatorMsg + _authorizationCodeStr);
+}
+
+void AppServer::sendOpenFileUrlMsg() {
+    sendMessage(openFileMsg + separatorMsg + _openFileUrlStr);
 }
 
 void AppServer::showSettings() {

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -28,6 +28,7 @@
 #endif
 #include "config.h"
 #include "version.h"
+#include "openfileurlhandler.h"
 #include "requests/serverrequests.h"
 #include "comm/oldcommserver.h"
 #include "comm/commmanager.h"
@@ -55,12 +56,14 @@ class Theme;
  * @ingroup gui
  */
 
-class AuthorizationCodeEventFilter : public QObject {
-        // On macOS, the authorization code is retrieved by catching the `QEvent::FileOpen` and extracting its URL.
+class UrlSchemeEventFilter : public QObject {
+        // On macOS, kdrive:// URLs (OAuth authorization code, file opening request) are retrieved by catching the
+        // `QEvent::FileOpen` and extracting its URL.
         Q_OBJECT
 
     signals:
         void authorizationCodeReceived(const QString &code, const QString &state);
+        void openFileUrlReceived(const QString &url);
 
     private:
         bool eventFilter(QObject *obj, QEvent *event) override {
@@ -78,6 +81,11 @@ class AuthorizationCodeEventFilter : public QObject {
                         // non-empty.
                         emit authorizationCodeReceived(code, state);
                     }
+                    return true;
+                }
+
+                if (OpenFileUrlHandler::isOpenFileUrl(url)) {
+                    emit openFileUrlReceived(url.toString());
                     return true;
                 }
             }
@@ -127,6 +135,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         inline bool settingsAsked() { return _settingsAsked; }
         inline bool synthesisAsked() { return _synthesisAsked; }
         inline bool authorizationCodeReceived() { return !_authorizationCodeStr.isEmpty(); }
+        inline bool openFileUrlAsked() { return !_openFileUrlStr.isEmpty(); }
         inline bool clearKeychainKeysAsked() { return _clearKeychainKeysAsked; }
 
         void showHelp();
@@ -136,6 +145,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         void sendShowSynthesisMsg();
         void sendRestartClientMsg();
         void sendAuthorizationCode();
+        void sendOpenFileUrlMsg();
         void handleClientDisconnection() { onClientDisconnectedReceived(); }
 
         void clearKeychainKeys();
@@ -257,7 +267,7 @@ class AppServer : public SharedTools::QtSingleApplication {
                                                  bool &updated, bool &quotaUpdated)>(&ServerRequests::loadDriveInfo);
 
     private:
-        AuthorizationCodeEventFilter _eventFilter;
+        UrlSchemeEventFilter _eventFilter;
 
         QStringList _arguments;
         log4cplus::Logger _logger;
@@ -271,6 +281,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         bool _settingsAsked{false};
         bool _synthesisAsked{false};
         QString _authorizationCodeStr;
+        QString _openFileUrlStr;
         bool _clearKeychainKeysAsked{false};
         bool _vfsInstallationDone{false};
         bool _vfsActivationDone{false};
@@ -395,6 +406,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         void crash() const;
 
 
+        friend class OpenFileUrlHandler;
         friend class TestAppServer;
 
     private slots:
@@ -412,5 +424,6 @@ class AppServer : public SharedTools::QtSingleApplication {
         void onMessageReceivedFromAnotherProcess(const QString &message, QObject *);
         void onSendNotifAsked(const QString &title, const QString &message);
         void onAuthorizationCodeReceived(const QString &code, const QString &state);
+        void onOpenFileUrlReceived(const QString &urlStr);
 };
 } // namespace KDC

--- a/src/server/mainserver.cpp
+++ b/src/server/mainserver.cpp
@@ -235,6 +235,11 @@ std::int32_t exec(std::unique_ptr<KDC::AppServer> &appPtr) {
             return 0;
         }
 
+        if (appPtr->openFileUrlAsked()) {
+            appPtr->sendOpenFileUrlMsg();
+            return 0;
+        }
+
         std::cout << "Asking the running server to start a newClient." << std::endl;
         appPtr->sendRestartClientMsg();
         return 0;

--- a/src/server/openfileurlhandler.cpp
+++ b/src/server/openfileurlhandler.cpp
@@ -1,0 +1,387 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "openfileurlhandler.h"
+#include "appserver.h"
+#include "libcommon/theme/theme.h"
+#include "libcommonserver/io/iohelper.h"
+#include "libcommonserver/log/log.h"
+#include "libcommonserver/utility/utility.h"
+#include "libparms/db/parmsdb.h"
+
+#include <QDesktopServices>
+#include <QSet>
+#include <QUrlQuery>
+
+#include <log4cplus/loggingmacros.h>
+
+namespace KDC {
+
+namespace {
+constexpr std::chrono::milliseconds resolveTickInterval(1000);
+constexpr std::chrono::milliseconds waitForSyncTickInterval(2000);
+constexpr std::chrono::milliseconds waitForHydrationTickInterval(500);
+
+// The syncs may not be started yet (e.g. when the URL is received at application startup): keep looking for the file
+// during `resolveTimeout` before giving up.
+constexpr std::chrono::milliseconds resolveTimeout(std::chrono::seconds(30));
+constexpr std::chrono::milliseconds waitForSyncTimeout(std::chrono::minutes(10));
+constexpr std::chrono::milliseconds waitForHydrationTimeout(std::chrono::hours(1));
+
+// A download job can transiently be neither ongoing nor completed while its completion callback runs: require
+// several consecutive negative checks before considering that the hydration has failed.
+constexpr int downloadNotOngoingCountMax = 2;
+} // namespace
+
+OpenFileUrlHandler::OpenFileUrlHandler(AppServer *appServer, const QUrl &url, QObject *parent) :
+    QObject(parent),
+    _appServer(appServer),
+    _url(url) {
+    (void) connect(&_tickTimer, &QTimer::timeout, this, &OpenFileUrlHandler::onTick);
+}
+
+void OpenFileUrlHandler::start() {
+    LOG_INFO(Log::instance()->getLogger(), "Processing file opening URL - url=" << _url.toString().toStdString());
+
+    if (!parseUrl(_url, _request)) {
+        LOG_WARN(Log::instance()->getLogger(), "Invalid file opening URL - url=" << _url.toString().toStdString());
+        fail(tr("This kDrive link is invalid."));
+        return;
+    }
+
+    setPhase(Phase::Resolve, resolveTickInterval);
+    processResolvePhase();
+}
+
+bool OpenFileUrlHandler::isOpenFileUrl(const QUrl &url) {
+    return url.isValid() && url.scheme() == "kdrive" && url.host() == "open";
+}
+
+bool OpenFileUrlHandler::parseUrl(const QUrl &url, Request &request) {
+    if (!isOpenFileUrl(url)) return false;
+
+    QString pathStr = url.path(QUrl::FullyDecoded);
+    while (pathStr.startsWith('/')) {
+        pathStr.remove(0, 1);
+    }
+    if (pathStr.isEmpty()) return false;
+
+    request.relativePath = QStr2Path(pathStr);
+    if (!isRelativePathSafe(request.relativePath)) return false;
+
+    const QUrlQuery query(url);
+    const QString driveIdStr = query.queryItemValue("driveId");
+    request.hasDriveId = !driveIdStr.isEmpty();
+    if (request.hasDriveId) {
+        bool ok = false;
+        request.driveId = driveIdStr.toLongLong(&ok);
+        if (!ok || request.driveId <= 0) return false;
+    }
+
+    return true;
+}
+
+bool OpenFileUrlHandler::isRelativePathSafe(const SyncPath &relativePath) {
+    if (relativePath.empty() || relativePath.has_root_name() || relativePath.is_absolute()) return false;
+
+    for (const auto &component: relativePath) {
+        if (component == ".." || component == ".") return false;
+    }
+
+    return true;
+}
+
+bool OpenFileUrlHandler::shouldOpenParentFolder(const SyncPath &path) {
+    static const QSet<QString> executableExtensions = {".exe", ".bat", ".cmd", ".com", ".scr", ".msi", ".ps1",
+                                                       ".vbs", ".js",  ".jar", ".sh",  ".app", ".apk"};
+    return executableExtensions.contains(Path2QStr(path.extension()).toLower());
+}
+
+void OpenFileUrlHandler::onTick() {
+    switch (_phase) {
+        case Phase::Resolve:
+            processResolvePhase();
+            break;
+        case Phase::WaitForSync:
+            processWaitForSyncPhase();
+            break;
+        case Phase::WaitForHydration:
+            processWaitForHydrationPhase();
+            break;
+    }
+}
+
+bool OpenFileUrlHandler::candidateSyncs(std::vector<Sync> &syncs) {
+    std::vector<Sync> syncList;
+    if (!ParmsDb::instance()->selectAllSyncs(syncList)) {
+        LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectAllSyncs");
+        return false;
+    }
+
+    for (const auto &sync: syncList) {
+        if (_request.hasDriveId) {
+            Drive drive;
+            bool found = false;
+            if (!ParmsDb::instance()->selectDrive(sync.driveDbId(), drive, found) || !found) {
+                LOG_WARN(Log::instance()->getLogger(), "Error in ParmsDb::selectDrive - driveDbId=" << sync.driveDbId());
+                continue;
+            }
+            if (drive.driveId() != _request.driveId) continue;
+        }
+        syncs.push_back(sync);
+    }
+
+    return true;
+}
+
+void OpenFileUrlHandler::processResolvePhase() {
+    std::vector<Sync> syncs;
+    if (!candidateSyncs(syncs)) {
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    // The file is already present locally (possibly as a dehydrated placeholder).
+    for (const auto &sync: syncs) {
+        const SyncPath localPath = sync.localPath() / _request.relativePath;
+        bool exists = false;
+        auto ioError = IoError::Success;
+        if (!IoHelper::checkIfPathExists(localPath, exists, ioError, IoHelper::PathCheckOption::Insensitive)) {
+            LOGW_WARN(Log::instance()->getLogger(),
+                      L"Error in IoHelper::checkIfPathExists: " << Utility::formatIoError(localPath, ioError));
+            continue;
+        }
+        if (exists) {
+            _syncDbId = sync.dbId();
+            _localPath = localPath;
+            hydrateOrOpen();
+            return;
+        }
+    }
+
+    // The file is not present locally: check whether it is already known on the remote side.
+    {
+        const std::scoped_lock lock(_appServer->syncPalMapMutex);
+        for (const auto &sync: syncs) {
+            const auto syncPalMapIt = _appServer->syncPalMap.find(sync.dbId());
+            if (syncPalMapIt == _appServer->syncPalMap.end() || !syncPalMapIt->second) continue;
+
+            bool exists = false;
+            if (!syncPalMapIt->second->checkIfExistsOnServer(_request.relativePath, exists)) continue;
+            if (exists) {
+                _syncDbId = sync.dbId();
+                _localPath = sync.localPath() / _request.relativePath;
+                if (!_waitingNotificationSent) {
+                    _waitingNotificationSent = true;
+                    notifyUser(tr("The requested file is being synchronized. It will open once available."));
+                }
+                setPhase(Phase::WaitForSync, waitForSyncTickInterval);
+                return;
+            }
+        }
+    }
+
+    if (_phaseTimer.hasExpired(resolveTimeout.count())) {
+        fail(tr("The file requested from a kDrive link could not be found in your kDrive."));
+    }
+}
+
+void OpenFileUrlHandler::processWaitForSyncPhase() {
+    bool exists = false;
+    auto ioError = IoError::Success;
+    if (IoHelper::checkIfPathExists(_localPath, exists, ioError, IoHelper::PathCheckOption::Insensitive) && exists) {
+        hydrateOrOpen();
+        return;
+    }
+
+    if (_phaseTimer.hasExpired(waitForSyncTimeout.count())) {
+        fail(tr("The file requested from a kDrive link could not be synchronized. Please try again later."));
+    }
+}
+
+void OpenFileUrlHandler::hydrateOrOpen() {
+    _tickTimer.stop();
+
+    ItemType itemType;
+    if (!IoHelper::getItemType(_localPath, itemType)) {
+        LOGW_WARN(Log::instance()->getLogger(),
+                  L"Error in IoHelper::getItemType: " << Utility::formatIoError(_localPath, itemType.ioError));
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    std::error_code ec;
+    const bool isDirectory = itemType.linkType == LinkType::None && std::filesystem::is_directory(_localPath, ec);
+    if (itemType.linkType != LinkType::None || isDirectory) {
+        // Symlinks and directories do not need any hydration.
+        openResolvedItem();
+        return;
+    }
+
+    std::shared_ptr<Vfs> vfs;
+    if (const auto exitInfo = _appServer->getVfs(_syncDbId, vfs); !exitInfo || !vfs) {
+        // No VFS plugin for this sync (e.g. LiteSync disabled): the file is a plain file, open it directly.
+        openResolvedItem();
+        return;
+    }
+
+    VfsStatus vfsStatus;
+    if (const auto exitInfo = vfs->status(_localPath, vfsStatus); !exitInfo) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in Vfs::status - " << Utility::formatSyncPath(_localPath));
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    if (!vfsStatus.isPlaceholder || vfsStatus.isHydrated) {
+        openResolvedItem();
+        return;
+    }
+
+    if (!vfsStatus.isSyncing && !triggerHydration()) {
+        fail(tr("The file requested from a kDrive link could not be downloaded."));
+        return;
+    }
+
+    if (!_waitingNotificationSent) {
+        _waitingNotificationSent = true;
+        notifyUser(tr("The requested file is being downloaded. It will open once available."));
+    }
+    setPhase(Phase::WaitForHydration, waitForHydrationTickInterval);
+}
+
+bool OpenFileUrlHandler::triggerHydration() {
+    std::shared_ptr<Vfs> vfs;
+    if (const auto exitInfo = _appServer->getVfs(_syncDbId, vfs); !exitInfo || !vfs) return false;
+
+#if defined(KD_MACOS)
+    // On macOS, setting the pin state to AlwaysLocal is required to trigger the hydration
+    // (see ExtensionJob::commandMakeAvailableLocallyDirect).
+    _initialPinState = vfs->pinState(_request.relativePath);
+    if (_initialPinState != PinState::AlwaysLocal) {
+        if (const auto exitInfo = vfs->setPinState(_request.relativePath, PinState::AlwaysLocal); !exitInfo) {
+            LOGW_WARN(Log::instance()->getLogger(), L"Error in Vfs::setPinState - " << Utility::formatSyncPath(_localPath));
+            return false;
+        }
+    }
+#endif
+
+    bool jobAdded = false;
+    {
+        const std::scoped_lock lock(_appServer->syncPalMapMutex);
+        const auto syncPalMapIt = _appServer->syncPalMap.find(_syncDbId);
+        jobAdded = syncPalMapIt != _appServer->syncPalMap.end() && syncPalMapIt->second &&
+                   syncPalMapIt->second->addDlDirectJob(_request.relativePath, _localPath, SyncPath()) == ExitCode::Ok;
+    }
+
+    if (!jobAdded) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in SyncPal::addDlDirectJob - " << Utility::formatSyncPath(_localPath));
+#if defined(KD_MACOS)
+        // Cancel the hydration and reset the pin state to its initial value.
+        vfs->cancelHydrate(_localPath);
+        if (_initialPinState != PinState::Unknown) (void) vfs->setPinState(_request.relativePath, _initialPinState);
+#endif
+        return false;
+    }
+
+    return true;
+}
+
+void OpenFileUrlHandler::processWaitForHydrationPhase() {
+    std::shared_ptr<Vfs> vfs;
+    if (const auto exitInfo = _appServer->getVfs(_syncDbId, vfs); !exitInfo || !vfs) {
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    VfsStatus vfsStatus;
+    if (const auto exitInfo = vfs->status(_localPath, vfsStatus); !exitInfo) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in Vfs::status - " << Utility::formatSyncPath(_localPath));
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    if (vfsStatus.isHydrated) {
+        openResolvedItem();
+        return;
+    }
+
+    bool downloadOngoing = vfsStatus.isSyncing;
+    if (!downloadOngoing) {
+        const std::scoped_lock lock(_appServer->syncPalMapMutex);
+        const auto syncPalMapIt = _appServer->syncPalMap.find(_syncDbId);
+        downloadOngoing = syncPalMapIt != _appServer->syncPalMap.end() && syncPalMapIt->second &&
+                          syncPalMapIt->second->isDownloadOngoing(_localPath);
+    }
+
+    if (!downloadOngoing) {
+        if (++_downloadNotOngoingCount >= downloadNotOngoingCountMax) {
+            fail(tr("The download of the file requested from a kDrive link failed."));
+            return;
+        }
+    } else {
+        _downloadNotOngoingCount = 0;
+    }
+
+    if (_phaseTimer.hasExpired(waitForHydrationTimeout.count())) {
+        fail(tr("The download of the file requested from a kDrive link took too long."));
+    }
+}
+
+void OpenFileUrlHandler::openResolvedItem() {
+    _tickTimer.stop();
+
+    SyncPath pathToOpen = _localPath;
+    if (shouldOpenParentFolder(_localPath)) {
+        LOGW_INFO(Log::instance()->getLogger(),
+                  L"Executable item, revealing its parent folder instead - " << Utility::formatSyncPath(_localPath));
+        pathToOpen = _localPath.parent_path();
+    }
+
+    if (!QDesktopServices::openUrl(QUrl::fromLocalFile(Path2QStr(pathToOpen)))) {
+        LOGW_WARN(Log::instance()->getLogger(), L"Error in QDesktopServices::openUrl - " << Utility::formatSyncPath(pathToOpen));
+        fail(tr("The file requested from a kDrive link could not be opened."));
+        return;
+    }
+
+    LOGW_INFO(Log::instance()->getLogger(), L"File opened from URL - " << Utility::formatSyncPath(pathToOpen));
+    succeed();
+}
+
+void OpenFileUrlHandler::setPhase(Phase phase, std::chrono::milliseconds tickInterval) {
+    _phase = phase;
+    _phaseTimer.restart();
+    _tickTimer.start(tickInterval);
+}
+
+void OpenFileUrlHandler::notifyUser(const QString &message) const {
+    _appServer->sendShowNotification(QString::fromStdString(Theme::instance()->appName()), message);
+}
+
+void OpenFileUrlHandler::succeed() {
+    _tickTimer.stop();
+    emit finished(true);
+}
+
+void OpenFileUrlHandler::fail(const QString &userMessage) {
+    _tickTimer.stop();
+    LOG_WARN(Log::instance()->getLogger(), "Failed to open file from URL - url=" << _url.toString().toStdString());
+    notifyUser(userMessage);
+    emit finished(false);
+}
+
+} // namespace KDC

--- a/src/server/openfileurlhandler.h
+++ b/src/server/openfileurlhandler.h
@@ -1,0 +1,105 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/types.h"
+
+#include <QElapsedTimer>
+#include <QObject>
+#include <QTimer>
+#include <QUrl>
+
+namespace KDC {
+
+class AppServer;
+class Sync;
+
+//! Handles "kdrive://open/<file path>[?driveId=<drive id>]" URLs (e.g. clicked in a web browser).
+/*!
+  The file path is relative to the local folder of a sync. The optional `driveId` query item restricts the
+  search to the syncs of a drive (`driveId` is the server side drive id, as displayed in web application URLs).
+
+  The handler resolves the file path against the configured syncs, then:
+  - opens the item directly if it is available locally,
+  - triggers its hydration first if it is a dehydrated LiteSync placeholder,
+  - waits for its synchronization if it exists on the remote side only.
+*/
+class OpenFileUrlHandler : public QObject {
+        Q_OBJECT
+
+    public:
+        struct Request {
+                SyncPath relativePath;
+                DriveId driveId{0};
+                bool hasDriveId{false};
+        };
+
+        OpenFileUrlHandler(AppServer *appServer, const QUrl &url, QObject *parent = nullptr);
+
+        void start();
+
+        //! Returns true if `url` is a file opening URL, i.e. "kdrive://open/...".
+        static bool isOpenFileUrl(const QUrl &url);
+        //! Extracts the file path and the optional drive id from `url`. Returns false if the URL is invalid or unsafe.
+        static bool parseUrl(const QUrl &url, Request &request);
+        //! Returns true if `relativePath` is not empty, relative and does not contain any "." or ".." component.
+        static bool isRelativePathSafe(const SyncPath &relativePath);
+        //! Returns true if `path` designates executable content that must be revealed in its parent folder instead of
+        //! being launched.
+        static bool shouldOpenParentFolder(const SyncPath &path);
+
+    signals:
+        void finished(bool success);
+
+    private:
+        enum class Phase {
+            Resolve, // Look for the file in the configured syncs.
+            WaitForSync, // The file exists on the remote side only, wait for it to appear locally.
+            WaitForHydration // The file is being hydrated, wait for the download to complete.
+        };
+
+        void onTick();
+        void processResolvePhase();
+        void processWaitForSyncPhase();
+        void processWaitForHydrationPhase();
+        void hydrateOrOpen();
+        bool triggerHydration();
+        void openResolvedItem();
+        bool candidateSyncs(std::vector<Sync> &syncs);
+        void setPhase(Phase phase, std::chrono::milliseconds tickInterval);
+        void notifyUser(const QString &message) const;
+        void succeed();
+        void fail(const QString &userMessage);
+
+        AppServer *_appServer{nullptr};
+        QUrl _url;
+        Request _request;
+        Phase _phase{Phase::Resolve};
+        QTimer _tickTimer;
+        QElapsedTimer _phaseTimer;
+        SyncDbId _syncDbId{0};
+        SyncPath _localPath;
+        bool _waitingNotificationSent{false};
+        int _downloadNotOngoingCount{0};
+#if defined(KD_MACOS)
+        PinState _initialPinState{PinState::Unknown};
+#endif
+};
+
+} // namespace KDC

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -22,6 +22,7 @@ set(server_srcs_path ${CMAKE_SOURCE_DIR}/src/server)
 
 set(server_SRCS
     ${server_srcs_path}/appserver.h ${server_srcs_path}/appserver.cpp
+    ${server_srcs_path}/openfileurlhandler.h ${server_srcs_path}/openfileurlhandler.cpp
     ${server_srcs_path}/comm/oldcommserver.h ${server_srcs_path}/comm/oldcommserver.cpp
     ${server_srcs_path}/comm/abstractcommchannel.h ${server_srcs_path}/comm/abstractcommchannel.cpp
     ${server_srcs_path}/comm/socketcommserver.h ${server_srcs_path}/comm/socketcommserver.cpp
@@ -198,6 +199,7 @@ set(testserver_SRCS
     workers/testworkers.h workers/testworkers.cpp
     requests/testserverrequests.h requests/testserverrequests.cpp
     appserver/testappserver.h appserver/testappserver.cpp
+    openfileurlhandler/testopenfileurlhandler.h openfileurlhandler/testopenfileurlhandler.cpp
 
     comm/testsocketcomm.h comm/testsocketcomm.cpp
     comm/testcommhelpers.h comm/testcommhelpers.cpp

--- a/test/server/openfileurlhandler/testopenfileurlhandler.cpp
+++ b/test/server/openfileurlhandler/testopenfileurlhandler.cpp
@@ -1,0 +1,123 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "testopenfileurlhandler.h"
+
+#include "openfileurlhandler.h"
+
+#include <QUrl>
+
+namespace KDC {
+
+void TestOpenFileUrlHandler::setUp() {
+    TestBase::start();
+}
+
+void TestOpenFileUrlHandler::tearDown() {
+    TestBase::stop();
+}
+
+void TestOpenFileUrlHandler::testIsOpenFileUrl() {
+    CPPUNIT_ASSERT(OpenFileUrlHandler::isOpenFileUrl(QUrl("kdrive://open/Documents/report.docx")));
+    CPPUNIT_ASSERT(OpenFileUrlHandler::isOpenFileUrl(QUrl("kdrive://open/report.docx?driveId=123456")));
+    CPPUNIT_ASSERT(OpenFileUrlHandler::isOpenFileUrl(QUrl("KDRIVE://OPEN/report.docx"))); // Scheme and host are case-insensitive.
+
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isOpenFileUrl(QUrl()));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isOpenFileUrl(QUrl("kdrive://auth-desktop?code=1&state=2"))); // OAuth redirection.
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isOpenFileUrl(QUrl("kdrive://other/report.docx")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isOpenFileUrl(QUrl("https://open/report.docx")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isOpenFileUrl(QUrl("report.docx")));
+}
+
+void TestOpenFileUrlHandler::testParseUrl() {
+    {
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/Documents/report.docx"), request));
+        CPPUNIT_ASSERT(SyncPath("Documents/report.docx") == request.relativePath);
+        CPPUNIT_ASSERT(!request.hasDriveId);
+    }
+
+    {
+        // Percent-encoded characters are decoded.
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/My%20folder/r%C3%A9sum%C3%A9.pdf"), request));
+        CPPUNIT_ASSERT(SyncPath("My folder") / SyncPath(u8"résumé.pdf") == request.relativePath);
+    }
+
+    {
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/report.docx?driveId=123456"), request));
+        CPPUNIT_ASSERT(SyncPath("report.docx") == request.relativePath);
+        CPPUNIT_ASSERT(request.hasDriveId);
+        CPPUNIT_ASSERT_EQUAL(DriveId(123456), request.driveId);
+    }
+
+    {
+        // Empty path.
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open"), request));
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/"), request));
+    }
+
+    {
+        // Directory traversal attempts.
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/../../etc/passwd"), request));
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/Documents/%2E%2E/secret.txt"), request));
+    }
+
+    {
+        // Invalid drive ids.
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/report.docx?driveId=abc"), request));
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://open/report.docx?driveId=-1"), request));
+    }
+
+    {
+        // Not a file opening URL.
+        OpenFileUrlHandler::Request request;
+        CPPUNIT_ASSERT(!OpenFileUrlHandler::parseUrl(QUrl("kdrive://auth-desktop?code=1&state=2"), request));
+    }
+}
+
+void TestOpenFileUrlHandler::testIsRelativePathSafe() {
+    CPPUNIT_ASSERT(OpenFileUrlHandler::isRelativePathSafe(SyncPath("report.docx")));
+    CPPUNIT_ASSERT(OpenFileUrlHandler::isRelativePathSafe(SyncPath("Documents/report.docx")));
+
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath()));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath("../report.docx")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath("Documents/../../report.docx")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath("./report.docx")));
+#if defined(KD_WINDOWS)
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath(LR"(C:\Windows\System32\cmd.exe)")));
+#else
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::isRelativePathSafe(SyncPath("/etc/passwd")));
+#endif
+}
+
+void TestOpenFileUrlHandler::testShouldOpenParentFolder() {
+    CPPUNIT_ASSERT(OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("tools/setup.exe")));
+    CPPUNIT_ASSERT(OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("script.sh")));
+    CPPUNIT_ASSERT(OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("Setup.EXE"))); // Extension check is case-insensitive.
+
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("Documents/report.docx")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("photo.jpg")));
+    CPPUNIT_ASSERT(!OpenFileUrlHandler::shouldOpenParentFolder(SyncPath("no_extension")));
+}
+
+} // namespace KDC

--- a/test/server/openfileurlhandler/testopenfileurlhandler.h
+++ b/test/server/openfileurlhandler/testopenfileurlhandler.h
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "testincludes.h"
+
+namespace KDC {
+
+class TestOpenFileUrlHandler : public CppUnit::TestFixture, public TestBase {
+        CPPUNIT_TEST_SUITE(TestOpenFileUrlHandler);
+        CPPUNIT_TEST(testIsOpenFileUrl);
+        CPPUNIT_TEST(testParseUrl);
+        CPPUNIT_TEST(testIsRelativePathSafe);
+        CPPUNIT_TEST(testShouldOpenParentFolder);
+        CPPUNIT_TEST_SUITE_END();
+
+    public:
+        void setUp() final;
+        void tearDown() final;
+
+        void testIsOpenFileUrl();
+        void testParseUrl();
+        void testIsRelativePathSafe();
+        void testShouldOpenParentFolder();
+};
+
+} // namespace KDC

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -29,6 +29,7 @@
 #endif
 #include "requests/testserverrequests.h"
 #include "appserver/testappserver.h"
+#include "openfileurlhandler/testopenfileurlhandler.h"
 #include "comm/guicommchannel/testguicommchannel.h"
 #include "comm/testsocketcomm.h"
 #if defined(KD_WINDOWS)
@@ -50,6 +51,7 @@ CPPUNIT_TEST_SUITE_REGISTRATION(TestWindowsUpdater);
 #endif
 CPPUNIT_TEST_SUITE_REGISTRATION(TestServerRequests);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestAppServer);
+CPPUNIT_TEST_SUITE_REGISTRATION(TestOpenFileUrlHandler);
 CPPUNIT_TEST_SUITE_REGISTRATION(TestSocketComm);
 #if defined(KD_WINDOWS)
 CPPUNIT_TEST_SUITE_REGISTRATION(TestPipeComm);


### PR DESCRIPTION
## Description

This PR adds support for opening a synchronized file directly from a web browser link, similar to what SharePoint/OneDrive offer, using the URL format:

```
kdrive://open/<file path relative to the sync folder>[?driveId=<server drive id>]
```

Example: `kdrive://open/Documents/Report.docx?driveId=123456`

### Behavior

- The file path is resolved against the local folders of all configured syncs. The optional `driveId` query item (the server-side drive id, as shown in web application URLs) restricts the search to the syncs of one drive.
- **File available locally** → it is opened with its default application.
- **Dehydrated LiteSync placeholder** → its hydration is triggered first, following the exact same path as the "Make available locally" context menu action (pin state on macOS + `SyncPal::addDlDirectJob`), and the file opens once the download completes. The user is notified that the download is in progress.
- **File not synchronized locally yet** → if it is known on the remote side (`SyncPal::checkIfExistsOnServer`), the handler waits for the synchronization to bring it locally (up to 10 minutes), then opens it. On a cold start, resolution is retried for 30 seconds while the syncs come up.
- **Safety**: absolute paths and paths containing `..` components are rejected; executable content (`.exe`, `.bat`, `.sh`, `.jar`, …) is revealed in its parent folder instead of being launched.

### How the URL reaches the application

The `kdrive` scheme is already registered on the three platforms by `Utility::registerLoginRedirection()` (used for the `kdrive://auth-desktop` OAuth redirect), so no new OS registration is needed:

- **Windows / Linux**: the URL arrives as a command-line argument, parsed in `AppServer::parseOptions`. When an instance is already running, it is forwarded through the existing `QtSingleApplication` message channel (new `openFile` message, mirroring the `redirectLogin` one).
- **macOS**: the URL arrives as a `QEvent::FileOpen`, caught by the existing event filter (renamed `AuthorizationCodeEventFilter` → `UrlSchemeEventFilter` since it now handles two URL kinds).

### Implementation

- New `OpenFileUrlHandler` class (`src/server/openfileurlhandler.{h,cpp}`): a small `QTimer`-driven state machine (Resolve → WaitForSync → WaitForHydration) running on the server main thread; all per-tick checks are cheap (DB/snapshot/VFS status lookups).
- URL parsing, path safety validation and the executable-extension check are static and covered by unit tests (`test/server/openfileurlhandler/`).
- `src/server/AGENTS.md` updated with the kdrive:// URL scheme documentation.

### Notes for reviewers

- The `open` host segment is required because the host part of a URL is case-insensitive: putting the first path component in the host position would corrupt case-sensitive folder names.
- On hydration failure detection, two consecutive negative `isDownloadOngoing` checks are required before failing, to avoid a race with the download job completion callback.
- User-facing strings are new `tr()` entries; translation files are expected to be regenerated by the usual lupdate flow.

