### PR TITLE
fix(sentry): handle Sentry initialization failure gracefully

### DIFF
--- a/src/libcommon/log/sentry/handler.cpp
+++ b/src/libcommon/log/sentry/handler.cpp
@@ -180,13 +180,14 @@ sentry_value_t beforeSendCallback(sentry_value_t event, void *hint, void *closur
 }
 
 std::shared_ptr<Handler> Handler::instance() {
-    if (!_instance) {
-        assert(false && "Handler must be initialized before calling instance");
-        // TODO: When the logger will be moved to the common library, add a log there.
-        return std::shared_ptr<Handler>(new Handler()); // Create a dummy instance to avoid crash but should never
-                                                        // happen (the sentry will not be sent)
+    if (_instance) {
+        return _instance;
     }
-    return _instance;
+    // Sentry is disabled (e.g. KDRIVE_SENTRY_ENVIRONMENT="") or not yet initialized. This is a legitimate runtime
+    // state, not a programming error: return a shared, inert handler so instance()->... calls are safe no-ops
+    // (all Sentry paths are guarded by _isSentryActivated == false). Cached to avoid allocating on every call.
+    static std::shared_ptr<Handler> disabledInstance(new Handler());
+    return disabledInstance;
 }
 
 void Handler::init(AppType appType, int32_t breadCrumbsSize, const std::string &dsnOverride,
@@ -315,12 +316,14 @@ void Handler::init(AppType appType, int32_t breadCrumbsSize, const std::string &
 #endif
     sentry_options_set_max_spans(options, 1000); // Maximum number of spans per transaction
 
-    // Init sentry
-    int res = sentry_init(options);
-    if (res) {
-        std::cerr << "sentry_init returned " << res << std::endl;
+    // Init sentry. A non-zero result means Sentry (an optional telemetry component) failed to start, e.g. the
+    // crashpad handler is missing or the database path is not writable. That is a runtime failure, not a
+    // programming error: log it and keep Sentry inert instead of aborting the whole application.
+    if (const int res = sentry_init(options); res != 0) {
+        std::cerr << "sentry_init returned " << res << "; Sentry disabled" << std::endl;
+        _instance->_isSentryActivated = false;
+        return; // sentry_init takes ownership of `options`; do not free them here.
     }
-    assert(res == 0);
     _instance->setDistributionChannel(DistributionChannel::Unknown);
 }
 

--- a/src/libcommon/log/sentry/handler.cpp
+++ b/src/libcommon/log/sentry/handler.cpp
@@ -321,7 +321,7 @@ void Handler::init(AppType appType, int32_t breadCrumbsSize, const std::string &
     // programming error: log it and keep Sentry inert instead of aborting the whole application.
     if (const int32_t res = sentry_init(options); res != 0) {
         std::cerr << "sentry_init returned " << res << "; Sentry disabled" << std::endl;
-        _instance->_isSentryActivated = false;
+        _instance->setIsSentryActivated(false);
         return; // sentry_init takes ownership of `options`; do not free them here.
     }
     _instance->setDistributionChannel(DistributionChannel::Unknown);
@@ -335,7 +335,7 @@ void Handler::shutdown() {
     // and Handler::shutdown's scope owns the shared_ptr and decrements the refcount at the end of the method, so it is properly
     // destroyed once sentry_close() has returned, ensuring the Handler outlives any in-flight Sentry callbacks.
     const auto instance = std::move(_instance);
-    instance->_isSentryActivated = false;
+    instance->setIsSentryActivated(false);
     try {
         sentry_close();
     } catch (const std::exception &e) {

--- a/src/libcommon/log/sentry/handler.cpp
+++ b/src/libcommon/log/sentry/handler.cpp
@@ -185,9 +185,9 @@ std::shared_ptr<Handler> Handler::instance() {
     }
     // Sentry is disabled (e.g. KDRIVE_SENTRY_ENVIRONMENT="") or not yet initialized. This is a legitimate runtime
     // state, not a programming error: return a shared, inert handler so instance()->... calls are safe no-ops
-    // (all Sentry paths are guarded by _isSentryActivated == false). Cached to avoid allocating on every call.
-    static std::shared_ptr<Handler> disabledInstance(new Handler());
-    return disabledInstance;
+    // (all Sentry paths are guarded by _isSentryActivated == false).
+    struct DisabledHandler final : Handler {};
+    return std::make_shared<DisabledHandler>();
 }
 
 void Handler::init(AppType appType, int32_t breadCrumbsSize, const std::string &dsnOverride,
@@ -319,7 +319,7 @@ void Handler::init(AppType appType, int32_t breadCrumbsSize, const std::string &
     // Init sentry. A non-zero result means Sentry (an optional telemetry component) failed to start, e.g. the
     // crashpad handler is missing or the database path is not writable. That is a runtime failure, not a
     // programming error: log it and keep Sentry inert instead of aborting the whole application.
-    if (const int res = sentry_init(options); res != 0) {
+    if (const int32_t res = sentry_init(options); res != 0) {
         std::cerr << "sentry_init returned " << res << "; Sentry disabled" << std::endl;
         _instance->_isSentryActivated = false;
         return; // sentry_init takes ownership of `options`; do not free them here.


### PR DESCRIPTION
```bash
$ export KDRIVE_SENTRY_ENVIRONMENT=''

$ KDRIVE_ENABLE_LOG_TO_CONSOLE=1 ./build-linux/build/build/Debug/bin/kDrive
kDrive server starting
Working dir="./build-linux/build/build/Debug/bin"
APPIMAGE=
APPDIR=
Failed to initialize instances shared memory:  "QSharedMemory::handle: doesn't exist"
2026-07-22 14:38:45:043 [I] (123397194347072) log.cpp:134 - Logger initialization done
2026-07-22 14:38:45:046 [I] (123397194347072) appserver.cpp:268 - Started Linux fallback single-application peer
2026-07-22 14:38:45:046 [I] (123397194347072) utility_linux.cpp:349 - Registering login URL scheme in path='/home/rgld/.local/share/applications/kDrive.desktop' with executable path='/home/rgld/Projects/desktop-kDrive/build-linux/build/build/Debug/bin/kDrive'
2026-07-22 14:38:45:056 [I] (123397194347072) utility_linux.cpp:377 - Registered URL scheme x-scheme-handler/kdrive with xdg-mime
2026-07-22 14:38:45:057 [I] (123397194347072) appserver.cpp:314 - New DB exists : /home/rgld/.config/kDrive/.parms.db => true
2026-07-22 14:38:45:057 [I] (123397194347072) appserver.cpp:315 - Old config exists : /home/rgld/.config/kDrive/kDrive.cfg => false
2026-07-22 14:38:45:057 [D] (123397194347072) db.cpp:527 - sqlite3 version=3.53.0
2026-07-22 14:38:45:057 [D] (123397194347072) db.cpp:546 - sqlite3 locking_mode=normal
2026-07-22 14:38:45:057 [D] (123397194347072) db.cpp:565 - sqlite3 journal_mode=WAL
2026-07-22 14:38:45:057 [D] (123397194347072) db.cpp:579 - sqlite3 synchronous=NORMAL
```