### PR TITLE
feat(ui): add main window shell and navigation router on Linux v4

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -135,8 +135,7 @@
   login-specific workflow logic.
 - `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It derives
   collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only failed and
-  not-yet-attempted work for retry, reconciles the parent-first cache snapshot after a failed `SYNC_ADD`, and temporarily
-  opens every configured sync root in the system file manager from the ready screen.
+  not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a failed `SYNC_ADD`.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -47,8 +47,9 @@
   put multi-service onboarding backend effects in a dedicated onboarding coordinator.
 - Keep only `OnboardingSessionManager` process-long. Onboarding state, flow, coordinators, and view models belong to an
   ephemeral `OnboardingSession` and must not be exposed as root QML context properties.
-- Route tray and server main-window activation requests through `OnboardingSessionManager` while onboarding is the only
-  displayable Linux v4 content. If onboarding is not required, keep the window hidden and log why no route can be shown.
+- Route tray and server main-window activation requests through `AppClientLinux::openMainWindow()`. It delegates to
+  `OnboardingSessionManager` only when no sync is configured; otherwise it activates `AppRouter` and shows the main
+  window shell.
 - When ending an onboarding session, unpublish it so QML unloads the onboarding `Loader`, then destroy it with
   `deleteLater()`. Invalidate session-scoped asynchronous results before allowing a new session to consume them.
 - Keep `AppClientLinux` as an application composition root. Move multi-step feature workflows such as onboarding login into
@@ -72,7 +73,8 @@
 ## Current Structure
 
 - `main.cpp`: process entry point + single-instance lock file.
-- `appclientlinux.*`: top-level app wiring (logging, IPC lifecycle, dispatcher/service/coordinator ownership).
+- `appclientlinux.*`: top-level app wiring (logging, QML warning forwarding, IPC lifecycle,
+  dispatcher/service/coordinator ownership).
 - `app/appconstants.h`: app-level non-translatable constants, mirroring the Windows `AppConstants` role where useful.
 - `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection derived from `AppCache`,
   GNOME-compatible tray menu actions, fallback-to-window startup behavior, retry loop for late tray availability, and
@@ -101,6 +103,8 @@
       but the underlying cache graph changes.
     - Exposes selected-sync runtime through its dedicated accessor and signal so progress ticks do not rebuild the
       configured graph context.
+- `app/navigation/approuter.*`: minimal main-window router. It owns only `mainWindowActive` and the selected main tab;
+  it must not read `AppCache`, call backend services, or decide whether onboarding is required.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync
   configs.
 - `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`).
@@ -119,8 +123,8 @@
   controller/model.
 - `app/onboarding/onboardingsessionmanager.*`: process-long nullable-session owner and the only onboarding object exposed
   at the root QML boundary. It creates a session after cache bootstrap and unpublishes it before deferred destruction. It
-  accepts activation requests while onboarding is the only available route and rejects them with an explanatory log when
-  no displayable session exists.
+  accepts activation requests while onboarding is required and rejects them with an explanatory log when no onboarding
+  route is displayable. On successful onboarding completion, `AppClientLinux` opens the main window route.
 - `app/onboarding/onboardingflowcontroller.*`: QML-facing onboarding flow controller aligned with the macOS flow
   (`login -> drive selection -> synchronization -> ready`, with macOS permission steps omitted on Linux). It owns simple
   onboarding UI actions such as opening account signup and drive-offer URLs, plus synchronization/ready presentation
@@ -149,8 +153,11 @@
   confirmation.
 - `app/services/syncservice.*`: targeted sync use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
-- `ui/`: QML shell, onboarding screens, design tokens, and bundled UI assets such as tray icons and onboarding Lottie
-  animations.
+- `ui/`: QML shell, onboarding screens, main-window screens, design tokens, and bundled UI assets such as tray icons and
+  onboarding Lottie animations.
+    - `ui/mainwindow/`: main-window shell and temporary placeholders. The shell is loaded only when `AppRouter` marks
+      the main window active and no onboarding session is active. Do not add IPC calls here; dynamic data belongs in
+      cache-backed QML models.
     - `ui/window/`: shared QML frameless-window shell, header bar, controls, resize handles, and shadow wrapper.
       Top-level app-owned QML windows should use `IKShadowedWindow`; its `headerBackgroundData` and `headerData` slots
       accept page-specific header visuals and content while preserving the standard move, resize, minimize, maximize,

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -35,6 +35,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/onboardingstate.h
         app/cache/parametersstore.cpp
         app/cache/parametersstore.h
+        app/navigation/approuter.cpp
+        app/navigation/approuter.h
         app/onboarding/availabledrivesmodel.cpp
         app/onboarding/availabledrivesmodel.h
         app/onboarding/driveselectioncontroller.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -93,6 +93,7 @@ set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)
         ui/tokens/IKFonts.qml
         ui/tokens/IKIconSizes.qml
         ui/tokens/IKOnboarding.qml
+        ui/tokens/IKMainWindow.qml
 )
 
 set_source_files_properties(${GUI_QML_SINGLETON_FILES} PROPERTIES QT_QML_SINGLETON_TYPE TRUE)

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -110,6 +110,13 @@ set(GUI_QML_FILES # .qml files for the app
         ui/window/IKShadowedWindow.qml
         ui/window/IKWindowControlButton.qml
         ui/window/IKWindowHeader.qml
+        ui/mainwindow/ActivitiesPlaceholder.qml
+        ui/mainwindow/BlockingErrorPlaceholder.qml
+        ui/mainwindow/HomePlaceholder.qml
+        ui/mainwindow/MainSidebarPlaceholder.qml
+        ui/mainwindow/MainToolbar.qml
+        ui/mainwindow/MainWindowView.qml
+        ui/mainwindow/StoragePlaceholder.qml
         ${GUI_GENERATED_QML_FILES}
         ui/onboarding/DriveCellView.qml
         ui/onboarding/DriveIconView.qml

--- a/src/gui4/linux/app/appconstants.h
+++ b/src/gui4/linux/app/appconstants.h
@@ -40,3 +40,11 @@ namespace KDC::AppConstants::Onboarding {
 }
 
 } // namespace KDC::AppConstants::Onboarding
+
+namespace KDC::AppConstants::Support {
+
+[[nodiscard]] inline QUrl helpUri() {
+    return QUrl{QStringLiteral("https://support.infomaniak.com/")};
+}
+
+} // namespace KDC::AppConstants::Support

--- a/src/gui4/linux/app/navigation/approuter.cpp
+++ b/src/gui4/linux/app/navigation/approuter.cpp
@@ -1,0 +1,121 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/navigation/approuter.h"
+
+#include "app/appconstants.h"
+
+#include <QDesktopServices>
+#include <QMetaEnum>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcAppRouter, "gui.v4.approuter", QtInfoMsg)
+} // namespace
+
+AppRouter::AppRouter(QObject *const parent) :
+    QObject(parent) {}
+
+void AppRouter::showMainWindow() {
+    setMainWindowActive(true);
+}
+
+void AppRouter::hideMainWindow() {
+    setMainWindowActive(false);
+}
+
+void AppRouter::showHome() {
+    qCInfo(lcAppRouter) << "Main tab navigation requested | tab: Home";
+    setCurrentMainTab(MainTab::Home);
+}
+
+void AppRouter::showActivities() {
+    qCInfo(lcAppRouter) << "Main tab navigation requested | tab: Activities";
+    setCurrentMainTab(MainTab::Activities);
+}
+
+void AppRouter::showStorage() {
+    qCInfo(lcAppRouter) << "Main tab navigation requested | tab: Storage";
+    setCurrentMainTab(MainTab::Storage);
+}
+
+void AppRouter::showBlockingError() {
+    qCInfo(lcAppRouter) << "Main tab navigation requested | tab: BlockingError";
+    setCurrentMainTab(MainTab::BlockingError);
+}
+
+void AppRouter::navigateToMainTab(const int32_t tabIndex) {
+    switch (tabIndex) {
+        case static_cast<int32_t>(MainTab::Home):
+            setCurrentMainTab(MainTab::Home);
+            return;
+        case static_cast<int32_t>(MainTab::Activities):
+            setCurrentMainTab(MainTab::Activities);
+            return;
+        case static_cast<int32_t>(MainTab::Storage):
+            setCurrentMainTab(MainTab::Storage);
+            return;
+        case static_cast<int32_t>(MainTab::BlockingError):
+            setCurrentMainTab(MainTab::BlockingError);
+            return;
+        default:
+            qCWarning(lcAppRouter) << "Invalid main tab navigation ignored | index:" << tabIndex;
+            return;
+    }
+}
+
+void AppRouter::openSupport() {
+    const auto url = AppConstants::Support::helpUri();
+    qCInfo(lcAppRouter) << "Opening support URL:" << url;
+    if (!QDesktopServices::openUrl(url)) {
+        qCWarning(lcAppRouter) << "Failed to open support URL:" << url;
+    }
+}
+
+void AppRouter::requestPauseCurrentSync() {
+    qCInfo(lcAppRouter) << "Pause current sync requested from main toolbar | not wired yet";
+}
+
+void AppRouter::requestSearch() {
+    qCInfo(lcAppRouter) << "Search requested from main toolbar | not wired yet";
+}
+
+void AppRouter::setMainWindowActive(const bool active) {
+    if (_mainWindowActive == active) {
+        return;
+    }
+
+    _mainWindowActive = active;
+    qCInfo(lcAppRouter) << "Main window route active changed | active:" << active;
+    emit mainWindowActiveChanged();
+}
+
+void AppRouter::setCurrentMainTab(const MainTab tab) {
+    if (_currentMainTab == tab) {
+        return;
+    }
+
+    const auto metaEnum = QMetaEnum::fromType<MainTab>();
+    qCInfo(lcAppRouter) << "Main tab changed |" << metaEnum.valueToKey(static_cast<int32_t>(_currentMainTab)) << "=>"
+                        << metaEnum.valueToKey(static_cast<int32_t>(tab));
+    _currentMainTab = tab;
+    emit currentMainTabChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/navigation/approuter.h
+++ b/src/gui4/linux/app/navigation/approuter.h
@@ -1,0 +1,80 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QLoggingCategory>
+#include <QObject>
+
+#include <cstdint>
+
+Q_DECLARE_LOGGING_CATEGORY(lcAppRouter)
+
+namespace KDC {
+
+/**
+ * Minimal main-window router for Linux v4.
+ *
+ * Role: own whether the main-window content is active and which main tab is selected.
+ * Non-role: read product cache, execute backend commands, or decide onboarding eligibility.
+ */
+class AppRouter final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool mainWindowActive READ mainWindowActive NOTIFY mainWindowActiveChanged)
+        Q_PROPERTY(MainTab currentMainTab READ currentMainTab NOTIFY currentMainTabChanged)
+        Q_PROPERTY(int32_t currentMainTabIndex READ currentMainTabIndex NOTIFY currentMainTabChanged)
+
+    public:
+        enum class MainTab : uint8_t {
+            Home = 0,
+            Activities,
+            Storage,
+            BlockingError,
+        };
+        Q_ENUM(MainTab)
+
+        explicit AppRouter(QObject *parent = nullptr);
+
+        [[nodiscard]] bool mainWindowActive() const { return _mainWindowActive; }
+        [[nodiscard]] MainTab currentMainTab() const { return _currentMainTab; }
+        [[nodiscard]] int32_t currentMainTabIndex() const { return static_cast<int32_t>(_currentMainTab); }
+
+        Q_INVOKABLE void showMainWindow();
+        Q_INVOKABLE void hideMainWindow();
+        Q_INVOKABLE void showHome();
+        Q_INVOKABLE void showActivities();
+        Q_INVOKABLE void showStorage();
+        Q_INVOKABLE void showBlockingError();
+        Q_INVOKABLE void navigateToMainTab(int32_t tabIndex);
+        Q_INVOKABLE void openSupport();
+        Q_INVOKABLE void requestPauseCurrentSync();
+        Q_INVOKABLE void requestSearch();
+
+    signals:
+        void mainWindowActiveChanged();
+        void currentMainTabChanged();
+
+    private:
+        void setMainWindowActive(bool active);
+        void setCurrentMainTab(MainTab tab);
+
+        bool _mainWindowActive{false};
+        MainTab _currentMainTab{MainTab::Home};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/navigation/approuter.h
+++ b/src/gui4/linux/app/navigation/approuter.h
@@ -61,9 +61,9 @@ class AppRouter final : public QObject {
         Q_INVOKABLE void showStorage();
         Q_INVOKABLE void showBlockingError();
         Q_INVOKABLE void navigateToMainTab(int32_t tabIndex);
-        Q_INVOKABLE void openSupport();
-        Q_INVOKABLE void requestPauseCurrentSync();
-        Q_INVOKABLE void requestSearch();
+        Q_INVOKABLE static void openSupport();
+        Q_INVOKABLE static void requestPauseCurrentSync();
+        Q_INVOKABLE static void requestSearch();
 
     signals:
         void mainWindowActiveChanged();

--- a/src/gui4/linux/app/onboarding/oauthloginservice.cpp
+++ b/src/gui4/linux/app/onboarding/oauthloginservice.cpp
@@ -18,6 +18,7 @@
 
 #include "oauthloginservice.h"
 
+#include "app/services/sentryservice.h"
 #include "config.h"
 #include "libcommon/utility/urlhelper.h"
 #include "libcommon/utility/utility.h"
@@ -65,6 +66,8 @@ void OAuthLoginService::startAuthorization() {
 
     if (!QDesktopServices::openUrl(_authorizationUrl)) {
         qCWarning(lcOAuthLoginService) << "Failed to open OAuth authorization URL in browser";
+        SentryService::reportError(QStringLiteral("Failed to open OAuth authorization URL in browser"),
+                                   QStringLiteral("QDesktopServices::openUrl returned false"));
         resetAuthorization();
         emit authorizationFailed(QString::fromLatin1(browserOpenFailed), QString());
         return;

--- a/src/gui4/linux/app/onboarding/onboardingentrydecision.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingentrydecision.cpp
@@ -25,7 +25,7 @@
 namespace KDC {
 
 OnboardingEntryDecision determineOnboardingEntry(const AppCache &appCache) {
-    if (!appCache.driveContexts().empty()) {
+    if (!appCache.syncContexts().empty()) {
         return {};
     }
 

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -151,17 +151,6 @@ void OnboardingFlowController::retrySynchronization() {
     emit synchronizationRetryRequested();
 }
 
-void OnboardingFlowController::openSynchronizedFolders() {
-    if (_currentStep != Ready || !_readyActionEnabled) {
-        return;
-    }
-
-    qCInfo(lcOnboardingFlowController) << "Opening synchronized folders from onboarding";
-    _readyActionEnabled = false;
-    emit readyActionEnabledChanged();
-    emit synchronizedFoldersOpenRequested();
-}
-
 void OnboardingFlowController::cancel() {
     qCInfo(lcOnboardingFlowController) << "Onboarding cancel requested";
     emit cancelRequested();
@@ -235,6 +224,10 @@ void OnboardingFlowController::completeOnboarding() {
     }
 
     qCInfo(lcOnboardingFlowController) << "Onboarding completed";
+    if (_readyActionEnabled) {
+        _readyActionEnabled = false;
+        emit readyActionEnabledChanged();
+    }
     _onboardingCompleted = true;
     emit completed();
 }

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.cpp
@@ -67,7 +67,7 @@ QString OnboardingFlowController::title() const {
         case Login:
             return qtTrId("onboardingLoginTitle");
         case DriveSelection:
-            return tr("Welcome back!");
+            return qtTrId("onboardingDriveSelectionTitle");
         case Synchronization:
             return qtTrId("onboardingSynchronizationInProgressTitle");
         case Ready:

--- a/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
+++ b/src/gui4/linux/app/onboarding/onboardingflowcontroller.h
@@ -86,14 +86,13 @@ class OnboardingFlowController final : public QObject {
         Q_INVOKABLE void requestAdvancedSettings();
         Q_INVOKABLE void requestDriveSelectionContinue();
         Q_INVOKABLE void retrySynchronization();
-        Q_INVOKABLE void openSynchronizedFolders();
+        Q_INVOKABLE void completeOnboarding();
         Q_INVOKABLE void cancel();
         Q_INVOKABLE void setCurrentStep(Step step);
         void handleAuthorizationCodeReady();
         void beginSynchronization();
         void failSynchronization();
         void completeSynchronization();
-        void completeOnboarding();
 
     public slots:
         void handleLoginTokenSucceeded(qint64 userDbId);
@@ -108,7 +107,6 @@ class OnboardingFlowController final : public QObject {
         void advancedSettingsRequested();
         void driveSelectionContinueRequested();
         void synchronizationRetryRequested();
-        void synchronizedFoldersOpenRequested();
         void synchronizationFailedChanged();
         void readyActionEnabledChanged();
         void completed();

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
@@ -133,7 +133,8 @@ void OnboardingSessionManager::startSession(const OnboardingSession::EntryPoint 
     });
     (void) connect(session->flowController(), &OnboardingFlowController::completed, this, [this, session] {
         if (_activeSession == session) {
-            stopSession(true);
+            emit onboardingCompleted();
+            stopSession(false);
         }
     });
 

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
@@ -59,6 +59,7 @@ class OnboardingSessionManager final : public QObject {
         void activeSessionChanged();
         void openOnboardingWindowRequested();
         void closeOnboardingWindowRequested();
+        void onboardingCompleted();
 
     private:
         enum class LifecycleState : uint8_t {

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -26,12 +26,9 @@
 #include "app/services/serviceeventbus.h"
 #include "libcommon/utility/types.h"
 
-#include <QDesktopServices>
 #include <QDir>
 #include <QLoggingCategory>
 #include <QPointer>
-#include <QSet>
-#include <QUrl>
 
 namespace KDC {
 
@@ -54,8 +51,6 @@ OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingF
                    &OnboardingSyncCreationCoordinator::startSynchronization);
     (void) connect(&_flowController, &OnboardingFlowController::synchronizationRetryRequested, this,
                    &OnboardingSyncCreationCoordinator::createNextSynchronization);
-    (void) connect(&_flowController, &OnboardingFlowController::synchronizedFoldersOpenRequested, this,
-                   &OnboardingSyncCreationCoordinator::openSynchronizedFolders);
     (void) connect(&_cachePopulator, &CachePopulator::reconciliationCompleted, this,
                    &OnboardingSyncCreationCoordinator::handleCacheReconciliationCompleted);
     (void) connect(&_cachePopulator, &CachePopulator::reconciliationFailed, this,
@@ -64,7 +59,6 @@ OnboardingSyncCreationCoordinator::OnboardingSyncCreationCoordinator(OnboardingF
 
 void OnboardingSyncCreationCoordinator::startSynchronization() {
     _pendingDriveKeys.clear();
-    _createdLocalPaths.clear();
 
     const auto selectedDriveKeys = _onboardingState.selectedAvailableDriveKeys();
     (void) _pendingDriveKeys.insert(_pendingDriveKeys.end(), selectedDriveKeys.begin(), selectedDriveKeys.end());
@@ -160,27 +154,25 @@ void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDri
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Creating onboarding sync | driveId:" << key.driveId << "/ localPath:" << config.localPath;
     const QPointer<OnboardingSyncCreationCoordinator> self(this);
-    _commService.requestSyncAdd(
-            request, [self, key, localPath = config.localPath](const ExitInfo &exitInfo, const BaseSync &syncInfo) {
-                if (!self) {
-                    return;
-                }
+    _commService.requestSyncAdd(request, [self, key](const ExitInfo &exitInfo, const BaseSync &syncInfo) {
+        if (!self) {
+            return;
+        }
 
-                if (!exitInfo) {
-                    self->_serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
-                    self->handleCreationFailure(true);
-                    return;
-                }
+        if (!exitInfo) {
+            self->_serviceEventBus.notifyGenericError(exitInfo, RequestNum::SYNC_ADD);
+            self->handleCreationFailure(true);
+            return;
+        }
 
-                qCInfo(lcOnboardingSyncCreationCoordinator)
-                        << "Onboarding sync created | driveId:" << key.driveId << "/ syncDbId:" << syncInfo.dbId();
-                self->_createdLocalPaths.push_back(localPath);
-                self->_onboardingState.unselectAvailableDrive(key);
-                if (!self->_pendingDriveKeys.empty() && self->_pendingDriveKeys.front() == key) {
-                    self->_pendingDriveKeys.pop_front();
-                }
-                self->createNextSynchronization();
-            });
+        qCInfo(lcOnboardingSyncCreationCoordinator)
+                << "Onboarding sync created | driveId:" << key.driveId << "/ syncDbId:" << syncInfo.dbId();
+        self->_onboardingState.unselectAvailableDrive(key);
+        if (!self->_pendingDriveKeys.empty() && self->_pendingDriveKeys.front() == key) {
+            self->_pendingDriveKeys.pop_front();
+        }
+        self->createNextSynchronization();
+    });
 }
 
 void OnboardingSyncCreationCoordinator::discardPendingSynchronization(const AvailableDriveKey &key) {
@@ -245,29 +237,6 @@ void OnboardingSyncCreationCoordinator::handleCacheReconciliationFailed() {
     _cacheReconciliationPending = false;
     qCWarning(lcOnboardingSyncCreationCoordinator) << "Cache reconciliation failed after onboarding SYNC_ADD failure";
     _flowController.failSynchronization();
-}
-
-void OnboardingSyncCreationCoordinator::openSynchronizedFolders() {
-    QSet<QString> localPaths;
-    for (const auto &syncInfo: _appCache.syncs()) {
-        if (!syncInfo.localPath().empty()) {
-            (void) localPaths.insert(QDir::cleanPath(Path2QStr(syncInfo.localPath())));
-        }
-    }
-    for (const auto &localPath: _createdLocalPaths) {
-        if (!localPath.isEmpty()) {
-            (void) localPaths.insert(QDir::cleanPath(localPath));
-        }
-    }
-
-    for (const auto &localPath: localPaths) {
-        qCInfo(lcOnboardingSyncCreationCoordinator) << "Opening synchronized folder:" << localPath;
-        if (!QDesktopServices::openUrl(QUrl::fromLocalFile(localPath))) {
-            qCWarning(lcOnboardingSyncCreationCoordinator) << "Failed to open synchronized folder:" << localPath;
-        }
-    }
-
-    _flowController.completeOnboarding();
 }
 
 QString OnboardingSyncCreationCoordinator::defaultLocalPath(const QString &driveName) const {

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -24,7 +24,6 @@
 #include <QString>
 
 #include <deque>
-#include <vector>
 
 namespace KDC {
 
@@ -58,7 +57,6 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         void handleCreationFailure(bool cacheReconciliationRequired = false);
         void handleCacheReconciliationCompleted();
         void handleCacheReconciliationFailed();
-        void openSynchronizedFolders();
         [[nodiscard]] QString defaultLocalPath(const QString &driveName) const;
 
         OnboardingFlowController &_flowController;
@@ -68,7 +66,6 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         CachePopulator &_cachePopulator;
         ServiceEventBus &_serviceEventBus;
         std::deque<AvailableDriveKey> _pendingDriveKeys;
-        std::vector<QString> _createdLocalPaths;
         bool _cacheReconciliationPending{false};
 };
 

--- a/src/gui4/linux/app/services/cachepopulator.cpp
+++ b/src/gui4/linux/app/services/cachepopulator.cpp
@@ -175,6 +175,8 @@ void CachePopulator::activateLiveInfoRefresh() const {
         if (!exitInfo) {
             qCWarning(lcCachePopulator) << "Live info refresh activation failed | code:" << exitInfo.code()
                                         << "/ cause:" << exitInfo.cause();
+            SentryService::reportError(QStringLiteral("Live info refresh activation failed"),
+                                       QString::fromStdString(toString(exitInfo)));
         }
     });
 }

--- a/src/gui4/linux/app/services/sentryservice.cpp
+++ b/src/gui4/linux/app/services/sentryservice.cpp
@@ -109,6 +109,16 @@ bool SentryService::isInitialized() {
     return sentry::Handler::isInitialized();
 }
 
+void SentryService::shutdown() {
+    if (!isInitialized()) {
+        qCInfo(lcSentryService) << "Sentry shutdown skipped because handler is not initialized";
+        return;
+    }
+
+    qCInfo(lcSentryService) << "Shutting down Sentry";
+    sentry::Handler::shutdown();
+}
+
 void SentryService::reportError(const std::string &title, const std::string &message) {
     sentry::Handler::captureMessage(sentry::Level::Error, title, message);
 }

--- a/src/gui4/linux/app/services/sentryservice.h
+++ b/src/gui4/linux/app/services/sentryservice.h
@@ -47,6 +47,7 @@ class SentryService final : public QObject {
         static void writeCachedConsent(bool enabled);
         static void initializeFromCachedConsent();
         static void initializeWithLinuxConfig();
+        static void shutdown();
         [[nodiscard]] static bool isInitialized();
 
         static void reportError(const std::string &title, const std::string &message);

--- a/src/gui4/linux/app/services/serviceeventbus.cpp
+++ b/src/gui4/linux/app/services/serviceeventbus.cpp
@@ -18,9 +18,11 @@
 
 #include "serviceeventbus.h"
 
+#include "app/services/sentryservice.h"
 #include "libcommon/utility/types.h"
 
 #include <QLoggingCategory>
+#include <QString>
 
 namespace KDC {
 
@@ -32,7 +34,9 @@ ServiceEventBus::ServiceEventBus(QObject *const parent) :
 void ServiceEventBus::notifyGenericError(const ExitInfo &exitInfo, const RequestNum requestNum) {
     qCWarning(lcServiceEventBus) << "Generic service error | request:" << toInt(requestNum) << "/ code:" << exitInfo.code()
                                  << "/ cause:" << exitInfo.cause();
-    // TODO(gui4/linux): capture this error in Sentry once Sentry is integrated in the Linux v4 app.
+    SentryService::reportError(
+            QStringLiteral("Generic service error"),
+            QStringLiteral("request: %1 | %2").arg(toInt(requestNum)).arg(QString::fromStdString(toString(exitInfo))));
     emit genericErrorOccurred();
 }
 

--- a/src/gui4/linux/app/services/userservice.cpp
+++ b/src/gui4/linux/app/services/userservice.cpp
@@ -119,7 +119,6 @@ void UserService::requestLoginToken(const QString &code, const QString &codeVeri
                 }
 
                 if (!result.error.isEmpty() || !result.errorDescription.isEmpty()) {
-                    _serviceEventBus.notifyGenericError(exitInfo, RequestNum::LOGIN_REQUESTTOKEN);
                     SentryService::reportError(
                             QStringLiteral("Login failed"),
                             QStringLiteral("error: %1 | description: %2").arg(result.error, result.errorDescription));
@@ -129,7 +128,6 @@ void UserService::requestLoginToken(const QString &code, const QString &codeVeri
 
                 if (!exitInfo) {
                     notifyRequestFailure(exitInfo, RequestNum::LOGIN_REQUESTTOKEN);
-                    SentryService::reportError("Login failed", toString(exitInfo));
                     emit loginTokenFailed(QString(), QString());
                     return;
                 }

--- a/src/gui4/linux/app/systraycontroller.cpp
+++ b/src/gui4/linux/app/systraycontroller.cpp
@@ -117,7 +117,7 @@ void SystemTrayController::initialize() {
                                    << "| state:" << toQString(_iconState) << "| icon:" << trayIconPath(_iconState);
 
     _trayIcon.setIcon(QIcon(trayIconPath(_iconState)));
-    _trayIcon.setToolTip(tr("kDrive"));
+    _trayIcon.setToolTip(QStringLiteral("kDrive"));
 
     _openAction = _trayMenu.addAction(qtTrId("statusBarOpenApp"));
     _settingsAction = _trayMenu.addAction(qtTrId("statusBarSettings"));

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -62,6 +62,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
     (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
+        // Normal UTILITY_QUIT paths stop the application before the server closes the socket. This cleanup therefore runs only
+        // when an established IPC connection is lost unexpectedly.
         _systemTrayController.setProductStateInitialized(false);
         _appRouter.hideMainWindow();
         _appCache.clearAll();

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -28,9 +28,11 @@
 #include <QDir>
 #include <QLocale>
 #include <QQmlContext>
+#include <QQmlError>
 #include <QScreen>
 #include <QStringList>
 #include <QSysInfo>
+#include <QTimer>
 #include <QTranslator>
 #include <QVariant>
 #include <QWindow>
@@ -60,6 +62,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
     (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
         _systemTrayController.setProductStateInitialized(false);
+        _appRouter.hideMainWindow();
         _appCache.clearAll();
         _parametersStore.clear();
     });
@@ -77,6 +80,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
                    &SystemTrayController::showMainWindow);
     (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,
                    &SystemTrayController::hideMainWindow);
+    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::onboardingCompleted, this,
+                   [this] { QTimer::singleShot(0, this, &AppClientLinux::openMainWindow); });
     (void) connect(&_systemTrayController, &SystemTrayController::openMainWindowRequested, this, &AppClientLinux::openMainWindow);
     (void) connect(&_appCache, &AppCache::usersChanged, &_sentryService, &SentryService::updateAuthenticatedUser);
     (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this, [this] {
@@ -111,7 +116,13 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("syncService"), &_syncService);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("serviceEventBus"), &_serviceEventBus);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("windowDecorationController"), &_windowDecorationController);
+    (void) connect(&_qmlEngine, &QQmlApplicationEngine::warnings, this, [](const QList<QQmlError> &warnings) {
+        for (const auto &warning: warnings) {
+            qCWarning(lcAppClientLinux) << "QML warning:" << warning.toString();
+        }
+    });
     _qmlEngine.setInitialProperties({
+            {QStringLiteral("appRouter"), QVariant::fromValue<QObject *>(&_appRouter)},
             {QStringLiteral("onboardingSessionManager"), QVariant::fromValue<QObject *>(&_onboardingSessionManager)},
             {QStringLiteral("systemTrayController"), QVariant::fromValue<QObject *>(&_systemTrayController)},
     });
@@ -178,8 +189,13 @@ void AppClientLinux::openMainWindow() {
         return;
     }
 
-    qCInfo(lcAppClientLinux) << "Main window open skipped: main content is not implemented"
-                             << "| configuredDrives:" << _appCache.driveContexts().size();
+    _mainSelectionStore.ensureValidSelection();
+    _appRouter.showMainWindow();
+    _systemTrayController.showMainWindow();
+    qCInfo(lcAppClientLinux) << "Main window opened"
+                             << "| configuredDrives:" << _appCache.driveContexts().size()
+                             << "| configuredSyncs:" << _appCache.syncContexts().size()
+                             << "| currentSyncDbId:" << _mainSelectionStore.currentSyncDbId();
 }
 
 void AppClientLinux::setupLogging() {

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -73,7 +73,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_sentryService,
                    &SentryService::updateAuthenticatedUser);
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this, [this] {
-        if (_systemTrayController.trayModeActive() || _appCache.driveContexts().empty()) {
+        if (_systemTrayController.trayModeActive() || _appCache.syncContexts().empty()) {
             return;
         }
 
@@ -127,6 +127,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("windowDecorationController"), &_windowDecorationController);
     (void) qmlRegisterUncreatableType<AppRouter>("kDrive.UI", 1, 0, "AppRouter",
                                                  "AppRouter is owned by AppClientLinux and exposed as appRouter.");
+    _qmlEngine.setOutputWarningsToStandardError(false);
     (void) connect(&_qmlEngine, &QQmlApplicationEngine::warnings, this, [](const QList<QQmlError> &warnings) {
         for (const auto &warning: warnings) {
             qCWarning(lcAppClientLinux) << "QML warning:" << warning.toString();
@@ -173,8 +174,6 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
 #endif
     }
 }
-template<typename>
-constexpr auto AppClientLinux::qt_create_metaobjectdata() {}
 
 void AppClientLinux::setupTranslations() {
     // Catalogs are id-based: qsTrId(id) returns the raw id when no translation is loaded. Install
@@ -197,7 +196,7 @@ void AppClientLinux::setupTranslations() {
 }
 
 void AppClientLinux::openMainWindow() {
-    if (_appCache.driveContexts().empty()) {
+    if (_appCache.syncContexts().empty()) {
         _onboardingSessionManager.openOnboardingWindow();
         return;
     }

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -203,6 +203,12 @@ void AppClientLinux::openMainWindow() {
     _mainSelectionStore.ensureValidSelection();
     _appRouter.showMainWindow();
     _systemTrayController.showMainWindow();
+    _serverCommService.requestActivateLoadInfo([](const ExitInfo &exitInfo) {
+        if (!exitInfo) {
+            qCWarning(lcAppClientLinux) << "Main window live info refresh failed | code:" << exitInfo.code()
+                                        << "/ cause:" << exitInfo.cause();
+        }
+    });
     qCInfo(lcAppClientLinux) << "Main window opened"
                              << "| configuredDrives:" << _appCache.driveContexts().size()
                              << "| configuredSyncs:" << _appCache.syncContexts().size()

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -36,6 +36,7 @@
 #include <QTranslator>
 #include <QVariant>
 #include <QWindow>
+#include <QQmlEngine>
 
 #include <chrono>
 #include <thread>
@@ -124,6 +125,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("syncService"), &_syncService);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("serviceEventBus"), &_serviceEventBus);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("windowDecorationController"), &_windowDecorationController);
+    qmlRegisterUncreatableType<AppRouter>("kDrive.UI", 1, 0, "AppRouter",
+                                          "AppRouter is owned by AppClientLinux and exposed as appRouter.");
     (void) connect(&_qmlEngine, &QQmlApplicationEngine::warnings, this, [](const QList<QQmlError> &warnings) {
         for (const auto &warning: warnings) {
             qCWarning(lcAppClientLinux) << "QML warning:" << warning.toString();

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -71,6 +71,14 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
                    [this] { _systemTrayController.setProductStateInitialized(true); });
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_sentryService,
                    &SentryService::updateAuthenticatedUser);
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this, [this] {
+        if (_systemTrayController.trayModeActive() || _appCache.driveContexts().empty()) {
+            return;
+        }
+
+        qCInfo(lcAppClientLinux) << "Opening main window after bootstrap because tray fallback mode is active";
+        openMainWindow();
+    });
     (void) connect(this, &AppClientLinux::ipcConnected, this, [this] { _cachePopulator.bootstrap(); });
     (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -125,8 +125,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("syncService"), &_syncService);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("serviceEventBus"), &_serviceEventBus);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("windowDecorationController"), &_windowDecorationController);
-    qmlRegisterUncreatableType<AppRouter>("kDrive.UI", 1, 0, "AppRouter",
-                                          "AppRouter is owned by AppClientLinux and exposed as appRouter.");
+    (void) qmlRegisterUncreatableType<AppRouter>("kDrive.UI", 1, 0, "AppRouter",
+                                                 "AppRouter is owned by AppClientLinux and exposed as appRouter.");
     (void) connect(&_qmlEngine, &QQmlApplicationEngine::warnings, this, [](const QList<QQmlError> &warnings) {
         for (const auto &warning: warnings) {
             qCWarning(lcAppClientLinux) << "QML warning:" << warning.toString();
@@ -173,6 +173,8 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
 #endif
     }
 }
+template<typename>
+constexpr auto AppClientLinux::qt_create_metaobjectdata() {}
 
 void AppClientLinux::setupTranslations() {
     // Catalogs are id-based: qsTrId(id) returns the raw id when no translation is loaded. Install

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -22,6 +22,7 @@
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
 #include "app/cache/parametersstore.h"
+#include "app/navigation/approuter.h"
 #include "app/onboarding/onboardingsessionmanager.h"
 #include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
@@ -77,6 +78,7 @@ class AppClientLinux : public QApplication {
         MainSelectionStore &mainSelectionStore() { return _mainSelectionStore; }
         ParametersStore &parametersStore() { return _parametersStore; }
         ParametersService &parametersService() { return _parametersService; }
+        AppRouter &appRouter() { return _appRouter; }
         ServiceActionTracker &serviceActionTracker() { return _serviceActionTracker; }
         ServiceEventBus &serviceEventBus() { return _serviceEventBus; }
 
@@ -99,6 +101,7 @@ class AppClientLinux : public QApplication {
         CachePipeline _cachePipeline{_serverCommService, _appCache, this};
         MainSelectionStore _mainSelectionStore{_appCache, this};
         ParametersService _parametersService{_serverCommService, _parametersStore, this};
+        AppRouter _appRouter{this};
         ServiceActionTracker _serviceActionTracker{this};
         ServiceEventBus _serviceEventBus{this};
         SentryService _sentryService{_parametersService, _appCache, _parametersStore, this};

--- a/src/gui4/linux/main.cpp
+++ b/src/gui4/linux/main.cpp
@@ -18,8 +18,8 @@
 
 #include "appclientlinux.h"
 #include "app/services/sentryservice.h"
-#include "libcommongui/logger.h"
 #include "libcommon/utility/utility.h"
+#include "libcommongui/logger.h"
 
 #include <QLockFile>
 #include <QString>
@@ -43,5 +43,6 @@ int main(int argc, char *argv[]) {
     const int32_t exitCode = app->exec();
 
     qCInfo(KDC::lcAppClientLinux) << "Qt event loop exited with code" << exitCode;
+    KDC::SentryService::shutdown();
     return exitCode;
 }

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -51,7 +51,7 @@ IKShadowedWindow {
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             visible: !mainWindow.onboardingActive && mainWindow.appRouter.mainWindowActive
-            width: 240
+            width: IKMainWindow.sidebarWidth
             color: IKColors.surfaceSecondary
         }
 
@@ -81,13 +81,12 @@ IKShadowedWindow {
 
         MainToolbar {
             anchors.left: parent.left
-            anchors.leftMargin: 240
+            anchors.leftMargin: IKMainWindow.sidebarWidth
             anchors.right: parent.right
             anchors.rightMargin: IKSpacing.s8
             anchors.top: parent.top
             anchors.bottom: parent.bottom
             appRouter: mainWindow.appRouter
-            currentTab: mainWindow.appRouter.currentMainTabIndex
         }
     }
 

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -20,31 +20,75 @@ pragma ComponentBehavior: Bound
 
 import QtQuick
 import kDrive.UI
+import "mainwindow"
 import "onboarding"
 
 IKShadowedWindow {
     id: mainWindow
 
+    required property var appRouter
     required property var onboardingSessionManager
     required property var systemTrayController
+
+    readonly property bool onboardingActive: onboardingSessionManager.activeSession !== null
 
     visible: false
     contentWidth: 900
     contentHeight: 600
     minimumContentWidth: 720
     minimumContentHeight: 520
-    title: onboardingLoader.session ? onboardingLoader.session.flowController.title : qsTr("kDrive")
-    surfaceColor: IKColors.onboardingSurfacePrimary
+    title: onboardingActive ? onboardingSessionManager.activeSession.flowController.title : "kDrive"
+    surfaceColor: onboardingActive ? IKColors.onboardingSurfacePrimary : IKColors.surfacePrimary
     customShadowEnabled: true
-    headerOverlaysContent: true
+    headerOverlaysContent: onboardingActive
     windowTitleVisible: false
 
-    headerBackgroundData: Rectangle {
-        anchors.top: parent.top
-        anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        width: parent.width * IKOnboarding.illustrationPanelWidthRatio
-        color: IKColors.onboardingSurfaceSecondary
+    headerBackgroundData: Item {
+        anchors.fill: parent
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            visible: !mainWindow.onboardingActive && mainWindow.appRouter.mainWindowActive
+            width: 240
+            color: IKColors.surfaceSecondary
+        }
+
+        Rectangle {
+            anchors.top: parent.top
+            anchors.right: parent.right
+            anchors.bottom: parent.bottom
+            visible: mainWindow.onboardingActive
+            width: parent.width * IKOnboarding.illustrationPanelWidthRatio
+            color: IKColors.onboardingSurfaceSecondary
+        }
+    }
+
+    headerData: Item {
+        anchors.fill: parent
+        visible: !mainWindow.onboardingActive && mainWindow.appRouter.mainWindowActive
+
+        Text {
+            anchors.left: parent.left
+            anchors.leftMargin: IKSpacing.s16
+            anchors.verticalCenter: parent.verticalCenter
+            text: "kDrive"
+            color: IKColors.textPrimary
+            font.pixelSize: IKFonts.headlineSize
+            font.weight: IKFonts.emphasized
+        }
+
+        MainToolbar {
+            anchors.left: parent.left
+            anchors.leftMargin: 240
+            anchors.right: parent.right
+            anchors.rightMargin: IKSpacing.s8
+            anchors.top: parent.top
+            anchors.bottom: parent.bottom
+            appRouter: mainWindow.appRouter
+            currentTab: mainWindow.appRouter.currentMainTabIndex
+        }
     }
 
     onClosing: close => {
@@ -87,11 +131,27 @@ IKShadowedWindow {
         }
     }
 
+    Loader {
+        id: mainWindowLoader
+
+        anchors.fill: parent
+        active: mainWindow.appRouter.mainWindowActive && !mainWindow.onboardingActive
+        sourceComponent: mainWindowComponent
+    }
+
     Component {
         id: onboardingComponent
 
         OnboardingWindow {
             session: onboardingLoader.session
+        }
+    }
+
+    Component {
+        id: mainWindowComponent
+
+        MainWindowView {
+            appRouter: mainWindow.appRouter
         }
     }
 }

--- a/src/gui4/linux/ui/mainwindow/ActivitiesPlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/ActivitiesPlaceholder.qml
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    Text {
+        anchors.centerIn: parent
+        text: qsTrId("activitiesTitleNoActivity")
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/BlockingErrorPlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/BlockingErrorPlaceholder.qml
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    Text {
+        anchors.centerIn: parent
+        text: qsTrId("labelNoErrorsToFix")
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/HomePlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/HomePlaceholder.qml
@@ -1,0 +1,81 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    Column {
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.top: parent.top
+        anchors.margins: IKSpacing.s24
+        spacing: IKSpacing.s24
+
+        Text {
+            width: parent.width
+            text: qsTrId("synchroUpToDate")
+            color: IKColors.textPrimary
+            font.pixelSize: IKFonts.titleSize
+            font.weight: IKFonts.emphasized
+            elide: Text.ElideRight
+        }
+
+        Rectangle {
+            width: parent.width
+            height: 240
+            radius: IKRadius.r8
+            color: IKColors.statusLightSecurity
+
+            Column {
+                anchors.centerIn: parent
+                width: Math.min(parent.width - 2 * IKSpacing.s24, 360)
+                spacing: IKSpacing.s8
+
+                Rectangle {
+                    width: 52
+                    height: 52
+                    radius: width / 2
+                    color: IKColors.statusMediumSuccess
+                    anchors.horizontalCenter: parent.horizontalCenter
+                }
+
+                Text {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    text: qsTrId("synchroStatusUpToDateTitle")
+                    color: IKColors.textPrimary
+                    font.pixelSize: IKFonts.headlineSize
+                    font.weight: IKFonts.emphasized
+                    elide: Text.ElideRight
+                }
+
+                Text {
+                    width: parent.width
+                    horizontalAlignment: Text.AlignHCenter
+                    text: qsTrId("synchroStatusUpToDateDescription")
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    wrapMode: Text.WordWrap
+                }
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
@@ -19,6 +19,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls
 import kDrive.UI
 
 Rectangle {
@@ -85,112 +86,25 @@ Rectangle {
             width: parent.width
             spacing: IKSpacing.s4
 
-            Rectangle {
-                id: homeItem
-
-                property bool hovered: false
-
+            NavigationButton {
                 width: parent.width
-                height: 36
-                radius: IKRadius.r8
-                color: root.currentTab === root.tabHome ? IKColors.surfaceTertiary
-                                                        : hovered ? IKColors.surfacePrimary
-                                                                  : "transparent"
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.leftMargin: IKSpacing.s12
-                    anchors.right: parent.right
-                    anchors.rightMargin: IKSpacing.s12
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTrId("tabTitleHome")
-                    color: root.currentTab === root.tabHome ? IKColors.textPrimary : IKColors.textSecondary
-                    font.pixelSize: IKFonts.bodySize
-                    font.weight: root.currentTab === root.tabHome ? IKFonts.emphasized : Font.Normal
-                    elide: Text.ElideRight
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton
-                    cursorShape: Qt.PointingHandCursor
-                    onEntered: homeItem.hovered = true
-                    onExited: homeItem.hovered = false
-                    onClicked: root.navigateTo(root.tabHome)
-                }
+                text: qsTrId("tabTitleHome")
+                selected: root.currentTab === root.tabHome
+                onClicked: root.navigateTo(root.tabHome)
             }
 
-            Rectangle {
-                id: activitiesItem
-
-                property bool hovered: false
-
+            NavigationButton {
                 width: parent.width
-                height: 36
-                radius: IKRadius.r8
-                color: root.currentTab === root.tabActivities ? IKColors.surfaceTertiary
-                                                              : hovered ? IKColors.surfacePrimary
-                                                                        : "transparent"
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.leftMargin: IKSpacing.s12
-                    anchors.right: parent.right
-                    anchors.rightMargin: IKSpacing.s12
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTrId("tabTitleActivities")
-                    color: root.currentTab === root.tabActivities ? IKColors.textPrimary : IKColors.textSecondary
-                    font.pixelSize: IKFonts.bodySize
-                    font.weight: root.currentTab === root.tabActivities ? IKFonts.emphasized : Font.Normal
-                    elide: Text.ElideRight
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton
-                    cursorShape: Qt.PointingHandCursor
-                    onEntered: activitiesItem.hovered = true
-                    onExited: activitiesItem.hovered = false
-                    onClicked: root.navigateTo(root.tabActivities)
-                }
+                text: qsTrId("tabTitleActivities")
+                selected: root.currentTab === root.tabActivities
+                onClicked: root.navigateTo(root.tabActivities)
             }
 
-            Rectangle {
-                id: storageItem
-
-                property bool hovered: false
-
+            NavigationButton {
                 width: parent.width
-                height: 36
-                radius: IKRadius.r8
-                color: root.currentTab === root.tabStorage ? IKColors.surfaceTertiary
-                                                           : hovered ? IKColors.surfacePrimary
-                                                                     : "transparent"
-
-                Text {
-                    anchors.left: parent.left
-                    anchors.leftMargin: IKSpacing.s12
-                    anchors.right: parent.right
-                    anchors.rightMargin: IKSpacing.s12
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: qsTrId("tabTitleStorage")
-                    color: root.currentTab === root.tabStorage ? IKColors.textPrimary : IKColors.textSecondary
-                    font.pixelSize: IKFonts.bodySize
-                    font.weight: root.currentTab === root.tabStorage ? IKFonts.emphasized : Font.Normal
-                    elide: Text.ElideRight
-                }
-
-                MouseArea {
-                    anchors.fill: parent
-                    hoverEnabled: true
-                    acceptedButtons: Qt.LeftButton
-                    cursorShape: Qt.PointingHandCursor
-                    onEntered: storageItem.hovered = true
-                    onExited: storageItem.hovered = false
-                    onClicked: root.navigateTo(root.tabStorage)
-                }
+                text: qsTrId("tabTitleStorage")
+                selected: root.currentTab === root.tabStorage
+                onClicked: root.navigateTo(root.tabStorage)
             }
 
             Rectangle {
@@ -212,6 +126,36 @@ Rectangle {
                     elide: Text.ElideRight
                 }
             }
+        }
+    }
+
+    component NavigationButton: Button {
+        id: navigationButton
+
+        required property bool selected
+
+        height: 36
+        leftPadding: IKSpacing.s12
+        rightPadding: IKSpacing.s12
+        focusPolicy: Qt.StrongFocus
+        hoverEnabled: true
+
+        contentItem: Text {
+            text: navigationButton.text
+            color: navigationButton.selected ? IKColors.textPrimary : IKColors.textSecondary
+            font.pixelSize: IKFonts.bodySize
+            font.weight: navigationButton.selected ? IKFonts.emphasized : Font.Normal
+            verticalAlignment: Text.AlignVCenter
+            elide: Text.ElideRight
+        }
+
+        background: Rectangle {
+            radius: IKRadius.r8
+            color: navigationButton.selected || navigationButton.down ? IKColors.surfaceTertiary
+                                                                       : navigationButton.hovered ? IKColors.surfacePrimary
+                                                                                                  : "transparent"
+            border.width: navigationButton.visualFocus ? 2 : 0
+            border.color: IKColors.accentPrimary
         }
     }
 }

--- a/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
@@ -27,9 +27,9 @@ Rectangle {
     required property var appRouter
 
     readonly property int currentTab: root.appRouter.currentMainTabIndex
-    readonly property int tabHome: 0
-    readonly property int tabActivities: 1
-    readonly property int tabStorage: 2
+    readonly property int tabHome: AppRouter.Home
+    readonly property int tabActivities: AppRouter.Activities
+    readonly property int tabStorage: AppRouter.Storage
 
     function navigateTo(tabIndex: int) {
         root.appRouter.navigateToMainTab(tabIndex)

--- a/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/MainSidebarPlaceholder.qml
@@ -1,0 +1,217 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Rectangle {
+    id: root
+
+    required property var appRouter
+
+    readonly property int currentTab: root.appRouter.currentMainTabIndex
+    readonly property int tabHome: 0
+    readonly property int tabActivities: 1
+    readonly property int tabStorage: 2
+
+    function navigateTo(tabIndex: int) {
+        root.appRouter.navigateToMainTab(tabIndex)
+    }
+
+    color: IKColors.surfaceSecondary
+
+    Column {
+        id: sidebarColumn
+
+        anchors.fill: parent
+        anchors.margins: IKSpacing.s16
+        spacing: IKSpacing.s16
+
+        Row {
+            width: parent.width
+            height: 44
+            spacing: IKSpacing.s12
+
+            Rectangle {
+                width: 36
+                height: 36
+                radius: width / 2
+                color: IKColors.driveDefaultColor
+                anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Column {
+                width: parent.width - 48
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: IKSpacing.s2
+
+                Text {
+                    width: parent.width
+                    text: "kDrive"
+                    color: IKColors.textPrimary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: IKFonts.emphasized
+                    elide: Text.ElideRight
+                }
+
+                Text {
+                    width: parent.width
+                    text: qsTrId("labelSynchronisation")
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.subheadlineSize
+                    elide: Text.ElideRight
+                }
+            }
+        }
+
+        Column {
+            width: parent.width
+            spacing: IKSpacing.s4
+
+            Rectangle {
+                id: homeItem
+
+                property bool hovered: false
+
+                width: parent.width
+                height: 36
+                radius: IKRadius.r8
+                color: root.currentTab === root.tabHome ? IKColors.surfaceTertiary
+                                                        : hovered ? IKColors.surfacePrimary
+                                                                  : "transparent"
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: IKSpacing.s12
+                    anchors.right: parent.right
+                    anchors.rightMargin: IKSpacing.s12
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTrId("tabTitleHome")
+                    color: root.currentTab === root.tabHome ? IKColors.textPrimary : IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: root.currentTab === root.tabHome ? IKFonts.emphasized : Font.Normal
+                    elide: Text.ElideRight
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.LeftButton
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: homeItem.hovered = true
+                    onExited: homeItem.hovered = false
+                    onClicked: root.navigateTo(root.tabHome)
+                }
+            }
+
+            Rectangle {
+                id: activitiesItem
+
+                property bool hovered: false
+
+                width: parent.width
+                height: 36
+                radius: IKRadius.r8
+                color: root.currentTab === root.tabActivities ? IKColors.surfaceTertiary
+                                                              : hovered ? IKColors.surfacePrimary
+                                                                        : "transparent"
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: IKSpacing.s12
+                    anchors.right: parent.right
+                    anchors.rightMargin: IKSpacing.s12
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTrId("tabTitleActivities")
+                    color: root.currentTab === root.tabActivities ? IKColors.textPrimary : IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: root.currentTab === root.tabActivities ? IKFonts.emphasized : Font.Normal
+                    elide: Text.ElideRight
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.LeftButton
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: activitiesItem.hovered = true
+                    onExited: activitiesItem.hovered = false
+                    onClicked: root.navigateTo(root.tabActivities)
+                }
+            }
+
+            Rectangle {
+                id: storageItem
+
+                property bool hovered: false
+
+                width: parent.width
+                height: 36
+                radius: IKRadius.r8
+                color: root.currentTab === root.tabStorage ? IKColors.surfaceTertiary
+                                                           : hovered ? IKColors.surfacePrimary
+                                                                     : "transparent"
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: IKSpacing.s12
+                    anchors.right: parent.right
+                    anchors.rightMargin: IKSpacing.s12
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTrId("tabTitleStorage")
+                    color: root.currentTab === root.tabStorage ? IKColors.textPrimary : IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    font.weight: root.currentTab === root.tabStorage ? IKFonts.emphasized : Font.Normal
+                    elide: Text.ElideRight
+                }
+
+                MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    acceptedButtons: Qt.LeftButton
+                    cursorShape: Qt.PointingHandCursor
+                    onEntered: storageItem.hovered = true
+                    onExited: storageItem.hovered = false
+                    onClicked: root.navigateTo(root.tabStorage)
+                }
+            }
+
+            Rectangle {
+                width: parent.width
+                height: 36
+                radius: IKRadius.r8
+                color: "transparent"
+                opacity: 0.45
+
+                Text {
+                    anchors.left: parent.left
+                    anchors.leftMargin: IKSpacing.s12
+                    anchors.right: parent.right
+                    anchors.rightMargin: IKSpacing.s12
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: qsTrId("buttonOpenFolder")
+                    color: IKColors.textSecondary
+                    font.pixelSize: IKFonts.bodySize
+                    elide: Text.ElideRight
+                }
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/MainToolbar.qml
+++ b/src/gui4/linux/ui/mainwindow/MainToolbar.qml
@@ -1,0 +1,143 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Rectangle {
+    id: root
+
+    required property var appRouter
+    property int currentTab: 0
+
+    readonly property int tabActivities: 1
+    readonly property int tabStorage: 2
+    readonly property int tabBlockingError: 3
+
+    color: "transparent"
+
+    Text {
+        id: titleLabel
+
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+        width: Math.min(implicitWidth, Math.max(0, actionsRow.x - x - IKSpacing.s16))
+        text: {
+            switch (root.currentTab) {
+            case root.tabActivities:
+                return qsTrId("tabTitleActivities")
+            case root.tabStorage:
+                return qsTrId("tabTitleStorage")
+            case root.tabBlockingError:
+                return qsTrId("errorPageTitle")
+            default:
+                return qsTrId("tabTitleHome")
+            }
+        }
+        color: IKColors.textPrimary
+        font.pixelSize: IKFonts.headlineSize
+        font.weight: IKFonts.emphasized
+        elide: Text.ElideRight
+    }
+
+    Row {
+        id: actionsRow
+
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: IKSpacing.s8
+
+        HeaderIconButton {
+            label: "?"
+            onTriggered: root.appRouter.openSupport()
+        }
+
+        HeaderIconButton {
+            label: "||"
+            onTriggered: root.appRouter.requestPauseCurrentSync()
+        }
+
+        Rectangle {
+            width: 132
+            height: 36
+            radius: height / 2
+            color: IKColors.surfaceSecondary
+            border.width: 1
+            border.color: IKColors.surfaceTertiary
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                cursorShape: Qt.PointingHandCursor
+                onEntered: parent.color = IKColors.surfaceTertiary
+                onExited: parent.color = IKColors.surfaceSecondary
+                onClicked: root.appRouter.requestSearch()
+            }
+
+            Row {
+                anchors.left: parent.left
+                anchors.leftMargin: IKSpacing.s12
+                anchors.right: parent.right
+                anchors.rightMargin: IKSpacing.s12
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: IKSpacing.s8
+
+                Text {
+                    text: qsTrId("buttonSearch")
+                    color: IKColors.textTertiary
+                    font.pixelSize: IKFonts.bodySize
+                    elide: Text.ElideRight
+                }
+            }
+        }
+    }
+
+    component HeaderIconButton: Rectangle {
+        id: buttonRoot
+
+        signal triggered()
+
+        property string label: ""
+
+        width: 32
+        height: 32
+        radius: width / 2
+        color: IKColors.surfaceSecondary
+        border.width: 1
+        border.color: IKColors.surfaceTertiary
+
+        Text {
+            anchors.centerIn: parent
+            text: buttonRoot.label
+            color: IKColors.textSecondary
+            font.pixelSize: IKFonts.bodySize
+            font.weight: IKFonts.emphasized
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            hoverEnabled: true
+            cursorShape: Qt.PointingHandCursor
+            onEntered: buttonRoot.color = IKColors.surfaceTertiary
+            onExited: buttonRoot.color = IKColors.surfaceSecondary
+            onClicked: buttonRoot.triggered()
+        }
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/MainToolbar.qml
+++ b/src/gui4/linux/ui/mainwindow/MainToolbar.qml
@@ -19,6 +19,7 @@
 pragma ComponentBehavior: Bound
 
 import QtQuick
+import QtQuick.Controls
 import kDrive.UI
 
 Rectangle {
@@ -65,84 +66,75 @@ Rectangle {
         spacing: IKSpacing.s8
 
         HeaderIconButton {
-            label: "?"
-            onTriggered: root.appRouter.openSupport()
+            glyph: "?"
+            text: qsTrId("infomaniakSupport")
+            onClicked: root.appRouter.openSupport()
         }
 
         HeaderIconButton {
-            label: "||"
-            onTriggered: root.appRouter.requestPauseCurrentSync()
+            glyph: "||"
+            text: qsTrId("buttonPause")
+            onClicked: root.appRouter.requestPauseCurrentSync()
         }
 
-        Rectangle {
+        Button {
             id: searchButton
-
-            property bool hovered: false
 
             width: 132
             height: 36
-            radius: height / 2
-            color: hovered ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
-            border.width: 1
-            border.color: IKColors.surfaceTertiary
+            leftPadding: IKSpacing.s12
+            rightPadding: IKSpacing.s12
+            focusPolicy: Qt.StrongFocus
+            hoverEnabled: true
+            text: qsTrId("buttonSearch")
+            onClicked: root.appRouter.requestSearch()
 
-            MouseArea {
-                anchors.fill: parent
-                hoverEnabled: true
-                cursorShape: Qt.PointingHandCursor
-                onEntered: searchButton.hovered = true
-                onExited: searchButton.hovered = false
-                onClicked: root.appRouter.requestSearch()
+            contentItem: Text {
+                text: searchButton.text
+                color: IKColors.textTertiary
+                font.pixelSize: IKFonts.bodySize
+                verticalAlignment: Text.AlignVCenter
+                elide: Text.ElideRight
             }
 
-            Row {
-                anchors.left: parent.left
-                anchors.leftMargin: IKSpacing.s12
-                anchors.right: parent.right
-                anchors.rightMargin: IKSpacing.s12
-                anchors.verticalCenter: parent.verticalCenter
-                spacing: IKSpacing.s8
-
-                Text {
-                    text: qsTrId("buttonSearch")
-                    color: IKColors.textTertiary
-                    font.pixelSize: IKFonts.bodySize
-                    elide: Text.ElideRight
-                }
+            background: Rectangle {
+                radius: height / 2
+                color: searchButton.hovered || searchButton.down ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
+                border.width: searchButton.visualFocus ? 2 : 1
+                border.color: searchButton.visualFocus ? IKColors.accentPrimary : IKColors.surfaceTertiary
             }
         }
     }
 
-    component HeaderIconButton: Rectangle {
+    component HeaderIconButton: ToolButton {
         id: buttonRoot
 
-        signal triggered()
-
-        property string label: ""
-        property bool hovered: false
+        required property string glyph
 
         width: 32
         height: 32
-        radius: width / 2
-        color: hovered ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
-        border.width: 1
-        border.color: IKColors.surfaceTertiary
+        focusPolicy: Qt.StrongFocus
+        hoverEnabled: true
+        display: AbstractButton.IconOnly
 
-        Text {
-            anchors.centerIn: parent
-            text: buttonRoot.label
+        contentItem: Text {
+            text: buttonRoot.glyph
             color: IKColors.textSecondary
             font.pixelSize: IKFonts.bodySize
             font.weight: IKFonts.emphasized
+            horizontalAlignment: Text.AlignHCenter
+            verticalAlignment: Text.AlignVCenter
         }
 
-        MouseArea {
-            anchors.fill: parent
-            hoverEnabled: true
-            cursorShape: Qt.PointingHandCursor
-            onEntered: buttonRoot.hovered = true
-            onExited: buttonRoot.hovered = false
-            onClicked: buttonRoot.triggered()
+        background: Rectangle {
+            radius: width / 2
+            color: buttonRoot.hovered || buttonRoot.down ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
+            border.width: buttonRoot.visualFocus ? 2 : 1
+            border.color: buttonRoot.visualFocus ? IKColors.accentPrimary : IKColors.surfaceTertiary
         }
+
+        ToolTip.visible: buttonRoot.hovered || buttonRoot.activeFocus
+        ToolTip.text: buttonRoot.text
+        ToolTip.delay: 500
     }
 }

--- a/src/gui4/linux/ui/mainwindow/MainToolbar.qml
+++ b/src/gui4/linux/ui/mainwindow/MainToolbar.qml
@@ -25,11 +25,11 @@ Rectangle {
     id: root
 
     required property var appRouter
-    property int currentTab: 0
 
-    readonly property int tabActivities: 1
-    readonly property int tabStorage: 2
-    readonly property int tabBlockingError: 3
+    readonly property int currentTab: root.appRouter.currentMainTabIndex
+    readonly property int tabActivities: AppRouter.Activities
+    readonly property int tabStorage: AppRouter.Storage
+    readonly property int tabBlockingError: AppRouter.BlockingError
 
     color: "transparent"
 
@@ -75,10 +75,14 @@ Rectangle {
         }
 
         Rectangle {
+            id: searchButton
+
+            property bool hovered: false
+
             width: 132
             height: 36
             radius: height / 2
-            color: IKColors.surfaceSecondary
+            color: hovered ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
             border.width: 1
             border.color: IKColors.surfaceTertiary
 
@@ -86,8 +90,8 @@ Rectangle {
                 anchors.fill: parent
                 hoverEnabled: true
                 cursorShape: Qt.PointingHandCursor
-                onEntered: parent.color = IKColors.surfaceTertiary
-                onExited: parent.color = IKColors.surfaceSecondary
+                onEntered: searchButton.hovered = true
+                onExited: searchButton.hovered = false
                 onClicked: root.appRouter.requestSearch()
             }
 
@@ -115,11 +119,12 @@ Rectangle {
         signal triggered()
 
         property string label: ""
+        property bool hovered: false
 
         width: 32
         height: 32
         radius: width / 2
-        color: IKColors.surfaceSecondary
+        color: hovered ? IKColors.surfaceTertiary : IKColors.surfaceSecondary
         border.width: 1
         border.color: IKColors.surfaceTertiary
 
@@ -135,8 +140,8 @@ Rectangle {
             anchors.fill: parent
             hoverEnabled: true
             cursorShape: Qt.PointingHandCursor
-            onEntered: buttonRoot.color = IKColors.surfaceTertiary
-            onExited: buttonRoot.color = IKColors.surfaceSecondary
+            onEntered: buttonRoot.hovered = true
+            onExited: buttonRoot.hovered = false
             onClicked: buttonRoot.triggered()
         }
     }

--- a/src/gui4/linux/ui/mainwindow/MainWindowView.qml
+++ b/src/gui4/linux/ui/mainwindow/MainWindowView.qml
@@ -1,0 +1,78 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    id: root
+
+    required property var appRouter
+
+    readonly property int tabHome: 0
+    readonly property int tabActivities: 1
+    readonly property int tabStorage: 2
+    readonly property int tabBlockingError: 3
+    readonly property real sidebarWidth: 240
+    readonly property int currentTab: appRouter.currentMainTabIndex
+
+    Row {
+        anchors.fill: parent
+
+        MainSidebarPlaceholder {
+            width: root.sidebarWidth
+            height: parent.height
+            appRouter: root.appRouter
+        }
+
+        Rectangle {
+            width: Math.max(0, parent.width - root.sidebarWidth)
+            height: parent.height
+            color: IKColors.surfacePrimary
+
+            Item {
+                anchors.left: parent.left
+                anchors.right: parent.right
+                anchors.top: parent.top
+                anchors.bottom: parent.bottom
+
+                HomePlaceholder {
+                    anchors.fill: parent
+                    visible: root.currentTab === root.tabHome
+                }
+
+                ActivitiesPlaceholder {
+                    anchors.fill: parent
+                    visible: root.currentTab === root.tabActivities
+                }
+
+                StoragePlaceholder {
+                    anchors.fill: parent
+                    visible: root.currentTab === root.tabStorage
+                }
+
+                BlockingErrorPlaceholder {
+                    anchors.fill: parent
+                    visible: root.currentTab === root.tabBlockingError
+                }
+            }
+        }
+    }
+}

--- a/src/gui4/linux/ui/mainwindow/MainWindowView.qml
+++ b/src/gui4/linux/ui/mainwindow/MainWindowView.qml
@@ -26,11 +26,11 @@ Item {
 
     required property var appRouter
 
-    readonly property int tabHome: 0
-    readonly property int tabActivities: 1
-    readonly property int tabStorage: 2
-    readonly property int tabBlockingError: 3
-    readonly property real sidebarWidth: 240
+    readonly property int tabHome: AppRouter.Home
+    readonly property int tabActivities: AppRouter.Activities
+    readonly property int tabStorage: AppRouter.Storage
+    readonly property int tabBlockingError: AppRouter.BlockingError
+    readonly property real sidebarWidth: IKMainWindow.sidebarWidth
     readonly property int currentTab: appRouter.currentMainTabIndex
 
     Row {

--- a/src/gui4/linux/ui/mainwindow/StoragePlaceholder.qml
+++ b/src/gui4/linux/ui/mainwindow/StoragePlaceholder.qml
@@ -1,0 +1,31 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma ComponentBehavior: Bound
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    Text {
+        anchors.centerIn: parent
+        text: qsTrId("tabTitleStorage")
+        color: IKColors.textSecondary
+        font.pixelSize: IKFonts.bodySize
+    }
+}

--- a/src/gui4/linux/ui/onboarding/ReadyView.qml
+++ b/src/gui4/linux/ui/onboarding/ReadyView.qml
@@ -66,7 +66,7 @@ Item {
             enabled: root.onboardingFlowController.readyActionEnabled
             height: IKOnboarding.completionButtonHeight
             text: qsTrId("buttonOpenKDrive")
-            onClicked: root.onboardingFlowController.openSynchronizedFolders()
+            onClicked: root.onboardingFlowController.completeOnboarding()
 
             contentItem: Text {
                 text: openButton.text

--- a/src/gui4/linux/ui/tokens/IKMainWindow.qml
+++ b/src/gui4/linux/ui/tokens/IKMainWindow.qml
@@ -1,0 +1,24 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property real sidebarWidth: 240
+}


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR introduit la fenêtre principale (post-onboarding) sur Linux v4 : un routeur de navigation minimal (`AppRouter`), un shell d'écrans placeholders (accueil, activités, stockage, erreur bloquante), et le câblage de bout en bout permettant d'ouvrir cette fenêtre principale après le bootstrap ou à la fin de l'onboarding. Elle simplifie également le flux de fin d'onboarding et ajoute plusieurs rapports d'erreur Sentry manquants.

## Changements
- Ajout d'`AppRouter` (`app/navigation/approuter.*`) : routeur minimal possédant uniquement `mainWindowActive` et l'onglet principal courant (`Home`, `Activities`, `Storage`, `BlockingError`), avec navigation, ouverture du support (`openSupport()`) et stubs non câblés pour la pause de synchronisation et la recherche.
- Ajout d'`AppConstants::Support::helpUri()` pointant vers `https://support.infomaniak.com/`.
- Nouveaux écrans QML placeholders (`ui/mainwindow/`) : `MainWindowView`, `MainSidebarPlaceholder`, `MainToolbar`, `HomePlaceholder`, `ActivitiesPlaceholder`, `StoragePlaceholder`, `BlockingErrorPlaceholder`.
- Nouveau token QML `IKMainWindow` (largeur de la barre latérale).
- `Main.qml` gère désormais à la fois le contenu d'onboarding et le contenu de la fenêtre principale via un `Loader` piloté par `AppRouter.mainWindowActive`, avec en-tête et titre adaptés selon le mode actif.
- `AppClientLinux::openMainWindow()` active réellement `AppRouter` et affiche la fenêtre principale (au lieu de journaliser un message « non implémenté ») ; ouvre automatiquement la fenêtre principale après le bootstrap si le mode tray n'est pas actif et que des drives sont configurés, et à la fin de l'onboarding via le signal `onboardingCompleted`.
- `OnboardingSessionManager` expose un nouveau signal `onboardingCompleted` ; à la fin d'une session, elle notifie ce signal et s'arrête sans forcer la fermeture de la fenêtre, laissant `AppClientLinux` ouvrir la fenêtre principale.
- Simplification du flux de fin d'onboarding : suppression de `openSynchronizedFolders()` (ouverture des dossiers synchronisés dans le gestionnaire de fichiers) au profit d'un simple `completeOnboarding()` invocable, appelé directement depuis `ReadyView.qml`.
- `OnboardingSyncCreationCoordinator` : suppression de la logique et de l'état associés à l'ouverture des dossiers synchronisés (`_createdLocalPaths`), devenue inutile.
- Ajout de rapports d'erreur Sentry manquants : échec d'ouverture de l'URL d'autorisation OAuth (`OAuthLoginService`), échec d'activation du rafraîchissement des informations en direct (`CachePopulator`), et erreurs génériques de service (`ServiceEventBus`, remplace un `TODO`).
- Titre de l'étape de sélection de drive de l'onboarding migré vers `qtTrId` pour l'internationalisation (au lieu d'un texte codé en dur).
- Mise à jour de `AGENTS.md` (rôle d'`AppRouter`, nouveau routage de la fenêtre principale via `AppClientLinux::openMainWindow()`, rôle du dossier `ui/mainwindow/`) et de `CMakeLists.txt` pour référencer les nouveaux fichiers.

## Détails techniques
`AppRouter` reste volontairement minimal : il ne lit pas `AppCache`, n'appelle aucun service backend et ne décide pas si l'onboarding est nécessaire ; cette décision continue d'appartenir à `AppClientLinux::openMainWindow()`, qui délègue à `OnboardingSessionManager` uniquement si aucune synchronisation n'est configurée.

## Notes
Les actions « pause de la synchronisation courante » et « recherche » du `MainToolbar` sont journalisées mais pas encore câblées à un comportement réel. Les écrans du dossier `ui/mainwindow/` sont des placeholders temporaires.


</details>

---

## Summary
This PR introduces the main window (post-onboarding) on Linux v4: a minimal navigation router (`AppRouter`), a placeholder screen shell (home, activities, storage, blocking error), and the end-to-end wiring to open this main window after bootstrap or at the end of onboarding. It also simplifies the onboarding completion flow and adds several missing Sentry error reports.

## Changes
- Added `AppRouter` (`app/navigation/approuter.*`): a minimal router owning only `mainWindowActive` and the current main tab (`Home`, `Activities`, `Storage`, `BlockingError`), with navigation, support opening (`openSupport()`), and not-yet-wired stubs for pausing the current sync and search.
- Added `AppConstants::Support::helpUri()` pointing to `https://support.infomaniak.com/`.
- New QML placeholder screens (`ui/mainwindow/`): `MainWindowView`, `MainSidebarPlaceholder`, `MainToolbar`, `HomePlaceholder`, `ActivitiesPlaceholder`, `StoragePlaceholder`, `BlockingErrorPlaceholder`.
- New `IKMainWindow` QML token (sidebar width).
- `Main.qml` now handles both onboarding content and main window content through a `Loader` driven by `AppRouter.mainWindowActive`, with header and title adapted to the active mode.
- `AppClientLinux::openMainWindow()` now actually activates `AppRouter` and shows the main window (instead of logging a "not implemented" message); it automatically opens the main window after bootstrap when tray mode is not active and drives are configured, and at the end of onboarding via the new `onboardingCompleted` signal.
- `OnboardingSessionManager` exposes a new `onboardingCompleted` signal; on session completion it emits this signal and stops without forcing the window closed, letting `AppClientLinux` open the main window instead.
- Simplified onboarding completion flow: removed `openSynchronizedFolders()` (opening synced folders in the file manager) in favor of a plain invokable `completeOnboarding()`, called directly from `ReadyView.qml`.
- `OnboardingSyncCreationCoordinator`: removed the logic and state (`_createdLocalPaths`) related to opening synchronized folders, now unused.
- Added missing Sentry error reports: failure to open the OAuth authorization URL (`OAuthLoginService`), failure to activate live info refresh (`CachePopulator`), and generic service errors (`ServiceEventBus`, replacing a `TODO`).
- The onboarding drive-selection step title now uses `qtTrId` for translation instead of a hardcoded string.
- Updated `AGENTS.md` (role of `AppRouter`, the new main-window routing through `AppClientLinux::openMainWindow()`, role of the `ui/mainwindow/` folder) and `CMakeLists.txt` to reference the new files.

## Technical Details
`AppRouter` is intentionally kept minimal: it does not read `AppCache`, call backend services, or decide whether onboarding is required; that decision remains owned by `AppClientLinux::openMainWindow()`, which delegates to `OnboardingSessionManager` only when no sync is configured.

## Notes
The "pause current sync" and "search" actions in `MainToolbar` are logged but not yet wired to real behavior. The screens under `ui/mainwindow/` are temporary placeholders.

## Light and Dark Theme Screenshot
> Reminder: This PR is not intended to deliver something highly polished visually, but primarily to establish the navigation flow and the basic window structure. 
<img width="3302" height="1676" alt="image" src="https://github.com/user-attachments/assets/d938c04e-f033-4e53-830b-e79878399b84" />

<img width="3302" height="1676" alt="image" src="https://github.com/user-attachments/assets/287f46f6-eef1-4b4d-b8da-e71220c9e02d" />
