### PR TITLE
fix(gui4): address SonarQube findings on Linux GUI4 client

### DIFF
--- a/src/gui4/linux/app/cache/appcachequeries.cpp
+++ b/src/gui4/linux/app/cache/appcachequeries.cpp
@@ -349,8 +349,7 @@ std::vector<DriveContext> AppCache::driveContexts() const {
 }
 
 std::vector<AvailableDriveContext> AppCache::availableDriveContexts(const UserDbId userDbId) const {
-    const auto userInfo = user(userDbId);
-    if (!userInfo) {
+    if (const auto userInfo = user(userDbId); !userInfo) {
         return {};
     }
 

--- a/src/gui4/linux/app/onboarding/onboardinglogincoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardinglogincoordinator.cpp
@@ -58,9 +58,9 @@ OnboardingLoginCoordinator::OnboardingLoginCoordinator(OnboardingFlowController 
                    [this](const qint64 userDbId) { loadAvailableDrivesWhenUserIsCached(userDbId); });
     (void) connect(&_userService, &UserService::loginTokenFailed, &_flowController, &OnboardingFlowController::handleLoginFailed);
     (void) connect(&_userService, &UserService::availableDrivesLoaded, this,
-                   &OnboardingLoginCoordinator::completeLoginWhenAvailableDrivesAreLoaded);
+                   &OnboardingLoginCoordinator::clearPendingAvailableDrivesLoad);
     (void) connect(&_userService, &UserService::availableDrivesLoadFailed, this,
-                   &OnboardingLoginCoordinator::handleAvailableDrivesLoadFailed);
+                   &OnboardingLoginCoordinator::clearPendingAvailableDrivesLoad);
 
     (void) connect(&_appCache, &AppCache::usersChanged, this, [this] {
         if (!_pendingUserDbId.has_value()) {
@@ -113,15 +113,7 @@ void OnboardingLoginCoordinator::loadAvailableDrivesWhenUserIsCached(const UserD
     _userService.loadAvailableDrives(userDbId);
 }
 
-void OnboardingLoginCoordinator::completeLoginWhenAvailableDrivesAreLoaded(const UserDbId userDbId) {
-    if (_pendingAvailableDrivesUserDbId != userDbId) {
-        return;
-    }
-
-    _pendingAvailableDrivesUserDbId.reset();
-}
-
-void OnboardingLoginCoordinator::handleAvailableDrivesLoadFailed(const UserDbId userDbId) {
+void OnboardingLoginCoordinator::clearPendingAvailableDrivesLoad(const UserDbId userDbId) {
     if (_pendingAvailableDrivesUserDbId != userDbId) {
         return;
     }

--- a/src/gui4/linux/app/onboarding/onboardinglogincoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardinglogincoordinator.h
@@ -57,8 +57,7 @@ class OnboardingLoginCoordinator : public QObject {
         void handleAuthorizationCodeReady(const QString &code, const QString &codeVerifier);
         void handleLoginStateChanged();
         void loadAvailableDrivesWhenUserIsCached(UserDbId userDbId);
-        void completeLoginWhenAvailableDrivesAreLoaded(UserDbId userDbId);
-        void handleAvailableDrivesLoadFailed(UserDbId userDbId);
+        void clearPendingAvailableDrivesLoad(UserDbId userDbId);
 
         OnboardingFlowController &_flowController;
         CommService &_commService;

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.cpp
@@ -99,38 +99,43 @@ void OnboardingSyncCreationCoordinator::prepareSynchronization(const AvailableDr
     qCInfo(lcOnboardingSyncCreationCoordinator)
             << "Requesting onboarding sync path | driveId:" << key.driveId << "/ basePath:" << basePath;
     const QPointer<OnboardingSyncCreationCoordinator> self(this);
-    _commService.requestFindGoodPathForNewSync(
-            QStr2Path(basePath), [self, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
-                if (!self) {
-                    return;
-                }
+    _commService.requestFindGoodPathForNewSync(QStr2Path(basePath),
+                                               [self, key](const ExitInfo &exitInfo, const GoodPathResult &result) {
+                                                   if (!self) {
+                                                       return;
+                                                   }
 
-                if (!exitInfo) {
-                    self->_serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
-                    self->handleCreationFailure();
-                    return;
-                }
+                                                   self->handleGoodPathResult(key, exitInfo, result);
+                                               });
+}
 
-                if (!self->_onboardingState.isAvailableDriveSelected(key) || !self->_appCache.availableDrive(key).has_value()) {
-                    qCWarning(lcOnboardingSyncCreationCoordinator)
-                            << "Discarding prepared onboarding sync: drive is no longer selectable | userDbId:" << key.userDbId
-                            << "/ driveId:" << key.driveId;
-                    self->discardPendingSynchronization(key);
-                    return;
-                }
+void OnboardingSyncCreationCoordinator::handleGoodPathResult(const AvailableDriveKey &key, const ExitInfo &exitInfo,
+                                                             const GoodPathResult &result) {
+    if (!exitInfo) {
+        _serviceEventBus.notifyGenericError(exitInfo, RequestNum::UTILITY_FINDGOODPATHFORNEWSYNC);
+        handleCreationFailure();
+        return;
+    }
 
-                PendingSyncConfig config;
-                config.localPath = Path2QStr(result.goodPath);
-                if (config.localPath.isEmpty()) {
-                    qCWarning(lcOnboardingSyncCreationCoordinator)
-                            << "Server returned an empty onboarding sync path | driveId:" << key.driveId;
-                    self->handleCreationFailure();
-                    return;
-                }
+    if (!_onboardingState.isAvailableDriveSelected(key) || !_appCache.availableDrive(key).has_value()) {
+        qCWarning(lcOnboardingSyncCreationCoordinator)
+                << "Discarding prepared onboarding sync: drive is no longer selectable | userDbId:" << key.userDbId
+                << "/ driveId:" << key.driveId;
+        discardPendingSynchronization(key);
+        return;
+    }
 
-                self->_onboardingState.setPendingSyncConfig(key, config);
-                self->createSynchronization(key, config);
-            });
+    PendingSyncConfig config;
+    config.localPath = Path2QStr(result.goodPath);
+    if (config.localPath.isEmpty()) {
+        qCWarning(lcOnboardingSyncCreationCoordinator)
+                << "Server returned an empty onboarding sync path | driveId:" << key.driveId;
+        handleCreationFailure();
+        return;
+    }
+
+    _onboardingState.setPendingSyncConfig(key, config);
+    createSynchronization(key, config);
 }
 
 void OnboardingSyncCreationCoordinator::createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config) {

--- a/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
+++ b/src/gui4/linux/app/onboarding/onboardingsynccreationcoordinator.h
@@ -33,6 +33,7 @@ class CommService;
 class OnboardingFlowController;
 class OnboardingState;
 class ServiceEventBus;
+struct GoodPathResult;
 
 /**
  * Coordinates automatic sync creation at the end of Linux v4 onboarding.
@@ -52,6 +53,7 @@ class OnboardingSyncCreationCoordinator final : public QObject {
         void startSynchronization();
         void createNextSynchronization();
         void prepareSynchronization(const AvailableDriveKey &key);
+        void handleGoodPathResult(const AvailableDriveKey &key, const ExitInfo &exitInfo, const GoodPathResult &result);
         void createSynchronization(const AvailableDriveKey &key, const PendingSyncConfig &config);
         void discardPendingSynchronization(const AvailableDriveKey &key);
         void handleCreationFailure(bool cacheReconciliationRequired = false);

--- a/src/gui4/linux/app/services/cachepopulator.cpp
+++ b/src/gui4/linux/app/services/cachepopulator.cpp
@@ -119,31 +119,35 @@ void CachePopulator::loadSyncErrors(const PopulationMode mode) {
             return;
         }
 
-        std::vector<Error> syncErrors;
-        std::vector<Error> serverErrors;
-        syncErrors.reserve(list.size());
-        serverErrors.reserve(list.size());
-        for (const auto &info: list) {
-            switch (info.level()) {
-                using enum KDC::ErrorLevel;
-
-                case Node:
-                case SyncPal:
-                    syncErrors.push_back(info);
-                    break;
-                case Server:
-                    serverErrors.push_back(info);
-                    break;
-                default:
-                    qCWarning(lcCachePopulator)
-                            << "Received error with unknown level:" << toInt(info.level()) << "and dbId:" << info.dbId();
-            }
-        }
-
-        _appCache.replaceSyncErrors(syncErrors);
-        _appCache.replaceServerErrors(serverErrors);
+        replaceErrorsByLevel(list);
         markBranchCompleted(mode, PopulationBranch::UserData);
     });
+}
+
+void CachePopulator::replaceErrorsByLevel(const std::vector<Error> &list) {
+    std::vector<Error> syncErrors;
+    std::vector<Error> serverErrors;
+    syncErrors.reserve(list.size());
+    serverErrors.reserve(list.size());
+    for (const auto &info: list) {
+        switch (info.level()) {
+            using enum KDC::ErrorLevel;
+
+            case Node:
+            case SyncPal:
+                syncErrors.push_back(info);
+                break;
+            case Server:
+                serverErrors.push_back(info);
+                break;
+            default:
+                qCWarning(lcCachePopulator) << "Received error with unknown level:" << toInt(info.level())
+                                            << "and dbId:" << info.dbId();
+        }
+    }
+
+    _appCache.replaceSyncErrors(syncErrors);
+    _appCache.replaceServerErrors(serverErrors);
 }
 
 void CachePopulator::markBranchCompleted(const PopulationMode mode, const PopulationBranch branch) {

--- a/src/gui4/linux/app/services/cachepopulator.h
+++ b/src/gui4/linux/app/services/cachepopulator.h
@@ -91,6 +91,7 @@ class CachePopulator : public QObject {
         void loadDrives(PopulationMode mode);
         void loadSyncs(PopulationMode mode);
         void loadSyncErrors(PopulationMode mode);
+        void replaceErrorsByLevel(const std::vector<Error> &list);
         void markBranchCompleted(PopulationMode mode, PopulationBranch branch);
         void activateLiveInfoRefresh() const;
         [[nodiscard]] bool handlePopulationFailure(const char *stage, const ExitInfo &exitInfo, PopulationMode mode);

--- a/src/gui4/linux/app/services/serviceactiontracker.cpp
+++ b/src/gui4/linux/app/services/serviceactiontracker.cpp
@@ -91,7 +91,7 @@ void ServiceActionTracker::endActions(const ServiceKey &serviceKey, const Action
     }
 
     auto &serviceActions = serviceIt.value();
-    auto actionIt = serviceActions.find(actionKey);
+    const auto actionIt = serviceActions.find(actionKey);
     if (actionIt == serviceActions.end()) {
         qCWarning(lcServiceActionTracker) << operation << "called for unknown actionKey:" << actionKey
                                           << "| serviceKey:" << serviceKey << "| scopeId:" << scopeId;

--- a/src/gui4/linux/app/services/serviceactiontracker.cpp
+++ b/src/gui4/linux/app/services/serviceactiontracker.cpp
@@ -126,7 +126,7 @@ void ServiceActionTracker::endActions(const ServiceKey &serviceKey, const Action
     }
 
     if (_pendingCountByService.value(serviceKey, 0) == 0) {
-        _pendingCountByService.remove(serviceKey);
+        (void) _pendingCountByService.remove(serviceKey);
         emit servicePendingChanged(serviceKey, false);
     }
 }

--- a/src/gui4/linux/communicationlayer/ipcclient.cpp
+++ b/src/gui4/linux/communicationlayer/ipcclient.cpp
@@ -301,7 +301,7 @@ void IpcClient::handleResponseMessage(const Poco::DynamicStruct &ipcMessage, con
     qCDebug(lcIpcClient) << "Response received | RequestNum:" << requestNum << "/ id:" << id << "/ ExitInfo:" << exitInfo;
     if (const auto it = _pendingCallbacks.find(id); it != _pendingCallbacks.end()) {
         const auto callback = std::move(it.value());
-        _pendingCallbacks.erase(it);
+        (void) _pendingCallbacks.erase(it);
 
         try {
             callback(exitInfo, params);
@@ -435,8 +435,8 @@ bool IpcClient::extractNextMessage(std::string &buffer, std::string &outMessage)
         } else if (buffer[i] == '}') {
             --balance;
             if (balance == 0) {
-                outMessage.assign(buffer, 0, i + 1);
-                buffer.erase(0, i + 1);
+                (void) outMessage.assign(buffer, 0, i + 1);
+                (void) buffer.erase(0, i + 1);
                 return true;
             }
         }

--- a/src/gui4/linux/main.cpp
+++ b/src/gui4/linux/main.cpp
@@ -38,9 +38,8 @@ int main(int argc, char *argv[]) {
 
     KDC::SentryService::initializeFromCachedConsent();
 
-    // see https://doc.qt.io/qt-6/qapplication.html#details
-    const QScopedPointer app(new KDC::AppClientLinux(argc, argv));
-    const int32_t exitCode = app->exec();
+    KDC::AppClientLinux app(argc, argv);
+    const int32_t exitCode = KDC::AppClientLinux::exec();
 
     qCInfo(KDC::lcAppClientLinux) << "Qt event loop exited with code" << exitCode;
     KDC::SentryService::shutdown();


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR corrige une série de signalements  remontés par SonarQube/SonarCloud sur le client Linux (`gui4`), en réduisant la duplication de code, en clarifiant les valeurs de retour ignorées et en simplifiant plusieurs méthodes jugées trop complexes. Aucun changement de comportement n'est visé.

## Changements
- `main.cpp` : remplace l'allocation dynamique de `AppClientLinux` via `QScopedPointer` par une instance sur la pile, et appelle `exec()` comme méthode statique conformément à la documentation Qt.
- `cachepopulator` : extrait la logique de répartition des erreurs par niveau (`Node`/`SyncPal`/`Server`) dans une nouvelle méthode privée `replaceErrorsByLevel()`, afin de réduire la complexité de `loadSyncErrors()`.
- `onboardingsynccreationcoordinator` : extrait le traitement du résultat de `requestFindGoodPathForNewSync()` dans une nouvelle méthode `handleGoodPathResult()`, sortant la logique métier de la lambda de callback.
- `onboardinglogincoordinator` : fusionne les gestionnaires `completeLoginWhenAvailableDrivesAreLoaded` et `handleAvailableDrivesLoadFailed`, dont les corps étaient strictement identiques, en une seule méthode `clearPendingAvailableDrivesLoad()`.
- `appcachequeries` : simplifie `availableDriveContexts()` en utilisant une instruction d'initialisation dans le `if` pour restreindre la portée de la variable `userInfo`.
- `serviceactiontracker` et `ipcclient` : marque explicitement en `(void)` les valeurs de retour ignorées de `QMap::remove`, `QMultiMap::erase`, `std::string::assign` et `std::string::erase`, et déclare `actionIt` en `const` puisqu'il n'est pas réassigné.

</details>

---

## Summary
This PR addresses a set of findings reported by SonarQube/SonarCloud on the Linux client (`gui4`), reducing code duplication, clarifying discarded return values, and simplifying a few methods flagged as overly complex. No behavior change is intended.

## Changes
- `main.cpp`: replaces the heap-allocated `AppClientLinux` via `QScopedPointer` with a stack instance, and calls `exec()` as a static method as recommended by the Qt documentation.
- `cachepopulator`: extracts the error-by-level dispatch logic (`Node`/`SyncPal`/`Server`) into a new private `replaceErrorsByLevel()` method to reduce the complexity of `loadSyncErrors()`.
- `onboardingsynccreationcoordinator`: extracts the handling of the `requestFindGoodPathForNewSync()` result into a new `handleGoodPathResult()` method, moving business logic out of the callback lambda.
- `onboardinglogincoordinator`: merges the `completeLoginWhenAvailableDrivesAreLoaded` and `handleAvailableDrivesLoadFailed` handlers, whose bodies were strictly identical, into a single `clearPendingAvailableDrivesLoad()` method.
- `appcachequeries`: simplifies `availableDriveContexts()` by using an if-init-statement to narrow the scope of the `userInfo` variable.
- `serviceactiontracker` and `ipcclient`: explicitly discards the ignored return values of `QMap::remove`, `QMultiMap::erase`, `std::string::assign`, and `std::string::erase` with a `(void)` cast, and marks `actionIt` as `const` since it is never reassigned.