### PR TITLE
feat(parameters): add ParametersStore and update service on Linux v4

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -131,10 +131,12 @@
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
-- `app/services/cachepopulator.*`: sequential snapshot loader for application parameters, then users, accounts, drives,
-  syncs, and sync errors. It is used at initial connection and for explicit reconciliation after a
-  non-transactional backend mutation may have persisted parents without emitting their normal pushes; after each snapshot,
-  it activates the server live-info refresh so only drive updates reach `CachePipeline`.
+- `app/services/cachepopulator.*`: two-branch snapshot loader for application parameters and user data. The user-data
+  branch remains sequential and parent-first (users, accounts, drives, syncs, then sync errors); completion is emitted
+  only after both branches succeed, and overlapping population requests are ignored. It is used at initial connection
+  and for explicit reconciliation after a non-transactional backend mutation may have persisted parents without emitting
+  their normal pushes; after each snapshot, it activates the server live-info refresh so only drive updates reach
+  `CachePipeline`.
 - `app/services/driveservice.*`: targeted drive use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
 - `app/services/parametersservice.*`: targeted facade for application settings updates. It starts from the confirmed

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -29,6 +29,8 @@
 - Do not introduce raw `int` in new code when a fixed-width type fits (`uint8_t`, `int32_t`, ...).
 - Do not run `clang-format` on `CMakeLists.txt` in this repository.
 - For shared infrastructure classes, document the class role explicitly in the header comment when relevant.
+- Keep `ParametersStore` as a server-confirmed parameters snapshot only. Do not add global draft/pending state there;
+  screen-specific drafts, such as proxy edition, belong to the owning UI/view model.
 - In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
   bindings with an unused `_` element when only keys or only values are needed.
 - For Linux v4 model/UI checks, build only the `kdrive_qml` target unless a broader backend/server validation is
@@ -96,6 +98,10 @@
       but the underlying cache graph changes.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync
   configs.
+- `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`).
+  It is populated during the bootstrap sequence next to the product graph snapshot, but remains separate from `AppCache`
+  because the server is still the persistence source of truth for application settings. It stores only the last
+  server-confirmed snapshot; update workflows publish a new value only after `PARAMETERS_UPDATE` succeeds.
 - `app/onboarding/availabledrivesmodel.*`: QML adapter for onboarding drive selection. It derives rows from
   `AppCache::availableDriveContexts(selectedUserDbId)` and stores row selection through `OnboardingState`. It must not own
   screen-level loading, user, or navigation state.
@@ -125,12 +131,15 @@
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
-- `app/services/cachepopulator.*`: sequential parent-first snapshot loader for users, accounts, drives, syncs, and sync
-  errors. It is used at initial connection and for explicit reconciliation after a non-transactional backend mutation
-  may have persisted parents without emitting their normal pushes; after each snapshot, it activates the server
-  live-info refresh so only drive updates reach `CachePipeline`.
+- `app/services/cachepopulator.*`: sequential snapshot loader for application parameters, then users, accounts, drives,
+  syncs, and sync errors. It is used at initial connection and for explicit reconciliation after a
+  non-transactional backend mutation may have persisted parents without emitting their normal pushes; after each snapshot,
+  it activates the server live-info refresh so only drive updates reach `CachePipeline`.
 - `app/services/driveservice.*`: targeted drive use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
+- `app/services/parametersservice.*`: targeted facade for application settings updates. It starts from the confirmed
+  `ParametersStore` snapshot, sends the full `PARAMETERS_UPDATE` payload, and updates the store only after server
+  confirmation.
 - `app/services/syncservice.*`: targeted sync use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
 - `ui/`: QML shell, onboarding screens, design tokens, and bundled UI assets such as tray icons and onboarding Lottie

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -63,6 +63,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/services/cachepopulator.h
         app/services/driveservice.cpp
         app/services/driveservice.h
+        app/services/parametersservice.cpp
+        app/services/parametersservice.h
         app/services/serviceactiontracker.cpp
         app/services/serviceactiontracker.h
         app/services/serviceeventbus.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -33,6 +33,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/mainselectionstore.h
         app/cache/onboardingstate.cpp
         app/cache/onboardingstate.h
+        app/cache/parametersstore.cpp
+        app/cache/parametersstore.h
         app/onboarding/availabledrivesmodel.cpp
         app/onboarding/availabledrivesmodel.h
         app/onboarding/driveselectioncontroller.cpp

--- a/src/gui4/linux/app/cache/parametersstore.cpp
+++ b/src/gui4/linux/app/cache/parametersstore.cpp
@@ -1,0 +1,142 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "parametersstore.h"
+
+Q_LOGGING_CATEGORY(lcParametersStore, "gui.v4.parametersstore", QtInfoMsg)
+
+namespace KDC {
+
+ParametersStore::ParametersStore(QObject *const parent) :
+    QObject(parent) {}
+
+bool ParametersStore::populated() const {
+    return _parametersInfo.has_value();
+}
+
+bool ParametersStore::updatePending() const {
+    return _draftParametersInfo.has_value();
+}
+
+std::optional<ParametersInfo> ParametersStore::currentParametersInfo() const {
+    return _parametersInfo;
+}
+
+std::optional<ParametersInfo> ParametersStore::draftParametersInfo() const {
+    return _draftParametersInfo;
+}
+
+std::optional<ParametersInfo> ParametersStore::effectiveParametersInfo() const {
+    if (_draftParametersInfo.has_value()) {
+        return _draftParametersInfo;
+    }
+    return _parametersInfo;
+}
+
+void ParametersStore::replaceParametersInfo(const ParametersInfo &parametersInfo) {
+    const bool wasPopulated = populated();
+    const bool hadPendingUpdate = updatePending();
+    if (_parametersInfo.has_value() && *_parametersInfo == parametersInfo && !hadPendingUpdate) {
+        return;
+    }
+
+    _parametersInfo = parametersInfo;
+    _draftParametersInfo.reset();
+    qCInfo(lcParametersStore) << "Parameters snapshot updated";
+    if (wasPopulated != populated()) {
+        emit populatedChanged();
+    }
+    if (hadPendingUpdate) {
+        emit updatePendingChanged();
+        emit draftParametersInfoChanged();
+    }
+    emit parametersInfoChanged();
+    emit effectiveParametersInfoChanged();
+}
+
+void ParametersStore::beginUpdate(const ParametersInfo &draftParametersInfo) {
+    const bool hadPendingUpdate = updatePending();
+    if (_draftParametersInfo.has_value() && *_draftParametersInfo == draftParametersInfo) {
+        return;
+    }
+
+    _draftParametersInfo = draftParametersInfo;
+    qCInfo(lcParametersStore) << "Parameters draft update started";
+    if (hadPendingUpdate != updatePending()) {
+        emit updatePendingChanged();
+    }
+    emit draftParametersInfoChanged();
+    emit effectiveParametersInfoChanged();
+}
+
+void ParametersStore::confirmUpdate(const ParametersInfo &confirmedParametersInfo) {
+    const bool wasPopulated = populated();
+    const bool hadPendingUpdate = updatePending();
+    const bool confirmedChanged = !_parametersInfo.has_value() || *_parametersInfo != confirmedParametersInfo;
+
+    _parametersInfo = confirmedParametersInfo;
+    _draftParametersInfo.reset();
+    qCInfo(lcParametersStore) << "Parameters draft update confirmed";
+
+    if (wasPopulated != populated()) {
+        emit populatedChanged();
+    }
+    if (hadPendingUpdate) {
+        emit updatePendingChanged();
+        emit draftParametersInfoChanged();
+    }
+    if (confirmedChanged) {
+        emit parametersInfoChanged();
+    }
+    emit effectiveParametersInfoChanged();
+}
+
+void ParametersStore::rejectUpdate() {
+    if (!_draftParametersInfo.has_value()) {
+        return;
+    }
+
+    _draftParametersInfo.reset();
+    qCInfo(lcParametersStore) << "Parameters draft update rejected";
+    emit updatePendingChanged();
+    emit draftParametersInfoChanged();
+    emit effectiveParametersInfoChanged();
+}
+
+void ParametersStore::clear() {
+    const bool wasPopulated = populated();
+    const bool hadPendingUpdate = updatePending();
+    if (!wasPopulated && !hadPendingUpdate) {
+        return;
+    }
+
+    _parametersInfo.reset();
+    _draftParametersInfo.reset();
+    qCInfo(lcParametersStore) << "Parameters snapshot cleared";
+    if (wasPopulated) {
+        emit populatedChanged();
+        emit parametersInfoChanged();
+    }
+    if (hadPendingUpdate) {
+        emit updatePendingChanged();
+        emit draftParametersInfoChanged();
+    }
+    emit effectiveParametersInfoChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/parametersstore.cpp
+++ b/src/gui4/linux/app/cache/parametersstore.cpp
@@ -25,36 +25,27 @@ namespace KDC {
 ParametersStore::ParametersStore(QObject *const parent) :
     QObject(parent) {}
 
-bool ParametersStore::populated() const {
-    return _parametersInfo.has_value();
-}
-
 std::optional<ParametersInfo> ParametersStore::parametersInfo() const {
     return _parametersInfo;
 }
 
 void ParametersStore::replaceParametersInfo(const ParametersInfo &parametersInfo) {
-    const bool wasPopulated = populated();
     if (_parametersInfo.has_value() && *_parametersInfo == parametersInfo) {
         return;
     }
 
     _parametersInfo = parametersInfo;
     qCInfo(lcParametersStore) << "Parameters snapshot updated";
-    if (wasPopulated != populated()) {
-        emit populatedChanged();
-    }
     emit parametersInfoChanged();
 }
 
 void ParametersStore::clear() {
-    if (const bool wasPopulated = populated(); !wasPopulated) {
+    if (!_parametersInfo.has_value()) {
         return;
     }
 
     _parametersInfo.reset();
     qCInfo(lcParametersStore) << "Parameters snapshot cleared";
-    emit populatedChanged();
     emit parametersInfoChanged();
 }
 

--- a/src/gui4/linux/app/cache/parametersstore.cpp
+++ b/src/gui4/linux/app/cache/parametersstore.cpp
@@ -29,114 +29,33 @@ bool ParametersStore::populated() const {
     return _parametersInfo.has_value();
 }
 
-bool ParametersStore::updatePending() const {
-    return _draftParametersInfo.has_value();
-}
-
-std::optional<ParametersInfo> ParametersStore::currentParametersInfo() const {
-    return _parametersInfo;
-}
-
-std::optional<ParametersInfo> ParametersStore::draftParametersInfo() const {
-    return _draftParametersInfo;
-}
-
-std::optional<ParametersInfo> ParametersStore::effectiveParametersInfo() const {
-    if (_draftParametersInfo.has_value()) {
-        return _draftParametersInfo;
-    }
+std::optional<ParametersInfo> ParametersStore::parametersInfo() const {
     return _parametersInfo;
 }
 
 void ParametersStore::replaceParametersInfo(const ParametersInfo &parametersInfo) {
     const bool wasPopulated = populated();
-    const bool hadPendingUpdate = updatePending();
-    if (_parametersInfo.has_value() && *_parametersInfo == parametersInfo && !hadPendingUpdate) {
+    if (_parametersInfo.has_value() && *_parametersInfo == parametersInfo) {
         return;
     }
 
     _parametersInfo = parametersInfo;
-    _draftParametersInfo.reset();
     qCInfo(lcParametersStore) << "Parameters snapshot updated";
     if (wasPopulated != populated()) {
         emit populatedChanged();
     }
-    if (hadPendingUpdate) {
-        emit updatePendingChanged();
-        emit draftParametersInfoChanged();
-    }
     emit parametersInfoChanged();
-    emit effectiveParametersInfoChanged();
-}
-
-void ParametersStore::beginUpdate(const ParametersInfo &draftParametersInfo) {
-    const bool hadPendingUpdate = updatePending();
-    if (_draftParametersInfo.has_value() && *_draftParametersInfo == draftParametersInfo) {
-        return;
-    }
-
-    _draftParametersInfo = draftParametersInfo;
-    qCInfo(lcParametersStore) << "Parameters draft update started";
-    if (hadPendingUpdate != updatePending()) {
-        emit updatePendingChanged();
-    }
-    emit draftParametersInfoChanged();
-    emit effectiveParametersInfoChanged();
-}
-
-void ParametersStore::confirmUpdate(const ParametersInfo &confirmedParametersInfo) {
-    const bool wasPopulated = populated();
-    const bool hadPendingUpdate = updatePending();
-    const bool confirmedChanged = !_parametersInfo.has_value() || *_parametersInfo != confirmedParametersInfo;
-
-    _parametersInfo = confirmedParametersInfo;
-    _draftParametersInfo.reset();
-    qCInfo(lcParametersStore) << "Parameters draft update confirmed";
-
-    if (wasPopulated != populated()) {
-        emit populatedChanged();
-    }
-    if (hadPendingUpdate) {
-        emit updatePendingChanged();
-        emit draftParametersInfoChanged();
-    }
-    if (confirmedChanged) {
-        emit parametersInfoChanged();
-    }
-    emit effectiveParametersInfoChanged();
-}
-
-void ParametersStore::rejectUpdate() {
-    if (!_draftParametersInfo.has_value()) {
-        return;
-    }
-
-    _draftParametersInfo.reset();
-    qCInfo(lcParametersStore) << "Parameters draft update rejected";
-    emit updatePendingChanged();
-    emit draftParametersInfoChanged();
-    emit effectiveParametersInfoChanged();
 }
 
 void ParametersStore::clear() {
-    const bool wasPopulated = populated();
-    const bool hadPendingUpdate = updatePending();
-    if (!wasPopulated && !hadPendingUpdate) {
+    if (const bool wasPopulated = populated(); !wasPopulated) {
         return;
     }
 
     _parametersInfo.reset();
-    _draftParametersInfo.reset();
     qCInfo(lcParametersStore) << "Parameters snapshot cleared";
-    if (wasPopulated) {
-        emit populatedChanged();
-        emit parametersInfoChanged();
-    }
-    if (hadPendingUpdate) {
-        emit updatePendingChanged();
-        emit draftParametersInfoChanged();
-    }
-    emit effectiveParametersInfoChanged();
+    emit populatedChanged();
+    emit parametersInfoChanged();
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/parametersstore.h
+++ b/src/gui4/linux/app/cache/parametersstore.h
@@ -32,75 +32,33 @@ namespace KDC {
 /**
  * Process-wide cache for server-owned application parameters.
  *
- * Role: hold the latest confirmed ParametersInfo snapshot fetched from the server bootstrap, plus an optional draft
- * snapshot while an update is awaiting server confirmation. The server remains the persistence source of truth.
+ * Role: hold the latest server-confirmed ParametersInfo snapshot fetched from bootstrap or a successful
+ * PARAMETERS_UPDATE. The server remains the persistence source of truth; screen-level drafts belong to the UI/view
+ * model that owns the edit workflow.
  */
 class ParametersStore final : public QObject {
         Q_OBJECT
         Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
-        Q_PROPERTY(bool updatePending READ updatePending NOTIFY updatePendingChanged)
 
     public:
         explicit ParametersStore(QObject *parent = nullptr);
 
         [[nodiscard]] bool populated() const;
-        [[nodiscard]] bool updatePending() const;
 
         /**
          * Last server-confirmed parameters snapshot.
-         *
-         * This is the durable GUI-side source of truth. It changes after bootstrap, refresh, or a successful
-         * PARAMETERS_UPDATE response, never when an optimistic update is merely pending.
          */
-        [[nodiscard]] std::optional<ParametersInfo> currentParametersInfo() const;
-
-        /**
-         * Optimistic parameters snapshot awaiting server confirmation.
-         *
-         * Present only between beginUpdate() and confirmUpdate()/rejectUpdate(). UI can use it for immediate feedback,
-         * but services that require confirmed persistence should keep using currentParametersInfo().
-         */
-        [[nodiscard]] std::optional<ParametersInfo> draftParametersInfo() const;
-
-        /**
-         * Parameters snapshot that should be displayed to users.
-         *
-         * Returns draftParametersInfo() while an update is pending, otherwise currentParametersInfo(). This may differ
-         * from the confirmed server state until PARAMETERS_UPDATE succeeds.
-         */
-        [[nodiscard]] std::optional<ParametersInfo> effectiveParametersInfo() const;
+        [[nodiscard]] std::optional<ParametersInfo> parametersInfo() const;
 
         void replaceParametersInfo(const ParametersInfo &parametersInfo);
-
-        /**
-         * Starts an optimistic update. Does not modify currentParametersInfo().
-         *
-         * The caller must send PARAMETERS_UPDATE separately and then call confirmUpdate() or rejectUpdate() from the
-         * server response handler.
-         */
-        void beginUpdate(const ParametersInfo &draftParametersInfo);
-
-        /**
-         * Commits a server-confirmed update and clears the optimistic draft.
-         */
-        void confirmUpdate(const ParametersInfo &confirmedParametersInfo);
-
-        /**
-         * Discards the optimistic draft after a failed server update. The confirmed snapshot is left untouched.
-         */
-        void rejectUpdate();
         void clear();
 
     signals:
         void populatedChanged();
-        void updatePendingChanged();
         void parametersInfoChanged();
-        void draftParametersInfoChanged();
-        void effectiveParametersInfoChanged();
 
     private:
         std::optional<ParametersInfo> _parametersInfo;
-        std::optional<ParametersInfo> _draftParametersInfo;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/parametersstore.h
+++ b/src/gui4/linux/app/cache/parametersstore.h
@@ -38,12 +38,9 @@ namespace KDC {
  */
 class ParametersStore final : public QObject {
         Q_OBJECT
-        Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
 
     public:
         explicit ParametersStore(QObject *parent = nullptr);
-
-        [[nodiscard]] bool populated() const;
 
         /**
          * Last server-confirmed parameters snapshot.
@@ -54,7 +51,6 @@ class ParametersStore final : public QObject {
         void clear();
 
     signals:
-        void populatedChanged();
         void parametersInfoChanged();
 
     private:

--- a/src/gui4/linux/app/cache/parametersstore.h
+++ b/src/gui4/linux/app/cache/parametersstore.h
@@ -1,0 +1,106 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/info/parametersinfo.h"
+
+#include <QLoggingCategory>
+#include <QObject>
+
+#include <optional>
+
+Q_DECLARE_LOGGING_CATEGORY(lcParametersStore)
+
+namespace KDC {
+
+/**
+ * Process-wide cache for server-owned application parameters.
+ *
+ * Role: hold the latest confirmed ParametersInfo snapshot fetched from the server bootstrap, plus an optional draft
+ * snapshot while an update is awaiting server confirmation. The server remains the persistence source of truth.
+ */
+class ParametersStore final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool populated READ populated NOTIFY populatedChanged)
+        Q_PROPERTY(bool updatePending READ updatePending NOTIFY updatePendingChanged)
+
+    public:
+        explicit ParametersStore(QObject *parent = nullptr);
+
+        [[nodiscard]] bool populated() const;
+        [[nodiscard]] bool updatePending() const;
+
+        /**
+         * Last server-confirmed parameters snapshot.
+         *
+         * This is the durable GUI-side source of truth. It changes after bootstrap, refresh, or a successful
+         * PARAMETERS_UPDATE response, never when an optimistic update is merely pending.
+         */
+        [[nodiscard]] std::optional<ParametersInfo> currentParametersInfo() const;
+
+        /**
+         * Optimistic parameters snapshot awaiting server confirmation.
+         *
+         * Present only between beginUpdate() and confirmUpdate()/rejectUpdate(). UI can use it for immediate feedback,
+         * but services that require confirmed persistence should keep using currentParametersInfo().
+         */
+        [[nodiscard]] std::optional<ParametersInfo> draftParametersInfo() const;
+
+        /**
+         * Parameters snapshot that should be displayed to users.
+         *
+         * Returns draftParametersInfo() while an update is pending, otherwise currentParametersInfo(). This may differ
+         * from the confirmed server state until PARAMETERS_UPDATE succeeds.
+         */
+        [[nodiscard]] std::optional<ParametersInfo> effectiveParametersInfo() const;
+
+        void replaceParametersInfo(const ParametersInfo &parametersInfo);
+
+        /**
+         * Starts an optimistic update. Does not modify currentParametersInfo().
+         *
+         * The caller must send PARAMETERS_UPDATE separately and then call confirmUpdate() or rejectUpdate() from the
+         * server response handler.
+         */
+        void beginUpdate(const ParametersInfo &draftParametersInfo);
+
+        /**
+         * Commits a server-confirmed update and clears the optimistic draft.
+         */
+        void confirmUpdate(const ParametersInfo &confirmedParametersInfo);
+
+        /**
+         * Discards the optimistic draft after a failed server update. The confirmed snapshot is left untouched.
+         */
+        void rejectUpdate();
+        void clear();
+
+    signals:
+        void populatedChanged();
+        void updatePendingChanged();
+        void parametersInfoChanged();
+        void draftParametersInfoChanged();
+        void effectiveParametersInfoChanged();
+
+    private:
+        std::optional<ParametersInfo> _parametersInfo;
+        std::optional<ParametersInfo> _draftParametersInfo;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/cachepopulator.cpp
+++ b/src/gui4/linux/app/services/cachepopulator.cpp
@@ -37,17 +37,30 @@ Q_LOGGING_CATEGORY(lcCachePopulator, "gui.v4.cachepopulator", QtInfoMsg)
 }
 } // namespace
 
-CachePopulator::CachePopulator(CommService &commService, AppCache &appCache, QObject *const parent) :
+CachePopulator::CachePopulator(CommService &commService, AppCache &appCache, ParametersStore &parametersStore,
+                               QObject *const parent) :
     QObject(parent),
     _commService(commService),
-    _appCache(appCache) {}
+    _appCache(appCache),
+    _parametersStore(parametersStore) {}
 
 void CachePopulator::bootstrap() {
-    loadUsers(PopulationMode::Bootstrap);
+    loadParameters(PopulationMode::Bootstrap);
+}
+
+void CachePopulator::loadParameters(const PopulationMode mode) {
+    _commService.requestParametersInfo([this, mode](const ExitInfo &exitInfo, const ParametersInfo &parametersInfo) {
+        if (!exitInfo && handlePopulationFailure("parameters", exitInfo, mode)) {
+            return;
+        }
+
+        _parametersStore.replaceParametersInfo(parametersInfo);
+        loadUsers(mode);
+    });
 }
 
 void CachePopulator::reconcile() {
-    loadUsers(PopulationMode::Reconciliation);
+    loadParameters(PopulationMode::Reconciliation);
 }
 
 void CachePopulator::loadUsers(const PopulationMode mode) {

--- a/src/gui4/linux/app/services/cachepopulator.cpp
+++ b/src/gui4/linux/app/services/cachepopulator.cpp
@@ -45,7 +45,17 @@ CachePopulator::CachePopulator(CommService &commService, AppCache &appCache, Par
     _parametersStore(parametersStore) {}
 
 void CachePopulator::bootstrap() {
-    loadParameters(PopulationMode::Bootstrap);
+    startPopulation(PopulationMode::Bootstrap);
+}
+
+void CachePopulator::reconcile() {
+    startPopulation(PopulationMode::Reconciliation);
+}
+
+void CachePopulator::startPopulation(const PopulationMode mode) {
+    _populationProgress = {};
+    loadParameters(mode);
+    loadUserData(mode);
 }
 
 void CachePopulator::loadParameters(const PopulationMode mode) {
@@ -55,15 +65,11 @@ void CachePopulator::loadParameters(const PopulationMode mode) {
         }
 
         _parametersStore.replaceParametersInfo(parametersInfo);
-        loadUsers(mode);
+        markBranchCompleted(mode, PopulationBranch::Parameters);
     });
 }
 
-void CachePopulator::reconcile() {
-    loadParameters(PopulationMode::Reconciliation);
-}
-
-void CachePopulator::loadUsers(const PopulationMode mode) {
+void CachePopulator::loadUserData(const PopulationMode mode) {
     _commService.requestUserDisplayInfoList([this, mode](const ExitInfo &exitInfo, const std::vector<UserDisplayInfo> &list) {
         if (!exitInfo && handlePopulationFailure("users", exitInfo, mode)) {
             return;
@@ -136,13 +142,31 @@ void CachePopulator::loadSyncErrors(const PopulationMode mode) {
 
         _appCache.replaceSyncErrors(syncErrors);
         _appCache.replaceServerErrors(serverErrors);
-        if (mode == PopulationMode::Bootstrap) {
-            emit bootstrapCompleted();
-        } else {
-            emit reconciliationCompleted();
-        }
-        activateLiveInfoRefresh();
+        markBranchCompleted(mode, PopulationBranch::UserData);
     });
+}
+
+void CachePopulator::markBranchCompleted(const PopulationMode mode, const PopulationBranch branch) {
+    switch (branch) {
+        case PopulationBranch::Parameters:
+            _populationProgress.parametersCompleted = true;
+            break;
+        case PopulationBranch::UserData:
+            _populationProgress.userDataCompleted = true;
+            break;
+    }
+
+    if (_populationProgress.terminalSignalEmitted || !_populationProgress.parametersCompleted || !_populationProgress.userDataCompleted) {
+        return;
+    }
+
+    _populationProgress.terminalSignalEmitted = true;
+    if (mode == PopulationMode::Bootstrap) {
+        emit bootstrapCompleted();
+    } else {
+        emit reconciliationCompleted();
+    }
+    activateLiveInfoRefresh();
 }
 
 void CachePopulator::activateLiveInfoRefresh() const {
@@ -161,7 +185,10 @@ bool CachePopulator::handlePopulationFailure(const char *const stage, const Exit
 
     qCWarning(lcCachePopulator) << "Cache reconciliation failed at" << stage << "| code:" << exitInfo.code()
                                 << "/ cause:" << exitInfo.cause();
-    emit reconciliationFailed();
+    if (!_populationProgress.terminalSignalEmitted) {
+        _populationProgress.terminalSignalEmitted = true;
+        emit reconciliationFailed();
+    }
     return true;
 }
 

--- a/src/gui4/linux/app/services/cachepopulator.h
+++ b/src/gui4/linux/app/services/cachepopulator.h
@@ -29,14 +29,14 @@
 namespace KDC {
 
 /**
- * Sequential parent-first snapshot loader for Linux v4 cache population and explicit reconciliation.
+ * Snapshot loader for Linux v4 cache population and explicit reconciliation.
  *
- * Loads parameters first, then users, accounts, drives, syncs, and errors so GUI state is populated in parent-first
- * order. Product entities go to AppCache; application parameters go to ParametersStore. Initial bootstrap remains fatal
- * on failure because the app has no coherent cache to run from. Reconciliation reuses the same sequence after
- * recoverable mutations and reports failures to the caller without emitting the bootstrap signal. Once a snapshot is
- * complete, asks the server to refresh live user/account/drive metadata so quota-only drive updates are pushed through
- * CachePipeline.
+ * Loads application parameters and user data as two asynchronous branches. The user-data branch remains parent-first:
+ * users, accounts, drives, syncs, then errors. Product entities go to AppCache; application parameters go to
+ * ParametersStore. Completion is reported only after both branches succeed. Initial bootstrap remains fatal on failure
+ * because the app has no coherent cache to run from. Reconciliation reports failures to the caller without emitting the
+ * bootstrap signal. Once a snapshot is complete, asks the server to refresh live user/account/drive metadata so
+ * quota-only drive updates are pushed through CachePipeline.
  */
 class CachePopulator : public QObject {
         Q_OBJECT
@@ -47,7 +47,8 @@ class CachePopulator : public QObject {
         /**
          * Populates the initial cache snapshot.
          *
-         * Failure is fatal because Linux v4 cannot safely start without a coherent user/account/drive/sync graph.
+         * Failure is fatal because Linux v4 cannot safely start without parameters and a coherent
+         * user/account/drive/sync graph.
          */
         void bootstrap();
 
@@ -72,18 +73,32 @@ class CachePopulator : public QObject {
             Reconciliation,
         };
 
+        enum class PopulationBranch : uint8_t {
+            Parameters,
+            UserData,
+        };
+
+        struct PopulationProgress {
+                bool parametersCompleted{false};
+                bool userDataCompleted{false};
+                bool terminalSignalEmitted{false};
+        };
+
+        void startPopulation(PopulationMode mode);
         void loadParameters(PopulationMode mode);
-        void loadUsers(PopulationMode mode);
+        void loadUserData(PopulationMode mode);
         void loadAccounts(PopulationMode mode);
         void loadDrives(PopulationMode mode);
         void loadSyncs(PopulationMode mode);
         void loadSyncErrors(PopulationMode mode);
+        void markBranchCompleted(PopulationMode mode, PopulationBranch branch);
         void activateLiveInfoRefresh() const;
         [[nodiscard]] bool handlePopulationFailure(const char *stage, const ExitInfo &exitInfo, PopulationMode mode);
 
         CommService &_commService;
         AppCache &_appCache;
         ParametersStore &_parametersStore;
+        PopulationProgress _populationProgress;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/cachepopulator.h
+++ b/src/gui4/linux/app/services/cachepopulator.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "app/cache/appcache.h"
+#include "app/cache/parametersstore.h"
 #include "app/services/commservice.h"
 
 #include <QObject>
@@ -30,17 +31,19 @@ namespace KDC {
 /**
  * Sequential parent-first snapshot loader for Linux v4 cache population and explicit reconciliation.
  *
- * Loads users, then accounts, then drives, then syncs, then errors so the graph-backed AppCache is populated in
- * parent-first order. Initial bootstrap remains fatal on failure because the app has no coherent cache to run from.
- * Reconciliation reuses the same sequence after recoverable mutations and reports failures to the caller without
- * emitting the bootstrap signal. Once a snapshot is complete, asks the server to refresh live user/account/drive metadata
- * so quota-only drive updates are pushed through CachePipeline.
+ * Loads parameters first, then users, accounts, drives, syncs, and errors so GUI state is populated in parent-first
+ * order. Product entities go to AppCache; application parameters go to ParametersStore. Initial bootstrap remains fatal
+ * on failure because the app has no coherent cache to run from. Reconciliation reuses the same sequence after
+ * recoverable mutations and reports failures to the caller without emitting the bootstrap signal. Once a snapshot is
+ * complete, asks the server to refresh live user/account/drive metadata so quota-only drive updates are pushed through
+ * CachePipeline.
  */
 class CachePopulator : public QObject {
         Q_OBJECT
 
     public:
-        explicit CachePopulator(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+        explicit CachePopulator(CommService &commService, AppCache &appCache, ParametersStore &parametersStore,
+                                QObject *parent = nullptr);
         /**
          * Populates the initial cache snapshot.
          *
@@ -69,6 +72,7 @@ class CachePopulator : public QObject {
             Reconciliation,
         };
 
+        void loadParameters(PopulationMode mode);
         void loadUsers(PopulationMode mode);
         void loadAccounts(PopulationMode mode);
         void loadDrives(PopulationMode mode);
@@ -79,6 +83,7 @@ class CachePopulator : public QObject {
 
         CommService &_commService;
         AppCache &_appCache;
+        ParametersStore &_parametersStore;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/parametersservice.cpp
+++ b/src/gui4/linux/app/services/parametersservice.cpp
@@ -1,0 +1,76 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "parametersservice.h"
+
+#include "app/cache/parametersstore.h"
+
+#include <QLoggingCategory>
+#include <QString>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcParametersService, "gui.v4.parametersservice", QtInfoMsg)
+} // namespace
+
+ParametersService::ParametersService(CommService &commService, ParametersStore &parametersStore, QObject *const parent) :
+    QObject(parent),
+    _commService(commService),
+    _parametersStore(parametersStore) {}
+
+void ParametersService::updateParameters(const ParametersMutation &mutation, const UpdateCallback &callback) const {
+    if (!mutation) {
+        qCWarning(lcParametersService) << "Parameters update ignored because no mutation was provided";
+        if (callback) {
+            callback({ExitCode::LogicError, ExitCause::InvalidArgument});
+        }
+        return;
+    }
+
+    const auto currentParametersInfo = _parametersStore.parametersInfo();
+    if (!currentParametersInfo.has_value()) {
+        qCWarning(lcParametersService) << "Parameters update ignored because server parameters are not loaded yet";
+        if (callback) {
+            callback({ExitCode::DataError, ExitCause::NotFound});
+        }
+        return;
+    }
+
+    ParametersInfo updatedParametersInfo = *currentParametersInfo;
+    mutation(updatedParametersInfo);
+    _commService.requestParametersUpdate(
+            updatedParametersInfo, [this, updatedParametersInfo, callback](const ExitInfo &exitInfo) {
+                if (!exitInfo) {
+                    qCWarning(lcParametersService)
+                            << "Parameters update rejected by server | ExitInfo:" << QString::fromStdString(toString(exitInfo));
+                    if (callback) {
+                        callback(exitInfo);
+                    }
+                    return;
+                }
+
+                qCInfo(lcParametersService) << "Parameters update confirmed by server";
+                _parametersStore.replaceParametersInfo(updatedParametersInfo);
+                if (callback) {
+                    callback(exitInfo);
+                }
+            });
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/parametersservice.h
+++ b/src/gui4/linux/app/services/parametersservice.h
@@ -1,0 +1,54 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/services/commservice.h"
+#include "libcommon/info/parametersinfo.h"
+
+#include <QObject>
+
+#include <functional>
+
+namespace KDC {
+
+class ParametersStore;
+
+/**
+ * High-level facade for server-owned application parameter updates.
+ *
+ * Role: start from the confirmed ParametersStore snapshot, send a full PARAMETERS_UPDATE payload, and publish the new
+ * snapshot only after the server confirms it. UI-specific drafts are owned by the relevant view model/screen.
+ */
+class ParametersService final : public QObject {
+        Q_OBJECT
+
+    public:
+        using ParametersMutation = std::function<void(ParametersInfo &)>;
+        using UpdateCallback = CommService::VoidCallback;
+
+        explicit ParametersService(CommService &commService, ParametersStore &parametersStore, QObject *parent = nullptr);
+
+        void updateParameters(const ParametersMutation &mutation, const UpdateCallback &callback) const;
+
+    private:
+        CommService &_commService;
+        ParametersStore &_parametersStore;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/sentryservice.cpp
+++ b/src/gui4/linux/app/services/sentryservice.cpp
@@ -19,7 +19,8 @@
 #include "sentryservice.h"
 
 #include "app/cache/appcache.h"
-#include "app/services/commservice.h"
+#include "app/cache/parametersstore.h"
+#include "app/services/parametersservice.h"
 #include "config.h"
 #include "libcommon/log/sentry/handler.h"
 
@@ -40,10 +41,15 @@ constexpr char sentryConsentKey[] = "sentry/enabled";
 
 namespace KDC {
 
-SentryService::SentryService(CommService &commService, AppCache &appCache, QObject *const parent) :
+SentryService::SentryService(ParametersService &parametersService, AppCache &appCache, ParametersStore &parametersStore,
+                             QObject *const parent) :
     QObject(parent),
-    _commService(commService),
-    _appCache(appCache) {}
+    _parametersService(parametersService),
+    _appCache(appCache),
+    _parametersStore(parametersStore) {
+    (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this,
+                   &SentryService::reconcileConsentWithParametersStore);
+}
 
 std::optional<bool> SentryService::readCachedConsent() {
     const QSettings settings(QSettings::IniFormat, QSettings::UserScope, settingsOrganization, settingsApplication);
@@ -129,43 +135,19 @@ void SentryService::reportFatalAndExit(const QString &title, const QString &mess
     reportFatalAndExit(title.toStdString(), message.toStdString());
 }
 
-void SentryService::reconcileConsentWithServer() {
-    qCInfo(lcSentryService) << "Reconciling Sentry consent with server";
-    _commService.requestParametersInfo([this](const ExitInfo &exitInfo, const ParametersInfo &parametersInfo) {
-        if (!exitInfo) {
-            qCWarning(lcSentryService) << "Sentry consent reconciliation failed | ExitInfo:"
-                                       << QString::fromStdString(toString(exitInfo));
-            return;
-        }
-
-        qCInfo(lcSentryService) << "Sentry consent reconciled with server | enabled:" << parametersInfo.sentryEnabled();
-        setCurrentParametersInfo(parametersInfo);
-        writeCachedConsent(parametersInfo.sentryEnabled());
-        applyConsent(parametersInfo.sentryEnabled());
-    });
-}
-
-void SentryService::setConsent(const bool enabled) {
+void SentryService::setConsent(const bool enabled) const {
     qCInfo(lcSentryService) << "Sentry consent update requested | enabled:" << enabled;
-    if (!_currentParametersInfo.has_value()) {
-        qCWarning(lcSentryService) << "Sentry consent update ignored because server parameters are not loaded yet";
-        return;
-    }
+    _parametersService.updateParameters(
+            [enabled](ParametersInfo &parametersInfo) { parametersInfo.setSentryEnabled(enabled); },
+            [enabled](const ExitInfo &exitInfo) {
+                if (!exitInfo) {
+                    qCWarning(lcSentryService) << "Sentry consent update failed; keeping confirmed store value | ExitInfo:"
+                                               << QString::fromStdString(toString(exitInfo));
+                    return;
+                }
 
-    ParametersInfo updatedParametersInfo = *_currentParametersInfo;
-    updatedParametersInfo.setSentryEnabled(enabled);
-    _commService.requestParametersUpdate(updatedParametersInfo, [this, updatedParametersInfo, enabled](const ExitInfo &exitInfo) {
-        if (!exitInfo) {
-            qCWarning(lcSentryService) << "Sentry consent update failed | ExitInfo:"
-                                       << QString::fromStdString(toString(exitInfo));
-            return;
-        }
-
-        qCInfo(lcSentryService) << "Sentry consent update confirmed by server | enabled:" << enabled;
-        setCurrentParametersInfo(updatedParametersInfo);
-        writeCachedConsent(enabled);
-        applyConsent(enabled);
-    });
+                qCInfo(lcSentryService) << "Sentry consent update confirmed by server | enabled:" << enabled;
+            });
 }
 
 void SentryService::updateAuthenticatedUser() const {
@@ -218,8 +200,17 @@ void SentryService::applyConsent(const bool enabled) {
     qCInfo(lcSentryService) << "Sentry shutdown skipped because handler is not initialized";
 }
 
-void SentryService::setCurrentParametersInfo(const ParametersInfo &parametersInfo) {
-    _currentParametersInfo = parametersInfo;
+void SentryService::reconcileConsentWithParametersStore() {
+    const auto currentParametersInfo = _parametersStore.parametersInfo();
+    if (!currentParametersInfo.has_value()) {
+        qCInfo(lcSentryService) << "Sentry consent reconciliation skipped because parameters are not loaded";
+        return;
+    }
+
+    qCInfo(lcSentryService) << "Sentry consent reconciled with parameters store | enabled:"
+                            << currentParametersInfo->sentryEnabled();
+    writeCachedConsent(currentParametersInfo->sentryEnabled());
+    applyConsent(currentParametersInfo->sentryEnabled());
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/services/sentryservice.cpp
+++ b/src/gui4/linux/app/services/sentryservice.cpp
@@ -137,17 +137,23 @@ void SentryService::reportFatalAndExit(const QString &title, const QString &mess
 
 void SentryService::setConsent(const bool enabled) const {
     qCInfo(lcSentryService) << "Sentry consent update requested | enabled:" << enabled;
-    _parametersService.updateParameters(
-            [enabled](ParametersInfo &parametersInfo) { parametersInfo.setSentryEnabled(enabled); },
-            [enabled](const ExitInfo &exitInfo) {
-                if (!exitInfo) {
-                    qCWarning(lcSentryService) << "Sentry consent update failed; keeping confirmed store value | ExitInfo:"
-                                               << QString::fromStdString(toString(exitInfo));
-                    return;
-                }
 
-                qCInfo(lcSentryService) << "Sentry consent update confirmed by server | enabled:" << enabled;
-            });
+    const ParametersService::ParametersMutation mutation = [enabled](ParametersInfo &parametersInfo) {
+        parametersInfo.setSentryEnabled(enabled);
+    };
+
+    const ParametersService::UpdateCallback callback = [enabled](const ExitInfo &exitInfo) {
+        if (!exitInfo) {
+            qCWarning(lcSentryService) << "Sentry consent update failed; keeping confirmed store value | ExitInfo:"
+                                       << QString::fromStdString(toString(exitInfo));
+            return;
+        }
+
+        qCInfo(lcSentryService) << "Sentry consent update confirmed by server | enabled:" << enabled;
+    };
+
+
+    _parametersService.updateParameters(mutation, callback);
 }
 
 void SentryService::updateAuthenticatedUser() const {

--- a/src/gui4/linux/app/services/sentryservice.h
+++ b/src/gui4/linux/app/services/sentryservice.h
@@ -18,8 +18,6 @@
 
 #pragma once
 
-#include "libcommon/info/parametersinfo.h"
-
 #include <QObject>
 #include <QString>
 
@@ -29,7 +27,8 @@
 namespace KDC {
 
 class AppCache;
-class CommService;
+class ParametersService;
+class ParametersStore;
 
 /**
  * Linux v4 Sentry coordinator.
@@ -41,7 +40,8 @@ class SentryService final : public QObject {
         Q_OBJECT
 
     public:
-        explicit SentryService(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+        explicit SentryService(ParametersService &parametersService, AppCache &appCache, ParametersStore &parametersStore,
+                               QObject *parent = nullptr);
 
         [[nodiscard]] static std::optional<bool> readCachedConsent();
         static void writeCachedConsent(bool enabled);
@@ -55,17 +55,16 @@ class SentryService final : public QObject {
         [[noreturn]] static void reportFatalAndExit(const char *title, const char *message);
         [[noreturn]] static void reportFatalAndExit(const QString &title, const QString &message);
 
-        void reconcileConsentWithServer();
-        void setConsent(bool enabled);
+        void setConsent(bool enabled) const;
         void updateAuthenticatedUser() const;
 
     private:
+        void reconcileConsentWithParametersStore();
         void applyConsent(bool enabled);
-        void setCurrentParametersInfo(const ParametersInfo &parametersInfo);
 
-        CommService &_commService;
+        ParametersService &_parametersService;
         AppCache &_appCache;
-        std::optional<ParametersInfo> _currentParametersInfo;
+        ParametersStore &_parametersStore;
 };
 
 } // namespace KDC

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -61,6 +61,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
         _systemTrayController.setProductStateInitialized(false);
         _appCache.clearAll();
+        _parametersStore.clear();
     });
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_cachePipeline, &CachePipeline::markPopulated);
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_systemTrayController,
@@ -68,7 +69,6 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_sentryService,
                    &SentryService::updateAuthenticatedUser);
     (void) connect(this, &AppClientLinux::ipcConnected, this, [this] { _cachePopulator.bootstrap(); });
-    (void) connect(this, &AppClientLinux::ipcConnected, &_sentryService, &SentryService::reconcileConsentWithServer);
     (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
@@ -95,6 +95,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     });
 
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("appCache"), &_appCache);
+    _qmlEngine.rootContext()->setContextProperty(QStringLiteral("parametersStore"), &_parametersStore);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("userService"), &_userService);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("driveService"), &_driveService);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("syncService"), &_syncService);

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -79,6 +79,16 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
                    &SystemTrayController::hideMainWindow);
     (void) connect(&_systemTrayController, &SystemTrayController::openMainWindowRequested, this, &AppClientLinux::openMainWindow);
     (void) connect(&_appCache, &AppCache::usersChanged, &_sentryService, &SentryService::updateAuthenticatedUser);
+    (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this, [this] {
+        const auto parametersInfo = _parametersStore.parametersInfo();
+        if (!parametersInfo.has_value()) {
+            return;
+        }
+
+        Logger::instance()->setMinLogLevel(toInt(parametersInfo->logLevel()));
+        qCInfo(lcAppClientLinux) << "Logger minimum level updated from parameters | level:"
+                                 << QString::fromStdString(toString(parametersInfo->logLevel()));
+    });
     (void) connect(&_systemTrayController, &SystemTrayController::quitRequested, this, [this] {
         qCInfo(lcAppClientLinux) << "Quit requested from system tray";
         if (!_ipcClient.isConnected()) {
@@ -179,7 +189,6 @@ void AppClientLinux::setupLogging() {
     logger->setupLogDir();
     logger->setLogExpire(std::chrono::days(CommonUtility::logsPurgeRate));
     logger->enterNextLogFile();
-    // TODO: Set the minimum log level from parameters once the parameters cache is available (Logger::minLogLevel)
 
     qCInfo(lcAppClientLinux) << "***** Application & System Informations *****";
     qCInfo(lcAppClientLinux) << "app version:" << CommonUtility::currentVersion();

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -21,10 +21,12 @@
 #include "app/cache/appcache.h"
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
+#include "app/cache/parametersstore.h"
 #include "app/onboarding/onboardingsessionmanager.h"
 #include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
 #include "app/services/driveservice.h"
+#include "app/services/parametersservice.h"
 #include "app/services/serviceactiontracker.h"
 #include "app/services/serviceeventbus.h"
 #include "app/services/sentryservice.h"
@@ -73,6 +75,8 @@ class AppClientLinux : public QApplication {
         CommService &serverCommService() { return _serverCommService; }
         AppCache &appCache() { return _appCache; }
         MainSelectionStore &mainSelectionStore() { return _mainSelectionStore; }
+        ParametersStore &parametersStore() { return _parametersStore; }
+        ParametersService &parametersService() { return _parametersService; }
         ServiceActionTracker &serviceActionTracker() { return _serviceActionTracker; }
         ServiceEventBus &serviceEventBus() { return _serviceEventBus; }
 
@@ -91,12 +95,14 @@ class AppClientLinux : public QApplication {
         SignalDispatcher _signalDispatcher{this};
         CommService _serverCommService{_ipcClient, _signalDispatcher, this};
         AppCache _appCache{this};
+        ParametersStore _parametersStore{this};
         CachePipeline _cachePipeline{_serverCommService, _appCache, this};
         MainSelectionStore _mainSelectionStore{_appCache, this};
+        ParametersService _parametersService{_serverCommService, _parametersStore, this};
         ServiceActionTracker _serviceActionTracker{this};
         ServiceEventBus _serviceEventBus{this};
-        SentryService _sentryService{_serverCommService, _appCache, this};
-        CachePopulator _cachePopulator{_serverCommService, _appCache, this};
+        SentryService _sentryService{_parametersService, _appCache, _parametersStore, this};
+        CachePopulator _cachePopulator{_serverCommService, _appCache, _parametersStore, this};
         UserService _userService{_serverCommService, _appCache, _serviceActionTracker, _serviceEventBus, this};
         OnboardingSessionManager _onboardingSessionManager{_cachePopulator, _appCache,        _serverCommService,
                                                            _userService,    _serviceEventBus, this};

--- a/src/libcommon/info/parametersinfo.h
+++ b/src/libcommon/info/parametersinfo.h
@@ -80,10 +80,11 @@ class ParametersInfo {
                    (lhs.autoStart() == rhs.autoStart()) && (lhs.moveToTrash() == rhs.moveToTrash()) &&
                    (lhs.notificationsDisabled() == rhs.notificationsDisabled()) && (lhs.useLog() == rhs.useLog()) &&
                    (lhs.logLevel() == rhs.logLevel()) && (lhs.extendedLog() == rhs.extendedLog()) &&
-                   (lhs.purgeOldLogs() == rhs.purgeOldLogs()) && (lhs.darkTheme() == rhs.darkTheme()) &&
-                   (lhs.dialogGeometry() == rhs.dialogGeometry()) && (lhs.maxAllowedCpu() == rhs.maxAllowedCpu()) &&
-                   (lhs.distributionChannel() == rhs.distributionChannel()) && (lhs.sentryEnabled() == rhs.sentryEnabled()) &&
-                   (lhs.matomoEnabled() == rhs.matomoEnabled()) && (lhs.notifyBeforeDelete() == rhs.notifyBeforeDelete());
+                   (lhs.purgeOldLogs() == rhs.purgeOldLogs()) && lhs.proxyConfigInfo() == rhs.proxyConfigInfo() &&
+                   (lhs.darkTheme() == rhs.darkTheme()) && (lhs.dialogGeometry() == rhs.dialogGeometry()) &&
+                   (lhs.maxAllowedCpu() == rhs.maxAllowedCpu()) && (lhs.distributionChannel() == rhs.distributionChannel()) &&
+                   (lhs.sentryEnabled() == rhs.sentryEnabled()) && (lhs.matomoEnabled() == rhs.matomoEnabled()) &&
+                   (lhs.notifyBeforeDelete() == rhs.notifyBeforeDelete());
         }
 
         void toDynamicStruct(Poco::DynamicStruct &) const;

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -21,12 +21,12 @@
 #include "libcommon/utility/utility.h"
 
 #include <QDir>
+#include <QLoggingCategory>
+#include <QRegularExpression>
 #include <QStringList>
 #include <QThread>
-#include <QMap>
-#include <QRegularExpression>
-#include <QLoggingCategory>
 
+#include <cstdint>
 #include <iostream>
 
 #if defined(KD_WINDOWS)
@@ -46,8 +46,22 @@ constexpr char logMessagePattern[] =
 
 namespace KDC {
 
-static const QMap<QtMsgType, int> qtMsgTypeLevel = {{QtDebugMsg, 0},    {QtInfoMsg, 1},   {QtWarningMsg, 2},
-                                                    {QtCriticalMsg, 3}, {QtSystemMsg, 3}, {QtFatalMsg, 4}};
+static int8_t logLevelForMessageType(const QtMsgType type) noexcept {
+    switch (type) {
+        case QtDebugMsg:
+            return 0;
+        case QtInfoMsg:
+            return 1;
+        case QtWarningMsg:
+            return 2;
+        case QtCriticalMsg: // In Qt's implem, QtCriticalMsg == QtSystemMsg
+            return 3;
+        case QtFatalMsg:
+            return 4;
+    }
+
+    Q_UNREACHABLE();
+}
 
 static QString formatLogMessageWithShortFile(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
     SyncName fileName;
@@ -71,8 +85,10 @@ static void earlyLogCatcher(const QtMsgType type, const QMessageLogContext &ctx,
 }
 
 static void kdriveLogCatcher(QtMsgType type, const QMessageLogContext &ctx, const QString &message) {
-    auto logger = Logger::instance();
-    if (qtMsgTypeLevel[type] < logger->minLogLevel()) return;
+    const auto logger = Logger::instance();
+    if (logLevelForMessageType(type) < logger->minLogLevel()) {
+        return;
+    }
 
     if (!logger->isNoop()) {
         logger->doLog(formatLogMessageWithShortFile(type, ctx, message));

--- a/src/libcommongui/logger.cpp
+++ b/src/libcommongui/logger.cpp
@@ -46,7 +46,7 @@ constexpr char logMessagePattern[] =
 
 namespace KDC {
 
-static const QMap<QtMsgType, int> qtMsgTypeLevel = {{QtInfoMsg, 0},     {QtDebugMsg, 1},  {QtWarningMsg, 2},
+static const QMap<QtMsgType, int> qtMsgTypeLevel = {{QtDebugMsg, 0},    {QtInfoMsg, 1},   {QtWarningMsg, 2},
                                                     {QtCriticalMsg, 3}, {QtSystemMsg, 3}, {QtFatalMsg, 4}};
 
 static QString formatLogMessageWithShortFile(const QtMsgType type, const QMessageLogContext &ctx, const QString &message) {


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR met en place un cache dédié aux paramètres applicatifs (`ParametersStore`) sur Linux v4, ainsi qu'une façade de mise à jour (`ParametersService`), et migre `SentryService` et le niveau de log du `Logger` pour s'appuyer sur ce nouveau cache plutôt que d'interroger le serveur directement.

## Changements
- Ajout de `ParametersStore` (`app/cache/parametersstore.*`) : cache process-wide contenant le dernier instantané `ParametersInfo` confirmé par le serveur, avec les signaux `populatedChanged` et `parametersInfoChanged`.
- Ajout de `ParametersService` (`app/services/parametersservice.*`) : façade qui part de l'instantané confirmé du `ParametersStore`, applique une mutation, envoie le payload complet `PARAMETERS_UPDATE` et ne met à jour le store qu'après confirmation du serveur.
- `CachePopulator` charge désormais les paramètres en premier (`loadParameters()`) avant les utilisateurs, comptes, drives et synchronisations, aussi bien au bootstrap qu'à la reconciliation. Son constructeur prend désormais une référence à `ParametersStore`.
- `SentryService` est refactorisé pour dépendre de `ParametersService` et `ParametersStore` au lieu de `CommService` et d'un `std::optional<ParametersInfo>` interne. Le consentement Sentry est désormais réconcilié via le signal `parametersInfoChanged` (`reconcileConsentWithParametersStore`) plutôt que par un appel explicite `reconcileConsentWithServer()` sur `ipcConnected`.
- `AppClientLinux` instancie `_parametersStore` et `_parametersService`, les expose au QML (`parametersStore`, `parametersService`), vide le store à la déconnexion IPC, et met à jour le niveau minimum de log du `Logger` dès que les paramètres serveur changent.
- `ParametersInfo::operator==` inclut désormais `proxyConfigInfo()` dans la comparaison d'égalité (champ précédemment absent du test).
- `libcommongui/logger.cpp` remplace la `QMap<QtMsgType, int>` de correspondance des niveaux par une fonction `logLevelForMessageType()`, avec un ordre clarifié (Debug=0, Info=1, Warning=2, Critical/System=3, Fatal=4).
- Mise à jour de `AGENTS.md` (documentation des rôles de `ParametersStore`, `ParametersService` et de la nouvelle séquence de `CachePopulator`) et de `CMakeLists.txt` pour référencer les nouveaux fichiers.

## Détails techniques
`ParametersStore` reste volontairement séparé d'`AppCache` : le serveur demeure la source de vérité pour les paramètres applicatifs, et le store ne contient que le dernier instantané confirmé, sans état de brouillon (les brouillons d'écran, par exemple pour la configuration du proxy, restent la responsabilité du view model de l'écran concerné).

## Notes
Le TODO existant dans `appclientlinux.cpp` concernant l'initialisation du niveau de log minimum depuis les paramètres a été résolu par ce changement.

</details>

---

## Summary
This PR introduces a dedicated application parameters cache (`ParametersStore`) on Linux v4, along with an update facade (`ParametersService`), and migrates `SentryService` and the `Logger`'s minimum log level to rely on this new cache instead of querying the server directly.

## Changes
- Added `ParametersStore` (`app/cache/parametersstore.*`): a process-wide cache holding the last server-confirmed `ParametersInfo` snapshot, with `populatedChanged` and `parametersInfoChanged` signals.
- Added `ParametersService` (`app/services/parametersservice.*`): a facade that starts from the confirmed `ParametersStore` snapshot, applies a mutation, sends the full `PARAMETERS_UPDATE` payload, and only updates the store after server confirmation.
- `CachePopulator` now loads parameters first (`loadParameters()`) before users, accounts, drives, and syncs, for both bootstrap and reconciliation. Its constructor now takes a `ParametersStore` reference.
- `SentryService` is refactored to depend on `ParametersService` and `ParametersStore` instead of `CommService` and an internal `std::optional<ParametersInfo>`. Sentry consent is now reconciled via the `parametersInfoChanged` signal (`reconcileConsentWithParametersStore`) instead of an explicit `reconcileConsentWithServer()` call on `ipcConnected`.
- `AppClientLinux` instantiates `_parametersStore` and `_parametersService`, exposes them to QML (`parametersStore`, `parametersService`), clears the store on IPC disconnection, and updates the `Logger`'s minimum log level whenever server parameters change.
- `ParametersInfo::operator==` now includes `proxyConfigInfo()` in the equality comparison (a field previously missing from the check).
- `libcommongui/logger.cpp` replaces the `QMap<QtMsgType, int>` level lookup with a `logLevelForMessageType()` function, with a clarified ordering (Debug=0, Info=1, Warning=2, Critical/System=3, Fatal=4).
- Updated `AGENTS.md` (documenting the roles of `ParametersStore`, `ParametersService`, and the new `CachePopulator` sequence) and `CMakeLists.txt` to reference the new files.

## Technical Details
`ParametersStore` is intentionally kept separate from `AppCache`: the server remains the source of truth for application parameters, and the store only holds the last confirmed snapshot with no draft state (screen-level drafts, such as proxy editing, remain owned by the relevant screen's view model).

## Notes
This resolves the existing TODO in `appclientlinux.cpp` about initializing the minimum log level from parameters once the parameters cache became available.