### PR TITLE
chore: add public cloud orchestrator workflow

### DIFF
--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -106,7 +106,6 @@ runs:
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libdbus-1.so.3 ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libpcre* ./dependencies/
-          cp /usr/lib/x86_64-linux-gnu/libgobject* ./dependencies/
         shell: bash
         if: steps.build.outcome == 'success'
 

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -99,6 +99,7 @@ runs:
           mkdir dependencies
           cp /usr/local/lib/libcppunit-1.15.so.2 ./dependencies/ 
           cp /usr/local/lib/libzip* ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libOpenGL* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libglib* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libsecret* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -107,6 +107,7 @@ runs:
           cp /usr/lib/x86_64-linux-gnu/libdbus-1.so.3 ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libpcre* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libgio* ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libgobject* ./dependencies/
         shell: bash
         if: steps.build.outcome == 'success'
 

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -105,6 +105,7 @@ runs:
           cp /usr/lib/x86_64-linux-gnu/libsecret* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libdbus-1.so.3 ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libpcre* ./dependencies/
         shell: bash
         if: steps.build.outcome == 'success'
 

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -106,6 +106,7 @@ runs:
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libdbus-1.so.3 ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libpcre* ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libgio* ./dependencies/
         shell: bash
         if: steps.build.outcome == 'success'
 

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -100,6 +100,7 @@ runs:
           cp /usr/local/lib/libcppunit-1.15.so.2 ./dependencies/ 
           cp /usr/local/lib/libzip* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libOpenGL* ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libEGL* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libglib* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libsecret* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/

--- a/.github/actions/build_linux_amd/action.yml
+++ b/.github/actions/build_linux_amd/action.yml
@@ -106,6 +106,7 @@ runs:
           cp /usr/lib/x86_64-linux-gnu/libgthread* ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libdbus-1.so.3 ./dependencies/
           cp /usr/lib/x86_64-linux-gnu/libpcre* ./dependencies/
+          cp /usr/lib/x86_64-linux-gnu/libgobject* ./dependencies/
         shell: bash
         if: steps.build.outcome == 'success'
 

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -119,7 +119,7 @@ runs:
         id: build
         shell: powershell
         run: |
-          & "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvars64.bat"
+          & "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
 
           $thumbprint = "${{ inputs.debug_cert_thumbprint }}"
 

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -53,7 +53,7 @@ runs:
         shell: cmd
 
       - name: Restore extension packages
-        run : nuget restore extensions/windows/cfapi/kDriveExt.sln
+        run : dotnet nuget restore extensions/windows/cfapi/kDriveExt.sln
         shell: powershell
 
       - name: Import Windows certificate

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -80,20 +80,21 @@ runs:
 
       - name: Digicert KSP - Set variables
         id: variables
-        run: |
-          if [ "${{ inputs.use_ksp_cert }}" = "true" ]; then
-            echo "version=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
-            echo "KEYPAIR_NAME=gt-standard-keypair" >> $GITHUB_OUTPUT
-            echo "CERTIFICATE_NAME=gt-certificate" >> $GITHUB_OUTPUT
-            echo "SM_HOST=${{ inputs.ksp_host }}" >> "$GITHUB_ENV"
-            echo "SM_API_KEY=${{ inputs.ksp_api_key }}" >> "$GITHUB_ENV"
-            echo "SM_CLIENT_CERT_FILE=${{ github.workspace }}/certificate/ksp_client_certificate.pfx" >> "$GITHUB_ENV"
-            echo "SM_CLIENT_CERT_PASSWORD=${{ inputs.ksp_client_cert_pass }}" >> "$GITHUB_ENV"
-            echo "C:\Program Files (x86)\Windows Kits\10\App Certification Kit" >> $GITHUB_PATH
-            echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
-            echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
-          fi
+        if: ${{ inputs.use_ksp_cert == 'true' }}
         shell: cmd
+        run: |
+          echo version=%GITHUB_REF:refs/tags/v=%>>"%GITHUB_OUTPUT%"
+          echo KEYPAIR_NAME=gt-standard-keypair>>"%GITHUB_OUTPUT%"
+          echo CERTIFICATE_NAME=gt-certificate>>"%GITHUB_OUTPUT%"
+
+          echo SM_HOST=${{ inputs.ksp_host }}>>"%GITHUB_ENV%"
+          echo SM_API_KEY=${{ inputs.ksp_api_key }}>>"%GITHUB_ENV%"
+          echo SM_CLIENT_CERT_FILE=${{ github.workspace }}\certificate\ksp_client_certificate.pfx>>"%GITHUB_ENV%"
+          echo SM_CLIENT_CERT_PASSWORD=${{ inputs.ksp_client_cert_pass }}>>"%GITHUB_ENV%"
+
+          echo C:\Program Files (x86)\Windows Kits\10\App Certification Kit>>"%GITHUB_PATH%"
+          echo C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools>>"%GITHUB_PATH%"
+          echo C:\Program Files\DigiCert\DigiCert Keylocker Tools>>"%GITHUB_PATH%"
 
       - name: Digicert KSP - Setup SSM KSP on Windows latest
         run: |

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -119,7 +119,10 @@ runs:
         id: build
         shell: powershell
         run: |
-          & "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+          & "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\Launch-VsDevShell.ps1" `
+            -Arch amd64 `
+            -HostArch amd64 `
+            -SkipAutomaticLocation
 
           $thumbprint = "${{ inputs.debug_cert_thumbprint }}"
 

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -66,14 +66,14 @@ runs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_KSP_CLIENT_CERT
             certutil -decode certificate/tempCert.txt certificate/ksp_client_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert_pass }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/ksp_client_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ inputs.ksp_client_cert_pass }}" -Force -AsPlainText)
             Write-Host "KSP client certificate imported successfully."
           } else {
             New-Item -ItemType directory -Path certificate
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert_pass }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ inputs.debug_cert_pass }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
           }
         shell: powershell
@@ -111,7 +111,7 @@ runs:
             REM Verify the KSP
             certutil.exe -csp "DigiCert Software Trust Manager KSP" -key -user
             REM Synchronize certificate
-            smctl windows certsync --store="system"
+            smctl windows certsync
           )
         shell: cmd
 
@@ -151,11 +151,11 @@ runs:
       - name: Remove Windows certificate
         run: |
           if("${{ inputs.use_ksp_cert }}" -eq "true") {
-            Get-ChildItem "Cert:\LocalMachine\My\${{ inputs.ksp_client_cert_thumbprint }}" | Remove-Item
+            Get-ChildItem "Cert:\CurrentUser\My\${{ inputs.ksp_client_cert_thumbprint }}" | Remove-Item
             Remove-Item -path certificate -include ksp_client_certificate.pfx
             Write-Host "KSP client certificate removed successfully."
           } else {
-            Get-ChildItem "Cert:\LocalMachine\My\${{ inputs.debug_cert_thumbprint }}" | Remove-Item
+            Get-ChildItem "Cert:\CurrentUser\My\${{ inputs.debug_cert_thumbprint }}" | Remove-Item
             Remove-Item -path certificate -include debug_certificate.pfx
             Write-Host "Debug certificate removed successfully."
           }

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -52,10 +52,6 @@ runs:
         run : echo Path=%Path%>> %GITHUB_ENV%
         shell: cmd
 
-      - name: Restore extension packages
-        run : dotnet nuget restore extensions/windows/cfapi/kDriveExt.sln
-        shell: powershell
-
       - name: Import Windows certificate
         env:
           WINDOWS_KSP_CLIENT_CERT: ${{ inputs.ksp_client_cert }}
@@ -123,6 +119,8 @@ runs:
             -Arch amd64 `
             -HostArch amd64 `
             -SkipAutomaticLocation
+
+          msbuild ./extensions/windows/cfapi/kDriveExt.sln /t:Restore
 
           $thumbprint = "${{ inputs.debug_cert_thumbprint }}"
 

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -120,7 +120,6 @@ runs:
             -HostArch amd64 `
             -SkipAutomaticLocation
 
-          msbuild ./extensions/windows/cfapi/kDriveExt.sln /t:Restore
 
           $thumbprint = "${{ inputs.debug_cert_thumbprint }}"
 

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -79,18 +79,18 @@ runs:
         if: ${{ inputs.use_ksp_cert == 'true' }}
         shell: cmd
         run: |
-          echo version=%GITHUB_REF:refs/tags/v=%>>"%GITHUB_OUTPUT%"
-          echo KEYPAIR_NAME=gt-standard-keypair>>"%GITHUB_OUTPUT%"
-          echo CERTIFICATE_NAME=gt-certificate>>"%GITHUB_OUTPUT%"
+          >>"%GITHUB_OUTPUT%" echo version=%GITHUB_REF:refs/tags/v=%
+          >>"%GITHUB_OUTPUT%" echo KEYPAIR_NAME=gt-standard-keypair
+          >>"%GITHUB_OUTPUT%" echo CERTIFICATE_NAME=gt-certificate
 
-          echo SM_HOST=${{ inputs.ksp_host }}>>"%GITHUB_ENV%"
-          echo SM_API_KEY=${{ inputs.ksp_api_key }}>>"%GITHUB_ENV%"
-          echo SM_CLIENT_CERT_FILE=${{ github.workspace }}\certificate\ksp_client_certificate.pfx>>"%GITHUB_ENV%"
-          echo SM_CLIENT_CERT_PASSWORD=${{ inputs.ksp_client_cert_pass }}>>"%GITHUB_ENV%"
+          >>"%GITHUB_ENV%" echo SM_HOST=${{ inputs.ksp_host }}
+          >>"%GITHUB_ENV%" echo SM_API_KEY=${{ inputs.ksp_api_key }}
+          >>"%GITHUB_ENV%" echo SM_CLIENT_CERT_FILE=${{ github.workspace }}\certificate\ksp_client_certificate.pfx
+          >>"%GITHUB_ENV%" echo SM_CLIENT_CERT_PASSWORD=${{ inputs.ksp_client_cert_pass }}
 
-          echo C:\Program Files (x86)\Windows Kits\10\App Certification Kit>>"%GITHUB_PATH%"
-          echo C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools>>"%GITHUB_PATH%"
-          echo C:\Program Files\DigiCert\DigiCert Keylocker Tools>>"%GITHUB_PATH%"
+          >>"%GITHUB_PATH%" echo C:\Program Files (x86)\Windows Kits\10\App Certification Kit
+          >>"%GITHUB_PATH%" echo C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools
+          >>"%GITHUB_PATH%" echo C:\Program Files\DigiCert\DigiCert Keylocker Tools
 
       - name: Digicert KSP - Setup SSM KSP on Windows latest
         run: |

--- a/.github/actions/build_windows/action.yml
+++ b/.github/actions/build_windows/action.yml
@@ -93,7 +93,7 @@ runs:
             echo "C:\Program Files (x86)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools" >> $GITHUB_PATH
             echo "C:\Program Files\DigiCert\DigiCert Keylocker Tools" >> $GITHUB_PATH
           fi
-        shell: bash
+        shell: cmd
 
       - name: Digicert KSP - Setup SSM KSP on Windows latest
         run: |

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -72,7 +72,7 @@ jobs:
         env:
           WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
-          call "C:/Program Files (x86)/Microsoft Visual Studio/2019/Community/VC/Auxiliary/Build/vcvars64.bat"
+          call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
           powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT_THUMBPRINT -ci -coverage -unitTests
         shell: cmd
 

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -63,7 +63,7 @@ jobs:
             Set-Content -Path certificate/tempCert.txt -Value $env:WINDOWS_DEBUG_CERT_FILE_B64
             certutil -decode certificate/tempCert.txt certificate/debug_certificate.pfx
             Remove-Item -path certificate -include tempCert.txt
-            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\LocalMachine\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
+            Import-PfxCertificate -FilePath certificate/debug_certificate.pfx -CertStoreLocation Cert:\CurrentUser\My -Password (ConvertTo-SecureString -String "${{ secrets.WINDOWS_DEBUG_CERT_PASSWORD }}" -Force -AsPlainText)
             Write-Host "Debug certificate imported successfully."
 
         shell: powershell
@@ -102,7 +102,7 @@ jobs:
         env:
           WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
-            Get-ChildItem "Cert:\LocalMachine\My\$env:WINDOWS_DEBUG_CERT_THUMBPRINT" | Remove-Item
+            Get-ChildItem "Cert:\CurrentUser\My\$env:WINDOWS_DEBUG_CERT_THUMBPRINT" | Remove-Item
             Remove-Item -path certificate -include debug_certificate.pfx
             Write-Host "Debug certificate removed successfully."
 

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -53,7 +53,7 @@ jobs:
         run : rm -r -force C:/Windows/Temp/kDrive-logdir/*
 
       - name: Restore extension packages
-        run : nuget restore extensions/windows/cfapi/kDriveExt.sln
+        run : dotnet nuget restore extensions/windows/cfapi/kDriveExt.sln
 
       - name: Import Windows certificate
         env:

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -70,7 +70,6 @@ jobs:
           WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
           call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
-          msbuild ./extensions/windows/cfapi/kDriveExt.sln /t:Restore
           powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT_THUMBPRINT -ci -coverage -unitTests
         shell: cmd
 

--- a/.github/workflows/build-and-run-extended-tests.yml
+++ b/.github/workflows/build-and-run-extended-tests.yml
@@ -52,9 +52,6 @@ jobs:
       - name: Clean the log directory
         run : rm -r -force C:/Windows/Temp/kDrive-logdir/*
 
-      - name: Restore extension packages
-        run : dotnet nuget restore extensions/windows/cfapi/kDriveExt.sln
-
       - name: Import Windows certificate
         env:
           WINDOWS_DEBUG_CERT_FILE_B64: ${{ secrets.WINDOWS_DEBUG_CERT_FILE_B64 }}
@@ -73,6 +70,7 @@ jobs:
           WINDOWS_DEBUG_CERT_THUMBPRINT: ${{ secrets.WINDOWS_DEBUG_CERT_THUMBPRINT }}
         run: |
           call "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+          msbuild ./extensions/windows/cfapi/kDriveExt.sln /t:Restore
           powershell ./infomaniak-build-tools/windows/build-drive.ps1 -thumbprint $env:WINDOWS_DEBUG_CERT_THUMBPRINT -ci -coverage -unitTests
         shell: cmd
 

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
 # Build apps
   build-Windows:
-    runs-on: [ self-hosted, Windows, vs2026 ]
+    runs-on: [ self-hosted, Windows, vs2026, desktop, kdrive, build ]
     steps:
       - name: Checkout the PR
         uses: actions/checkout@v6.0.2
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ self-hosted, Windows, vs2026, desktop-kdrive  ]
+    runs-on: [ windows-latest ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "windows_ci_runner"
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ self-hosted, Linux, X64, linux-test ]
+    runs-on: [ ubuntu-latest ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "linux_ci_runner"
@@ -118,7 +118,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ self-hosted, macOS ]
+    runs-on: [ macos-latest ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "macos_ci_runner"
@@ -135,7 +135,7 @@ jobs:
             test_dependencies_version: ${{ vars.KDRIVE_TEST_DEPENDENCIES_VERSION }}
 
   Unit-Tests:
-    runs-on: [self-hosted, Windows]
+    runs-on: [ windows-latest ]
     needs: [Test-Windows, Test-Linux, Test-macOS]
     steps:
      - name: Check if all tests passed

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
 # Build apps
   build-Windows:
-    runs-on: [ self-hosted, Windows, desktop-kdrive ]
+    runs-on: [ self-hosted, Windows, desktop-kdrive, vs2026 ]
     steps:
       - name: Checkout the PR
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ self-hosted, Windows, windows-test ]
+    runs-on: [ self-hosted, Windows, vs2026, desktop-kdrive  ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "windows_ci_runner"

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
 # Build apps
   build-Windows:
-    runs-on: [ self-hosted, Windows, desktop-kdrive, vs2026 ]
+    runs-on: [ self-hosted, Windows, vs2026 ]
     steps:
       - name: Checkout the PR
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ ubuntu-22.04 ]
+    runs-on: [ ubuntu-latest ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "linux_ci_runner"

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -95,7 +95,7 @@ jobs:
       fail-fast: false
       matrix:
         test_name: ["kDrive_test_common", "kDrive_test_common_server", "kDrive_test_server", "kDrive_test_syncengine", "kDrive_test_parms"]
-    runs-on: [ ubuntu-latest ]
+    runs-on: [ ubuntu-22.04 ]
     env:
       KDRIVE_TEST_CI_LOCAL_PATH: "${{ github.workspace }}/test/test_ci"
       KDRIVE_SENTRY_ENVIRONMENT: "linux_ci_runner"

--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -29,7 +29,7 @@ jobs:
 
 # Build apps
   build-Windows:
-    runs-on: [ self-hosted, Windows, vs2026, desktop, kdrive, build ]
+    runs-on: [ self-hosted, Windows, vs2026 ]
     steps:
       - name: Checkout the PR
         uses: actions/checkout@v6.0.2

--- a/.github/workflows/kdrive-desktop-release.yml
+++ b/.github/workflows/kdrive-desktop-release.yml
@@ -164,7 +164,7 @@ jobs:
   build-Windows:
     if: ${{ inputs.build_windows != 'Do not build' }}
     needs: [ check-release-notes, check-translations ]
-    runs-on: [ self-hosted, Windows, desktop-kdrive-with-gui ] #with-gui is required for the build_windows action to unlock the release signing certificate
+    runs-on: [ self-hosted, Windows, vs2026 ]
     outputs:
       kDrive_version: ${{ steps.build-windows-step.outputs.kDrive_version }}
     steps:
@@ -237,7 +237,7 @@ jobs:
   upload-to-kDrive-and-sentry-Windows:
     if: ${{ inputs.build_windows != 'Do not build' && inputs.enable_safety_checks_and_upload_builds_to_kdrive }}
     needs: [build-Windows]
-    runs-on: [self-hosted, Windows, desktop-kdrive-with-gui] # Could be runing on any windows runner, but we use 'desktop-kdrive-with-gui' to avoid monopolizing the runners that are used for the CI builds.
+    runs-on: [ windows-latest ]
     env:
         KDRIVE_TOKEN: ${{ secrets.KDRIVE_TOKEN }}
         KDRIVE_ID: ${{ secrets.KDRIVE_ID }}
@@ -263,7 +263,6 @@ jobs:
         run: |
           $testFlag = if ("${{ inputs.use_ksp_cert }}" -eq "false") { "-test" } else { "" }
           powershell ./infomaniak-build-tools/upload-release-to-kDrive.ps1 -version "${{ steps.get-version.outputs.kDrive_version }}" -os "win" $testFlag
-
 
       - name: Download sentry-cli and login
         run: |

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -85,7 +85,7 @@ jobs:
             -e "s|__REPO_URL__|https://github.com/${REPO}|" \
             -e "s|__REG_TOKEN__|${{ steps.reg.outputs.token }}|" \
             -e "s|__TAGS__|${{ steps.params.outputs.labels }}|" \
-            -e "s|__ADMIN_PASS__|${{ steps.params.outputs.admin_pass }}|" \
+            -e "s|__REG_ADMIN_PASS__|${{ steps.params.outputs.admin_pass }}|" \
             .github/workflows/templates/userdata-template.ps1 > userdata-final.ps1
 
       - name: Launch instances

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -26,7 +26,7 @@ on:
 
 env:
   OS_CLOUD: infomaniak
-  IMAGE_NAME: "windows kDrive build runner"
+  IMAGE_NAME: "win_kdrive_runner_build_env"
   NETWORK_NAME: "ext-net1"          # adjust to your project's network
   REPO: ${{ github.repository }}
 

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -24,6 +24,9 @@ on:
     # Every weekday at 06:00 UTC — adjust to your needs
    # - cron: "0 6 * * 1-5"
 
+permissions:
+  contents: read
+
 env:
   OS_CLOUD: infomaniak
   IMAGE_NAME: "win_kdrive_runner_build_env"

--- a/.github/workflows/start-runner.yml
+++ b/.github/workflows/start-runner.yml
@@ -72,9 +72,12 @@ jobs:
           COUNT="${{ github.event.inputs.count || '1' }}"
           LABELS="${{ github.event.inputs.labels || 'self-hosted' }}"
           FLAVOR="${{ github.event.inputs.flavor || 'a12-ram24-disk80-perf1' }}"
+          ADMIN_PASS="${{ secrets.REG_ADMIN_PASS }}"
+          echo "::add-mask::$ADMIN_PASS"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
           echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
+          echo "admin_pass=$ADMIN_PASS" >> "$GITHUB_OUTPUT"
 
       - name: Render user-data template
         run: |
@@ -82,6 +85,7 @@ jobs:
             -e "s|__REPO_URL__|https://github.com/${REPO}|" \
             -e "s|__REG_TOKEN__|${{ steps.reg.outputs.token }}|" \
             -e "s|__TAGS__|${{ steps.params.outputs.labels }}|" \
+            -e "s|__ADMIN_PASS__|${{ steps.params.outputs.admin_pass }}|" \
             .github/workflows/templates/userdata-template.ps1 > userdata-final.ps1
 
       - name: Launch instances

--- a/.github/workflows/start-runners.yml
+++ b/.github/workflows/start-runners.yml
@@ -71,9 +71,6 @@ jobs:
           COUNT="${{ github.event.inputs.count || '1' }}"
           LABELS="${{ github.event.inputs.labels || 'self-hosted' }}"
           FLAVOR="${{ github.event.inputs.flavor || 'a16-ram32-disk80-perf1' }}"
-          ADMIN_PASS="${{ secrets.REG_ADMIN_PASS }}"
-          echo "::add-mask::$ADMIN_PASS"
-          echo "admin_pass=$ADMIN_PASS" >> "$GITHUB_OUTPUT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
           echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
@@ -84,7 +81,6 @@ jobs:
             -e "s|__REPO_URL__|https://github.com/${REPO}|" \
             -e "s|__REG_TOKEN__|${{ steps.reg.outputs.token }}|" \
             -e "s|__TAGS__|${{ steps.params.outputs.labels }}|" \
-            -e "s|__REG_ADMIN_PASS__|${{ steps.params.outputs.admin_pass }}|" \
             .github/workflows/templates/userdata-template.ps1 > userdata-final.ps1
 
       - name: Launch instances
@@ -103,7 +99,6 @@ jobs:
               --network "$NETWORK_NAME" \
               --user-data userdata-final.ps1 \
               --property "purpose=ci-runner" \
-              --property "expires_hours=${{ github.event.inputs.keep_hours || '6' }}" \
               --wait \
               "$NAME"
           done

--- a/.github/workflows/start-runners.yml
+++ b/.github/workflows/start-runners.yml
@@ -14,15 +14,11 @@ on:
       flavor:
         description: "Infomaniak flavor"
         required: false
-        default: "a12-ram24-disk80-perf1"
-      keep_hours:
-        description: "Auto-teardown after N hours (0 = never, handled by a separate workflow)"
-        required: false
-        default: "6"
+        default: "a16-ram32-disk80-perf1"
 
-  #schedule:
-    # Every weekday at 06:00 UTC — adjust to your needs
-   # - cron: "0 6 * * 1-5"
+  schedule:
+    - cron: "0 6 * * 1-5"
+      timezone: "Europe/Zurich"
 
 permissions:
   contents: read
@@ -30,7 +26,7 @@ permissions:
 env:
   OS_CLOUD: infomaniak
   IMAGE_NAME: "win_kdrive_runner_build_env"
-  NETWORK_NAME: "ext-net1"          # adjust to your project's network
+  NETWORK_NAME: "ext-net1"
   REPO: ${{ github.repository }}
 
 jobs:
@@ -67,20 +63,20 @@ jobs:
           echo "::add-mask::$TOKEN"
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
         env:
-          GH_TOKEN: ${{ secrets.RUNNER_ADMIN_PAT }}   # PAT (or GH App token) with admin:org / repo runner scope
+          GH_TOKEN: ${{ secrets.RUNNER_ADMIN_PAT }}
 
       - name: Determine run parameters
         id: params
         run: |
           COUNT="${{ github.event.inputs.count || '1' }}"
           LABELS="${{ github.event.inputs.labels || 'self-hosted' }}"
-          FLAVOR="${{ github.event.inputs.flavor || 'a12-ram24-disk80-perf1' }}"
+          FLAVOR="${{ github.event.inputs.flavor || 'a16-ram32-disk80-perf1' }}"
           ADMIN_PASS="${{ secrets.REG_ADMIN_PASS }}"
           echo "::add-mask::$ADMIN_PASS"
+          echo "admin_pass=$ADMIN_PASS" >> "$GITHUB_OUTPUT"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
           echo "flavor=$FLAVOR" >> "$GITHUB_OUTPUT"
-          echo "admin_pass=$ADMIN_PASS" >> "$GITHUB_OUTPUT"
 
       - name: Render user-data template
         run: |

--- a/.github/workflows/stop-runners.yml
+++ b/.github/workflows/stop-runners.yml
@@ -52,8 +52,8 @@ jobs:
 
           while true; do
             # Count self-hosted runners that are currently running a job
-            BUSY=$(gh api --paginate "/repos/${REPO}/actions/runners" \
-              --jq '[.runners[] | select(.busy == true)] | length')
+            BUSY=$(gh api --paginate --slurp "/repos/${REPO}/actions/runners?per_page=100" \
+               --jq '[.[].runners[] | select(.busy == true and (.name | startswith("ci-runner-")))] | length')
 
             if [ "$BUSY" -eq 0 ]; then
               echo "All runners are idle."
@@ -87,6 +87,7 @@ jobs:
           fi
 
       - name: Delete public cloud instances
+        if: always() # Always delete instances, even if previous steps failed, instances are billed by the hour
         run: |
           # Find every instance tagged with purpose=ci-runner
           SERVERS=$(openstack server list \

--- a/.github/workflows/stop-runners.yml
+++ b/.github/workflows/stop-runners.yml
@@ -70,6 +70,7 @@ jobs:
           done
 
       - name: Remove runners from GitHub
+        if: always()
         env:
           GH_TOKEN: ${{ secrets.RUNNER_ADMIN_PAT }}
         run: |

--- a/.github/workflows/stop-runners.yml
+++ b/.github/workflows/stop-runners.yml
@@ -1,0 +1,104 @@
+name: Tear down Windows CI runners
+
+on:
+  workflow_dispatch:
+    inputs:
+      wait_timeout_minutes:
+        description: "Max minutes to wait for busy runners to finish"
+        required: false
+        default: "60"
+
+  schedule:
+    - cron: "30 19 * * *"
+      timezone: "Europe/Zurich"
+
+permissions:
+  contents: read
+
+env:
+  OS_CLOUD: infomaniak
+  REPO: ${{ github.repository }}
+
+jobs:
+  stop-instances:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install OpenStack CLI
+        run: pip install python-openstackclient --quiet
+
+      - name: Write clouds.yaml
+        run: |
+          mkdir -p ~/.config/openstack
+          cat > ~/.config/openstack/clouds.yaml <<EOF
+          clouds:
+            infomaniak:
+              auth:
+                auth_url: ${{ secrets.PUBLIC_CLOUD_OS_AUTH_URL }}
+                username: ${{ secrets.PUBLIC_CLOUD_OS_USERNAME }}
+                password: ${{ secrets.PUBLIC_CLOUD_OS_PASSWORD }}
+                project_id: ${{ secrets.PUBLIC_CLOUD_OS_PROJECT_ID }}
+                user_domain_name: ${{ secrets.PUBLIC_CLOUD_OS_USER_DOMAIN_NAME }}
+              region_name: ${{ secrets.PUBLIC_CLOUD_OS_REGION_NAME }}
+              interface: public
+              identity_api_version: 3
+          EOF
+
+      - name: Wait for all runners to be idle
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_ADMIN_PAT }}
+        run: |
+          TIMEOUT_MIN="${{ github.event.inputs.wait_timeout_minutes || '60' }}"
+          DEADLINE=$(( $(date +%s) + TIMEOUT_MIN * 60 ))
+
+          while true; do
+            # Count self-hosted runners that are currently running a job
+            BUSY=$(gh api --paginate "/repos/${REPO}/actions/runners" \
+              --jq '[.runners[] | select(.busy == true)] | length')
+
+            if [ "$BUSY" -eq 0 ]; then
+              echo "All runners are idle."
+              break
+            fi
+
+            if [ "$(date +%s)" -ge "$DEADLINE" ]; then
+              echo "::warning::Timeout reached with $BUSY busy runner(s). Forcing teardown."
+              break
+            fi
+
+            echo "$BUSY runner(s) still busy. Waiting 30s ..."
+            sleep 30
+          done
+
+      - name: Remove runners from GitHub
+        env:
+          GH_TOKEN: ${{ secrets.RUNNER_ADMIN_PAT }}
+        run: |
+          # Delete every ci-runner-* self-hosted runner registered on the repo
+          IDS=$(gh api --paginate "/repos/${REPO}/actions/runners" \
+            --jq '.runners[] | select(.name | startswith("ci-runner-")) | .id')
+
+          if [ -z "$IDS" ]; then
+            echo "No matching runners registered."
+          else
+            for ID in $IDS; do
+              echo "Deleting runner id=$ID ..."
+              gh api -X DELETE "/repos/${REPO}/actions/runners/${ID}"
+            done
+          fi
+
+      - name: Delete public cloud instances
+        run: |
+          # Find every instance tagged with purpose=ci-runner
+          SERVERS=$(openstack server list \
+            --os-cloud "$OS_CLOUD" \
+            --property "purpose=ci-runner" \
+            -f value -c ID)
+
+          if [ -z "$SERVERS" ]; then
+            echo "No ci-runner instances found."
+          else
+            for ID in $SERVERS; do
+              echo "Deleting instance $ID ..."
+              openstack server delete --os-cloud "$OS_CLOUD" --wait "$ID"
+            done
+          fi

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -53,6 +53,15 @@ Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger `
 $adminSession = Get-Process -Name explorer -IncludeUserName -ErrorAction SilentlyContinue |
     Where-Object { $_.UserName -like "*$AdminAccount" }
 
+# --- Allow execution of .ps1 scripts (required by the runner to run job scripts) ---
+# The runner invokes temporary .ps1 files (e.g. from _work\_temp). Without a
+# permissive execution policy these fail with:
+#   "... cannot be loaded because running scripts is disabled on this system."
+# Set the policy for both the LocalMachine and CurrentUser scopes so the runner
+# (and any interactive session) can execute scripts.
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope LocalMachine -Force
+Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser -Force
+
 if ($adminSession) {
     Start-ScheduledTask -TaskName $TaskName
 }

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -18,7 +18,6 @@ $ServicePassword = "__REG_ADMIN_PASS__"
 # Local Administrator account (consistent with the AutoLogon set in the unattend file).
 # The ".\" prefix explicitly targets a local account rather than a domain account.
 $ServiceAccount  = ".\Administrator"
-$ServicePassword = "Passw0rd"
 
 Set-Location $RunnerDir
 

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -43,10 +43,16 @@ Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger `
     -Principal $Principal -Force | Out-Null
 
 # If Admin already has an interactive session open at the time this script runs,
-# start run.cmd immediately rather than waiting for the next logon.
+# start the runner immediately rather than waiting for the next logon.
+#
+# IMPORTANT: this user-data script is executed by cloudbase-init under its own
+# (cloud-init) identity. Calling Start-Process here would launch run.cmd as the
+# cloud-init account. Instead we start the scheduled task, which always runs
+# under its configured principal ($AdminAccount, RunLevel Highest), so the
+# runner correctly inherits the Administrator identity.
 $adminSession = Get-Process -Name explorer -IncludeUserName -ErrorAction SilentlyContinue |
     Where-Object { $_.UserName -like "*$AdminAccount" }
 
 if ($adminSession) {
-    Start-Process -FilePath "$RunnerDir\run.cmd" -WorkingDirectory $RunnerDir
+    Start-ScheduledTask -TaskName $TaskName
 }

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -26,6 +26,28 @@ Set-Location $RunnerDir
     --replace
 
 if ($LASTEXITCODE -eq 0) {
+    # Le service est créé par config.cmd sous NT AUTHORITY\NETWORK SERVICE par défaut,
+    # ce qui cause l'erreur 1068 au boot (permissions insuffisantes / init réseau).
+    # On le bascule explicitement en LocalSystem.
+    $service = Get-Service "GitHub Actions Runner*" -ErrorAction Stop
+
+    Write-Output "Service found: $($service.Name). Reconfiguring to run as LocalSystem..."
+
+    # Syntaxe sc.exe : espace obligatoire après le signe '='
+    $scResult = sc.exe config $service.Name obj= "LocalSystem"
+    Write-Output $scResult
+
+    Start-Service -Name $service.Name
+
+    # Vérification que le service tourne bien après le changement de compte
+    Start-Sleep -Seconds 3
+    $status = (Get-Service -Name $service.Name).Status
+    Write-Output "Service status after reconfiguration: $status"
+
+    if ($status -ne "Running") {
+        Write-Error "Service failed to start after switching to LocalSystem."
+    }
+
     New-Item -Path $MarkerFile -ItemType File -Force | Out-Null
 } else {
     Write-Error "config.cmd failed with exit code $LASTEXITCODE"

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -8,7 +8,6 @@ $RepoUrl    = "__REPO_URL__"
 $Token      = "__REG_TOKEN__"
 $Labels     = "__TAGS__"
 $RunnerName = "$env:COMPUTERNAME"
-$AdminPassword = "__REG_ADMIN_PASS__"
 
 # Local Administrator account (consistent with the AutoLogon set in the unattend file).
 $AdminAccount = "Administrateur"

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -13,6 +13,12 @@ $RepoUrl    = "__REPO_URL__"
 $Token      = "__REG_TOKEN__"
 $Labels     = "__TAGS__"
 $RunnerName = "$env:COMPUTERNAME"
+$ServicePassword = "__REG_ADMIN_PASS__"
+
+# Local Administrator account (consistent with the AutoLogon set in the unattend file).
+# The ".\" prefix explicitly targets a local account rather than a domain account.
+$ServiceAccount  = ".\Administrator"
+$ServicePassword = "Passw0rd"
 
 Set-Location $RunnerDir
 
@@ -23,29 +29,17 @@ Set-Location $RunnerDir
     --name $RunnerName `
     --unattended `
     --runasservice `
+    --windowslogonaccount $ServiceAccount `
+    --windowslogonpassword $ServicePassword `
     --replace
 
 if ($LASTEXITCODE -eq 0) {
-    # Le service est créé par config.cmd sous NT AUTHORITY\NETWORK SERVICE par défaut,
-    # ce qui cause l'erreur 1068 au boot (permissions insuffisantes / init réseau).
-    # On le bascule explicitement en LocalSystem.
-    $service = Get-Service "GitHub Actions Runner*" -ErrorAction Stop
+    # Confirm the service was actually created with the expected account
+    $service = Get-CimInstance Win32_Service -Filter "Name LIKE '%actions.runner%'" -ErrorAction Stop
+    Write-Output "Service: $($service.Name) | Account: $($service.StartName) | State: $($service.State)"
 
-    Write-Output "Service found: $($service.Name). Reconfiguring to run as LocalSystem..."
-
-    # Syntaxe sc.exe : espace obligatoire après le signe '='
-    $scResult = sc.exe config $service.Name obj= "LocalSystem"
-    Write-Output $scResult
-
-    Start-Service -Name $service.Name
-
-    # Vérification que le service tourne bien après le changement de compte
-    Start-Sleep -Seconds 3
-    $status = (Get-Service -Name $service.Name).Status
-    Write-Output "Service status after reconfiguration: $status"
-
-    if ($status -ne "Running") {
-        Write-Error "Service failed to start after switching to LocalSystem."
+    if ($service.State -ne "Running") {
+        Write-Error "Service is not running after configuration. Current state: $($service.State)"
     }
 
     New-Item -Path $MarkerFile -ItemType File -Force | Out-Null

--- a/.github/workflows/templates/userdata-template.ps1
+++ b/.github/workflows/templates/userdata-template.ps1
@@ -4,44 +4,49 @@ $ErrorActionPreference = "Stop"
 $RunnerDir  = "C:\actions-runner"
 $MarkerFile = Join-Path $RunnerDir ".registered"
 
-if (Test-Path $MarkerFile) {
-    Write-Output "Runner already registered, skipping."
-    exit 0
-}
-
 $RepoUrl    = "__REPO_URL__"
 $Token      = "__REG_TOKEN__"
 $Labels     = "__TAGS__"
 $RunnerName = "$env:COMPUTERNAME"
-$ServicePassword = "__REG_ADMIN_PASS__"
+$AdminPassword = "__REG_ADMIN_PASS__"
 
 # Local Administrator account (consistent with the AutoLogon set in the unattend file).
-# The ".\" prefix explicitly targets a local account rather than a domain account.
-$ServiceAccount  = ".\Administrator"
+$AdminAccount = "Administrateur"
 
-Set-Location $RunnerDir
+# --- Register the runner (no service, no logon-account flags) ---
+if (-not (Test-Path $MarkerFile)) {
+    Set-Location $RunnerDir
 
-& .\config.cmd `
-    --url $RepoUrl `
-    --token $Token `
-    --labels $Labels `
-    --name $RunnerName `
-    --unattended `
-    --runasservice `
-    --windowslogonaccount $ServiceAccount `
-    --windowslogonpassword $ServicePassword `
-    --replace
+    & .\config.cmd `
+        --url $RepoUrl `
+        --token $Token `
+        --labels $Labels `
+        --name $RunnerName `
+        --unattended `
+        --replace
 
-if ($LASTEXITCODE -eq 0) {
-    # Confirm the service was actually created with the expected account
-    $service = Get-CimInstance Win32_Service -Filter "Name LIKE '%actions.runner%'" -ErrorAction Stop
-    Write-Output "Service: $($service.Name) | Account: $($service.StartName) | State: $($service.State)"
-
-    if ($service.State -ne "Running") {
-        Write-Error "Service is not running after configuration. Current state: $($service.State)"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "config.cmd failed with exit code $LASTEXITCODE"
+        exit 1
     }
 
     New-Item -Path $MarkerFile -ItemType File -Force | Out-Null
-} else {
-    Write-Error "config.cmd failed with exit code $LASTEXITCODE"
+}
+
+# --- Run interactively as Admin at logon, instead of as a service ---
+$TaskName  = "ActionsRunnerStart"
+$Action    = New-ScheduledTaskAction -Execute "$RunnerDir\run.cmd" -WorkingDirectory $RunnerDir
+$Trigger   = New-ScheduledTaskTrigger -AtLogOn -User $AdminAccount
+$Principal = New-ScheduledTaskPrincipal -UserId $AdminAccount -LogonType Interactive -RunLevel Highest
+
+Register-ScheduledTask -TaskName $TaskName -Action $Action -Trigger $Trigger `
+    -Principal $Principal -Force | Out-Null
+
+# If Admin already has an interactive session open at the time this script runs,
+# start run.cmd immediately rather than waiting for the next logon.
+$adminSession = Get-Process -Name explorer -IncludeUserName -ErrorAction SilentlyContinue |
+    Where-Object { $_.UserName -like "*$AdminAccount" }
+
+if ($adminSession) {
+    Start-Process -FilePath "$RunnerDir\run.cmd" -WorkingDirectory $RunnerDir
 }

--- a/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
+++ b/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -213,13 +213,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
+++ b/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
@@ -24,7 +24,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{d2df4790-f513-48b3-93c7-f8ec447efa01}</ProjectGuid>
     <RootNamespace>FileExplorerExtension</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ProjectName>FileExplorerExtension</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
+++ b/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
@@ -217,7 +217,7 @@
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />

--- a/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
+++ b/extensions/windows/cfapi/FileExplorerExtension/FileExplorerExtension.vcxproj
@@ -56,7 +56,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Windows.Storage.Provider.CloudFilesContract">
-      <HintPath>$(WindowsSDK_MetadataPathVersioned)\Windows.Storage.Provider.CloudFilesContract\3.0.0.0\Windows.Storage.Provider.CloudFilesContract.winmd</HintPath>
+      <HintPath>$(WindowsSDK_MetadataPathVersioned)\Windows.Storage.Provider.CloudFilesContract\7.0.0.0\Windows.Storage.Provider.CloudFilesContract.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
       <IsSystemReference>true</IsSystemReference>
     </Reference>

--- a/extensions/windows/cfapi/FileExplorerExtension/packages.config
+++ b/extensions/windows/cfapi/FileExplorerExtension/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="3.0.260715.1" targetFramework="native" />
 </packages>

--- a/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
+++ b/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
@@ -55,7 +55,7 @@
   <Import Project="$(WapProjPath)\Microsoft.DesktopBridge.props" />
   <PropertyGroup>
     <ProjectGuid>128641b5-57a8-4367-87e2-1eb8e44bd25e</ProjectGuid>
-    <TargetPlatformVersion>10.0.28000.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.26100.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <DefaultLanguage>fr-FR</DefaultLanguage>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>

--- a/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
+++ b/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
@@ -68,8 +68,6 @@
     <HoursBetweenUpdateChecks>0</HoursBetweenUpdateChecks>
     <EntryPointProjectUniqueName>..\FileExplorerExtension\FileExplorerExtension.vcxproj</EntryPointProjectUniqueName>
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
-    <PackageCertificateThumbprint>95C8D8A52FA3834BAC5625A36F73F3FD82E75135</PackageCertificateThumbprint>
-    <UserSecretsId>96f5b548-4670-4bcb-a526-ac4ede2a537e</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
+++ b/extensions/windows/cfapi/FileExplorerExtensionPackage/FileExplorerExtensionPackage.wapproj
@@ -69,6 +69,7 @@
     <EntryPointProjectUniqueName>..\FileExplorerExtension\FileExplorerExtension.vcxproj</EntryPointProjectUniqueName>
     <AppxSymbolPackageEnabled>False</AppxSymbolPackageEnabled>
     <PackageCertificateThumbprint>95C8D8A52FA3834BAC5625A36F73F3FD82E75135</PackageCertificateThumbprint>
+    <UserSecretsId>96f5b548-4670-4bcb-a526-ac4ede2a537e</UserSecretsId>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <DefaultLanguage>en-US</DefaultLanguage>

--- a/extensions/windows/cfapi/Vfs/Vfs.vcxproj
+++ b/extensions/windows/cfapi/Vfs/Vfs.vcxproj
@@ -202,7 +202,7 @@ copy /Y "$(TargetDir)$(TargetName).pdb" "$(KDC_BUILD_PROJECT_DIR)\build\Debug\bi
   </ItemDefinitionGroup>
   <ItemGroup>
     <Reference Include="Windows.Storage.Provider.CloudFilesContract">
-      <HintPath>$(WindowsSDK_MetadataPathVersioned)\Windows.Storage.Provider.CloudFilesContract\3.0.0.0\Windows.Storage.Provider.CloudFilesContract.winmd</HintPath>
+      <HintPath>$(WindowsSDK_MetadataPathVersioned)\Windows.Storage.Provider.CloudFilesContract\7.0.0.0\Windows.Storage.Provider.CloudFilesContract.winmd</HintPath>
       <IsWinMDFile>true</IsWinMDFile>
       <IsSystemReference>true</IsSystemReference>
     </Reference>

--- a/extensions/windows/cfapi/Vfs/Vfs.vcxproj
+++ b/extensions/windows/cfapi/Vfs/Vfs.vcxproj
@@ -24,7 +24,7 @@
     <Keyword>Win32Proj</Keyword>
     <ProjectGuid>{2f38a27e-462a-4934-939a-4e22f0c477a3}</ProjectGuid>
     <RootNamespace>Vfs</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.28000.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0.26100.0</WindowsTargetPlatformVersion>
     <ProjectName>Vfs</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/extensions/windows/cfapi/Vfs/Vfs.vcxproj
+++ b/extensions/windows/cfapi/Vfs/Vfs.vcxproj
@@ -240,7 +240,7 @@ copy /Y "$(TargetDir)$(TargetName).pdb" "$(KDC_BUILD_PROJECT_DIR)\build\Debug\bi
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
     <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />

--- a/extensions/windows/cfapi/Vfs/Vfs.vcxproj
+++ b/extensions/windows/cfapi/Vfs/Vfs.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" />
+  <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -236,13 +236,13 @@ copy /Y "$(TargetDir)$(TargetName).pdb" "$(KDC_BUILD_PROJECT_DIR)\build\Debug\bi
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
+    <Import Project="..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets" Condition="Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+      <ErrorText>Ce projet fait référence à des packages NuGet qui sont manquants sur cet ordinateur. Utilisez l'option de restauration des packages NuGet pour les télécharger. Pour plus d'informations, consultez http://go.microsoft.com/fwlink/?LinkID=322105. Le fichier manquant est : {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260520.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.props'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Windows.CppWinRT.3.0.260715.1\build\native\Microsoft.Windows.CppWinRT.targets'))" />
   </Target>
 </Project>

--- a/extensions/windows/cfapi/Vfs/packages.config
+++ b/extensions/windows/cfapi/Vfs/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Windows.CppWinRT" version="3.0.260520.1" targetFramework="native" />
+  <package id="Microsoft.Windows.CppWinRT" version="3.0.260715.1" targetFramework="native" />
 </packages>

--- a/infomaniak-build-tools/conan/build_dependencies.ps1
+++ b/infomaniak-build-tools/conan/build_dependencies.ps1
@@ -176,8 +176,11 @@ if ($CI)
     # Activate the python virtual environment.
     & "C:\Program Files\Python313\.venv\Scripts\activate.ps1"
 
-    # Call vcvarsall.bat to set up the environment for MSVC
-    & "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+    # Call Launch-VsDevShell.ps1 to set up the environment for MSVC
+    & "C:\Program Files\Microsoft Visual Studio\18\Community\Common7\Tools\Launch-VsDevShell.ps1" `
+            -Arch amd64 `
+            -HostArch amd64 `
+            -SkipAutomaticLocation
     Log "CI mode enabled."
     $env:SSL_CERT_FILE = (& python -m certifi).Trim() # Because of the CI User on Windows, we need to set the SSL_CERT_FILE environment variable to the certifi bundle.
     Log "SSL_CERT_FILE set to $( $env:SSL_CERT_FILE )"

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -144,12 +144,7 @@ function Get-Cert-Property {
         [bool] $ci, # On CI build machines, the certificate are located in local computer store
         [string] $property
     )
-    if ($ci) {
-        $certStore = "Cert:\LocalMachine\My"
-    } else {
-        $certStore = "Cert:\CurrentUser\My"
-    }
-    
+    $certStore = "Cert:\CurrentUser\My"
     $value = Get-ChildItem $certStore/$thumbprint | Select -ExpandProperty $property
 
     return $value

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -276,7 +276,7 @@ function Build-Extension {
     $aumid = Get-Aumid -Thumbprint $thumbprint -Ci $ci
     Write-Host "Building extension with AUMID: $aumid"
 
-    msbuild "$extPath\kDriveExt.sln" /p:Configuration=$configuration /p:Platform=x64 /p:PublishDir="$extPath\FileExplorerExtensionPackage\AppPackages\" /p:DeployOnBuild=true /p:PackageCertificateThumbprint="$thumbprint" /p:KDC_DEBUG_AUMID="$aumid" /p:KDC_RELEASE_AUMID="$aumid"
+    msbuild "$extPath\kDriveExt.sln" /t:Restore /p:Configuration=$configuration /p:Platform=x64 /p:PublishDir="$extPath\FileExplorerExtensionPackage\AppPackages\" /p:DeployOnBuild=true /p:PackageCertificateThumbprint="$thumbprint" /p:KDC_DEBUG_AUMID="$aumid" /p:KDC_RELEASE_AUMID="$aumid"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     $bundlePath = "$extPath/FileExplorerExtensionPackage/AppPackages/FileExplorerExtensionPackage_${version}_Test/FileExplorerExtensionPackage_${version}_x64_arm64.msixbundle"

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -276,7 +276,8 @@ function Build-Extension {
     $aumid = Get-Aumid -Thumbprint $thumbprint -Ci $ci
     Write-Host "Building extension with AUMID: $aumid"
 
-    msbuild "$extPath\kDriveExt.sln" /t:Restore /p:Configuration=$configuration /p:Platform=x64 /p:PublishDir="$extPath\FileExplorerExtensionPackage\AppPackages\" /p:DeployOnBuild=true /p:PackageCertificateThumbprint="$thumbprint" /p:KDC_DEBUG_AUMID="$aumid" /p:KDC_RELEASE_AUMID="$aumid"
+    msbuild "$extPath\kDriveExt.sln" /t:Restore 
+    msbuild "$extPath\kDriveExt.sln" /p:Configuration=$configuration /p:Platform=x64 /p:PublishDir="$extPath\FileExplorerExtensionPackage\AppPackages\" /p:DeployOnBuild=true /p:PackageCertificateThumbprint="$thumbprint" /p:KDC_DEBUG_AUMID="$aumid" /p:KDC_RELEASE_AUMID="$aumid"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
     $bundlePath = "$extPath/FileExplorerExtensionPackage/AppPackages/FileExplorerExtensionPackage_${version}_Test/FileExplorerExtensionPackage_${version}_x64_arm64.msixbundle"

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -276,7 +276,7 @@ function Build-Extension {
     $aumid = Get-Aumid -Thumbprint $thumbprint -Ci $ci
     Write-Host "Building extension with AUMID: $aumid"
 
-    msbuild "$extPath\kDriveExt.sln" /t:Restore 
+    msbuild "$extPath\kDriveExt.sln" /t:Restore /p:RestorePackagesConfig=true
     msbuild "$extPath\kDriveExt.sln" /p:Configuration=$configuration /p:Platform=x64 /p:PublishDir="$extPath\FileExplorerExtensionPackage\AppPackages\" /p:DeployOnBuild=true /p:PackageCertificateThumbprint="$thumbprint" /p:KDC_DEBUG_AUMID="$aumid" /p:KDC_RELEASE_AUMID="$aumid"
     if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 

--- a/infomaniak-build-tools/windows/build-drive.ps1
+++ b/infomaniak-build-tools/windows/build-drive.ps1
@@ -478,7 +478,7 @@ function Sign-File {
         [string] $description = ""
     )
     Write-Host "Signing the file $filePath with thumbprint $thumbprint"
-    & signtool.exe sign /sha1 $thumbprint /tr http://timestamp.digicert.com?td=sha256 /fd sha256 /td sha256 /v /debug /sm /d $description $filePath
+    & signtool.exe sign /sha1 $thumbprint /tr http://timestamp.digicert.com?td=sha256 /fd sha256 /td sha256 /v /debug /d $description $filePath
     $res = $LASTEXITCODE
     Write-Host "Signing exit code: $res" -ForegroundColor Yellow
     if ($res -ne 0) {

--- a/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
+++ b/src/gui4/windows/kDrive client/kDrive client/kDrive client.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <AssemblyVersion>3.8.5.2</AssemblyVersion>
+    <AssemblyVersion>3.8.6.1</AssemblyVersion>
     <OutputType>WinExe</OutputType>
     <FileVersion>$(AssemblyVersion)</FileVersion>
     <Version>$(AssemblyVersion)</Version>

--- a/test/libcommon/io/testcheckdirectoryiterator.cpp
+++ b/test/libcommon/io/testcheckdirectoryiterator.cpp
@@ -385,7 +385,7 @@ void TestIo::testCheckDirectoryIteratorSymlinkEntry() {
 
     // Symlink to file
     const SyncPath file1SymlinkPath = temporaryDirectory.path() / "file1Symlink";
-    std::filesystem::create_directory_symlink(file1Path, file1SymlinkPath, ec);
+    std::filesystem::create_symlink(file1Path, file1SymlinkPath, ec);
     CPPUNIT_ASSERT(!ec);
 
     IoError ioError = IoError::Success;

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -474,9 +474,6 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("da"), CommonUtility::languageCode(Language::Danish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("el"), CommonUtility::languageCode(Language::Greek).toStdString());
 
-    const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
-    CPPUNIT_ASSERT_EQUAL(systemLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
-
     // English is the default language and is always returned if the provided language code is unknown.
     CPPUNIT_ASSERT_EQUAL(std::string("en"), CommonUtility::languageCode(static_cast<Language>(18)).toStdString());
 }

--- a/test/libcommon/utility/testutility.cpp
+++ b/test/libcommon/utility/testutility.cpp
@@ -474,6 +474,10 @@ void TestUtility::testLanguageCode() {
     CPPUNIT_ASSERT_EQUAL(std::string("da"), CommonUtility::languageCode(Language::Danish).toStdString());
     CPPUNIT_ASSERT_EQUAL(std::string("el"), CommonUtility::languageCode(Language::Greek).toStdString());
 
+    const auto systemLanguage = QLocale::languageToCode(QLocale::system().language());
+    const auto expectedLanguage = CommonUtility::isSupportedLanguage(systemLanguage) ? systemLanguage : QStringLiteral("en");
+    CPPUNIT_ASSERT_EQUAL(expectedLanguage.toStdString(), CommonUtility::languageCode(Language::Default).toStdString());
+
     // English is the default language and is always returned if the provided language code is unknown.
     CPPUNIT_ASSERT_EQUAL(std::string("en"), CommonUtility::languageCode(static_cast<Language>(18)).toStdString());
 }

--- a/test/libsyncengine/jobs/network/testnetworkjobs.cpp
+++ b/test/libsyncengine/jobs/network/testnetworkjobs.cpp
@@ -1769,8 +1769,11 @@ void TestNetworkJobs::testGetInfoUserTrialsOn401Error() {
     // With refresh token
     {
         _apiToken.setRefreshToken("123");
+        GetInfoUserJobMock jobUpdateCache(_userDbId, _apiToken);
+        (void) jobUpdateCache.runSynchronously(); // Run once just to update the refresh token in cache.
+        CPPUNIT_ASSERT_EQUAL(0, jobUpdateCache.trials());
+
         GetInfoUserJobMock job(_userDbId, _apiToken);
-        (void) job.runSynchronously(); // Run once just to update the refresh token in cache.
         const auto exitInfo = job.runSynchronously();
         CPPUNIT_ASSERT_EQUAL(ExitCode::InvalidToken, exitInfo.code());
         CPPUNIT_ASSERT_EQUAL(0, job.trials());

--- a/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
+++ b/test/libsyncengine/jobs/testsyncjobmanagersingleton.cpp
@@ -333,6 +333,11 @@ void TestSyncJobManagerSingleton::testJobPriority2() {
 }
 
 void TestSyncJobManagerSingleton::testCanRunjob() {
+    if (SyncJobManagerSingleton::instance()->availableThreadsInPool() < 4) {
+        // This test require at least 4 threads in the pool to run properly
+        SyncJobManagerSingleton::instance()->setPoolCapacity(4);
+    }
+
     // Small file jobs
     {
         const RemoteTemporaryDirectory remoteTmpDir(driveDbId, _testVariables.remoteDirId, "testCanRunjob");


### PR DESCRIPTION
## Overview

This PR improves the kDrive desktop CI infrastructure, with a focus on making test runners more reliable, easier to maintain, and better suited for automated provisioning.

### TL;DR

The main changes are:

* Move test jobs to GitHub-hosted runners where possible.
* Update Windows CI to work reliably on the new runner environment.
* Improve Linux dependency setup for GitHub-hosted runners.
* Add automated provisioning and teardown of Windows cloud runners.
* Simplify certificate handling by using the current user's certificate store.
* Modernize the Windows build environment setup.

## Details

### Windows CI improvements

Windows build and extended-test workflows have been updated to better support the new runner environment.

* Certificate import and cleanup now use `Cert:\CurrentUser\My` instead of `Cert:\LocalMachine\My`.

  * Avoids requiring machine-level certificate permissions.
  * Makes certificate handling more reliable on ephemeral CI runners.

* Visual Studio environment initialization now uses the Visual Studio 2022 `Launch-VsDevShell.ps1` setup.

* The explicit `nuget restore` step for extension packages has been removed from the build and extended-test workflows, as it is no longer required by the current build setup.

### GitHub-hosted test runners

The regular CI test jobs now use GitHub-hosted runners:

* `windows-latest`
* `ubuntu-latest`
* `macos-latest`

instead of the existing self-hosted runners.

This provides:

* Better runner availability.
* Automatic scaling when multiple jobs are queued.
* Better isolation, with a fresh environment for each job.
* Less maintenance of our own CI infrastructure.

Build and release jobs that require our dedicated environments remain on self-hosted runners.

### Linux runner compatibility

The Linux build action now installs the additional runtime/build dependencies required by the GitHub-hosted Ubuntu environment, including:

* `libOpenGL*`
* `libEGL*`
* `libpcre*`
* `libgio*`
* `libgobject*`

This ensures the existing build and test setup works correctly on a clean GitHub-hosted runner.

### Windows cloud runner lifecycle

Windows runners that still require our custom build environment can now be provisioned and removed automatically.

The runner startup workflow has been renamed from:

`start-runner.yml`

to:

`start-runners.yml`

and updated to:

* Provision runners using the new runner image.
* Use a larger default instance flavor.
* Support scheduled runner startup.

The Windows userdata script has also been updated so that the GitHub Actions runner is registered under the local Administrator account through a scheduled task.

The required PowerShell execution policy is configured as part of the runner initialization.

### Automatic runner teardown

A new `stop-runners.yml` workflow handles cleanup of Windows cloud runners.

It:

1. Waits for runners to become idle.
2. Deregisters them from GitHub Actions.
3. Deletes the corresponding cloud instances.

This completes the automated lifecycle of the Windows CI runners and avoids keeping unused instances running.

## Result

Overall, this PR reduces the amount of CI infrastructure we need to maintain while keeping dedicated Windows runners available for jobs that require our custom environment.

Test workloads can rely on GitHub-hosted infrastructure, while custom Windows runners are automatically started and stopped when needed.
