### PR TITLE
fix(windows): clean up orphaned sync root registry entries

### DIFF
--- a/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
+++ b/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
@@ -56,76 +56,79 @@ void CloudProviderRegistrar::updateRegistrationWithShell(std::wstring &syncRootI
     HKEY hKey;
     std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID;
     TRACE_DEBUG(L"Provider already registered, opening key %s", subKey.c_str());
-    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
-        TRACE_DEBUG(L"Opened key %s", subKey.c_str());
-        if (namespaceCLSID) {
-            // Get CLSID
-            TRACE_DEBUG(L"Getting NamespaceCLSID value");
-            if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
-                ERROR_SUCCESS) {
-                TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
-            }
-        }
-        TRACE_DEBUG(L"Setting registry values");
-        // Set default key
-        if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
-                          (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
-            TRACE_ERROR(L"Could not set default registry value");
-        }
-
-        // Update AMUID key
-        std::wstring name(REGKEY_AUMID);
-        const std::wstring aumidValue = KDC_AUMID;
-        std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
-        updateRegistryEntry(hKey, name, value);
-
-        // Update IconResource
-        name = REGKEY_ICONRESOURCE;
-        WCHAR exePath[MAX_FULL_PATH];
-        if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
-            TRACE_ERROR(L"Error in GetModuleFileNameW");
-        }
-        value = exePath;
-        if (!value.empty()) {
-            updateRegistryEntry(hKey, name, value);
-        }
-
-        TRACE_DEBUG(L"Closing key %s", subKey.c_str());
-        if (RegCloseKey(hKey) != ERROR_SUCCESS) {
-            TRACE_ERROR(L"Could not close key %s", subKey.c_str());
-        }
-
-        if (namespaceCLSID) {
-            // Update DefaultIcon keys
-            struct RegKeyInfo {
-                    HKEY rootKey;
-                    std::wstring subKey;
-            };
-            std::vector<RegKeyInfo> regKeys = {
-                    {HKEY_CLASSES_ROOT,
-                     REGPATH_HKEY_CLASSES_ROOT_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
-                    {HKEY_CLASSES_ROOT, REGPATH_HKEY_CLASSES_ROOT_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                std::wstring(REGKEY_DEFAULTICON)},
-                    {HKEY_CURRENT_USER,
-                     REGPATH_HKEY_CURRENT_USER_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
-                    {HKEY_CURRENT_USER, REGPATH_HKEY_CURRENT_USER_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                std::wstring(REGKEY_DEFAULTICON)}};
-
-            for (const auto &regKeyInfo: regKeys) {
-                if (RegOpenKeyEx(regKeyInfo.rootKey, regKeyInfo.subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
-                    // Update DefaultIcon value
-                    updateRegistryEntry(hKey, L"", value);
-                    if (RegCloseKey(hKey) != ERROR_SUCCESS) {
-                        TRACE_ERROR(L"Could not close key %s", regKeyInfo.subKey.c_str());
-                    }
-                } else {
-                    TRACE_ERROR(L"Could not open key %s", regKeyInfo.subKey.c_str());
-                }
-            }
-        }
-
-    } else {
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) != ERROR_SUCCESS) {
         TRACE_ERROR(L"Could not open key %s", subKey.c_str());
+        return;
+    }
+
+    TRACE_DEBUG(L"Opened key %s", subKey.c_str());
+
+    if (namespaceCLSID) {
+        // Get CLSID
+        TRACE_DEBUG(L"Getting NamespaceCLSID value");
+        if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
+            ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
+        }
+    }
+
+    TRACE_DEBUG(L"Setting registry values");
+    // Set default key
+    if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
+                      (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
+        TRACE_ERROR(L"Could not set default registry value");
+    }
+
+    // Update AMUID key
+    std::wstring name(REGKEY_AUMID);
+    const std::wstring aumidValue = KDC_AUMID;
+    std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
+    updateRegistryEntry(hKey, name, value);
+
+    // Update IconResource
+    name = REGKEY_ICONRESOURCE;
+    WCHAR exePath[MAX_FULL_PATH];
+    if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
+        TRACE_ERROR(L"Error in GetModuleFileNameW");
+    }
+    value = exePath;
+    if (!value.empty()) {
+        updateRegistryEntry(hKey, name, value);
+    }
+
+    TRACE_DEBUG(L"Closing key %s", subKey.c_str());
+    if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+        TRACE_ERROR(L"Could not close key %s", subKey.c_str());
+    }
+
+    if (!namespaceCLSID) return;
+
+    // Update DefaultIcon keys
+    struct RegKeyInfo {
+            HKEY rootKey;
+            std::wstring subKey;
+    };
+    std::vector<RegKeyInfo> regKeys = {
+            {HKEY_CLASSES_ROOT,
+             REGPATH_HKEY_CLASSES_ROOT_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
+            {HKEY_CLASSES_ROOT,
+             REGPATH_HKEY_CLASSES_ROOT_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
+            {HKEY_CURRENT_USER,
+             REGPATH_HKEY_CURRENT_USER_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
+            {HKEY_CURRENT_USER,
+             REGPATH_HKEY_CURRENT_USER_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)}};
+
+    for (const auto &regKeyInfo: regKeys) {
+        if (RegOpenKeyEx(regKeyInfo.rootKey, regKeyInfo.subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not open key %s", regKeyInfo.subKey.c_str());
+            continue;
+        }
+
+        // Update DefaultIcon value
+        updateRegistryEntry(hKey, L"", value);
+        if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not close key %s", regKeyInfo.subKey.c_str());
+        }
     }
 }
 
@@ -232,8 +235,8 @@ bool CloudProviderRegistrar::createRegistrationWithShell(ProviderInfo *providerI
 
         TRACE_INFO(L"AUMID value: %s", aumidValue.c_str());
 
-        if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (BYTE *) value.c_str(), (DWORD) (value.size() + 1) * sizeof(wchar_t)) !=
-            ERROR_SUCCESS) {
+        if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (const BYTE *) value.c_str(),
+                          (DWORD) (value.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
             TRACE_ERROR(L"Could not set registry value %s=%s", name.c_str(), value.c_str());
         }
 
@@ -278,34 +281,36 @@ std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInf
             }
 
             /* ORPHANED REGISTRY ENTRIES CLEANUP
-            *
-            * Problem:
-            * Orphaned sync root entries can remain in the Windows registry when:
-            *   1. During uninstallation, only the current user's sync roots are removed. Other users' LiteSync
-            *      roots remain in the registry.
-            *   2. If a user manually deletes the application database (%localappdata%/kDrive/parms.db), sync
-            *      roots are never cleaned up from the registry.
-            *
-            * Impact:
-            * A sync root is identified by its syncDbID, driveId, and Windows user SID. These orphaned entries
-            * cause problems when the user later tries to sync the same drive to a different location. The
-            * Windows API returns an error indicating the new folder is not a cloud sync root, because a registry
-            * entry already exists with the same ID but a different path.
-            *
-            * Reproduction steps:
-            *   1. Create a LiteSync synchronization.
-            *   2. Close the app and delete parms.db.
-            *   3. Try to create a new LiteSync synchronization.
-            *   4. The sync fails to start.
-            *
-            * Solution:
-            * On sync registration, verify that the registered path matches the current path. If they differ,
-            * unregister the old sync root before registering the new one.
-            */
+             *
+             * Problem:
+             * Orphaned sync root entries can remain in the Windows registry when:
+             *   1. During uninstallation, only the current user's sync roots are removed. Other users' LiteSync
+             *      roots remain in the registry.
+             *   2. If a user manually deletes the application database (%localappdata%/kDrive/parms.db), sync
+             *      roots are never cleaned up from the registry.
+             *
+             * Impact:
+             * A sync root is identified by its syncDbID, driveId, and Windows user SID. These orphaned entries
+             * cause problems when the user later tries to sync the same drive to a different location. The
+             * Windows API returns an error indicating the new folder is not a cloud sync root, because a registry
+             * entry already exists with the same ID but a different path.
+             *
+             * Reproduction steps:
+             *   1. Create a LiteSync synchronization.
+             *   2. Close the app and delete parms.db.
+             *   3. Try to create a new LiteSync synchronization.
+             *   4. The sync fails to start.
+             *
+             * Solution:
+             * On sync registration, verify that the registered path matches the current path. If they differ,
+             * unregister the old sync root before registering the new one.
+             */
 
             TRACE_INFO(L"Sync root path has changed from %s to %s, unregistering previous sync root before registering new one",
                        previousPath.c_str(), currentPath.c_str());
-            unregister(syncRootID);
+            if (!unregister(syncRootID)) {
+                TRACE_ERROR(L"Could not unregister previous sync root with ID: %s", syncRootID.c_str());
+            }
         }
 
         if (!createRegistrationWithShell(providerInfo, syncRootID, namespaceCLSID, namespaceCLSIDSize)) {
@@ -370,8 +375,8 @@ std::wstring CloudProviderRegistrar::getSyncRootId(const ProviderInfo *providerI
 
 
 std::filesystem::path CloudProviderRegistrar::getSyncRootPath(const std::wstring &syncRootID) {
-    HKEY hKey;
-    std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID + L"\\" + REGKEY_USERSYNCROOTS;
+    HKEY hKey = nullptr;
+    const std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID + L"\\" + REGKEY_USERSYNCROOTS;
 
     if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
         TRACE_ERROR(L"Could not open key %s", subKey.c_str());
@@ -381,15 +386,15 @@ std::filesystem::path CloudProviderRegistrar::getSyncRootPath(const std::wstring
     std::filesystem::path syncRootPath;
 
     DWORD index = 0;
-    wchar_t valueName[128];
-    BYTE data[65534]; // Maximum path length in Windows is 32,767 characters (wchar are 2 bytes long)
+    wchar_t valueName[128] = {0};
+    BYTE data[65534] = {0}; // Maximum path length in Windows is 32,767 characters (wchar are 2 bytes long)
 
     while (true) {
         DWORD valueNameSize = std::size(valueName);
         DWORD dataSize = sizeof(data);
         DWORD type = 0; // REG_SZ
 
-        LONG result = RegEnumValueW(hKey, index++, valueName, &valueNameSize, nullptr, &type, data, &dataSize);
+        const LONG result = RegEnumValueW(hKey, index++, valueName, &valueNameSize, nullptr, &type, data, &dataSize);
 
         if (result == ERROR_NO_MORE_ITEMS) {
             TRACE_ERROR(L"The provided sync root ID %s does not have any path set", syncRootID.c_str());
@@ -407,7 +412,7 @@ std::filesystem::path CloudProviderRegistrar::getSyncRootPath(const std::wstring
         if (type != REG_SZ) continue;
 
 
-        syncRootPath.assign(reinterpret_cast<wchar_t *>(data));
+        (void) syncRootPath.assign(reinterpret_cast<wchar_t *>(data));
 
         if (!syncRootPath.has_root_path()) {
             TRACE_WARNING(L"Found a non path value in %s, this is not expected, continuing enumeration", subKey);
@@ -415,7 +420,6 @@ std::filesystem::path CloudProviderRegistrar::getSyncRootPath(const std::wstring
         }
 
         TRACE_DEBUG(L"Found sync root path %s", syncRootPath.c_str());
-        break;
     }
 
     TRACE_DEBUG(L"Closing key %s", subKey.c_str());

--- a/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
+++ b/extensions/windows/cfapi/Vfs/cloudproviderregistrar.cpp
@@ -38,6 +38,7 @@ using namespace Windows::Security::Cryptography;
 #define REGPATH_HKEY_CURRENT_USER_WOW6432_CLSID L"Software\\Classes\\WOW6432Node\\CLSID\\"
 #define REGKEY_NAMESPACECLSID L"NamespaceCLSID"
 #define REGKEY_AUMID L"AUMID"
+#define REGKEY_USERSYNCROOTS L"UserSyncRoots"
 #define REGKEY_ICONRESOURCE L"IconResource"
 #define REGKEY_DEFAULTICON L"DefaultIcon"
 
@@ -48,6 +49,202 @@ void updateRegistryEntry(const HKEY &hKey, const std::wstring &name, const std::
         ERROR_SUCCESS) {
         TRACE_ERROR(L"Could not set registry value %s=%s", name.c_str(), value.c_str());
     }
+}
+
+void CloudProviderRegistrar::updateRegistrationWithShell(std::wstring &syncRootID, wchar_t *namespaceCLSID,
+                                                         DWORD *namespaceCLSIDSize) {
+    HKEY hKey;
+    std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID;
+    TRACE_DEBUG(L"Provider already registered, opening key %s", subKey.c_str());
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
+        TRACE_DEBUG(L"Opened key %s", subKey.c_str());
+        if (namespaceCLSID) {
+            // Get CLSID
+            TRACE_DEBUG(L"Getting NamespaceCLSID value");
+            if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
+                ERROR_SUCCESS) {
+                TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
+            }
+        }
+        TRACE_DEBUG(L"Setting registry values");
+        // Set default key
+        if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
+                          (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not set default registry value");
+        }
+
+        // Update AMUID key
+        std::wstring name(REGKEY_AUMID);
+        const std::wstring aumidValue = KDC_AUMID;
+        std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
+        updateRegistryEntry(hKey, name, value);
+
+        // Update IconResource
+        name = REGKEY_ICONRESOURCE;
+        WCHAR exePath[MAX_FULL_PATH];
+        if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
+            TRACE_ERROR(L"Error in GetModuleFileNameW");
+        }
+        value = exePath;
+        if (!value.empty()) {
+            updateRegistryEntry(hKey, name, value);
+        }
+
+        TRACE_DEBUG(L"Closing key %s", subKey.c_str());
+        if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not close key %s", subKey.c_str());
+        }
+
+        if (namespaceCLSID) {
+            // Update DefaultIcon keys
+            struct RegKeyInfo {
+                    HKEY rootKey;
+                    std::wstring subKey;
+            };
+            std::vector<RegKeyInfo> regKeys = {
+                    {HKEY_CLASSES_ROOT,
+                     REGPATH_HKEY_CLASSES_ROOT_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
+                    {HKEY_CLASSES_ROOT, REGPATH_HKEY_CLASSES_ROOT_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
+                                                std::wstring(REGKEY_DEFAULTICON)},
+                    {HKEY_CURRENT_USER,
+                     REGPATH_HKEY_CURRENT_USER_CLSID + std::wstring(namespaceCLSID) + L"\\" + std::wstring(REGKEY_DEFAULTICON)},
+                    {HKEY_CURRENT_USER, REGPATH_HKEY_CURRENT_USER_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
+                                                std::wstring(REGKEY_DEFAULTICON)}};
+
+            for (const auto &regKeyInfo: regKeys) {
+                if (RegOpenKeyEx(regKeyInfo.rootKey, regKeyInfo.subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
+                    // Update DefaultIcon value
+                    updateRegistryEntry(hKey, L"", value);
+                    if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+                        TRACE_ERROR(L"Could not close key %s", regKeyInfo.subKey.c_str());
+                    }
+                } else {
+                    TRACE_ERROR(L"Could not open key %s", regKeyInfo.subKey.c_str());
+                }
+            }
+        }
+
+    } else {
+        TRACE_ERROR(L"Could not open key %s", subKey.c_str());
+    }
+}
+
+bool CloudProviderRegistrar::createRegistrationWithShell(ProviderInfo *providerInfo, std::wstring &syncRootID,
+                                                         wchar_t *namespaceCLSID, DWORD *namespaceCLSIDSize) {
+    TRACE_DEBUG(L"Registering new provider");
+    if (!providerInfo->folderPath()) {
+        TRACE_ERROR(L"Folder path is empty");
+        return false;
+    }
+
+    if (!providerInfo->folderName()) {
+        TRACE_ERROR(L"Folder name is empty");
+        return false;
+    }
+
+    if (!providerInfo->id()) {
+        TRACE_ERROR(L"Sync root id is empty");
+        return false;
+    }
+
+    winrt::StorageProviderSyncRootInfo info;
+    info.Id(syncRootID);
+
+#ifndef NDEBUG
+    // Silent WINRT_ASSERT(!is_sta())
+    int reportMode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
+#endif
+    TRACE_DEBUG(L"Getting StorageFolder from path");
+    auto folder = winrt::StorageFolder::GetFolderFromPathAsync(providerInfo->folderPath()).get();
+#ifndef NDEBUG
+    // Restore old report mode
+    _CrtSetReportMode(_CRT_ASSERT, reportMode);
+#endif
+
+    info.Path(folder);
+
+    info.DisplayNameResource(providerInfo->folderName());
+
+    WCHAR exePath[MAX_FULL_PATH];
+    TRACE_DEBUG(L"Getting module file name for icon resource");
+    if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
+        TRACE_ERROR(L"Error in GetModuleFileNameW");
+        return false;
+    }
+    info.IconResource(exePath); // App icon
+
+    info.HydrationPolicy(winrt::StorageProviderHydrationPolicy::Full);
+    info.HydrationPolicyModifier(winrt::StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed);
+    info.PopulationPolicy(winrt::StorageProviderPopulationPolicy::AlwaysFull);
+    info.InSyncPolicy(winrt::StorageProviderInSyncPolicy::FileCreationTime |
+                      winrt::StorageProviderInSyncPolicy::DirectoryCreationTime);
+    info.Version(Utilities::s_version);
+    info.ShowSiblingsAsGroup(false);
+    info.HardlinkPolicy(winrt::StorageProviderHardlinkPolicy::None);
+
+    wchar_t uriStr[MAX_URI];
+    std::swprintf(uriStr, MAX_URI, Utilities::s_trashURI.c_str(), providerInfo->driveId());
+    info.RecycleBinUri(winrt::Uri(uriStr));
+
+    // Context
+    std::wstring syncRootIdentity(providerInfo->id());
+
+    TRACE_DEBUG(L"Converting sync root identity to binary");
+    winrt::IBuffer contextBuffer =
+            winrt::CryptographicBuffer::ConvertStringToBinary(syncRootIdentity.data(), winrt::BinaryStringEncoding::Utf8);
+    info.Context(contextBuffer);
+
+    if (!info.Path() || info.DisplayNameResource().empty() || info.Id().empty()) {
+        TRACE_ERROR(L"Invalid StorageProviderSyncRootInfo");
+        return false;
+    }
+
+    TRACE_DEBUG(L"Calling StorageProviderSyncRootManager::Register");
+    winrt::StorageProviderSyncRootManager::Register(info);
+    TRACE_DEBUG(L"Registered new provider with syncRootID=%s", syncRootID.c_str());
+    // Give the cache some time to invalidate
+    Sleep(1000);
+
+    HKEY hKey;
+    std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID;
+    TRACE_DEBUG(L"Opening key %s", subKey.c_str());
+    if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
+        TRACE_DEBUG(L"Opened key %s", subKey.c_str());
+        if (namespaceCLSID) {
+            TRACE_DEBUG(L"Getting NamespaceCLSID value");
+            // Get CLSID
+            if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
+                ERROR_SUCCESS) {
+                TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
+            }
+        }
+        TRACE_DEBUG(L"Setting registry values");
+        // Set default key
+        if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
+                          (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not set default registry value");
+        }
+
+        // Create AMUID key
+        const std::wstring name(REGKEY_AUMID);
+        const std::wstring aumidValue = KDC_AUMID;
+        const std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
+
+        TRACE_INFO(L"AUMID value: %s", aumidValue.c_str());
+
+        if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (BYTE *) value.c_str(), (DWORD) (value.size() + 1) * sizeof(wchar_t)) !=
+            ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not set registry value %s=%s", name.c_str(), value.c_str());
+        }
+
+        TRACE_DEBUG(L"Closing key %s", subKey.c_str());
+        if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not close key %s", subKey.c_str());
+        }
+    } else {
+        TRACE_ERROR(L"Could not open key %s", subKey.c_str());
+    }
+    return true;
 }
 
 std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInfo, wchar_t *namespaceCLSID,
@@ -73,196 +270,50 @@ std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInf
         }
 
         if (found) {
-            HKEY hKey;
-            std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID;
-            TRACE_DEBUG(L"Provider already registered, opening key %s", subKey.c_str());
-            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
-                TRACE_DEBUG(L"Opened key %s", subKey.c_str());
-                if (namespaceCLSID) {
-                    // Get CLSID
-                    TRACE_DEBUG(L"Getting NamespaceCLSID value");
-                    if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
-                        ERROR_SUCCESS) {
-                        TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
-                    }
-                }
-                TRACE_DEBUG(L"Setting registry values");
-                // Set default key
-                if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
-                                  (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
-                    TRACE_ERROR(L"Could not set default registry value");
-                }
-
-                // Update AMUID key
-                std::wstring name(REGKEY_AUMID);
-                const std::wstring aumidValue = KDC_AUMID;
-                std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
-                updateRegistryEntry(hKey, name, value);
-
-                // Update IconResource
-                name = REGKEY_ICONRESOURCE;
-                WCHAR exePath[MAX_FULL_PATH];
-                if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
-                    TRACE_ERROR(L"Error in GetModuleFileNameW");
-                }
-                value = exePath;
-                if (!value.empty()) {
-                    updateRegistryEntry(hKey, name, value);
-                }
-
-                TRACE_DEBUG(L"Closing key %s", subKey.c_str());
-                if (RegCloseKey(hKey) != ERROR_SUCCESS) {
-                    TRACE_ERROR(L"Could not close key %s", subKey.c_str());
-                }
-
-                if (namespaceCLSID) {
-                    // Update DefaultIcon keys
-                    struct RegKeyInfo {
-                            HKEY rootKey;
-                            std::wstring subKey;
-                    };
-                    std::vector<RegKeyInfo> regKeys = {
-                            {HKEY_CLASSES_ROOT, REGPATH_HKEY_CLASSES_ROOT_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                        std::wstring(REGKEY_DEFAULTICON)},
-                            {HKEY_CLASSES_ROOT, REGPATH_HKEY_CLASSES_ROOT_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                        std::wstring(REGKEY_DEFAULTICON)},
-                            {HKEY_CURRENT_USER, REGPATH_HKEY_CURRENT_USER_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                        std::wstring(REGKEY_DEFAULTICON)},
-                            {HKEY_CURRENT_USER, REGPATH_HKEY_CURRENT_USER_WOW6432_CLSID + std::wstring(namespaceCLSID) + L"\\" +
-                                                        std::wstring(REGKEY_DEFAULTICON)}};
-
-                    for (const auto &regKeyInfo: regKeys) {
-                        if (RegOpenKeyEx(regKeyInfo.rootKey, regKeyInfo.subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) ==
-                            ERROR_SUCCESS) {
-                            // Update DefaultIcon value
-                            updateRegistryEntry(hKey, L"", value);
-                            if (RegCloseKey(hKey) != ERROR_SUCCESS) {
-                                TRACE_ERROR(L"Could not close key %s", regKeyInfo.subKey.c_str());
-                            }
-                        } else {
-                            TRACE_ERROR(L"Could not open key %s", regKeyInfo.subKey.c_str());
-                        }
-                    }
-                }
-
-            } else {
-                TRACE_ERROR(L"Could not open key %s", subKey.c_str());
-            }
-        } else {
-            TRACE_DEBUG(L"Registering new provider");
-            if (!providerInfo->folderPath()) {
-                TRACE_ERROR(L"Folder path is empty");
-                return std::wstring();
+            std::filesystem::path previousPath = getSyncRootPath(syncRootID);
+            std::filesystem::path currentPath = providerInfo->folderPath();
+            if (currentPath.lexically_normal() == previousPath.lexically_normal()) {
+                updateRegistrationWithShell(syncRootID, namespaceCLSID, namespaceCLSIDSize);
+                return syncRootID;
             }
 
-            if (!providerInfo->folderName()) {
-                TRACE_ERROR(L"Folder name is empty");
-                return std::wstring();
-            }
+            /* ORPHANED REGISTRY ENTRIES CLEANUP
+            *
+            * Problem:
+            * Orphaned sync root entries can remain in the Windows registry when:
+            *   1. During uninstallation, only the current user's sync roots are removed. Other users' LiteSync
+            *      roots remain in the registry.
+            *   2. If a user manually deletes the application database (%localappdata%/kDrive/parms.db), sync
+            *      roots are never cleaned up from the registry.
+            *
+            * Impact:
+            * A sync root is identified by its syncDbID, driveId, and Windows user SID. These orphaned entries
+            * cause problems when the user later tries to sync the same drive to a different location. The
+            * Windows API returns an error indicating the new folder is not a cloud sync root, because a registry
+            * entry already exists with the same ID but a different path.
+            *
+            * Reproduction steps:
+            *   1. Create a LiteSync synchronization.
+            *   2. Close the app and delete parms.db.
+            *   3. Try to create a new LiteSync synchronization.
+            *   4. The sync fails to start.
+            *
+            * Solution:
+            * On sync registration, verify that the registered path matches the current path. If they differ,
+            * unregister the old sync root before registering the new one.
+            */
 
-            if (!providerInfo->id()) {
-                TRACE_ERROR(L"Sync root id is empty");
-                return std::wstring();
-            }
-
-            winrt::StorageProviderSyncRootInfo info;
-            info.Id(syncRootID);
-
-#ifndef NDEBUG
-            // Silent WINRT_ASSERT(!is_sta())
-            int reportMode = _CrtSetReportMode(_CRT_ASSERT, _CRTDBG_MODE_DEBUG);
-#endif
-            TRACE_DEBUG(L"Getting StorageFolder from path");
-            auto folder = winrt::StorageFolder::GetFolderFromPathAsync(providerInfo->folderPath()).get();
-#ifndef NDEBUG
-            // Restore old report mode
-            _CrtSetReportMode(_CRT_ASSERT, reportMode);
-#endif
-
-            info.Path(folder);
-
-            info.DisplayNameResource(providerInfo->folderName());
-
-            WCHAR exePath[MAX_FULL_PATH];
-            TRACE_DEBUG(L"Getting module file name for icon resource");
-            if (!GetModuleFileNameW(nullptr, exePath, MAX_FULL_PATH)) {
-                TRACE_ERROR(L"Error in GetModuleFileNameW");
-                return std::wstring();
-            }
-            info.IconResource(exePath); // App icon
-
-            info.HydrationPolicy(winrt::StorageProviderHydrationPolicy::Full);
-            info.HydrationPolicyModifier(winrt::StorageProviderHydrationPolicyModifier::AutoDehydrationAllowed);
-            info.PopulationPolicy(winrt::StorageProviderPopulationPolicy::AlwaysFull);
-            info.InSyncPolicy(winrt::StorageProviderInSyncPolicy::FileCreationTime |
-                              winrt::StorageProviderInSyncPolicy::DirectoryCreationTime);
-            info.Version(Utilities::s_version);
-            info.ShowSiblingsAsGroup(false);
-            info.HardlinkPolicy(winrt::StorageProviderHardlinkPolicy::None);
-
-            wchar_t uriStr[MAX_URI];
-            std::swprintf(uriStr, MAX_URI, Utilities::s_trashURI.c_str(), providerInfo->driveId());
-            info.RecycleBinUri(winrt::Uri(uriStr));
-
-            // Context
-            std::wstring syncRootIdentity(providerInfo->id());
-
-            TRACE_DEBUG(L"Converting sync root identity to binary");
-            winrt::IBuffer contextBuffer =
-                    winrt::CryptographicBuffer::ConvertStringToBinary(syncRootIdentity.data(), winrt::BinaryStringEncoding::Utf8);
-            info.Context(contextBuffer);
-
-            if (!info.Path() || info.DisplayNameResource().empty() || info.Id().empty()) {
-                TRACE_ERROR(L"Invalid StorageProviderSyncRootInfo");
-                return std::wstring();
-            }
-
-            TRACE_DEBUG(L"Calling StorageProviderSyncRootManager::Register");
-            winrt::StorageProviderSyncRootManager::Register(info);
-            TRACE_DEBUG(L"Registered new provider with syncRootID=%s", syncRootID.c_str());
-            // Give the cache some time to invalidate
-            Sleep(1000);
-
-            HKEY hKey;
-            std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID;
-            TRACE_DEBUG(L"Opening key %s", subKey.c_str());
-            if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_ALL_ACCESS, &hKey) == ERROR_SUCCESS) {
-                TRACE_DEBUG(L"Opened key %s", subKey.c_str());
-                if (namespaceCLSID) {
-                    TRACE_DEBUG(L"Getting NamespaceCLSID value");
-                    // Get CLSID
-                    if (RegGetValue(hKey, 0, REGKEY_NAMESPACECLSID, RRF_RT_ANY, nullptr, namespaceCLSID, namespaceCLSIDSize) !=
-                        ERROR_SUCCESS) {
-                        TRACE_ERROR(L"Could not get registry value NamespaceCLSID");
-                    }
-                }
-                TRACE_DEBUG(L"Setting registry values");
-                // Set default key
-                if (RegSetValueEx(hKey, nullptr, 0, REG_SZ, (BYTE *) Utilities::s_appName.c_str(),
-                                  (DWORD) (Utilities::s_appName.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
-                    TRACE_ERROR(L"Could not set default registry value");
-                }
-
-                // Create AMUID key
-                const std::wstring name(REGKEY_AUMID);
-                const std::wstring aumidValue = KDC_AUMID;
-                const std::wstring value = L"Infomaniak.kDrive.Extension_" + aumidValue + L"!App";
-
-                TRACE_INFO(L"AUMID value: %s", aumidValue.c_str());
-
-                if (RegSetValueEx(hKey, name.c_str(), 0, REG_SZ, (BYTE *) value.c_str(),
-                                  (DWORD) (value.size() + 1) * sizeof(wchar_t)) != ERROR_SUCCESS) {
-                    TRACE_ERROR(L"Could not set registry value %s=%s", name.c_str(), value.c_str());
-                }
-
-                TRACE_DEBUG(L"Closing key %s", subKey.c_str());
-                if (RegCloseKey(hKey) != ERROR_SUCCESS) {
-                    TRACE_ERROR(L"Could not close key %s", subKey.c_str());
-                }
-            } else {
-                TRACE_ERROR(L"Could not open key %s", subKey.c_str());
-            }
+            TRACE_INFO(L"Sync root path has changed from %s to %s, unregistering previous sync root before registering new one",
+                       previousPath.c_str(), currentPath.c_str());
+            unregister(syncRootID);
         }
+
+        if (!createRegistrationWithShell(providerInfo, syncRootID, namespaceCLSID, namespaceCLSIDSize)) {
+            TRACE_ERROR(L"Could not create registration with shell");
+            return std::wstring();
+        }
+
+        return syncRootID;
     } catch (winrt::hresult_error const &ex) {
         TRACE_ERROR(L"Could not register the sync root, hr %08x - %s", static_cast<HRESULT>(winrt::to_hresult()),
                     ex.message().c_str());
@@ -271,8 +322,6 @@ std::wstring CloudProviderRegistrar::registerWithShell(ProviderInfo *providerInf
         TRACE_ERROR(L"Could not register the sync root, %ls", Utilities::utf8ToUtf16(ex.what()).c_str());
         return std::wstring();
     }
-
-    return syncRootID;
 }
 
 bool CloudProviderRegistrar::unregister(std::wstring syncRootID) {
@@ -317,6 +366,65 @@ std::wstring CloudProviderRegistrar::getSyncRootId(const ProviderInfo *providerI
     syncRootID.append(providerInfo->userId());
 
     return syncRootID;
+}
+
+
+std::filesystem::path CloudProviderRegistrar::getSyncRootPath(const std::wstring &syncRootID) {
+    HKEY hKey;
+    std::wstring subKey = REGPATH_SYNCROOTMANAGER + syncRootID + L"\\" + REGKEY_USERSYNCROOTS;
+
+    if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, subKey.c_str(), 0, KEY_READ, &hKey) != ERROR_SUCCESS) {
+        TRACE_ERROR(L"Could not open key %s", subKey.c_str());
+        return {};
+    }
+
+    std::filesystem::path syncRootPath;
+
+    DWORD index = 0;
+    wchar_t valueName[128];
+    BYTE data[65534]; // Maximum path length in Windows is 32,767 characters (wchar are 2 bytes long)
+
+    while (true) {
+        DWORD valueNameSize = std::size(valueName);
+        DWORD dataSize = sizeof(data);
+        DWORD type = 0; // REG_SZ
+
+        LONG result = RegEnumValueW(hKey, index++, valueName, &valueNameSize, nullptr, &type, data, &dataSize);
+
+        if (result == ERROR_NO_MORE_ITEMS) {
+            TRACE_ERROR(L"The provided sync root ID %s does not have any path set", syncRootID.c_str());
+            break;
+        }
+
+        if (result != ERROR_SUCCESS) {
+            TRACE_ERROR(L"Could not enumerate registry value under %s", subKey.c_str());
+            continue;
+        }
+
+        // Skip default value
+        if (valueNameSize == 0) continue;
+
+        if (type != REG_SZ) continue;
+
+
+        syncRootPath.assign(reinterpret_cast<wchar_t *>(data));
+
+        if (!syncRootPath.has_root_path()) {
+            TRACE_WARNING(L"Found a non path value in %s, this is not expected, continuing enumeration", subKey);
+            continue;
+        }
+
+        TRACE_DEBUG(L"Found sync root path %s", syncRootPath.c_str());
+        break;
+    }
+
+    TRACE_DEBUG(L"Closing key %s", subKey.c_str());
+
+    if (RegCloseKey(hKey) != ERROR_SUCCESS) {
+        TRACE_ERROR(L"Could not close key %s", subKey.c_str());
+    }
+
+    return syncRootPath;
 }
 
 winrt::com_array<wchar_t> CloudProviderRegistrar::convertSidToStringSid(PSID sid) {

--- a/extensions/windows/cfapi/Vfs/cloudproviderregistrar.h
+++ b/extensions/windows/cfapi/Vfs/cloudproviderregistrar.h
@@ -23,6 +23,7 @@
 
 #include <sddl.h>
 #include <winrt\base.h>
+#include <filesystem>
 
 class CloudProviderRegistrar {
     public:
@@ -32,6 +33,11 @@ class CloudProviderRegistrar {
     private:
         static std::unique_ptr<TOKEN_USER> getTokenInformation();
         static std::wstring getSyncRootId(const ProviderInfo *providerInfo);
+        static std::filesystem::path getSyncRootPath(const std::wstring &syncRootID);
+        static void updateRegistrationWithShell(std::wstring &syncRootID, wchar_t *namespaceCLSID, DWORD *namespaceCLSIDSize);
+        static bool createRegistrationWithShell(ProviderInfo *providerInfo, std::wstring &syncRootID, wchar_t *namespaceCLSID,
+                                                DWORD *namespaceCLSIDSize);
+
         /*static void addCustomState(
             _In_ winrt::IVector<winrt::StorageProviderItemPropertyDefinition> &customStates,
             _In_ LPCWSTR displayNameResource,


### PR DESCRIPTION
# Fix orphaned LiteSync registry entries 

## Problem

Orphaned Windows Sync Root registry entries can remain in the system in two situations:

1. **Application uninstallation**

   * Only the current user's sync roots are removed.
   * LiteSync roots registered for other Windows users remain in the registry.

2. **Manual database deletion**

   * If `%LOCALAPPDATA%\kDrive\parms.db` is deleted manually, the associated sync roots are never unregistered.

## Impact

A LiteSync root is uniquely identified by:

* `syncDbID`
* `driveId`
* Windows user `SID`

When an orphaned entry exists, creating a new synchronization for the same drive in a different location fails. Windows still associates the existing Sync Root ID with the old path and returns an error indicating that the new folder is not a valid cloud sync root.

## Reproduction

1. Create a LiteSync synchronization.
2. Close kDrive.
3. Delete `%LOCALAPPDATA%\kDrive\parms.db`.
4. Start kDrive and attempt to create a new LiteSync synchronization.
5. The synchronization fails to start.

## Solution

During Sync Root registration:

* Check whether a Sync Root with the same ID is already registered.
* Verify that the registered path matches the expected path.
* If the paths differ:

  1. Unregister the stale Sync Root.
  2. Register the new Sync Root.

This automatically recovers from orphaned registry entries and allows recreating synchronizations without requiring manual registry cleanup.

## Refactoring

As part of this change, the `registerWithShell()` method has been split into smaller, more focused methods:

* `registerWithShell()`
* `updateRegistrationWithShell()`
* `createRegistrationWithShell()`

This makes the registration flow easier to understand and separates the update and creation paths.
