### PR TITLE
feat: Sentry settings

### DIFF
--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -138,6 +138,7 @@
 				Cache/Observation/helpers/ObservedSynchros.swift,
 				Cache/Observation/helpers/ObservedUpdater.swift,
 				Cache/Observation/helpers/ObservedUser.swift,
+				Cache/SettingsCacheTests.swift,
 				Jobs/LoginJobTests.swift,
 				Logging/GzipCompressorTests.swift,
 				Logging/LogServiceTests.swift,

--- a/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/SplitView/PreferencesRepository.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/SplitView/PreferencesRepository.swift
@@ -18,11 +18,14 @@
 
 import Combine
 import Foundation
+import InfomaniakDI
 import kDriveCore
 import kDriveCoreUI
 
 @MainActor
 public final class PreferencesRepository: ObservableObject {
+    @LazyInjectService private var settingsCache: SettingsCaching
+
     @Published public private(set) var parametersInfo = UIParametersInfo()
 
     public init() {}
@@ -41,5 +44,6 @@ public final class PreferencesRepository: ObservableObject {
         try await ParametersJobs().updateParameters(parametersInfo: payload)
 
         try? await refreshData()
+        try? await settingsCache.refresh()
     }
 }

--- a/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/SplitView/PreferencesRepository.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/SplitView/PreferencesRepository.swift
@@ -31,19 +31,26 @@ public final class PreferencesRepository: ObservableObject {
     public init() {}
 
     public func refreshData() async throws {
-        let refreshedData = try await ParametersJobs().parametersInfo()
-        parametersInfo = UIParametersInfo(parametersInfo: refreshedData)
+        try await settingsCache.refresh()
+        if let refreshedData = await settingsCache.getSettings() {
+            parametersInfo = UIParametersInfo(parametersInfo: refreshedData)
+        }
     }
 
     public func update<T>(_ keyPath: WritableKeyPath<UIParametersInfo, T>, value: T) async throws {
         var updatedParameters = parametersInfo
         updatedParameters[keyPath: keyPath] = value
 
-        let currentData = try await ParametersJobs().parametersInfo()
-        let payload = updatedParameters.copyToParametersInfo(from: currentData)
-        try await ParametersJobs().updateParameters(parametersInfo: payload)
+        if await settingsCache.getSettings() == nil {
+            try await settingsCache.refresh()
+        }
+        guard let currentData = await settingsCache.getSettings() else { return }
 
-        try? await refreshData()
-        try? await settingsCache.refresh()
+        let payload = updatedParameters.copyToParametersInfo(from: currentData)
+        try await settingsCache.update(payload)
+
+        if let refreshedData = await settingsCache.getSettings() {
+            parametersInfo = UIParametersInfo(parametersInfo: refreshedData)
+        }
     }
 }

--- a/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Advanced/DataManagement/DataManagementPreferencesDetailView.swift
+++ b/src/gui4/macOS/kDrive/UI/Views/PreferencesWindow/Advanced/DataManagement/DataManagementPreferencesDetailView.swift
@@ -21,6 +21,8 @@ import kDriveResources
 import SwiftUI
 
 struct DataManagementPreferencesDetailView: View {
+    @ObservedSettings private var settings
+
     @State private var allowTracking = false
 
     let item: DataManagementItem
@@ -44,7 +46,10 @@ struct DataManagementPreferencesDetailView: View {
         }
         .groupedFormatStyle()
         .onAppear {
-            allowTracking = repository.parametersInfo[keyPath: item.keyPath]
+            allowTracking = settings[keyPath: item.keyPath]
+        }
+        .onChange(of: settings[keyPath: item.keyPath]) { newValue in
+            allowTracking = newValue
         }
         .onChange(of: allowTracking) { newValue in
             updateValue(\.$allowTracking, item.keyPath, newValue: newValue)
@@ -57,12 +62,12 @@ struct DataManagementPreferencesDetailView: View {
         newValue: T
     ) {
         Task {
-            guard newValue != repository.parametersInfo[keyPath: repositoryKeyPath] else { return }
+            guard newValue != settings[keyPath: repositoryKeyPath] else { return }
 
             do {
                 try await repository.update(repositoryKeyPath, value: newValue)
             } catch {
-                self[keyPath: stateKeyPath].wrappedValue = repository.parametersInfo[keyPath: repositoryKeyPath]
+                self[keyPath: stateKeyPath].wrappedValue = settings[keyPath: repositoryKeyPath]
             }
         }
     }

--- a/src/gui4/macOS/kDrive/Utils/DriveTargetAssembly.swift
+++ b/src/gui4/macOS/kDrive/Utils/DriveTargetAssembly.swift
@@ -53,6 +53,9 @@ final class DriveTargetAssembly: TargetAssembly {
             },
             Factory(type: SynchroErrorsObserving.self) { _, _ in
                 SynchroErrorsObserver()
+            },
+            Factory(type: SettingsObserving.self) { _, _ in
+                SettingsObserver()
             }
         ]
     }

--- a/src/gui4/macOS/kDrive/Utils/Observers/Settings/ObservedSettings.swift
+++ b/src/gui4/macOS/kDrive/Utils/Observers/Settings/ObservedSettings.swift
@@ -1,0 +1,49 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import InfomaniakDI
+import kDriveCoreUI
+import SwiftUI
+
+@propertyWrapper
+struct ObservedSettings: DynamicProperty {
+    @StateObject private var model = SettingsModel()
+
+    var wrappedValue: UIParametersInfo { model.settings }
+
+    var projectedValue: ObservedSettings { self }
+}
+
+private final class SettingsModel: ObservableObject {
+    @InjectService private var settingsObserver: SettingsObserving
+
+    @Published private(set) var settings = UIParametersInfo()
+
+    private var cancellable: AnyCancellable?
+
+    init() {
+        settings = settingsObserver.settings
+
+        cancellable = settingsObserver.settingsPublisher
+            .receive(on: RunLoop.main)
+            .sink { [weak self] output in
+                self?.settings = output
+            }
+    }
+}

--- a/src/gui4/macOS/kDrive/Utils/Observers/Settings/SettingsObserver.swift
+++ b/src/gui4/macOS/kDrive/Utils/Observers/Settings/SettingsObserver.swift
@@ -26,8 +26,6 @@ public protocol SettingsObserving: Sendable {
     var settingsPublisher: AnyPublisher<UIParametersInfo, Never> { get }
 }
 
-/// Observes the `SettingsCache` and republishes its content as a UI model (`UIParametersInfo`),
-/// mirroring the observation pattern used for the coherent server cache (e.g. `UISynchroStateObserver`).
 public final class SettingsObserver: SettingsObserving {
     @MainActor public private(set) var settings = UIParametersInfo() {
         didSet {

--- a/src/gui4/macOS/kDrive/Utils/Observers/Settings/SettingsObserver.swift
+++ b/src/gui4/macOS/kDrive/Utils/Observers/Settings/SettingsObserver.swift
@@ -1,0 +1,75 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import InfomaniakDI
+import kDriveCore
+import kDriveCoreUI
+
+public protocol SettingsObserving: Sendable {
+    var settings: UIParametersInfo { get }
+    var settingsPublisher: AnyPublisher<UIParametersInfo, Never> { get }
+}
+
+/// Observes the `SettingsCache` and republishes its content as a UI model (`UIParametersInfo`),
+/// mirroring the observation pattern used for the coherent server cache (e.g. `UISynchroStateObserver`).
+public final class SettingsObserver: SettingsObserving {
+    @MainActor public private(set) var settings = UIParametersInfo() {
+        didSet {
+            settingsSubject.send(settings)
+        }
+    }
+
+    @MainActor private let settingsSubject = PassthroughSubject<UIParametersInfo, Never>()
+    @MainActor public var settingsPublisher: AnyPublisher<UIParametersInfo, Never> {
+        settingsSubject.eraseToAnyPublisher()
+    }
+
+    @MainActor private var cancellable: AnyCancellable?
+
+    public init() {
+        Task { @MainActor [weak self] in
+            self?.observeSettings()
+        }
+    }
+
+    deinit {
+        Task { @MainActor [weak self] in
+            self?.cancellable?.cancel()
+        }
+    }
+
+    @MainActor
+    private func observeSettings() {
+        Task {
+            @InjectService var cache: SettingsCaching
+            if let currentSettings = await cache.getSettings() {
+                settings = UIParametersInfo(parametersInfo: currentSettings)
+            }
+
+            @InjectService var cacheObservable: SettingsCacheObservable
+            cancellable = cacheObservable.settingsPublisher
+                .map { UIParametersInfo(parametersInfo: $0) }
+                .removeDuplicates()
+                .receive(on: RunLoop.main)
+                .sink { [weak self] output in
+                    self?.settings = output
+                }
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveCore/Sentry/SentryService.swift
+++ b/src/gui4/macOS/kDriveCore/Sentry/SentryService.swift
@@ -16,13 +16,21 @@
  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+import Combine
+import Foundation
+import InfomaniakDI
 import Sentry
 
 public final class SentryService {
-    private var isSentryAuthorized = true
+    @LazyInjectService private var settingsCacheObservable: SettingsCacheObservable
+
+    private var isSentryAuthorized: Bool
+    private var cancellable: AnyCancellable?
 
     public init() {
-        fetchAuthorization()
+        // Apply the last known value immediately at startup, before the server connection is ready.
+        isSentryAuthorized = UserDefaults.standard.lastKnownSentryEnabled
+        observeSettings()
     }
 
     public func initSentry() {
@@ -38,7 +46,6 @@ public final class SentryService {
 
             options.beforeSend = { [weak self] event in
                 guard let self else { return nil }
-                fetchAuthorization()
 
                 #if DEBUG || TEST
                 return nil
@@ -49,11 +56,12 @@ public final class SentryService {
         }
     }
 
-    private func fetchAuthorization() {
-        Task {
-            if let isEnabled = try? await ParametersJobs().parametersInfo().sentryEnabled {
-                isSentryAuthorized = isEnabled
+    private func observeSettings() {
+        cancellable = settingsCacheObservable.settingsPublisher
+            .map(\.sentryEnabled)
+            .removeDuplicates()
+            .sink { [weak self] isEnabled in
+                self?.isSentryAuthorized = isEnabled
             }
-        }
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/SettingsCache.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/SettingsCache.swift
@@ -1,0 +1,60 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+
+public typealias SettingsPublisher = AnyPublisher<ParametersInfo, Never>
+
+public protocol SettingsCacheObservable: Sendable {
+    var settingsPublisher: SettingsPublisher { get }
+}
+
+public protocol SettingsCaching: Sendable {
+    func getSettings() async -> ParametersInfo?
+    func refresh() async throws
+}
+
+public actor SettingsCache: SettingsCaching, SettingsCacheObservable {
+    private var settings: ParametersInfo?
+
+    private nonisolated let settingsSubject = CurrentValueSubject<ParametersInfo?, Never>(nil)
+
+    public nonisolated var settingsPublisher: SettingsPublisher {
+        settingsSubject
+            .compactMap { $0 }
+            .eraseToAnyPublisher()
+    }
+
+    public init() {}
+
+    public func getSettings() -> ParametersInfo? {
+        settings
+    }
+
+    public func refresh() async throws {
+        let refreshedSettings = try await ParametersJobs().parametersInfo()
+        setSettings(refreshedSettings)
+    }
+
+    func setSettings(_ settings: ParametersInfo) {
+        self.settings = settings
+        UserDefaults.standard.lastKnownSentryEnabled = settings.sentryEnabled
+        settingsSubject.send(settings)
+    }
+}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/SettingsCache.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/SettingsCache.swift
@@ -28,6 +28,7 @@ public protocol SettingsCacheObservable: Sendable {
 public protocol SettingsCaching: Sendable {
     func getSettings() async -> ParametersInfo?
     func refresh() async throws
+    func update(_ parametersInfo: ParametersInfo) async throws
 }
 
 public actor SettingsCache: SettingsCaching, SettingsCacheObservable {
@@ -50,6 +51,11 @@ public actor SettingsCache: SettingsCaching, SettingsCacheObservable {
     public func refresh() async throws {
         let refreshedSettings = try await ParametersJobs().parametersInfo()
         setSettings(refreshedSettings)
+    }
+
+    public func update(_ parametersInfo: ParametersInfo) async throws {
+        try await ParametersJobs().updateParameters(parametersInfo: parametersInfo)
+        try await refresh()
     }
 
     func setSettings(_ settings: ParametersInfo) {

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
@@ -23,6 +23,7 @@ import InfomaniakDI
 @objc final class XPCConnectionManager: NSObject, @unchecked Sendable {
     @InjectService var signalHandler: XPCSignalHandlerProtocol
     @LazyInjectService var coherentCache: CoherentCache
+    @LazyInjectService var settingsCache: SettingsCaching
 
     @MainActor
     @Published private(set) var guiConnectionState: XPCConnectionState = .notConnected
@@ -203,6 +204,7 @@ import InfomaniakDI
         Task {
             IKLogger.xpc.log("[KD] coherentCache.clearAndRefresh")
             try await coherentCache.clearAndRefresh()
+            try? await settingsCache.refresh()
             await MainActor.run { [weak self] in
                 guard let self, let conn = appConnection else { return }
                 let currentId = ObjectIdentifier(conn)

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -60,6 +60,15 @@ open class TargetAssembly {
                                      factoryParameters: nil,
                                      resolver: resolver)
             },
+            Factory(type: SettingsCaching.self) { _, _ in
+                SettingsCache()
+            },
+            Factory(type: SettingsCacheObservable.self) { _, resolver in
+                try resolver.resolve(type: SettingsCaching.self,
+                                     forCustomTypeIdentifier: nil,
+                                     factoryParameters: nil,
+                                     resolver: resolver)
+            },
             Factory(type: VFSConversionStoring.self) { _, _ in
                 VFSConversionStore()
             },

--- a/src/gui4/macOS/kDriveCore/Utils/UserDefaults+Extension.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/UserDefaults+Extension.swift
@@ -23,6 +23,7 @@ public extension UserDefaults {
         public static let isFirstLaunch = "isFirstLaunch"
         public static let shouldPresentOnboarding = "shouldPresentOnboarding"
         public static let selectedSynchroDbId = "selectedSynchroDbId"
+        public static let lastKnownSentryEnabled = "lastKnownSentryEnabled"
     }
 }
 
@@ -33,6 +34,15 @@ public extension UserDefaults {
         }
         set {
             set(newValue, forKey: Key.selectedSynchroDbId)
+        }
+    }
+
+    var lastKnownSentryEnabled: Bool {
+        get {
+            object(forKey: Key.lastKnownSentryEnabled) as? Bool ?? true
+        }
+        set {
+            set(newValue, forKey: Key.lastKnownSentryEnabled)
         }
     }
 }

--- a/src/gui4/macOS/kDriveTests/Cache/SettingsCacheTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/SettingsCacheTests.swift
@@ -22,63 +22,58 @@ import Foundation
 import Testing
 
 extension SettingsCache {
-    var receivedSettingsValues: AsyncStream<ParametersInfo> {
+    var settingsEmissions: AsyncStream<Void> {
         AsyncStream { continuation in
             let cancellable = settingsPublisher
-                .sink { value in continuation.yield(value) }
+                .sink { _ in continuation.yield(()) }
 
             continuation.onTermination = { _ in cancellable.cancel() }
         }
     }
 }
 
+@MainActor
 @Suite("SettingsCache Test")
 struct SettingsCacheTests {
-    private static func makeParametersInfo(sentryEnabled: Bool) -> ParametersInfo {
-        ParametersInfo(
-            language: .English,
-            monoIcons: false,
-            autoStart: true,
-            moveToTrash: true,
-            notificationsDisabled: .Never,
-            useLog: true,
-            logLevel: .Debug,
-            extendedLog: false,
-            purgeOldLogs: true,
-            proxyConfigInfo: ProxyConfigInfo(type: .None, hostName: "", port: 0, needsAuth: false, user: "", pwd: ""),
-            darkTheme: false,
-            maxAllowedCpu: 50,
-            distributionChannel: .Prod,
-            sentryEnabled: sentryEnabled,
-            matomoEnabled: true,
-            askBeforeDelete: true
-        )
+    // MARK: - Test Data
+
+    private static func decodedResponse() throws -> CallbackMessage<ParametersInfoResponse> {
+        let bundle = Bundle(for: TestBundleMarker.self)
+
+        guard let url = bundle.url(forResource: "PARAMETERS_INFO", withExtension: "json") else {
+            fatalError("Unable to find specified JSON file")
+        }
+
+        let data = try Data(contentsOf: url)
+        return try JSONDecoder().decode(CallbackMessage<ParametersInfoResponse>.self, from: data)
     }
+
+    // MARK: - Tests
 
     @Test(.timeLimit(.minutes(1)))
     func publishesAndStoresSettings() async throws {
         // GIVEN
+        let settings = try Self.decodedResponse().body.parametersInfo
         let cache = SettingsCache()
-        let receivedValues = await cache.receivedSettingsValues // Start to save the received values
+        let emissions = await cache.settingsEmissions // Start observing before mutating
 
-        var receivedSettings: ParametersInfo?
+        var receivedSentryEnabled: Bool?
         var cancellables = Set<AnyCancellable>()
 
         let subscription = cache.settingsPublisher
-            .sink { settings in receivedSettings = settings }
+            .sink { receivedSentryEnabled = $0.sentryEnabled }
         subscription.store(in: &cancellables)
 
         // WHEN
-        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: false))
+        await cache.setSettings(settings)
 
         // THEN
-        _ = await receivedValues.first { _ in true }
+        _ = await emissions.first { _ in true }
 
-        #expect(receivedSettings != nil, "Should have received a settings update")
-        #expect(receivedSettings?.sentryEnabled == false, "Received settings should match expected")
+        #expect(receivedSentryEnabled == false, "Should have published the settings")
 
-        let storedSettings = await cache.getSettings()
-        #expect(storedSettings?.sentryEnabled == false, "Cache should retain the last settings")
+        let storedSentryEnabled = await cache.getSettings()?.sentryEnabled
+        #expect(storedSentryEnabled == false, "Cache should retain the last settings")
     }
 
     @Test(.timeLimit(.minutes(1)))
@@ -87,18 +82,19 @@ struct SettingsCacheTests {
         let originalValue = UserDefaults.standard.lastKnownSentryEnabled
         defer { UserDefaults.standard.lastKnownSentryEnabled = originalValue }
 
+        let settings = try Self.decodedResponse().body.parametersInfo
         let cache = SettingsCache()
 
-        // WHEN
-        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: false))
-
-        // THEN
-        #expect(UserDefaults.standard.lastKnownSentryEnabled == false, "Should persist the disabled flag")
+        // Seed the opposite value to prove `setSettings` actively writes the flag.
+        UserDefaults.standard.lastKnownSentryEnabled = true
 
         // WHEN
-        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: true))
+        await cache.setSettings(settings)
 
         // THEN
-        #expect(UserDefaults.standard.lastKnownSentryEnabled == true, "Should persist the enabled flag")
+        #expect(
+            UserDefaults.standard.lastKnownSentryEnabled == false,
+            "Should persist the Sentry flag coming from the settings"
+        )
     }
 }

--- a/src/gui4/macOS/kDriveTests/Cache/SettingsCacheTests.swift
+++ b/src/gui4/macOS/kDriveTests/Cache/SettingsCacheTests.swift
@@ -1,0 +1,104 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Combine
+import Foundation
+@testable import kDriveCore
+import Testing
+
+extension SettingsCache {
+    var receivedSettingsValues: AsyncStream<ParametersInfo> {
+        AsyncStream { continuation in
+            let cancellable = settingsPublisher
+                .sink { value in continuation.yield(value) }
+
+            continuation.onTermination = { _ in cancellable.cancel() }
+        }
+    }
+}
+
+@Suite("SettingsCache Test")
+struct SettingsCacheTests {
+    private static func makeParametersInfo(sentryEnabled: Bool) -> ParametersInfo {
+        ParametersInfo(
+            language: .English,
+            monoIcons: false,
+            autoStart: true,
+            moveToTrash: true,
+            notificationsDisabled: .Never,
+            useLog: true,
+            logLevel: .Debug,
+            extendedLog: false,
+            purgeOldLogs: true,
+            proxyConfigInfo: ProxyConfigInfo(type: .None, hostName: "", port: 0, needsAuth: false, user: "", pwd: ""),
+            darkTheme: false,
+            maxAllowedCpu: 50,
+            distributionChannel: .Prod,
+            sentryEnabled: sentryEnabled,
+            matomoEnabled: true,
+            askBeforeDelete: true
+        )
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func publishesAndStoresSettings() async throws {
+        // GIVEN
+        let cache = SettingsCache()
+        let receivedValues = await cache.receivedSettingsValues // Start to save the received values
+
+        var receivedSettings: ParametersInfo?
+        var cancellables = Set<AnyCancellable>()
+
+        let subscription = cache.settingsPublisher
+            .sink { settings in receivedSettings = settings }
+        subscription.store(in: &cancellables)
+
+        // WHEN
+        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: false))
+
+        // THEN
+        _ = await receivedValues.first { _ in true }
+
+        #expect(receivedSettings != nil, "Should have received a settings update")
+        #expect(receivedSettings?.sentryEnabled == false, "Received settings should match expected")
+
+        let storedSettings = await cache.getSettings()
+        #expect(storedSettings?.sentryEnabled == false, "Cache should retain the last settings")
+    }
+
+    @Test(.timeLimit(.minutes(1)))
+    func persistsLastKnownSentryEnabledFlag() async throws {
+        // GIVEN
+        let originalValue = UserDefaults.standard.lastKnownSentryEnabled
+        defer { UserDefaults.standard.lastKnownSentryEnabled = originalValue }
+
+        let cache = SettingsCache()
+
+        // WHEN
+        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: false))
+
+        // THEN
+        #expect(UserDefaults.standard.lastKnownSentryEnabled == false, "Should persist the disabled flag")
+
+        // WHEN
+        await cache.setSettings(Self.makeParametersInfo(sentryEnabled: true))
+
+        // THEN
+        #expect(UserDefaults.standard.lastKnownSentryEnabled == true, "Should persist the enabled flag")
+    }
+}


### PR DESCRIPTION
## Summary

Introduces an observable **settings cache** for the macOS redesign (`src/gui4/macOS`), modeled on the existing errors / coherent-server-cache pattern. The Sentry preference toggle and the runtime `SentryService` now observe this cache, and the last known Sentry-enabled flag is persisted so the correct value is applied at startup before the server connection is ready.

## Motivation

- `SentryService` previously re-queried the server on every event and defaulted to *enabled* until the first response — at cold start (before XPC connects) it couldn't honor the user's real choice.
- Parameters were fetched ad hoc by `PreferencesRepository`, with no single source of truth or app-wide observation.

## Changes

### New: `SettingsCache` (kDriveCore)
- `actor` conforming to `SettingsCaching` (write/read) + `SettingsCacheObservable` (Combine publisher), following the `LogUploadStatusCache` / coherent-cache convention.
- Owns **all** `ParametersJobs` server I/O:
  - `refresh()` — pull from server, publish, persist.
  - `update(_:)` — write to server, then refresh.
- On every update, persists the last known Sentry flag to `UserDefaults` (`lastKnownSentryEnabled`, default `true`).
- Registered in DI (`TargetAssembly`) as a shared instance behind both protocols.

### Startup + reset behavior
- `XPCConnectionManager` refreshes the settings cache right after `coherentCache.clearAndRefresh()` on every (re)connect, so a cache reset also updates settings.
- `SentryService` seeds `isSentryAuthorized` from `UserDefaults.lastKnownSentryEnabled` at init (applied immediately at startup) and then observes `settingsPublisher` instead of polling on each `beforeSend`.

### Sentry toggle observes the cache
- Added `SettingsObserver` + `@ObservedSettings` property wrapper (parallels `UISynchroStateObserver` / `@ObservedUISynchroState`), registered in `DriveTargetAssembly`.
- `DataManagementPreferencesDetailView` drives the toggle from the observed cache value.

### Refactor: `PreferencesRepository` → thin UI adapter
- No longer calls `ParametersJobs` directly; delegates read/write to `SettingsCache`, removing the duplicated fetch. Remains the `@ObservedObject` for the other preference screens (maps `ParametersInfo` → `UIParametersInfo`).

## Tests

- `SettingsCacheTests` verifies the cache publishes/stores settings and persists the Sentry flag to `UserDefaults`.
