### PR TITLE
fix(server): accept only one connection in SocketCommServer and OldCommServer

### DIFF
--- a/src/server/comm/oldcommserver.cpp
+++ b/src/server/comm/oldcommserver.cpp
@@ -172,15 +172,16 @@ void OldCommServer::onNewConnection() {
         return;
     }
 
-    LOG_DEBUG(Log::instance()->getLogger(), "New connection");
-
-    if (_tcpSocket) {
-        disconnect(_tcpSocket);
-        if (_tcpSocket->isOpen()) {
-            _tcpSocket->close();
+    if (_tcpSocket && _tcpSocket->state() == QAbstractSocket::ConnectedState) {
+        LOG_DEBUG(Log::instance()->getLogger(), "Rejecting new connection, already have an active connection");
+        if (auto *rejectedSocket = _tcpServer.nextPendingConnection()) {
+            rejectedSocket->close();
+            rejectedSocket->deleteLater();
         }
-        _tcpSocket->deleteLater();
+        return;
     }
+
+    LOG_DEBUG(Log::instance()->getLogger(), "New connection");
 
     _tcpSocket = _tcpServer.nextPendingConnection();
     if (!_tcpSocket || !_tcpSocket->isValid()) {

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -201,29 +201,31 @@ void SocketCommServer::close() {
     if (_stopAsked) {
         LOG_DEBUG(Log::instance()->getLogger(), name() << " is already stoping");
         return;
-    } else if (_isListening) {
-        LOG_DEBUG(Log::instance()->getLogger(), name() << " is stopping");
-        _stopAsked = true;
-        if (!_serverSocket.isNull()) {
-            Poco::Net::StreamSocket socket;
-            try {
-                socket.connect(Poco::Net::SocketAddress(host, getPort())); // Connect to unblock accept
-            } catch (Poco::Exception &ex) {
-                LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::connect: " << ex.displayText());
-            }
-        }
-
-        if (_serverSocketThread && _serverSocketThread->joinable()) {
-            _serverSocketThread->join();
-        }
-
-        LOG_DEBUG(Log::instance()->getLogger(), name() << " stopped");
-        _isListening = false;
-        _stopAsked = false;
-    } else {
-        LOG_DEBUG(Log::instance()->getLogger(), name() << " is not listening");
-        return;
     }
+
+    // Unblock a thread that may still be waiting in acceptConnection().
+    // Use the cached bound port: the server socket may already have been closed
+    // by execute() after accepting the single connection, so getPort() is not reliable here.
+    if (_boundPort != 0) {
+        try {
+            Poco::Net::StreamSocket socket;
+            socket.connect(Poco::Net::SocketAddress(host, _boundPort)); // Connect to unblock accept
+        } catch (Poco::Exception &ex) {
+            // Expected if the connection was already accepted / socket already closed.
+            LOG_DEBUG(Log::instance()->getLogger(), "Unblock connect failed (likely already accepted): " << ex.displayText());
+        }
+    }
+
+    // Always join the execute thread if it exists: execute() may have already cleared
+    // _isListening on its own after accepting a connection, so _isListening is not a
+    // reliable gate for whether the thread still needs joining.
+    if (_serverSocketThread && _serverSocketThread->joinable()) {
+        _serverSocketThread->join();
+    }
+
+    LOG_DEBUG(Log::instance()->getLogger(), name() << " stopped");
+    _isListening = false;
+    _stopAsked = false;
 }
 
 bool SocketCommServer::listen() {
@@ -236,7 +238,7 @@ bool SocketCommServer::listen() {
     auto executeFunc = std::function<void()>([this]() { execute(); });
     _serverSocketThread = std::make_unique<StdLoggingThread>(executeFunc);
 
-    // Wait until the server socket is listening (or timeout after 20s)
+    // Wait until the server socket is listening (or timeout after 5s).
     int remainTries = 500;
     while (!_isListening && remainTries > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
@@ -284,13 +286,18 @@ void SocketCommServer::execute() {
         }
     } while (!bindSuccess); // Loop until bind is successful
 
-    LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
-    saveCommPort(getPort());
-    while (!_stopAsked) {
+    // Cache the bound port while the socket is still valid, so close() can reach it
+    // even after we close the server socket below.
+    _boundPort = getPort();
+
+    LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << _boundPort);
+    saveCommPort(_boundPort);
+    if (!_stopAsked) {
         try {
             _serverSocket.listen();
         } catch (Poco::Exception &ex) {
             LOG_ERROR(Log::instance()->getLogger(), "Exception in ServerSocket::listen: " << ex.displayText());
+            _isListening = false;
             return;
         }
 
@@ -298,20 +305,30 @@ void SocketCommServer::execute() {
         Poco::Net::StreamSocket socket;
         try {
             socket = _serverSocket.acceptConnection();
+            _serverSocket.close(); // Only one connection is accepted; stop listening at the TCP layer.
         } catch (Poco::Exception &ex) {
             LOG_ERROR(Log::instance()->getLogger(), "Exception in ServerSocket::acceptConnection: " << ex.displayText());
+            _isListening = false;
             return;
         }
 
-        if (_stopAsked) break;
+        if (_stopAsked) {
+            _isListening = false;
+            return;
+        }
 
         const auto channel = makeCommChannel(socket);
         channel->setLostConnectionCbk([this](std::shared_ptr<AbstractCommChannel> ch) {
             std::function<void()> postponedLostConnectionCbk = [this, ch]() {
                 auto channelPtr = std::dynamic_pointer_cast<SocketCommChannel>(ch);
                 if (channelPtr && channelPtr->joinCallbackThread()) {
-                    const std::scoped_lock lock(_channelsMutex);
-                    (void) _channels.remove(ch);
+                    {
+                        const std::scoped_lock lock(_channelsMutex);
+                        (void) _channels.remove(ch);
+                    }
+                    // Notify the outside world LAST, once the server is done using its own
+                    // internals, so a consumer reacting to this callback can safely tear the
+                    // server down without racing our bookkeeping.
                     lostConnectionCbk(ch);
                 } else {
                     LOG_WARN(Log::instance()->getLogger(),
@@ -322,6 +339,7 @@ void SocketCommServer::execute() {
             // Postpone _channels.remove(ch), as it may destroy the channel and its
             // SocketCommChannel::callbackHandler thread while the current code
             // (SocketCommChannel::lostConnectionCbk) is executing from this same callbackHandler thread.
+            const std::scoped_lock lock(_postponedMutex);
             (void) _postponedLostConnectionCbks.emplace_back(std::make_shared<StdLoggingThread>(postponedLostConnectionCbk));
         });
 
@@ -331,13 +349,18 @@ void SocketCommServer::execute() {
         }
         newConnectionCbk();
         channel->startCallbackThread();
-        break;
     }
     _isListening = false;
 }
 void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
-    // Join and remove all postponed lost-connection callback threads
-    for (const auto &thread: _postponedLostConnectionCbks) {
+    // Swap the list out under the lock, then join outside the lock. Joining while holding
+    // _postponedMutex could deadlock against a thread that tries to emplace a new callback.
+    std::vector<std::shared_ptr<StdLoggingThread>> local;
+    {
+        const std::scoped_lock lock(_postponedMutex);
+        local.swap(_postponedLostConnectionCbks);
+    }
+    for (const auto &thread: local) {
         if (thread->joinable()) {
             thread->join();
         }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -281,7 +281,7 @@ void SocketCommServer::execute() {
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
     saveCommPort(getPort());
-    while (!_stopAsked) {
+    if (!_stopAsked) {
         try {
             _serverSocket.listen();
         } catch (Poco::Exception &ex) {
@@ -298,7 +298,10 @@ void SocketCommServer::execute() {
             return;
         }
 
-        if (_stopAsked) break;
+        if (_stopAsked) {
+            _isListening = false;
+            return;
+        }
 
         const auto channel = makeCommChannel(socket);
         channel->setLostConnectionCbk([this](std::shared_ptr<AbstractCommChannel> ch) {
@@ -326,17 +329,12 @@ void SocketCommServer::execute() {
         }
         newConnectionCbk();
         channel->startCallbackThread();
-
-        // Clear terminated postponed lost-connection callback threads to avoid accumulating too many threads in case of many
-        // connections/disconnections (edge case as the application is not expected to handle more than one connection at a time,
-        // but better be safe)
-        joinAndClearPostponedLostConnectionCbks();
     }
     _isListening = false;
 }
 void SocketCommServer::joinAndClearPostponedLostConnectionCbks() {
     // Join and remove all postponed lost-connection callback threads
-    for (const auto& thread: _postponedLostConnectionCbks) {
+    for (const auto &thread: _postponedLostConnectionCbks) {
         if (thread->joinable()) {
             thread->join();
         }

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -185,6 +185,11 @@ SocketCommServer::~SocketCommServer() {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in SocketCommChannel::close: " << ex.what());
     }
 
+    // Ensure the server thread is joined even if it exited on its own (e.g., after accepting a single connection)
+    if (_serverSocketThread && _serverSocketThread->joinable()) {
+        _serverSocketThread->join();
+    }
+
     joinAndClearPostponedLostConnectionCbks();
 }
 
@@ -281,7 +286,7 @@ void SocketCommServer::execute() {
 
     LOG_DEBUG(Log::instance()->getLogger(), name() << " listening on port " << getPort());
     saveCommPort(getPort());
-    if (!_stopAsked) {
+    while (!_stopAsked) {
         try {
             _serverSocket.listen();
         } catch (Poco::Exception &ex) {
@@ -298,10 +303,7 @@ void SocketCommServer::execute() {
             return;
         }
 
-        if (_stopAsked) {
-            _isListening = false;
-            return;
-        }
+        if (_stopAsked) break;
 
         const auto channel = makeCommChannel(socket);
         channel->setLostConnectionCbk([this](std::shared_ptr<AbstractCommChannel> ch) {
@@ -329,6 +331,7 @@ void SocketCommServer::execute() {
         }
         newConnectionCbk();
         channel->startCallbackThread();
+        break;
     }
     _isListening = false;
 }

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -74,6 +74,8 @@ class SocketCommServer : public AbstractCommServer {
         std::list<std::shared_ptr<AbstractCommChannel>> _channels;
         bool _isListening = false;
         bool _stopAsked = false;
+        std::mutex _postponedMutex;
+        Poco::UInt16 _boundPort;
         std::unique_ptr<StdLoggingThread> _serverSocketThread{nullptr};
         void execute();
         void joinAndClearPostponedLostConnectionCbks();

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -232,7 +232,7 @@ void TestSocketComm::testChannelReadAndWriteData() {
 void TestSocketComm::testServerAcceptsSingleConnection() {
     // Start the server
     auto _socketCommServerTest = std::make_unique<SocketCommServerTest>("TestSocketComm::testServerAcceptsSingleConnection");
-    _socketCommServerTest->listen();
+    CPPUNIT_ASSERT_MESSAGE("Server failed to start listening", _socketCommServerTest->listen());
 
     // Create client socket 1 and connect to the server
     Poco::Net::StreamSocket clientSocket1;
@@ -240,12 +240,11 @@ void TestSocketComm::testServerAcceptsSingleConnection() {
     auto clientSideChannel1 = std::make_shared<SocketCommChannelTest>(clientSocket1);
 
     // Wait for the server to accept the first connection
-    int remainWait = 100; // wait max 1 second
-    while (_socketCommServerTest->connections().empty() && remainWait-- > 0) {
+    for (int32_t remainWait = 100; remainWait > 0 && _socketCommServerTest->connections().empty(); --remainWait) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     CPPUNIT_ASSERT_MESSAGE("Server should accept first connection", !_socketCommServerTest->connections().empty());
-    CPPUNIT_ASSERT_EQUAL(size_t(1), _socketCommServerTest->connections().size());
+    CPPUNIT_ASSERT_EQUAL(static_cast<size_t>(1), _socketCommServerTest->connections().size());
 
     // Try to connect client 2 - server should not accept a second connection
     Poco::Net::StreamSocket clientSocket2;
@@ -253,19 +252,18 @@ void TestSocketComm::testServerAcceptsSingleConnection() {
         clientSocket2.connect(
                 Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()),
                 Poco::Timespan(0, 500000)); // 500ms timeout
-    } catch (Poco::Exception &) {
-        // Connection refused or timeout is acceptable — server is no longer accepting
+    } catch (Poco::Exception &ex) {
+        LOG_DEBUG(Log::instance()->getLogger(), "Second client connect failed as expected: " << ex.displayText());
     }
 
     // Wait to see if a second connection is accepted (it should not)
-    remainWait = 100; // wait max 1 second
-    while (_socketCommServerTest->connections().size() < 2 && remainWait-- > 0) {
+    for (int32_t remainWait = 100; remainWait > 0 && _socketCommServerTest->connections().size() < 2; --remainWait) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
     CPPUNIT_ASSERT_EQUAL_MESSAGE(
             "Server should not accept more than one connection",
-            size_t(1),
+            static_cast<size_t>(1),
             _socketCommServerTest->connections().size());
 }
 } // namespace KDC

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -228,4 +228,44 @@ void TestSocketComm::testChannelReadAndWriteData() {
     CPPUNIT_ASSERT(message.starts_with(longMessage.substr(99, 101)));
     CPPUNIT_ASSERT_EQUAL(uint64_t(0), serverSidechannel->bytesAvailable());
 }
+
+void TestSocketComm::testServerAcceptsSingleConnection() {
+    // Start the server
+    auto _socketCommServerTest = std::make_unique<SocketCommServerTest>("TestSocketComm::testServerAcceptsSingleConnection");
+    _socketCommServerTest->listen();
+
+    // Create client socket 1 and connect to the server
+    Poco::Net::StreamSocket clientSocket1;
+    clientSocket1.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()));
+    auto clientSideChannel1 = std::make_shared<SocketCommChannelTest>(clientSocket1);
+
+    // Wait for the server to accept the first connection
+    int remainWait = 100; // wait max 1 second
+    while (_socketCommServerTest->connections().empty() && remainWait-- > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    CPPUNIT_ASSERT_MESSAGE("Server should accept first connection", !_socketCommServerTest->connections().empty());
+    CPPUNIT_ASSERT_EQUAL(size_t(1), _socketCommServerTest->connections().size());
+
+    // Try to connect client 2 - server should not accept a second connection
+    Poco::Net::StreamSocket clientSocket2;
+    try {
+        clientSocket2.connect(
+                Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()),
+                Poco::Timespan(0, 500000)); // 500ms timeout
+    } catch (Poco::Exception &) {
+        // Connection refused or timeout is acceptable — server is no longer accepting
+    }
+
+    // Wait to see if a second connection is accepted (it should not)
+    remainWait = 100; // wait max 1 second
+    while (_socketCommServerTest->connections().size() < 2 && remainWait-- > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+
+    CPPUNIT_ASSERT_EQUAL_MESSAGE(
+            "Server should not accept more than one connection",
+            size_t(1),
+            _socketCommServerTest->connections().size());
+}
 } // namespace KDC

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -248,22 +248,22 @@ void TestSocketComm::testServerAcceptsSingleConnection() {
 
     // Try to connect client 2 - server should not accept a second connection
     Poco::Net::StreamSocket clientSocket2;
+    bool secondConnectionRejected = false;
     try {
-        clientSocket2.connect(
-                Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()),
-                Poco::Timespan(0, 500000)); // 500ms timeout
+        clientSocket2.connect(Poco::Net::SocketAddress(SocketCommServer::getHost(), _socketCommServerTest->getPort()),
+                              Poco::Timespan(0, 500000)); // 500ms timeout
     } catch (Poco::Exception &ex) {
-        LOG_DEBUG(Log::instance()->getLogger(), "Second client connect failed as expected: " << ex.displayText());
+        secondConnectionRejected = true;
+        LOG_DEBUG(Log::instance()->getLogger(), "Second client connect failed as expected");
     }
+    CPPUNIT_ASSERT_MESSAGE("Server should reject a second connection", secondConnectionRejected);
 
     // Wait to see if a second connection is accepted (it should not)
     for (int32_t remainWait = 100; remainWait > 0 && _socketCommServerTest->connections().size() < 2; --remainWait) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
 
-    CPPUNIT_ASSERT_EQUAL_MESSAGE(
-            "Server should not accept more than one connection",
-            static_cast<size_t>(1),
-            _socketCommServerTest->connections().size());
+    CPPUNIT_ASSERT_EQUAL_MESSAGE("Server should not accept more than one connection", static_cast<size_t>(1),
+                                 _socketCommServerTest->connections().size());
 }
 } // namespace KDC

--- a/test/server/comm/testsocketcomm.h
+++ b/test/server/comm/testsocketcomm.h
@@ -46,6 +46,7 @@ class SocketCommServerTest : public SocketCommServer {
 class TestSocketComm : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST_SUITE(TestSocketComm);
         CPPUNIT_TEST(testServerListen);
+        CPPUNIT_TEST(testServerAcceptsSingleConnection);
         CPPUNIT_TEST(testServerCallbacks);
         CPPUNIT_TEST(testChannelReadyReadCallback);
         CPPUNIT_TEST(testChannelReadAndWriteData);
@@ -56,6 +57,7 @@ class TestSocketComm : public CppUnit::TestFixture, public TestBase {
         void tearDown() override;
 
         void testServerListen();
+        void testServerAcceptsSingleConnection();
         void testServerCallbacks();
         void testChannelReadyReadCallback();
         void testChannelReadAndWriteData();


### PR DESCRIPTION

## Summary
This PR restricts the communication server to accepting only one connection at a time. The server will no longer accept new connections once an initial connection has been established.

## Changes
- **SocketCommServer::execute()** : replaced the `while` loop with an `if` block so the server thread accepts only one connection via `acceptConnection` before terminating.
- **OldCommServer::onNewConnection()** : now rejects new connections if an active connection already exists, instead of replacing the previous one.

## Technical Details
The previous behavior allowed the server to accept multiple consecutive connections, which could lead to race conditions. By limiting it to a single connection, we reduce complexity and avoid side effects related to the accumulation of postponed callback threads (`_postponedLostConnectionCbks`).

## Testing
- Added `TestSocketComm::testServerAcceptsSingleConnection` proving the server accepts only one connection and rejects subsequent ones.