### PR TITLE
chore(build): exclude keychain from installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(UNIX)
 endif()
 
 # keychain
-add_subdirectory(src/3rdparty/keychain)
+add_subdirectory(src/3rdparty/keychain EXCLUDE_FROM_ALL) # EXCLUDE_FROM_ALL: don't install libkeychain.a (internal static lib); still built as a link dependency
 if (UNIX AND NOT APPLE) # Add this on linux to fix keychain problems with gcc 15
     target_compile_options(keychain PRIVATE -Wno-uninitialized)
 endif()


### PR DESCRIPTION
This pull request makes a minor adjustment to the build configuration for the `keychain` library. The change ensures that `libkeychain.a` is not installed as part of the global build process, but is still built as an internal static library for linking.

* Build system update:
  * [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL45-R45): Added `EXCLUDE_FROM_ALL` to the `add_subdirectory` call for `src/3rdparty/keychain` to prevent installation of `libkeychain.a` while still building it as a link dependency.