### PR TITLE
feat(cache): centralize sync runtime info in AppCache

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -31,6 +31,8 @@
 - For shared infrastructure classes, document the class role explicitly in the header comment when relevant.
 - Keep `ParametersStore` as a server-confirmed parameters snapshot only. Do not add global draft/pending state there;
   screen-specific drafts, such as proxy edition, belong to the owning UI/view model.
+- Keep per-sync runtime status and progress exclusively in `AppCache`. Consumers such as the system tray and future UI
+  adapters must observe and query that shared state instead of maintaining private copies.
 - In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
   bindings with an unused `_` element when only keys or only values are needed.
 - For Linux v4 model/UI checks, build only the `kdrive_qml` target unless a broader backend/server validation is
@@ -72,9 +74,9 @@
 - `main.cpp`: process entry point + single-instance lock file.
 - `appclientlinux.*`: top-level app wiring (logging, IPC lifecycle, dispatcher/service/coordinator ownership).
 - `app/appconstants.h`: app-level non-translatable constants, mirroring the Windows `AppConstants` role where useful.
-- `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection, GNOME-compatible tray menu
-  actions, fallback-to-window startup behavior, retry loop for late tray availability, and main QML window show/hide
-  behavior.
+- `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection derived from `AppCache`,
+  GNOME-compatible tray menu actions, fallback-to-window startup behavior, retry loop for late tray availability, and
+  main QML window show/hide behavior.
 - `communicationlayer/ipcclient.*`: raw TCP JSON transport, request/reply correlation, reconnect-before-first-connect
   logic.
 - `communicationlayer/signaldispatcher.*`: server-push signal fanout to registered handlers.
@@ -85,17 +87,20 @@
   cross-service failures). Owned once by `AppClientLinux` and injected by reference into app services.
 - `app/services/sentryservice.*`: Linux v4 Sentry coordinator. Owns cached consent reconciliation, delayed
   linux-v4-specific Sentry initialization, authenticated user binding, and UI/process capture helpers.
-- `app/cache/appcache.*`: durable graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs,
-  split sync/server errors, per-user available drives, cascade removals, and derived read models.
+- `app/cache/appcache.*`: graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs, the
+  single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
+  and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
 - `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache` push signals.
-    - Drops push mutations before `CachePopulator::bootstrapCompleted()` and logs the invariant violation.
+    - Routes entity and sync-runtime pushes after population; drops earlier mutations and logs the invariant violation.
 - `app/cache/cachetypes.h`: cache read models and onboarding keys (`SyncContext`, `DriveContext`,
-  `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
+  `SyncRuntimeInfo`, `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
     - Configured-drive state uses the unified `libcommon/data/drive.h` `Drive` model; do not reintroduce the removed
       `DriveInfo` type in Linux v4.
 - `app/cache/mainselectionstore.*`: sync-first main-shell selection owner (`currentSyncDbId`) and selection healing.
     - Emits `currentSyncContextChanged()` as a coarse invalidation signal when the current sync context stays selected
       but the underlying cache graph changes.
+    - Exposes selected-sync runtime through its dedicated accessor and signal so progress ticks do not rebuild the
+      configured graph context.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync
   configs.
 - `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`).

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -111,14 +111,18 @@ void AppCache::replaceSyncs(const std::vector<BaseSync> &syncs) {
     for (auto &driveNode: _drivesByDbId | std::views::values) {
         driveNode.syncDbIds.clear();
     }
-    _syncsByDbId.clear();
+    auto previousSyncs = std::exchange(_syncsByDbId, {});
     for (const auto &info: syncs) {
         if (!_drivesByDbId.contains(info.driveDbId())) {
             qCWarning(lcAppCache) << "Sync dropped during replace | syncDbId:" << info.dbId()
                                   << "/ unknown driveDbId:" << info.driveDbId();
             continue;
         }
-        _syncsByDbId[info.dbId()] = SyncNode{info, info.driveDbId(), {}};
+        SyncRuntimeInfo runtimeInfo = {};
+        if (const auto previousIt = previousSyncs.find(info.dbId()); previousIt != previousSyncs.end()) {
+            runtimeInfo = previousIt->second.runtimeInfo;
+        }
+        _syncsByDbId[info.dbId()] = SyncNode{info, runtimeInfo, info.driveDbId(), {}};
     }
     pruneConfiguredGraph();
     emit syncsChanged();
@@ -294,6 +298,27 @@ void AppCache::removeSync(const SyncDbId syncDbId) {
     removeSyncCascade(syncDbId);
     emit syncsChanged();
     emit syncErrorsChanged();
+}
+
+void AppCache::updateSyncRuntimeInfo(const SyncDbId syncDbId, const SyncRuntimeInfo &runtimeInfo) {
+    const auto syncIt = _syncsByDbId.find(syncDbId);
+    if (syncIt == _syncsByDbId.end()) {
+        qCWarning(lcAppCache) << "Sync runtime update dropped | unknown syncDbId:" << syncDbId;
+        return;
+    }
+
+    if (syncIt->second.runtimeInfo == runtimeInfo) {
+        return;
+    }
+
+    const bool statusChanged = syncIt->second.runtimeInfo.status != runtimeInfo.status;
+    syncIt->second.runtimeInfo = runtimeInfo;
+    qCDebug(lcAppCache) << "Sync runtime updated | syncDbId:" << syncDbId << "/ status:" << toInt(runtimeInfo.status)
+                        << "/ step:" << toInt(runtimeInfo.step);
+    emit syncRuntimeInfoChanged(syncDbId);
+    if (statusChanged) {
+        emit syncStatusChanged(syncDbId);
+    }
 }
 
 void AppCache::upsertSyncError(const Error &info) {

--- a/src/gui4/linux/app/cache/appcache.cpp
+++ b/src/gui4/linux/app/cache/appcache.cpp
@@ -317,7 +317,7 @@ void AppCache::updateSyncRuntimeInfo(const SyncDbId syncDbId, const SyncRuntimeI
                         << "/ step:" << toInt(runtimeInfo.step);
     emit syncRuntimeInfoChanged(syncDbId);
     if (statusChanged) {
-        emit syncStatusChanged(syncDbId);
+        emit syncStatusChanged(syncDbId); // used by the systray to be triggered only when the status changed and not on progression for example.
     }
 }
 

--- a/src/gui4/linux/app/cache/appcache.h
+++ b/src/gui4/linux/app/cache/appcache.h
@@ -32,9 +32,10 @@ Q_DECLARE_LOGGING_CATEGORY(lcAppCache)
 namespace KDC {
 
 /**
- * Durable graph-backed cache and query layer for Linux v4 product state.
+ * Graph-backed cache and query layer for Linux v4 product state.
  *
- * Role: own configured entities, per-user available drives, graph relations, and derived read models.
+ * Role: own configured entities, volatile per-sync runtime information, per-user available drives, graph relations, and
+ * derived read models.
  * All mutations must run on the Qt main thread.
  */
 class AppCache : public QObject {
@@ -59,6 +60,8 @@ class AppCache : public QObject {
         [[nodiscard]] std::optional<Account> account(AccountDbId accountDbId) const;
         [[nodiscard]] std::optional<Drive> drive(DriveDbId driveDbId) const;
         [[nodiscard]] std::optional<BaseSync> sync(SyncDbId syncDbId) const;
+        // Returns the latest volatile server-pushed state for an existing sync.
+        [[nodiscard]] std::optional<SyncRuntimeInfo> syncRuntimeInfo(SyncDbId syncDbId) const;
         [[nodiscard]] std::optional<Error> syncError(ErrorDbId errorDbId) const;
         [[nodiscard]] std::optional<Error> serverError(ErrorDbId errorDbId) const;
         [[nodiscard]] std::optional<DriveAvailable> availableDrive(const AvailableDriveKey &key) const;
@@ -108,6 +111,8 @@ class AppCache : public QObject {
 
         void upsertSync(const BaseSync &info);
         void removeSync(SyncDbId syncDbId);
+        // Replaces the complete volatile runtime snapshot and emits only when its value changed.
+        void updateSyncRuntimeInfo(SyncDbId syncDbId, const SyncRuntimeInfo &runtimeInfo);
 
         void upsertSyncError(const Error &info);
         void removeSyncError(ErrorDbId errorDbId);
@@ -122,6 +127,9 @@ class AppCache : public QObject {
         void accountsChanged();
         void drivesChanged();
         void syncsChanged();
+        // Fine-grained runtime invalidations. Status changes are a subset of complete runtime changes.
+        void syncRuntimeInfoChanged(SyncDbId syncDbId);
+        void syncStatusChanged(SyncDbId syncDbId);
         void syncErrorsChanged();
         void serverErrorsChanged();
         void availableDrivesChanged(UserDbId userDbId);
@@ -147,6 +155,7 @@ class AppCache : public QObject {
 
         struct SyncNode {
                 BaseSync info;
+                SyncRuntimeInfo runtimeInfo;
                 DriveDbId parentDriveDbId{0};
                 std::vector<ErrorDbId> errorDbIds;
         };

--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -146,6 +146,14 @@ std::optional<BaseSync> AppCache::sync(const SyncDbId syncDbId) const {
     return it->second.info;
 }
 
+std::optional<SyncRuntimeInfo> AppCache::syncRuntimeInfo(const SyncDbId syncDbId) const {
+    const auto it = _syncsByDbId.find(syncDbId);
+    if (it == _syncsByDbId.end()) {
+        return std::nullopt;
+    }
+    return it->second.runtimeInfo;
+}
+
 std::optional<Error> AppCache::syncError(const ErrorDbId errorDbId) const {
     const auto it = _syncErrorsByDbId.find(errorDbId);
     if (it == _syncErrorsByDbId.end()) {

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -52,6 +52,7 @@ constexpr auto directCacheConnections =
                         makeCacheConnection("syncAdded", &CommService::syncAdded, &AppCache::upsertSync),
                         makeCacheConnection("syncUpdated", &CommService::syncUpdated, &AppCache::upsertSync),
                         makeCacheConnection("syncRemoved", &CommService::syncRemoved, &AppCache::removeSync),
+                        makeCacheConnection("syncProgressInfo", &CommService::syncProgressInfo, &AppCache::updateSyncRuntimeInfo),
                         makeCacheConnection("errorAdded", &CommService::errorAdded, &AppCache::upsertError),
                         makeCacheConnection("errorRemoved", &CommService::errorRemoved, &AppCache::removeError));
 } // namespace

--- a/src/gui4/linux/app/cache/cachetypes.h
+++ b/src/gui4/linux/app/cache/cachetypes.h
@@ -31,6 +31,7 @@
 #include <QString>
 
 #include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <optional>
 #include <vector>
@@ -58,6 +59,18 @@ class UserDisplayInfo : public User {
 
     private:
         QString _avatarSource;
+};
+
+struct SyncRuntimeInfo {
+        SyncStatus status{SyncStatus::Undefined};
+        SyncStep step{SyncStep::None};
+        int64_t currentFile{0};
+        int64_t totalFiles{0};
+        int64_t completedSize{0};
+        int64_t totalSize{0};
+        int64_t estimatedRemainingTime{0};
+
+        friend bool operator==(const SyncRuntimeInfo &lhs, const SyncRuntimeInfo &rhs) = default;
 };
 
 struct SyncContext {

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -30,6 +30,11 @@ MainSelectionStore::MainSelectionStore(AppCache &cache, QObject *const parent) :
     (void) connect(&_cache, &AppCache::accountsChanged, this, &MainSelectionStore::handleContextDataChanged);
     (void) connect(&_cache, &AppCache::drivesChanged, this, &MainSelectionStore::handleContextDataChanged);
     (void) connect(&_cache, &AppCache::syncErrorsChanged, this, &MainSelectionStore::handleContextDataChanged);
+    (void) connect(&_cache, &AppCache::syncRuntimeInfoChanged, this, [this](const SyncDbId syncDbId) {
+        if (syncDbId == _currentSyncDbId) {
+            emit currentSyncRuntimeInfoChanged();
+        }
+    });
 }
 
 qint64 MainSelectionStore::currentSyncDbId() const {
@@ -41,6 +46,13 @@ std::optional<SyncContext> MainSelectionStore::currentSyncContext() const {
         return std::nullopt;
     }
     return _cache.syncContext(_currentSyncDbId);
+}
+
+std::optional<SyncRuntimeInfo> MainSelectionStore::currentSyncRuntimeInfo() const {
+    if (_currentSyncDbId == 0) {
+        return std::nullopt;
+    }
+    return _cache.syncRuntimeInfo(_currentSyncDbId);
 }
 
 std::vector<SyncContext> MainSelectionStore::syncContexts() const {
@@ -103,6 +115,7 @@ void MainSelectionStore::setCurrentSyncDbId(const SyncDbId syncDbId) {
     _currentSyncDbId = syncDbId;
     emit currentSyncDbIdChanged();
     emit currentSyncContextChanged();
+    emit currentSyncRuntimeInfoChanged();
 }
 
 SyncDbId MainSelectionStore::firstAvailableSyncDbId() const {

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -35,6 +35,8 @@ namespace KDC {
  * Sync-first main-shell selection owner for Linux v4.
  *
  * Role: own currentSyncDbId and heal it when cache graph changes.
+ * Selected runtime state is exposed separately from the configured graph context so high-frequency progress updates stay
+ * lightweight.
  * Non-role: own cached entities or onboarding selections.
  * All mutations must run on the Qt main thread.
  */
@@ -47,6 +49,7 @@ class MainSelectionStore : public QObject {
 
         [[nodiscard]] qint64 currentSyncDbId() const;
         [[nodiscard]] std::optional<SyncContext> currentSyncContext() const;
+        [[nodiscard]] std::optional<SyncRuntimeInfo> currentSyncRuntimeInfo() const;
         [[nodiscard]] std::vector<SyncContext> syncContexts() const;
 
         Q_INVOKABLE void selectSync(qint64 syncDbId);
@@ -56,6 +59,7 @@ class MainSelectionStore : public QObject {
     signals:
         void currentSyncDbIdChanged();
         void currentSyncContextChanged();
+        void currentSyncRuntimeInfoChanged();
 
     private:
         void handleSyncsChanged();

--- a/src/gui4/linux/app/services/commservice.cpp
+++ b/src/gui4/linux/app/services/commservice.cpp
@@ -170,25 +170,20 @@ void CommService::registerSyncHandlers(SignalDispatcher &dispatcher) {
 
     dispatcher.registerHandler(SignalNum::SYNC_PROGRESSINFO, [this](const Poco::DynamicStruct &params) {
         SyncDbId syncDbId = 0;
-        auto status = SyncStatus::Undefined;
-        auto step = SyncStep::Idle;
+        SyncRuntimeInfo runtimeInfo;
+        runtimeInfo.step = SyncStep::Idle;
         CommonUtility::readValueFromStruct(params, msgParamSyncDbId, syncDbId);
-        CommonUtility::readValueFromStruct(params, msgParamSyncStatus, status);
-        CommonUtility::readValueFromStruct(params, msgParamSyncStep, step);
+        CommonUtility::readValueFromStruct(params, msgParamSyncStatus, runtimeInfo.status);
+        CommonUtility::readValueFromStruct(params, msgParamSyncStep, runtimeInfo.step);
 
         const Poco::DynamicStruct progressStruct = params[msgParamSyncProgress].extract<Poco::DynamicStruct>();
-        int64_t currentFile = 0;
-        int64_t totalFiles = 0;
-        int64_t completedSize = 0;
-        int64_t totalSize = 0;
-        int64_t estimatedRemainingTime = 0;
-        CommonUtility::readValueFromStruct(progressStruct, msgParamCurrentFile, currentFile);
-        CommonUtility::readValueFromStruct(progressStruct, msgParamTotalFiles, totalFiles);
-        CommonUtility::readValueFromStruct(progressStruct, msgParamCompletedSize, completedSize);
-        CommonUtility::readValueFromStruct(progressStruct, msgParamTotalSize, totalSize);
-        CommonUtility::readValueFromStruct(progressStruct, msgParamEstimatedRemainingTime, estimatedRemainingTime);
+        CommonUtility::readValueFromStruct(progressStruct, msgParamCurrentFile, runtimeInfo.currentFile);
+        CommonUtility::readValueFromStruct(progressStruct, msgParamTotalFiles, runtimeInfo.totalFiles);
+        CommonUtility::readValueFromStruct(progressStruct, msgParamCompletedSize, runtimeInfo.completedSize);
+        CommonUtility::readValueFromStruct(progressStruct, msgParamTotalSize, runtimeInfo.totalSize);
+        CommonUtility::readValueFromStruct(progressStruct, msgParamEstimatedRemainingTime, runtimeInfo.estimatedRemainingTime);
 
-        emit syncProgressInfo(syncDbId, status, step, currentFile, totalFiles, completedSize, totalSize, estimatedRemainingTime);
+        emit syncProgressInfo(syncDbId, runtimeInfo);
     });
 
     dispatcher.registerHandler(SignalNum::SYNC_COMPLETEDITEM, [this](const Poco::DynamicStruct &params) {

--- a/src/gui4/linux/app/services/commservice.h
+++ b/src/gui4/linux/app/services/commservice.h
@@ -246,8 +246,7 @@ class CommService : public QObject {
         void syncAdded(const BaseSync &info);
         void syncUpdated(const BaseSync &info);
         void syncRemoved(SyncDbId syncDbId);
-        void syncProgressInfo(SyncDbId syncDbId, SyncStatus status, SyncStep step, int64_t currentFile, int64_t totalFiles,
-                              int64_t completedSize, int64_t totalSize, int64_t estimatedRemainingTime);
+        void syncProgressInfo(SyncDbId syncDbId, const KDC::SyncRuntimeInfo &runtimeInfo);
         void itemCompleted(SyncDbId syncDbId, const SyncFileItemInfo &info);
 
         // --- Error ---

--- a/src/gui4/linux/app/systraycontroller.cpp
+++ b/src/gui4/linux/app/systraycontroller.cpp
@@ -19,7 +19,6 @@
 #include "systraycontroller.h"
 
 #include "app/cache/appcache.h"
-#include "app/services/commservice.h"
 
 #include <QAction>
 #include <QApplication>
@@ -45,9 +44,6 @@ bool forceNoTrayRequested() {
 }
 #endif
 
-QString toQString(const SyncStatus status) {
-    return QString::fromStdString(toString(status));
-}
 QString toQString(const TrayIconState state) {
     switch (state) {
         using enum TrayIconState;
@@ -144,25 +140,21 @@ void SystemTrayController::initialize() {
     _isInitialized = true;
 }
 
-void SystemTrayController::observe(AppCache &appCache, const CommService &commService) {
+void SystemTrayController::observe(AppCache &appCache) {
     _appCache = &appCache;
     _hasSyncErrors = !_appCache->syncErrors().empty();
 
     (void) connect(&appCache, &AppCache::syncsChanged, this, [this] {
         qCDebug(lcSystemTrayController) << "Sync cache changed, refreshing tray icon state";
-        reconcileKnownSyncStatuses();
         refreshIconState();
     });
+    (void) connect(&appCache, &AppCache::syncStatusChanged, this, [this](const SyncDbId) { refreshIconState(); });
     (void) connect(&appCache, &AppCache::syncErrorsChanged, this, [this] {
         qCDebug(lcSystemTrayController) << "Sync errors changed, refreshing tray icon state";
         _hasSyncErrors = !_appCache->syncErrors().empty();
         refreshIconState();
     });
-    (void) connect(&commService, &CommService::syncProgressInfo, this,
-                   [this](const SyncDbId syncDbId, const SyncStatus status, const SyncStep, const int64_t, const int64_t,
-                          const int64_t, const int64_t, const int64_t) { onSyncProgressInfo(syncDbId, status); });
 
-    reconcileKnownSyncStatuses();
     refreshIconState();
 }
 
@@ -318,7 +310,11 @@ void SystemTrayController::refreshIconState() {
         return;
     }
 
-    if (std::ranges::any_of(_syncStatuses, [](const auto &entry) { return isSyncStatus(entry.second); })) {
+    const auto syncs = _appCache->syncs();
+    if (std::ranges::any_of(syncs, [this](const BaseSync &sync) {
+            const auto runtimeInfo = _appCache->syncRuntimeInfo(sync.dbId());
+            return runtimeInfo.has_value() && isSyncStatus(runtimeInfo->status);
+        })) {
         setIconState(TrayIconState::Sync);
         return;
     }
@@ -333,43 +329,15 @@ void SystemTrayController::refreshIconState() {
         return;
     }
 
-    if (!_syncStatuses.empty() &&
-        std::ranges::all_of(_syncStatuses, [](const auto &entry) { return isPauseStatus(entry.second); })) {
+    if (!syncs.empty() && std::ranges::all_of(syncs, [this](const BaseSync &sync) {
+            const auto runtimeInfo = _appCache->syncRuntimeInfo(sync.dbId());
+            return runtimeInfo.has_value() && isPauseStatus(runtimeInfo->status);
+        })) {
         setIconState(TrayIconState::Pause);
         return;
     }
 
     setIconState(TrayIconState::Neutral);
-}
-
-void SystemTrayController::reconcileKnownSyncStatuses() {
-    if (!_appCache) {
-        _syncStatuses.clear();
-        return;
-    }
-
-    const auto syncs = _appCache->syncs();
-    (void) std::erase_if(_syncStatuses, [&syncs](const auto &entry) {
-        return std::ranges::none_of(syncs, [&entry](const BaseSync &sync) { return sync.dbId() == entry.first; });
-    });
-
-    for (const auto &sync: syncs) {
-        (void) _syncStatuses.try_emplace(sync.dbId(), SyncStatus::Undefined);
-    }
-}
-
-void SystemTrayController::onSyncProgressInfo(const SyncDbId syncDbId, const SyncStatus status) {
-    const auto previousStatusIt = _syncStatuses.find(syncDbId);
-    if (previousStatusIt != _syncStatuses.end() && previousStatusIt->second == status) {
-        return;
-    }
-
-    qCInfo(lcSystemTrayController) << "Sync status changed for tray icon | syncDbId:" << syncDbId << "| from:"
-                                   << (previousStatusIt == _syncStatuses.end() ? QStringLiteral("Unknown")
-                                                                               : toQString(previousStatusIt->second))
-                                   << "| to:" << toQString(status);
-    _syncStatuses[syncDbId] = status;
-    refreshIconState();
 }
 
 void SystemTrayController::onTrayActivated(const QSystemTrayIcon::ActivationReason reason) {

--- a/src/gui4/linux/app/systraycontroller.h
+++ b/src/gui4/linux/app/systraycontroller.h
@@ -26,15 +26,12 @@
 #include <QSystemTrayIcon>
 #include <QTimer>
 
-#include <unordered_map>
-
 class QAction;
 class QWindow;
 
 namespace KDC {
 
 class AppCache;
-class CommService;
 
 enum class TrayIconState {
     Neutral,
@@ -58,7 +55,7 @@ class SystemTrayController final : public QObject {
         explicit SystemTrayController(QObject *const parent = nullptr);
 
         void initialize();
-        void observe(AppCache &appCache, const CommService &commService);
+        void observe(AppCache &appCache);
         void setMainWindow(QWindow *const window);
         void setProductStateInitialized(bool initialized);
         void setNotificationActive(bool active);
@@ -80,8 +77,6 @@ class SystemTrayController final : public QObject {
         void attemptTrayActivation();
         void activateTrayMode();
         void refreshIconState();
-        void reconcileKnownSyncStatuses();
-        void onSyncProgressInfo(SyncDbId syncDbId, SyncStatus status);
         void onTrayActivated(QSystemTrayIcon::ActivationReason reason);
 
         AppCache *_appCache = nullptr;
@@ -91,7 +86,6 @@ class SystemTrayController final : public QObject {
         QAction *_openAction = nullptr;
         QAction *_settingsAction = nullptr;
         QAction *_quitAction = nullptr;
-        std::unordered_map<SyncDbId, SyncStatus> _syncStatuses;
         bool _hasSyncErrors = false;
         TrayIconState _iconState = TrayIconState::Neutral;
         QTimer _trayAvailabilityRetryTimer;

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -53,7 +53,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
 
     qCInfo(lcAppClientLinux) << "Linux v4 GUI bootstrap started";
     _systemTrayController.initialize();
-    _systemTrayController.observe(_appCache, _serverCommService);
+    _systemTrayController.observe(_appCache);
 
     (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
     (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Centralise les informations d'exécution (statut, étape, progression) de chaque synchronisation dans `AppCache`, en remplacement de l'état privé dupliqué que maintenait auparavant `SystemTrayController`.

## Changements
- Nouvelle structure `SyncRuntimeInfo` (statut, étape, fichier courant, taille complétée/totale, temps restant estimé) dans `cachetypes.h`.
- `AppCache` stocke désormais un instantané volatile de runtime par sync (`SyncNode::runtimeInfo`), exposé via `syncRuntimeInfo()` et mis à jour via `updateSyncRuntimeInfo()`.
- `replaceSyncs()` préserve le runtime des syncs conservés lors du remplacement du graphe de syncs.
- Deux nouveaux signaux `syncRuntimeInfoChanged(SyncDbId)` et `syncStatusChanged(SyncDbId)` (ce dernier n'émet que lors d'un changement de statut, utilisé par le systray).
- `CachePipeline` connecte directement `CommService::syncProgressInfo` à `AppCache::updateSyncRuntimeInfo`.
- `CommService::syncProgressInfo` simplifié : émet désormais un seul `SyncRuntimeInfo` au lieu de 7 paramètres séparés.
- `MainSelectionStore` expose `currentSyncRuntimeInfo()` avec un signal dédié `currentSyncRuntimeInfoChanged()`, découplé de `currentSyncContextChanged()` afin de ne pas reconstruire tout le contexte du graphe configuré à chaque tick de progression.
- `SystemTrayController` supprime son cache privé `_syncStatuses` ainsi que sa dépendance directe à `CommService` ; il interroge désormais `AppCache::syncRuntimeInfo()` et observe `AppCache::syncStatusChanged`.
- `AGENTS.md` mis à jour pour documenter `AppCache` comme source unique de vérité pour le runtime des syncs.

## Détails techniques
`updateSyncRuntimeInfo()` ignore les mises à jour pour un `syncDbId` inconnu et ne réémet rien si la valeur n'a pas changé (comparaison via l'`operator==` généré par défaut de `SyncRuntimeInfo`). Le signal `syncStatusChanged` est un sous-ensemble filtré de `syncRuntimeInfoChanged`, déclenché uniquement quand `status` change, ce qui permet au systray de ne se rafraîchir que sur les transitions d'état pertinentes plutôt qu'à chaque tick de progression.

## Notes
Aucun changement de comportement visible côté utilisateur ; il s'agit d'un refactor interne consolidant la source de vérité du runtime des syncs.

</details>

---

## Summary
Centralizes per-sync runtime information (status, step, progress) inside `AppCache`, replacing the private duplicated state previously maintained by `SystemTrayController`.

## Changes
- New `SyncRuntimeInfo` struct (status, step, current file, completed/total size, estimated remaining time) in `cachetypes.h`.
- `AppCache` now stores a volatile per-sync runtime snapshot (`SyncNode::runtimeInfo`), exposed via `syncRuntimeInfo()` and updated through `updateSyncRuntimeInfo()`.
- `replaceSyncs()` preserves runtime info for retained sync ids when the sync graph snapshot is replaced.
- Two new signals, `syncRuntimeInfoChanged(SyncDbId)` and `syncStatusChanged(SyncDbId)` (the latter only emits on an actual status change, used by the tray).
- `CachePipeline` wires `CommService::syncProgressInfo` directly to `AppCache::updateSyncRuntimeInfo`.
- `CommService::syncProgressInfo` signature simplified to emit a single `SyncRuntimeInfo` instead of 7 separate parameters.
- `MainSelectionStore` exposes `currentSyncRuntimeInfo()` with a dedicated `currentSyncRuntimeInfoChanged()` signal, decoupled from `currentSyncContextChanged()` so progress ticks don't rebuild the full configured graph context.
- `SystemTrayController` drops its private `_syncStatuses` map and its direct `CommService` dependency; it now queries `AppCache::syncRuntimeInfo()` and observes `AppCache::syncStatusChanged`.
- `AGENTS.md` updated to document `AppCache` as the single source of truth for sync runtime state.

## Technical Details
`updateSyncRuntimeInfo()` drops updates for unknown sync ids and is a no-op when the value hasn't changed (via `SyncRuntimeInfo`'s defaulted `operator==`). `syncStatusChanged` is a filtered subset of `syncRuntimeInfoChanged`, firing only when `status` changes, so the tray refreshes only on relevant state transitions rather than on every progress tick.

## Notes
No user-facing behavior change; this is an internal refactor consolidating the source of truth for sync runtime state.