### PR TITLE
fix(Onboarding): Improve onboarding flow

### DIFF
--- a/src/gui4/macOS/kDrive/AppDelegate.swift
+++ b/src/gui4/macOS/kDrive/AppDelegate.swift
@@ -25,6 +25,7 @@ import kDriveResources
 final class AppDelegate: NSObject, NSApplicationDelegate {
     private lazy var mainWindow = MainWindowController()
     private var preferencesWindow: PreferencesWindowController?
+    private var onboardingWindow: OnboardingWindowController?
 
     // periphery:ignore - We keep a strong reference on the statusBarManager
     private(set) var statusBarManager: StatusBarManager?
@@ -112,6 +113,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         preferencesWindow?.window?.makeKeyAndOrderFront(nil)
         preferencesWindow?.window?.isReleasedWhenClosed = false
+    }
+
+    func openOnboardingWindow() {
+        if onboardingWindow == nil {
+            let controller = OnboardingWindowController()
+            controller.onClose = { [weak self] in
+                self?.onboardingWindow = nil
+            }
+            onboardingWindow = controller
+        }
+
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        onboardingWindow?.window?.makeKeyAndOrderFront(nil)
     }
 
     @objc func quitApp() {

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewController.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewController.swift
@@ -179,7 +179,7 @@ extension DriveSelectionViewController {
             if !isSynchronized {
                 drivesListView.cells[singleDrive.id]?.state = .on
                 drivesListView.cells[singleDrive.id]?.isEnabled = false
-                viewModel.toggleDriveSelection(singleDrive)
+                viewModel.selectDrive(singleDrive)
             }
         }
 

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
@@ -23,6 +23,7 @@ import InfomaniakConcurrency
 import InfomaniakDI
 import kDriveCore
 import kDriveCoreUI
+import OrderedCollections
 
 @MainActor
 final class DriveSelectionViewModel: ObservableObject {
@@ -62,20 +63,31 @@ final class DriveSelectionViewModel: ObservableObject {
     }
 
     private func observeAvailableDrives() {
+        let currentUserDbId = flowCoordinator.currentUser?.dbId
+
         coherentCacheObservable.usersPublisher.allAvailableDrivesPublisher()
-            .map { $0.map { UIAvailableDrive(availableDrive: $0.availableDrive) } }
+            .map { availableDriveContexts in
+                availableDriveContexts
+                    .filter { Int($0.user.dbId) == currentUserDbId }
+                    .map { UIAvailableDrive(availableDrive: $0.availableDrive) }
+                    .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            }
+            .removeDuplicates()
             .receiveOnMain(store: &bindStore) { [weak self] availableDrives in
-                self?.availableDrives = availableDrives.sorted {
-                    return $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending
-                }
+                self?.availableDrives = availableDrives
                 self?.generateConfigurations(for: availableDrives)
             }
     }
 
     private func observeSynchronizedDrives() {
+        let currentUserDbId = flowCoordinator.currentUser?.dbId
+
         coherentCacheObservable.usersPublisher.allDrivesPublisher()
-            .map { $0.map { UIDrive(drive: $0.drive) } }
-            .removeDuplicates()
+            .map { driveContexts in
+                driveContexts
+                    .filter { Int($0.user.dbId) == currentUserDbId && !$0.drive.synchros.isEmpty }
+                    .map { UIDrive(drive: $0.drive) }
+            }
             .receiveOnMain(store: &bindStore) { [weak self] synchronizedDrives in
                 self?.synchronizedDrives = synchronizedDrives
             }
@@ -89,6 +101,11 @@ final class DriveSelectionViewModel: ObservableObject {
 
         _ = try await DriveJobs().availableDrives(userDbId: Int32(user.dbId))
         _ = try await SyncJobs().availableSync()
+    }
+
+    func selectDrive(_ drive: UIAvailableDrive) {
+        guard !selectedDrives.contains(drive) else { return }
+        selectedDrives.insert(drive)
     }
 
     func toggleDriveSelection(_ drive: UIAvailableDrive) {

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
@@ -23,7 +23,6 @@ import InfomaniakConcurrency
 import InfomaniakDI
 import kDriveCore
 import kDriveCoreUI
-import OrderedCollections
 
 @MainActor
 final class DriveSelectionViewModel: ObservableObject {
@@ -88,6 +87,7 @@ final class DriveSelectionViewModel: ObservableObject {
                     .filter { Int($0.user.dbId) == currentUserDbId && !$0.drive.synchros.isEmpty }
                     .map { UIDrive(drive: $0.drive) }
             }
+            .removeDuplicates()
             .receiveOnMain(store: &bindStore) { [weak self] synchronizedDrives in
                 self?.synchronizedDrives = synchronizedDrives
             }

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/DriveSelection/DriveSelectionViewModel.swift
@@ -23,6 +23,7 @@ import InfomaniakConcurrency
 import InfomaniakDI
 import kDriveCore
 import kDriveCoreUI
+import OrderedCollections
 
 @MainActor
 final class DriveSelectionViewModel: ObservableObject {

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingFlowCoordinator.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingFlowCoordinator.swift
@@ -38,6 +38,8 @@ final class OnboardingFlowCoordinator: ObservableObject {
     private let steps: [OnboardingStep]
     var synchronizations = [NewSyncCandidate]()
 
+    private let onFinish: (@MainActor () -> Void)?
+
     private static let defaultSteps: [OnboardingStep] = [
         .login,
         .drivesSelection,
@@ -47,9 +49,10 @@ final class OnboardingFlowCoordinator: ObservableObject {
         .appReady
     ]
 
-    init(user: UIUser?, steps: [OnboardingStep]?, initialStep: OnboardingStep?) {
+    init(user: UIUser?, steps: [OnboardingStep]?, initialStep: OnboardingStep?, onFinish: (@MainActor () -> Void)? = nil) {
         currentUser = user
         self.steps = steps ?? Self.defaultSteps
+        self.onFinish = onFinish
 
         currentStep = initialStep ?? steps?.first ?? .login
     }
@@ -80,6 +83,11 @@ final class OnboardingFlowCoordinator: ObservableObject {
     }
 
     private func didFinishOnboarding() {
+        if let onFinish {
+            onFinish()
+            return
+        }
+
         @InjectService var windowRouter: MainWindowRouter
         windowRouter.navigate(to: .mainWindow())
     }

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingViewController.swift
@@ -34,9 +34,9 @@ final class OnboardingViewController: NSViewController {
 
     private var bindStore = Set<AnyCancellable>()
 
-    init(user: UIUser?, steps: [OnboardingStep]?, initialStep: OnboardingStep?) {
+    init(user: UIUser?, steps: [OnboardingStep]?, initialStep: OnboardingStep?, onFinish: (@MainActor () -> Void)? = nil) {
         shouldGuessInitialStep = initialStep == nil
-        flowCoordinator = OnboardingFlowCoordinator(user: user, steps: steps, initialStep: initialStep)
+        flowCoordinator = OnboardingFlowCoordinator(user: user, steps: steps, initialStep: initialStep, onFinish: onFinish)
 
         contentView = NSView()
         animationsView = OnboardingAnimationsView(flowCoordinator: flowCoordinator)

--- a/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingWindowController.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/MainWindow/Onboarding/OnboardingWindowController.swift
@@ -1,0 +1,58 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Cocoa
+
+final class OnboardingWindowController: NSWindowController, NSWindowDelegate {
+    var onClose: (() -> Void)?
+
+    private static let contentRect = NSRect(x: 0, y: 0, width: 900, height: 600)
+
+    init() {
+        let window = NSWindow(
+            contentRect: Self.contentRect,
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        super.init(window: window)
+
+        window.center()
+        window.isReleasedWhenClosed = false
+        window.delegate = self
+
+        let onboardingViewController = OnboardingViewController(
+            user: nil,
+            steps: nil,
+            initialStep: .login
+        ) { [weak self] in
+            self?.close()
+        }
+
+        window.contentViewController = onboardingViewController
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        onClose?()
+    }
+}

--- a/src/gui4/macOS/kDrive/UI/Views/MainWindow/Onboarding/DriveSelection/DrivesListView.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/MainWindow/Onboarding/DriveSelection/DrivesListView.swift
@@ -20,9 +20,13 @@ import Cocoa
 import kDriveCoreUI
 import kDriveResources
 
+private final class FlippedStackView: NSStackView {
+    override var isFlipped: Bool { true }
+}
+
 class DrivesListView: NSView {
     private lazy var drivesStackView: NSStackView = {
-        let stackView = NSStackView()
+        let stackView = FlippedStackView()
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.orientation = .vertical
         stackView.alignment = .leading
@@ -128,12 +132,7 @@ class DrivesListView: NSView {
         layoutSubtreeIfNeeded()
         documentView.layoutSubtreeIfNeeded()
 
-        let yPosition = documentView.isFlipped
-            ? 0
-            : max(0, documentView.bounds.height - scrollView.contentView.bounds.height)
-
-        let topPoint = NSPoint(x: 0, y: yPosition)
-        scrollView.contentView.scroll(to: topPoint)
+        scrollView.contentView.scroll(to: .zero)
         scrollView.reflectScrolledClipView(scrollView.contentView)
     }
 

--- a/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Accounts/AccountsView.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Accounts/AccountsView.swift
@@ -16,7 +16,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import InfomaniakDI
 import kDriveCoreUI
 import kDriveResources
 import OrderedCollections
@@ -40,8 +39,7 @@ struct AccountsView: View {
 
                 Section {
                     Button(KDriveLocalizable.buttonConnectAccount) {
-                        @InjectService var router: MainWindowRouter
-                        router.navigate(to: .onboarding(nil, nil, .login))
+                        (NSApp.delegate as? AppDelegate)?.openOnboardingWindow()
                     }
                     .buttonStyle(.bordered)
                     .frame(maxWidth: .infinity, alignment: .trailing)

--- a/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Accounts/Components/AccountsPreferencesAddAccountView.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Accounts/Components/AccountsPreferencesAddAccountView.swift
@@ -16,7 +16,6 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import InfomaniakDI
 import kDriveCoreUI
 import kDriveResources
 import SwiftUI
@@ -33,8 +32,7 @@ struct AccountsPreferencesAddAccountView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
 
                 Button(KDriveLocalizable.buttonConnectAccount) {
-                    @InjectService var router: MainWindowRouter
-                    router.navigate(to: .onboarding(nil, nil, .login))
+                    (NSApp.delegate as? AppDelegate)?.openOnboardingWindow()
                 }
                 .buttonStyle(.bordered)
             }


### PR DESCRIPTION
### Drive Selection
- Only display the drives of the user currently in the flow
- Fix a bug about the scroll view when many drives are displayed

### Connect new account
- When the user wants to add an account, the app open the onboarding in a separate window so the user can easily come back to the app