### PR TITLE
fix(vfs): remove premature file metadata updates

### DIFF
--- a/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
+++ b/src/libsyncengine/jobs/network/kDrive_API/downloadjob.cpp
@@ -164,15 +164,6 @@ ExitInfo DownloadJob::runJob() noexcept {
             return {ExitCode::SystemError, ExitCause::FileAccessError};
         }
 
-        if (const ExitInfo exitInfo =
-                    _vfs->updateMetadata(_fileDownloadInfo.localpath, filestat.creationTime, filestat.modificationTime,
-                                         _fileDownloadInfo.expectedSize, std::to_string(filestat.inode));
-            !exitInfo) {
-            LOGW_WARN(_logger,
-                      L"Update metadata failed " << exitInfo << L" " << Utility::formatSyncPath(_fileDownloadInfo.localpath));
-            return exitInfo;
-        }
-
         if (const ExitInfo exitInfo = _vfs->forceStatus(_fileDownloadInfo.localpath, VfsStatus({.isSyncing = true})); !exitInfo) {
             LOGW_WARN(_logger,
                       L"Error in vfsForceStatus: " << Utility::formatSyncPath(_fileDownloadInfo.localpath) << L": " << exitInfo);


### PR DESCRIPTION
fix(vfs): remove premature file metadata updates

Remove calls to `_vfs->updateMetadata` and the associated error handling.

Updating metadata before the download completed could cause a mismatch between the reported file size and the actual size on disk. This mismatch could persist if the download failed.

The metadata is updated automatically when the temporary file is copied to its final destination.