### PR TITLE
refactor(appclient): reduce cognitive complexity by organizing setup methods

### DIFF
--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -28,6 +28,7 @@
 #include <QDir>
 #include <QLocale>
 #include <QQmlContext>
+#include <QQmlEngine>
 #include <QQmlError>
 #include <QScreen>
 #include <QStringList>
@@ -36,7 +37,6 @@
 #include <QTranslator>
 #include <QVariant>
 #include <QWindow>
-#include <QQmlEngine>
 
 #include <chrono>
 #include <thread>
@@ -55,71 +55,18 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     ApplicationIdentity::configureApplication(appIcon);
 
     qCInfo(lcAppClientLinux) << "Linux v4 GUI bootstrap started";
+    setupSystemTray();
+    setupSignalConnections();
+    setupQmlEngine(appIcon);
+    setupIpcConnection();
+}
+
+void AppClientLinux::setupSystemTray() {
     _systemTrayController.initialize();
     _systemTrayController.observe(_appCache);
+}
 
-    (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
-    (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
-    (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
-    (void) connect(this, &AppClientLinux::ipcDisconnected, &_appCache, [this] {
-        // Normal UTILITY_QUIT paths stop the application before the server closes the socket. This cleanup therefore runs only
-        // when an established IPC connection is lost unexpectedly.
-        _systemTrayController.setProductStateInitialized(false);
-        _appRouter.hideMainWindow();
-        _appCache.clearAll();
-        _parametersStore.clear();
-    });
-    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_cachePipeline, &CachePipeline::markPopulated);
-    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_systemTrayController,
-                   [this] { _systemTrayController.setProductStateInitialized(true); });
-    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_sentryService,
-                   &SentryService::updateAuthenticatedUser);
-    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this, [this] {
-        if (_systemTrayController.trayModeActive() || _appCache.syncContexts().empty()) {
-            return;
-        }
-
-        qCInfo(lcAppClientLinux) << "Opening main window after bootstrap because tray fallback mode is active";
-        openMainWindow();
-    });
-    (void) connect(this, &AppClientLinux::ipcConnected, this, [this] { _cachePopulator.bootstrap(); });
-    (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
-    (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
-    (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
-    (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
-    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
-                   &SystemTrayController::showMainWindow);
-    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,
-                   &SystemTrayController::hideMainWindow);
-    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::onboardingCompleted, this,
-                   [this] { QTimer::singleShot(0, this, &AppClientLinux::openMainWindow); });
-    (void) connect(&_systemTrayController, &SystemTrayController::openMainWindowRequested, this, &AppClientLinux::openMainWindow);
-    (void) connect(&_appCache, &AppCache::usersChanged, &_sentryService, &SentryService::updateAuthenticatedUser);
-    (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this, [this] {
-        const auto parametersInfo = _parametersStore.parametersInfo();
-        if (!parametersInfo.has_value()) {
-            return;
-        }
-
-        Logger::instance()->setMinLogLevel(toInt(parametersInfo->logLevel()));
-        qCInfo(lcAppClientLinux) << "Logger minimum level updated from parameters | level:"
-                                 << QString::fromStdString(toString(parametersInfo->logLevel()));
-    });
-    (void) connect(&_systemTrayController, &SystemTrayController::quitRequested, this, [this] {
-        qCInfo(lcAppClientLinux) << "Quit requested from system tray";
-        if (!_ipcClient.isConnected()) {
-            qCWarning(lcAppClientLinux) << "IPC is not connected, quitting application directly";
-            quit();
-            return;
-        }
-        _serverCommService.requestQuit([](const auto &exitInfo) {
-            if (!exitInfo) {
-                qCWarning(lcAppClientLinux) << "Server quit request failed";
-            }
-            quit();
-        });
-    });
-
+void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("appCache"), &_appCache);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("parametersStore"), &_parametersStore);
     _qmlEngine.rootContext()->setContextProperty(QStringLiteral("userService"), &_userService);
@@ -130,7 +77,7 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     (void) qmlRegisterUncreatableType<AppRouter>("kDrive.UI", 1, 0, "AppRouter",
                                                  "AppRouter is owned by AppClientLinux and exposed as appRouter.");
     (void) qmlRegisterUncreatableType<SyncSelectorModel>("kDrive.UI", 1, 0, "SyncSelectorModel",
-                                                        "SyncSelectorModel is owned by MainSidebarController.");
+                                                         "SyncSelectorModel is owned by MainSidebarController.");
     _qmlEngine.setOutputWarningsToStandardError(false);
     (void) connect(&_qmlEngine, &QQmlApplicationEngine::warnings, this, [](const QList<QQmlError> &warnings) {
         for (const auto &warning: warnings) {
@@ -158,7 +105,37 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     _systemTrayController.setMainWindow(mainWindow);
 
     qCDebug(lcAppClientLinux) << "IPC/cache/QML wiring initialized";
+}
 
+void AppClientLinux::setupSignalConnections() {
+    (void) connect(&_ipcClient, &IpcClient::connected, this, &AppClientLinux::ipcConnected);
+    (void) connect(&_ipcClient, &IpcClient::disconnected, this, &AppClientLinux::ipcDisconnected);
+    (void) connect(&_ipcClient, &IpcClient::serverSignalReceived, &_signalDispatcher, &SignalDispatcher::dispatch);
+    (void) connect(this, &AppClientLinux::ipcDisconnected, this, &AppClientLinux::handleIpcDisconnection);
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_cachePipeline, &CachePipeline::markPopulated);
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_systemTrayController,
+                   [this] { _systemTrayController.setProductStateInitialized(true); });
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, &_sentryService,
+                   &SentryService::updateAuthenticatedUser);
+    (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this, &AppClientLinux::handleBootstrapCompletion);
+    (void) connect(this, &AppClientLinux::ipcConnected, this, [this] { _cachePopulator.bootstrap(); });
+    (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
+    (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
+    (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
+    (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
+    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::openOnboardingWindowRequested, &_systemTrayController,
+                   &SystemTrayController::showMainWindow);
+    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::closeOnboardingWindowRequested, &_systemTrayController,
+                   &SystemTrayController::hideMainWindow);
+    (void) connect(&_onboardingSessionManager, &OnboardingSessionManager::onboardingCompleted, this,
+                   [this] { QTimer::singleShot(0, this, &AppClientLinux::openMainWindow); });
+    (void) connect(&_systemTrayController, &SystemTrayController::openMainWindowRequested, this, &AppClientLinux::openMainWindow);
+    (void) connect(&_appCache, &AppCache::usersChanged, &_sentryService, &SentryService::updateAuthenticatedUser);
+    (void) connect(&_parametersStore, &ParametersStore::parametersInfoChanged, this, &AppClientLinux::updateLoggerMinLevel);
+    (void) connect(&_systemTrayController, &SystemTrayController::quitRequested, this, &AppClientLinux::requestQuit);
+}
+
+void AppClientLinux::setupIpcConnection() {
     if (const QStringList arguments = QCoreApplication::arguments(); arguments.size() > 1) {
         bool isValidPort = false;
         const quint16 port = arguments[1].toUShort(&isValidPort);
@@ -180,21 +157,71 @@ AppClientLinux::AppClientLinux(int &argc, char **argv) :
     }
 }
 
+void AppClientLinux::handleIpcDisconnection() {
+    // Normal UTILITY_QUIT paths stop the application before the server closes the socket. This cleanup therefore runs only
+    // when an established IPC connection is lost unexpectedly.
+    _systemTrayController.setProductStateInitialized(false);
+    _appRouter.hideMainWindow();
+    _appCache.clearAll();
+    _parametersStore.clear();
+}
+
+void AppClientLinux::handleBootstrapCompletion() {
+    if (_systemTrayController.trayModeActive() || _appCache.syncContexts().empty()) {
+        return;
+    }
+
+    qCInfo(lcAppClientLinux) << "Opening main window after bootstrap because tray fallback mode is active";
+    openMainWindow();
+}
+
+void AppClientLinux::updateLoggerMinLevel() const {
+    const auto parametersInfo = _parametersStore.parametersInfo();
+    if (!parametersInfo.has_value()) {
+        return;
+    }
+
+    Logger::instance()->setMinLogLevel(toInt(parametersInfo->logLevel()));
+    qCInfo(lcAppClientLinux) << "Logger minimum level updated from parameters | level:"
+                             << QString::fromStdString(toString(parametersInfo->logLevel()));
+}
+
+void AppClientLinux::requestQuit() const {
+    qCInfo(lcAppClientLinux) << "Quit requested from system tray";
+    if (!_ipcClient.isConnected()) {
+        qCWarning(lcAppClientLinux) << "IPC is not connected, quitting application directly";
+        quit();
+        return;
+    }
+
+    _serverCommService.requestQuit([](const auto &exitInfo) {
+        if (!exitInfo) {
+            qCWarning(lcAppClientLinux) << "Server quit request failed";
+        }
+        quit();
+    });
+}
+
 void AppClientLinux::setupTranslations() {
     // Catalogs are id-based: qsTrId(id) returns the raw id when no translation is loaded. Install
     // client_en as a base so every id always resolves (keys not yet translated degrade to English),
     // then overlay the system locale on top. Qt queries translators last-installed-first, so the
     // locale wins where it has a translation and falls back to the English base otherwise.
     if (_baseTranslator.load(QStringLiteral("client_en"), QStringLiteral(":/i18n"))) {
-        (void) installTranslator(&_baseTranslator);
+        if (!installTranslator(&_baseTranslator)) {
+            qCWarning(lcAppClientLinux) << "Failed to install base English translation catalog";
+        }
     } else {
         qCWarning(lcAppClientLinux) << "base English translation catalog missing; UI may show source ids";
     }
 
     if (const QLocale locale = QLocale::system();
         _localizedTranslator.load(locale, QStringLiteral("client"), QStringLiteral("_"), QStringLiteral(":/i18n"))) {
-        (void) installTranslator(&_localizedTranslator);
-        qCInfo(lcAppClientLinux) << "translations loaded for locale" << locale.name();
+        if (!installTranslator(&_localizedTranslator)) {
+            qCWarning(lcAppClientLinux) << "Failed to install localized translation catalog for locale" << locale.name();
+        } else {
+            qCInfo(lcAppClientLinux) << "translations loaded for locale" << locale.name();
+        }
     } else {
         qCInfo(lcAppClientLinux) << "no catalog for locale" << locale.name() << "- using English base";
     }
@@ -216,28 +243,43 @@ void AppClientLinux::openMainWindow() {
         }
     });
     qCInfo(lcAppClientLinux) << "Main window opened"
-                             << "| configuredDrives:" << _appCache.driveContexts().size()
-                             << "| configuredSyncs:" << _appCache.syncContexts().size()
-                             << "| currentSyncDbId:" << _mainSelectionStore.currentSyncDbId();
+                             << "| size of configured drives:" << _appCache.driveContexts().size()
+                             << "| size of configured syncs:" << _appCache.syncContexts().size()
+                             << "| current sync DB ID:" << _mainSelectionStore.currentSyncDbId();
 }
 
 void AppClientLinux::setupLogging() {
+    configureLogger();
+    qCInfo(lcAppClientLinux) << "***** Application & System Informations *****";
+    logApplicationInformation();
+    logSystemInformation();
+    logDisplayInformation();
+    logQtInformation();
+    logScreenInformation();
+    qCInfo(lcAppClientLinux) << "********************";
+}
+
+void AppClientLinux::configureLogger() {
     auto *const logger = Logger::instance();
     logger->setIsClientLog(true);
     logger->setLogDebug(true);
     logger->setupLogDir();
     logger->setLogExpire(std::chrono::days(CommonUtility::logsPurgeRate));
     logger->enterNextLogFile();
+}
 
-    qCInfo(lcAppClientLinux) << "***** Application & System Informations *****";
+void AppClientLinux::logApplicationInformation() {
     qCInfo(lcAppClientLinux) << "app version:" << CommonUtility::currentVersion();
     qCInfo(lcAppClientLinux) << "version tag:" << CommonUtility::versionTag();
     qCInfo(lcAppClientLinux) << "version build:" << CommonUtility::versionBuild();
-    qCInfo(lcAppClientLinux) << "log directory:" << logger->logDirectoryPath();
+    qCInfo(lcAppClientLinux) << "log directory:" << Logger::instance()->logDirectoryPath();
     qCInfo(lcAppClientLinux) << "executable path:" << QDir::toNativeSeparators(QCoreApplication::applicationFilePath());
     qCInfo(lcAppClientLinux) << "application dir:" << QDir::toNativeSeparators(QCoreApplication::applicationDirPath());
     qCInfo(lcAppClientLinux) << "working directory:" << QDir::toNativeSeparators(QDir::currentPath());
     qCInfo(lcAppClientLinux) << "client pid:" << QCoreApplication::applicationPid();
+}
+
+void AppClientLinux::logSystemInformation() {
     qCInfo(lcAppClientLinux) << "user:" << qEnvironmentVariable("USER") << "| logname:" << qEnvironmentVariable("LOGNAME");
     qCInfo(lcAppClientLinux) << "uid:" << getuid() << "| euid:" << geteuid();
     qCInfo(lcAppClientLinux) << "home directory:" << QDir::toNativeSeparators(QDir::homePath());
@@ -247,21 +289,30 @@ void AppClientLinux::setupLogging() {
     qCInfo(lcAppClientLinux) << "cpu architecture:" << QSysInfo::currentCpuArchitecture();
     qCInfo(lcAppClientLinux) << "# of logical CPU cores:" << std::thread::hardware_concurrency();
     qCInfo(lcAppClientLinux) << "locale:" << QLocale::system().name();
+}
 
+void AppClientLinux::logDisplayInformation() {
     qCInfo(lcAppClientLinux) << "display server:" << qEnvironmentVariable("XDG_SESSION_TYPE");
     qCInfo(lcAppClientLinux) << "display (X11):" << qEnvironmentVariable("DISPLAY");
     qCInfo(lcAppClientLinux) << "display (Wayland):" << qEnvironmentVariable("WAYLAND_DISPLAY");
     qCInfo(lcAppClientLinux) << "desktop environment:" << qEnvironmentVariable("XDG_CURRENT_DESKTOP");
+}
 
+void AppClientLinux::logQtInformation() {
     qCInfo(lcAppClientLinux) << "Qt version:" << qVersion();
-    qCInfo(lcAppClientLinux) << "Qt platform:" << platformName();
-    if (qEnvironmentVariableIsSet("QT_SCALE_FACTOR"))
+    qCInfo(lcAppClientLinux) << "Qt platform:" << QGuiApplication::platformName();
+    if (qEnvironmentVariableIsSet("QT_SCALE_FACTOR")) {
         qCInfo(lcAppClientLinux) << "Qt scale factor:" << qEnvironmentVariable("QT_SCALE_FACTOR");
-    if (qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR"))
+    }
+    if (qEnvironmentVariableIsSet("QT_AUTO_SCREEN_SCALE_FACTOR")) {
         qCInfo(lcAppClientLinux) << "Qt auto screen scale:" << qEnvironmentVariable("QT_AUTO_SCREEN_SCALE_FACTOR");
-    if (qEnvironmentVariableIsSet("QT_FONT_DPI"))
+    }
+    if (qEnvironmentVariableIsSet("QT_FONT_DPI")) {
         qCInfo(lcAppClientLinux) << "Qt font DPI:" << qEnvironmentVariable("QT_FONT_DPI");
+    }
+}
 
+void AppClientLinux::logScreenInformation() {
     const auto screens = QGuiApplication::screens();
     qCInfo(lcAppClientLinux) << "# of screens:" << screens.size();
     for (const auto *screen: screens) {
@@ -271,7 +322,6 @@ void AppClientLinux::setupLogging() {
         qCInfo(lcAppClientLinux) << "  - logical DPI:" << screen->logicalDotsPerInch();
         qCInfo(lcAppClientLinux) << "  - scale factor:" << screen->devicePixelRatio();
     }
-    qCInfo(lcAppClientLinux) << "********************";
 }
 
 } // namespace KDC

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -29,9 +29,9 @@
 #include "app/services/commservice.h"
 #include "app/services/driveservice.h"
 #include "app/services/parametersservice.h"
+#include "app/services/sentryservice.h"
 #include "app/services/serviceactiontracker.h"
 #include "app/services/serviceeventbus.h"
-#include "app/services/sentryservice.h"
 #include "app/services/syncservice.h"
 #include "app/services/userservice.h"
 #include "app/systraycontroller.h"
@@ -40,6 +40,7 @@
 #include "ui/chrome/windowdecorationcontroller.h"
 
 #include <QApplication>
+#include <QIcon>
 #include <QLoggingCategory>
 #include <QQmlApplicationEngine>
 #include <QTranslator>
@@ -92,7 +93,21 @@ class AppClientLinux : public QApplication {
 
     private:
         static void setupLogging();
+        static void configureLogger();
+        static void logApplicationInformation();
+        static void logSystemInformation();
+        static void logDisplayInformation();
+        static void logQtInformation();
+        static void logScreenInformation();
         void setupTranslations();
+        void setupSystemTray();
+        void setupSignalConnections();
+        void setupQmlEngine(const QIcon &appIcon);
+        void setupIpcConnection();
+        void handleIpcDisconnection();
+        void handleBootstrapCompletion();
+        void updateLoggerMinLevel() const;
+        void requestQuit() const;
         void openMainWindow();
 
         IpcClient _ipcClient{this};


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR réduit la complexité cognitive du constructeur `AppClientLinux` et de la méthode `setupLogging` en les décomposant en méthodes privées plus petites et mieux nommées, sans changer le comportement fonctionnel de l'application.

## Changements
- Extraction du corps du constructeur `AppClientLinux` en quatre méthodes dédiées : `setupSystemTray`, `setupSignalConnections`, `setupQmlEngine` et `setupIpcConnection`.
- Extraction des lambdas de connexion de signaux en méthodes membres nommées : `handleIpcDisconnection`, `handleBootstrapCompletion`, `updateLoggerMinLevel` et `requestQuit`.
- Découpage de `setupLogging` en sous-méthodes spécialisées : `configureLogger`, `logApplicationInformation`, `logSystemInformation`, `logDisplayInformation`, `logQtInformation` et `logScreenInformation`.
- Vérification explicite de la valeur de retour de `installTranslator` dans `setupTranslations`, avec un avertissement loggé en cas d'échec (le `(void)` qui ignorait silencieusement l'échec a été retiré).
- Remplacement de l'appel `platformName()` par `QGuiApplication::platformName()` pour lever l'ambiguïté d'appel.
- Ajout des accolades manquantes sur les blocs `if` à une seule instruction dans `logQtInformation`, conformément aux conventions de style du projet.
- Réorganisation des inclusions (`QQmlEngine`, `sentryservice.h`) pour respecter l'ordre alphabétique, et ajout de l'inclusion manquante `QIcon`.
- Léger reformulation des logs du bootstrap de la fenêtre principale (`size of configured drives`, `size of configured syncs`, `current sync DB ID`).
- Mise à jour de `appclientlinux.h` avec les déclarations des nouvelles méthodes privées extraites.

## Détails techniques
Il s'agit d'un refactoring pur : aucune nouvelle fonctionnalité n'est ajoutée. Le but est de réduire le score de complexité cognitive rapporté par SonarQube sur le constructeur monolithique de `AppClientLinux` et sur `setupLogging`, qui enchaînaient de nombreuses connexions de signaux et des dizaines de lignes de logging séquentielles.

## Tests
Aucun changement de comportement fonctionnel attendu ; la vérification repose sur une relecture de code confirmant que chaque méthode extraite conserve exactement la même logique que le code d'origine.

</details>

---

## Summary
This PR reduces the cognitive complexity of the `AppClientLinux` constructor and the `setupLogging` method by splitting them into smaller, well-named private methods, without changing the application's functional behavior.

## Changes
- Extracted the body of the `AppClientLinux` constructor into four dedicated methods: `setupSystemTray`, `setupSignalConnections`, `setupQmlEngine`, and `setupIpcConnection`.
- Extracted signal-connection lambdas into named member methods: `handleIpcDisconnection`, `handleBootstrapCompletion`, `updateLoggerMinLevel`, and `requestQuit`.
- Split `setupLogging` into specialized sub-methods: `configureLogger`, `logApplicationInformation`, `logSystemInformation`, `logDisplayInformation`, `logQtInformation`, and `logScreenInformation`.
- Added explicit return-value checking for `installTranslator` in `setupTranslations`, logging a warning on failure (previously silently discarded via `(void)`).
- Replaced the ambiguous `platformName()` call with `QGuiApplication::platformName()`.
- Added missing braces to single-statement `if` blocks in `logQtInformation`, in line with the project's style conventions.
- Reordered includes (`QQmlEngine`, `sentryservice.h`) alphabetically and added the missing `QIcon` include.
- Slightly reworded main window bootstrap logs (`size of configured drives`, `size of configured syncs`, `current sync DB ID`).
- Updated `appclientlinux.h` with declarations for the newly extracted private methods.

## Technical Details
This is a pure refactor: no new functionality is introduced. The goal is to lower the cognitive complexity score reported by SonarQube for the monolithic `AppClientLinux` constructor and `setupLogging`, which previously chained many signal connections and dozens of sequential logging lines.


Depends on #2171