### PR TITLE
fix(macOS): Signal ordering

### DIFF
--- a/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
+++ b/src/gui4/macOS/kDrive.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 				Parsing/Signals/UtilityShowNotificationTest.swift,
 				Parsing/Signals/VfsConversionCompletedParsingTest.swift,
 				Router/MainViewRouterTests.swift,
+				Signal/SignalProcessorTests.swift,
 				UI/UISynchroNodeTests.swift,
 				XPC/JSON/AnyValidJobResponse.json,
 				XPC/JSON/ParsingError.json,

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Cache/CacheReconciler.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Cache/CacheReconciler.swift
@@ -1,0 +1,68 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+import InfomaniakDI
+
+public protocol CacheReconciling: Sendable {
+    /// Requests a coalesced full cache refresh to recover from a detected inconsistence
+    func scheduleRefresh() async
+}
+
+/// Recovers the coherent cache from inconsistencies caused by out-of-order server signals.
+///
+/// The server dispatches push signals on a concurrent thread pool, so causally-linked signals
+/// (`ACCOUNT_ADDED` → `DRIVE_ADDED` → `SYNC_ADDED`) can reach the client out of order. When a signal
+/// references a parent that is not in the cache yet, the handler drops it and the cache stays
+/// incomplete (e.g. a drive without its sync). This reconciler coalesces such failures into a single
+/// `refresh()` that re-fetches the authoritative state from the server. Once the refresh lands,
+/// subsequent signals resolve normally, so the reconciler naturally stops firing.
+public actor CacheReconciler: CacheReconciling {
+    @LazyInjectService private var coherentCache: CoherentCache
+
+    private let delayNanoseconds: UInt64
+    private var pendingRefresh: Task<Void, Never>?
+
+    public init(delayNanoseconds: UInt64 = 1_000_000_000) {
+        self.delayNanoseconds = delayNanoseconds
+    }
+
+    public func scheduleRefresh() {
+        guard pendingRefresh == nil else { return }
+
+        let delay = delayNanoseconds
+        pendingRefresh = Task { [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            await self?.performRefresh()
+            await self?.clearPendingRefresh()
+        }
+    }
+
+    private func clearPendingRefresh() {
+        pendingRefresh = nil
+    }
+
+    private func performRefresh() async {
+        do {
+            IKLogger.xpc.log("[KD] cache reconcile: refreshing after signal inconsistency")
+            try await coherentCache.refresh()
+        } catch {
+            IKLogger.xpc.error("[KD] cache reconcile refresh failed: \(error)")
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Signal/SignalProcessor.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Signal/SignalProcessor.swift
@@ -1,0 +1,51 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+
+public protocol SignalProcessing: Sendable {
+    /// Enqueues a raw server signal for serialized, in-order processing.
+    func enqueue(_ signal: Data)
+}
+
+/// Serializes the processing of server-push signals.
+///
+/// This actor funnels every signal through a single unbounded FIFO `AsyncStream` drained by one
+/// consumer task. Because that task awaits each signal to completion before pulling the next, signals
+/// are applied one at a time and in the exact order the server emitted them.
+public actor SignalProcessor: SignalProcessing {
+    private let handler: XPCSignalHandlerProtocol
+    private let stream: AsyncStream<Data>
+    private let continuation: AsyncStream<Data>.Continuation
+
+    public init(handler: sending XPCSignalHandlerProtocol) {
+        self.handler = handler
+        (stream, continuation) = AsyncStream.makeStream(of: Data.self, bufferingPolicy: .unbounded)
+        Task { await consume() }
+    }
+
+    public nonisolated func enqueue(_ signal: Data) {
+        continuation.yield(signal)
+    }
+
+    private func consume() async {
+        for await signal in stream {
+            await handler.handleServerSignal(signal)
+        }
+    }
+}

--- a/src/gui4/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/Signal/XPCSignalHandler.swift
@@ -57,11 +57,17 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
     private let utilitySignalHandler = UtilitySignalHandler()
     private let updaterSignalHandler = UpdaterSignalHandler()
 
+    @LazyInjectService private var cacheReconciler: CacheReconciling
+
     func handleServerSignal(_ signal: Data?) async {
         do {
             try await decodeAndUseServerSignal(signal)
         } catch {
             IKLogger.xpc.error("[KD] signal error :\(error)")
+
+            if error.indicatesCacheInconsistency {
+                await cacheReconciler.scheduleRefresh()
+            }
 
             SentrySDK.capture(message: "Error processing Signal") { scope in
                 scope.setLevel(.error)
@@ -144,6 +150,18 @@ struct XPCSignalHandler: XPCSignalHandlerProtocol {
 
         default:
             throw SignalError.unsupported(signalNum)
+        }
+    }
+}
+
+private extension Error {
+    var indicatesCacheInconsistency: Bool {
+        guard let cacheError = self as? ServerCoherentCache.CacheError else { return false }
+        switch cacheError {
+        case .userNotFound, .accountNotFound, .driveNotFound, .synchroNotFound:
+            return true
+        case .errorNotFound, .notAServerError:
+            return false
         }
     }
 }

--- a/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
+++ b/src/gui4/macOS/kDriveCore/ServerBridge/XPC/XPCConnectionManager.swift
@@ -21,7 +21,7 @@ import Foundation
 import InfomaniakDI
 
 @objc final class XPCConnectionManager: NSObject, @unchecked Sendable {
-    @InjectService var signalHandler: XPCSignalHandlerProtocol
+    @LazyInjectService var signalProcessor: SignalProcessing
     @LazyInjectService var coherentCache: CoherentCache
     @LazyInjectService var settingsCache: SettingsCaching
 
@@ -234,8 +234,6 @@ extension XPCConnectionManager: XPCLoginItemRemoteProtocol {
 
 extension XPCConnectionManager: XPCGuiRemoteProtocol {
     func processSignal(_ msg: Data) {
-        Task {
-            await signalHandler.handleServerSignal(msg)
-        }
+        signalProcessor.enqueue(msg)
     }
 }

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -91,6 +91,13 @@ open class TargetAssembly {
             Factory(type: XPCSignalHandlerProtocol.self) { _, _ in
                 XPCSignalHandler()
             },
+            Factory(type: SignalProcessing.self) { _, resolver in
+                let handler = try resolver.resolve(type: XPCSignalHandlerProtocol.self,
+                                                   forCustomTypeIdentifier: nil,
+                                                   factoryParameters: nil,
+                                                   resolver: resolver)
+                return SignalProcessor(handler: handler)
+            },
             Factory(type: AutoIncrementIDGenerator.self) { _, _ in
                 AutoIncrementIDGenerator()
             },

--- a/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
+++ b/src/gui4/macOS/kDriveCore/Utils/TargetAssembly.swift
@@ -98,6 +98,9 @@ open class TargetAssembly {
                                                    resolver: resolver)
                 return SignalProcessor(handler: handler)
             },
+            Factory(type: CacheReconciling.self) { _, _ in
+                CacheReconciler()
+            },
             Factory(type: AutoIncrementIDGenerator.self) { _, _ in
                 AutoIncrementIDGenerator()
             },

--- a/src/gui4/macOS/kDriveTests/Signal/SignalProcessorTests.swift
+++ b/src/gui4/macOS/kDriveTests/Signal/SignalProcessorTests.swift
@@ -25,7 +25,9 @@ private actor RecordingStore {
     private(set) var values: [Int] = []
     private var awaited: (target: Int, continuation: CheckedContinuation<Void, Never>)?
 
-    func snapshot() -> [Int] { values }
+    func snapshot() -> [Int] {
+        values
+    }
 
     /// Non-atomic replace: overwrites the whole array from a snapshot the caller took *before* a
     /// suspension point. If two handlers ran concurrently, the second replace would clobber the
@@ -71,7 +73,7 @@ struct SignalProcessorTests {
 
         let count = 200
         for index in 0 ..< count {
-            processor.enqueue(try encoder.encode(index))
+            try processor.enqueue(encoder.encode(index))
         }
 
         await store.waitFor(count: count)

--- a/src/gui4/macOS/kDriveTests/Signal/SignalProcessorTests.swift
+++ b/src/gui4/macOS/kDriveTests/Signal/SignalProcessorTests.swift
@@ -1,0 +1,84 @@
+/*
+ Infomaniak kDrive - Desktop
+ Copyright (C) 2023-2026 Infomaniak Network SA
+
+ This program is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import Foundation
+@testable import kDriveCore
+import Testing
+
+/// Collects the values processed by the fake signal handler and lets the test await a target count.
+private actor RecordingStore {
+    private(set) var values: [Int] = []
+    private var awaited: (target: Int, continuation: CheckedContinuation<Void, Never>)?
+
+    func snapshot() -> [Int] { values }
+
+    /// Non-atomic replace: overwrites the whole array from a snapshot the caller took *before* a
+    /// suspension point. If two handlers ran concurrently, the second replace would clobber the
+    /// first (lost update) and/or reorder values. Serial processing keeps every value, in order.
+    func replace(with newValues: [Int]) {
+        values = newValues
+        if let awaited, values.count >= awaited.target {
+            awaited.continuation.resume()
+            self.awaited = nil
+        }
+    }
+
+    func waitFor(count: Int) async {
+        if values.count >= count { return }
+        await withCheckedContinuation { continuation in
+            awaited = (count, continuation)
+        }
+    }
+}
+
+/// Fake handler that mimics the real signal handlers' read-modify-write over the (actor) cache,
+/// including a suspension point between the read and the write.
+private struct OrderRecordingSignalHandler: XPCSignalHandlerProtocol {
+    let store: RecordingStore
+
+    func handleServerSignal(_ signal: Data?) async {
+        guard let signal, let value = try? JSONDecoder().decode(Int.self, from: signal) else { return }
+
+        var current = await store.snapshot() // read
+        await Task.yield() // suspension window where interleaving would occur if not serialized
+        current.append(value) // modify
+        await store.replace(with: current) // write
+    }
+}
+
+@Suite("SignalProcessor serialization")
+struct SignalProcessorTests {
+    @Test("Processes every enqueued signal exactly once, in FIFO order")
+    func serializesSignalsInOrder() async throws {
+        let encoder = JSONEncoder()
+        let store = RecordingStore()
+        let processor = SignalProcessor(handler: OrderRecordingSignalHandler(store: store))
+
+        let count = 200
+        for index in 0 ..< count {
+            processor.enqueue(try encoder.encode(index))
+        }
+
+        await store.waitFor(count: count)
+
+        // If signals were handled concurrently, the racy read-modify-write above would drop or reorder
+        // values. Serial, in-order processing yields exactly 0..<count.
+        let values = await store.snapshot()
+        #expect(values == Array(0 ..< count))
+    }
+}


### PR DESCRIPTION
Make sure the processing of signals is done in order.
Clean and refresh cache if we detect an inconsistency in a safe manner.