### PR TITLE
fix(server): stop OldCommServer worker thread at shutdown

### DIFF
--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -541,6 +541,12 @@ void AppServer::cleanup() {
         LOG_DEBUG(_logger, "CommManager stopped");
     }
 
+    // Stop OldCommServer worker thread
+    if (useOldCommServer()) {
+        OldCommServer::instance()->stop();
+        LOG_DEBUG(_logger, "OldCommServer stopped");
+    }
+
     // Stop JobManager(s)
     GuiJobManagerSingleton::instance()->stop();
     LOG_DEBUG(_logger, "GuiJobManager stopped");
@@ -572,6 +578,11 @@ void AppServer::cleanup() {
     ExtJobManagerSingleton::clear();
     LOG_DEBUG(_logger, "ExtJobManager::clear() done");
 #endif
+
+    // Destroy the update manager while the Qt event loop is still alive and after the SyncJobManager running its network
+    // jobs is cleared. Otherwise it is destroyed during static destruction after ~AppServer, crashing at shutdown.
+    reset();
+    LOG_DEBUG(_logger, "UpdateManager destroyed");
 
     // Clear maps
     {

--- a/src/server/comm/oldcommserver.cpp
+++ b/src/server/comm/oldcommserver.cpp
@@ -53,12 +53,7 @@ std::shared_ptr<OldCommServer> OldCommServer::instance(QObject *parent) {
 
 OldCommServer::OldCommServer(QObject *parent) :
     QObject(parent),
-    _requestWorkerThread(new QtLoggingThread()),
-    _requestWorker(new Worker()),
-    _tcpSocket(nullptr),
-    _buffer(QByteArray()),
-    _hasQuittedProperly(false),
-    _stopping(false) {
+    _requestWorker(new Worker()) {
     // Start worker thread
     _requestWorker->moveToThread(_requestWorkerThread);
     connect(_requestWorkerThread, &QThread::started, _requestWorker, &Worker::onStart);

--- a/src/server/comm/oldcommserver.cpp
+++ b/src/server/comm/oldcommserver.cpp
@@ -28,6 +28,7 @@
 #include <QJsonDocument>
 #include <QJsonParseError>
 #include <QJsonObject>
+#include <QThread>
 #include <QTimer>
 
 #include <fstream>
@@ -56,7 +57,8 @@ OldCommServer::OldCommServer(QObject *parent) :
     _requestWorker(new Worker()),
     _tcpSocket(nullptr),
     _buffer(QByteArray()),
-    _hasQuittedProperly(false) {
+    _hasQuittedProperly(false),
+    _stopping(false) {
     // Start worker thread
     _requestWorker->moveToThread(_requestWorkerThread);
     connect(_requestWorkerThread, &QThread::started, _requestWorker, &Worker::onStart);
@@ -89,18 +91,43 @@ OldCommServer::~OldCommServer() {
 }
 
 void OldCommServer::stop() {
+    if (_stopping) {
+        return;
+    }
+
+    _stopping = true;
+
+    if (_tcpSocket) {
+        disconnect(_tcpSocket, nullptr, this, nullptr);
+        if (_tcpSocket->isOpen()) {
+            _tcpSocket->close();
+        }
+        _tcpSocket->deleteLater();
+        _tcpSocket = nullptr;
+    }
+
+    _tcpServer.close();
+    _buffer.clear();
+
     // Break out of Worker::onStart, then quit and join the worker thread. Without this the thread outlives shutdown.
     if (_requestWorker) {
         _requestWorker->stop();
     }
     if (_requestWorkerThread) {
         _requestWorkerThread->quit();
-        _requestWorkerThread->wait();
+        if (_requestWorkerThread == QThread::currentThread()) {
+            LOG_WARN(Log::instance()->getLogger(), "Skipping OldCommServer worker self-wait");
+        } else if (!_requestWorkerThread->wait(5000)) {
+            LOG_WARN(Log::instance()->getLogger(), "OldCommServer worker thread did not stop within timeout");
+        } else {
+            _requestWorkerThread = nullptr;
+            _requestWorker = nullptr;
+        }
     }
 }
 
 void OldCommServer::sendReply(int id, const QByteArray &result) {
-    if (_tcpSocket && _tcpSocket->isOpen()) {
+    if (!_stopping && _tcpSocket && _tcpSocket->isOpen()) {
         _requestWorker->addReply(id, result);
     }
 }
@@ -111,7 +138,7 @@ bool OldCommServer::sendSignal(const SignalNum num, const QByteArray &params) {
 }
 
 bool OldCommServer::sendSignal(SignalNum num, const QByteArray &params, int &id) {
-    if (_tcpSocket && _tcpSocket->isOpen()) {
+    if (!_stopping && _tcpSocket && _tcpSocket->isOpen()) {
         _requestWorker->addSignal(num, params, id);
         return true;
     }
@@ -119,6 +146,11 @@ bool OldCommServer::sendSignal(SignalNum num, const QByteArray &params, int &id)
 }
 
 void OldCommServer::start() {
+    if (_stopping) {
+        LOG_DEBUG(Log::instance()->getLogger(), "Ignoring OldCommServer start request during shutdown");
+        return;
+    }
+
     // (Re)start tcp server
     if (_tcpServer.isListening()) {
         _tcpServer.close();
@@ -141,6 +173,10 @@ void OldCommServer::start() {
 }
 
 void OldCommServer::onNewConnection() {
+    if (_stopping) {
+        return;
+    }
+
     LOG_DEBUG(Log::instance()->getLogger(), "New connection");
 
     if (_tcpSocket) {
@@ -169,6 +205,10 @@ void OldCommServer::onBytesWritten(qint64 numBytes) {
 }
 
 void OldCommServer::onReadyRead() {
+    if (_stopping) {
+        return;
+    }
+
     while (_tcpSocket && _tcpSocket->bytesAvailable() > 0) {
         // Read from socket
         _buffer.append(_tcpSocket->readAll());
@@ -221,6 +261,10 @@ void OldCommServer::onReadyRead() {
 
 void OldCommServer::onErrorOccurred(QAbstractSocket::SocketError socketError) {
     QTcpSocket *socket = reinterpret_cast<QTcpSocket *>(sender());
+
+    if (_stopping) {
+        return;
+    }
 
     if (!_hasQuittedProperly) {
         LOG_WARN(Log::instance()->getLogger(),
@@ -419,6 +463,7 @@ void Worker::onStart() {
     }
 
     LOG_DEBUG(Log::instance()->getLogger(), "Worker ended");
+    emit finished();
 }
 
 } // namespace KDC

--- a/src/server/comm/oldcommserver.cpp
+++ b/src/server/comm/oldcommserver.cpp
@@ -88,6 +88,17 @@ OldCommServer::~OldCommServer() {
     _instance = nullptr;
 }
 
+void OldCommServer::stop() {
+    // Break out of Worker::onStart, then quit and join the worker thread. Without this the thread outlives shutdown.
+    if (_requestWorker) {
+        _requestWorker->stop();
+    }
+    if (_requestWorkerThread) {
+        _requestWorkerThread->quit();
+        _requestWorkerThread->wait();
+    }
+}
+
 void OldCommServer::sendReply(int id, const QByteArray &result) {
     if (_tcpSocket && _tcpSocket->isOpen()) {
         _requestWorker->addReply(id, result);

--- a/src/server/comm/oldcommserver.h
+++ b/src/server/comm/oldcommserver.h
@@ -74,6 +74,7 @@ class OldCommServer : public QObject {
         QByteArray _buffer;
 
         bool _hasQuittedProperly;
+        bool _stopping;
 
         explicit OldCommServer(QObject *parent = nullptr);
 

--- a/src/server/comm/oldcommserver.h
+++ b/src/server/comm/oldcommserver.h
@@ -67,14 +67,14 @@ class OldCommServer : public QObject {
 
     private:
         static std::shared_ptr<OldCommServer> _instance;
-        QtLoggingThread *_requestWorkerThread;
+        QtLoggingThread *_requestWorkerThread = new QtLoggingThread();
         Worker *_requestWorker;
         QTcpServer _tcpServer;
-        QTcpSocket *_tcpSocket;
-        QByteArray _buffer;
+        QTcpSocket *_tcpSocket = nullptr;
+        QByteArray _buffer = QByteArray();
 
-        bool _hasQuittedProperly;
-        bool _stopping;
+        bool _hasQuittedProperly = false;
+        bool _stopping = false;
 
         explicit OldCommServer(QObject *parent = nullptr);
 

--- a/src/server/comm/oldcommserver.h
+++ b/src/server/comm/oldcommserver.h
@@ -53,6 +53,9 @@ class OldCommServer : public QObject {
         bool hasQuittedProperly() const { return _hasQuittedProperly; }
 
         void start();
+        // Stop and join the request worker thread. Must be called at shutdown, otherwise the thread stays blocked in
+        // Worker::onStart and outlives the app, racing with static destruction (intermittent SIGSEGV at exit).
+        void stop();
         inline bool isListening() { return _tcpServer.isListening(); }
         bool hasActiveConnexion() const {
             return _tcpSocket != nullptr && _tcpSocket->state() == QAbstractSocket::ConnectedState && _tcpSocket->isValid();


### PR DESCRIPTION
This pull request improves the shutdown procedure of the application by ensuring that background worker threads, particularly those associated with the `OldCommServer`, are properly stopped and cleaned up. This prevents intermittent crashes and resource leaks during application exit. Additionally, it ensures that the update manager is destroyed at the correct time to avoid shutdown-related crashes.

Shutdown and thread management improvements:

* Added a `stop()` method to `OldCommServer` that cleanly stops and joins the request worker thread, preventing the thread from outliving the application and causing race conditions or crashes at shutdown. (`src/server/comm/oldcommserver.cpp`, `src/server/comm/oldcommserver.h`) [[1]](diffhunk://#diff-88448ff60ec84d9a03ef3738e97e0e4f86cc33d84e7f2b647d646f858169deaeR91-R101) [[2]](diffhunk://#diff-6f1ba3cfe7cc7088b8f131e4bddebab04cf9fe60918e918ae295ac260ed82d24R56-R58)
* Updated `AppServer::cleanup()` to call `OldCommServer::stop()` if the old communication server is in use, ensuring its worker thread is stopped before shutdown. (`src/server/appserver.cpp`)

Resource destruction timing:

* Modified `AppServer::cleanup()` to explicitly destroy the update manager (`reset()`) after network jobs are cleared but before the Qt event loop ends, preventing crashes due to destruction order at shutdown. (`src/server/appserver.cpp`)