### PR TITLE
fix(poco): support Windows line endings in source patch

### DIFF
--- a/infomaniak-build-tools/conan/recipes/poco/all/conanfile.py
+++ b/infomaniak-build-tools/conan/recipes/poco/all/conanfile.py
@@ -5,7 +5,7 @@ from conan import ConanFile
 from conan.errors import ConanInvalidConfiguration
 from conan.tools.build import check_min_cppstd
 from conan.tools.cmake import CMake, CMakeDeps, CMakeToolchain, cmake_layout
-from conan.tools.files import copy, rm, rmdir, replace_in_file
+from conan.tools.files import copy, load, rm, rmdir, replace_in_file
 from conan.tools.microsoft import is_msvc, is_msvc_static_runtime, msvc_runtime_flag
 from conan.tools.scm import Git
 
@@ -194,14 +194,15 @@ class PocoConan(ConanFile):
 
     def build(self):
         foundation_cmake = os.path.join(self.source_folder, "Foundation", "CMakeLists.txt")
-        replace_in_file(self, foundation_cmake,
-            """\t# Unicode.cpp requires functions from these files. The can't be taken from the library
+        foundation_cmake_content = load(self, foundation_cmake)
+        line_ending = "\r\n" if "\r\n" in foundation_cmake_content else "\n"
+        search = """\t#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
 \tPOCO_SOURCES(SRCS RegExp
 \t\tsrc/pcre2_ucd.c
 \t\tsrc/pcre2_tables.c
 \t)
-""",
-            """\t# Unicode.cpp requires functions from these files.
+"""
+        replacement = """\t# Unicode.cpp requires functions from these files.
 \t# They can be used directly from PCRE2 only when linking the static library.
 \tif("${_PCRE2TYPE}" STREQUAL "SHARED_LIBRARY")
 \t\tPOCO_SOURCES(SRCS RegExp
@@ -209,7 +210,13 @@ class PocoConan(ConanFile):
 \t\t\tsrc/pcre2_tables.c
 \t\t)
 \tendif()
-""")
+"""
+        replace_in_file(
+            self,
+            foundation_cmake,
+            search.replace("\n", line_ending),
+            replacement.replace("\n", line_ending),
+        )
 
         # Remove debug suffix from library names when sharedlibrary_debug_suffix is False
         if not self.options.get_safe("sharedlibrary_debug_suffix", True):


### PR DESCRIPTION
This pull request updates the `build` method in the `conanfile.py` for the Poco recipe to improve handling of line endings and the patching process for `CMakeLists.txt`. The main changes involve dynamically detecting line endings and using the `load` function to read file content, ensuring compatibility across different platforms.

**Build process improvements:**

* Updated the patching logic in the `build` method to detect and preserve the line ending style (`\n` or `\r\n`) in `CMakeLists.txt`, ensuring consistent file formatting across platforms.
* Switched from directly using `replace_in_file` to first loading the file content with `load` and then performing the replacement, enhancing reliability and maintainability.

**Dependency updates:**

* Added the `load` function to the imports from `conan.tools.files` to support the new file reading logic.