### PR TITLE
feat(ui): add waiting screen shown during app bootstrap

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -91,9 +91,9 @@
 - `appclientlinux.*`: top-level app wiring (logging, QML warning forwarding, IPC lifecycle,
   dispatcher/service/coordinator ownership).
 - `app/appconstants.h`: app-level non-translatable constants, mirroring the Windows `AppConstants` role where useful.
-- `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection derived from `AppCache`,
-  GNOME-compatible tray menu actions, fallback-to-window startup behavior, retry loop for late tray availability, and
-  main QML window show/hide behavior.
+- `app/systraycontroller.*`: Linux system tray ownership, 5-state tray icon selection derived from `AppCache` plus
+  updater availability, GNOME-compatible tray menu actions, fallback-to-window startup behavior, retry loop for late
+  tray availability, and main QML window show/hide behavior.
 - `communicationlayer/ipcclient.*`: raw TCP JSON transport, request/reply correlation, reconnect-before-first-connect
   logic.
 - `communicationlayer/signaldispatcher.*`: server-push signal fanout to registered handlers.

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -177,6 +177,8 @@
     - `ui/windows/main/`: main-window shell and temporary placeholders. The shell is loaded only when `AppRouter` marks
       the main window active and no onboarding session is active. Do not add IPC calls here; dynamic data belongs in
       cache-backed QML models.
+    - `ui/windows/waiting/`: app-level preloading screen shown whenever the main window is opened before the initial IPC
+      connection and cache bootstrap complete. It yields to onboarding or the main shell once a product route is ready.
     - `ui/windows/onboarding/`: onboarding window composition and flow screens. Onboarding-only QML stays here unless it
       becomes reusable from another product window.
     - `ui/features/`: future reusable product features shared by several windows, such as sync configuration.
@@ -194,7 +196,6 @@
     - `ui/windows/onboarding/animations/`: versioned generated QML animation components produced from Lottie JSON payloads.
       Do not edit these files manually. They are excluded from `qmllint`; validation belongs to the generator and the
       QML compilation step.
-
 ### Regenerate Onboarding Lottie QML
 
 Run `lottietoqml` from the Qt/Conan package that provides `qtlottie`. The loader source JSON is supplied locally and is

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -98,6 +98,7 @@ set(GUI_QML_SINGLETON_FILES # QML singletons (tokens, theme, etc.)
         ui/tokens/IKIconSizes.qml
         ui/tokens/IKOnboarding.qml
         ui/tokens/IKMainWindow.qml
+        ui/tokens/IKWaiting.qml
 )
 
 set_source_files_properties(${GUI_QML_SINGLETON_FILES} PROPERTIES QT_QML_SINGLETON_TYPE TRUE)
@@ -117,6 +118,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/chrome/IKWindowHeader.qml
         ui/components/IKBadge.qml
         ui/components/IKDriveIcon.qml
+        ui/components/IKLoadingSpinner.qml
         ui/components/IKSidebarItem.qml
         ui/components/IKDriveSyncSelectorItem.qml
         ui/windows/main/ActivitiesPlaceholder.qml
@@ -140,6 +142,7 @@ set(GUI_QML_FILES # .qml files for the app
         ui/windows/onboarding/OnboardingWindow.qml
         ui/windows/onboarding/ReadyView.qml
         ui/windows/onboarding/SynchronizationView.qml
+        ui/windows/waiting/WaitingView.qml
         ${GUI_QML_SINGLETON_FILES}
 )
 

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.cpp
@@ -41,9 +41,16 @@ OnboardingSessionManager::OnboardingSessionManager(CachePopulator &cachePopulato
     _appCache(appCache),
     _commService(commService),
     _userService(userService),
-    _serviceEventBus(serviceEventBus) {
-    (void) connect(&cachePopulator, &CachePopulator::bootstrapCompleted, this,
-                   &OnboardingSessionManager::handleBootstrapCompleted);
+    _serviceEventBus(serviceEventBus) {}
+
+void OnboardingSessionManager::completeBootstrap() {
+    if (_bootstrapCompleted) {
+        qCWarning(lcOnboardingSessionManager) << "Onboarding bootstrap completion ignored: already completed";
+        return;
+    }
+
+    _bootstrapCompleted = true;
+    ensureSession();
 }
 
 void OnboardingSessionManager::openOnboardingWindow() {
@@ -102,14 +109,6 @@ void OnboardingSessionManager::openWindowIfDisplayable() {
 
     qCInfo(lcOnboardingSessionManager) << "Onboarding window open skipped: onboarding is not required"
                                        << "| configuredDrives:" << _appCache.driveContexts().size();
-}
-
-void OnboardingSessionManager::handleBootstrapCompleted() {
-    _bootstrapCompleted = true;
-    ensureSession();
-    if (_activeSession != nullptr) {
-        emit openOnboardingWindowRequested();
-    }
 }
 
 void OnboardingSessionManager::startSession(const OnboardingSession::EntryPoint entryPoint,

--- a/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
+++ b/src/gui4/linux/app/onboarding/onboardingsessionmanager.h
@@ -51,6 +51,13 @@ class OnboardingSessionManager final : public QObject {
         [[nodiscard]] OnboardingSession *activeSession() const { return _activeSession; }
 
         /**
+         * Publishes the onboarding route derived from the completed initial cache snapshot.
+         *
+         * Window activation remains owned by AppClientLinux so a waiting window dismissed during bootstrap stays hidden.
+         */
+        void completeBootstrap();
+
+        /**
          * Opens the onboarding window only when an onboarding session provides displayable content.
          */
         Q_INVOKABLE void openOnboardingWindow();
@@ -71,7 +78,6 @@ class OnboardingSessionManager final : public QObject {
 
         void ensureSession();
         void openWindowIfDisplayable();
-        void handleBootstrapCompleted();
         void startSession(OnboardingSession::EntryPoint entryPoint, std::optional<UserDbId> selectedUserDbId);
         void stopSession(bool closeWindow);
         void handleRetiringSessionDestroyed();

--- a/src/gui4/linux/app/systraycontroller.cpp
+++ b/src/gui4/linux/app/systraycontroller.cpp
@@ -19,6 +19,7 @@
 #include "systraycontroller.h"
 
 #include "app/cache/appcache.h"
+#include "libcommon/utility/cstypes.h"
 
 #include <QAction>
 #include <QApplication>
@@ -179,12 +180,40 @@ void SystemTrayController::setProductStateInitialized(const bool initialized) {
     refreshIconState();
 }
 
+void SystemTrayController::handleUpdateStateChanged(const UpdateState state) {
+    switch (state) {
+        case UpdateState::ManualUpdateAvailable:
+            setNotificationActive(true);
+            return;
+        case UpdateState::UpToDate:
+        case UpdateState::NoUpdate:
+            setNotificationActive(false);
+            return;
+        case UpdateState::Available:
+        case UpdateState::Checking:
+        case UpdateState::CheckError:
+        case UpdateState::Unknown:
+            qCDebug(lcSystemTrayController) << "Updater state preserves system tray notification | state:" << state;
+            return;
+        case UpdateState::Downloading:
+        case UpdateState::Ready:
+        case UpdateState::DownloadError:
+        case UpdateState::UpdateError:
+            qCWarning(lcSystemTrayController)
+                    << "Unexpected updater state on Linux, preserving system tray notification | state:" << state;
+            return;
+        case UpdateState::EnumEnd:
+            qCWarning(lcSystemTrayController) << "Invalid updater state received";
+            return;
+    }
+}
+
 void SystemTrayController::setNotificationActive(const bool active) {
     if (_isNotificationActive == active) {
         return;
     }
 
-    qCInfo(lcSystemTrayController) << "Manual system tray notification state changed | active:" << active;
+    qCInfo(lcSystemTrayController) << "System tray notification state changed | active:" << active;
     _isNotificationActive = active;
     refreshIconState();
 }

--- a/src/gui4/linux/app/systraycontroller.h
+++ b/src/gui4/linux/app/systraycontroller.h
@@ -32,6 +32,7 @@ class QWindow;
 namespace KDC {
 
 class AppCache;
+enum class UpdateState;
 
 enum class TrayIconState {
     Neutral,
@@ -58,6 +59,7 @@ class SystemTrayController final : public QObject {
         void observe(AppCache &appCache);
         void setMainWindow(QWindow *const window);
         void setProductStateInitialized(bool initialized);
+        void handleUpdateStateChanged(UpdateState state);
         void setNotificationActive(bool active);
         void setIconState(TrayIconState state);
         [[nodiscard]] bool trayModeActive() const { return _isTrayModeActive; }

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -104,8 +104,10 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
     mainWindow->setIcon(appIcon);
     _systemTrayController.setMainWindow(mainWindow);
     (void) connect(mainWindow, &QWindow::visibleChanged, this, [this](const bool visible) {
-        if (!visible && !_bootstrapCompleted) {
+        if (!visible && !_bootstrapCompleted && _mainWindowActivationPending) {
             _mainWindowActivationPending = false;
+            _mainWindowDismissedDuringBootstrap = true;
+            qCInfo(lcAppClientLinux) << "Waiting screen dismissed before bootstrap completion";
         }
     });
 
@@ -173,9 +175,16 @@ void AppClientLinux::handleIpcDisconnection() {
 
 void AppClientLinux::handleBootstrapCompletion() {
     _bootstrapCompleted = true;
+    _onboardingSessionManager.completeBootstrap();
 
     if (_appCache.syncContexts().empty()) {
+        const bool shouldOpenOnboarding = !_systemTrayController.trayModeActive() || !_mainWindowDismissedDuringBootstrap;
         _mainWindowActivationPending = false;
+        if (shouldOpenOnboarding) {
+            _onboardingSessionManager.openOnboardingWindow();
+        } else {
+            qCInfo(lcAppClientLinux) << "Onboarding route ready but kept hidden because the waiting screen was dismissed";
+        }
         return;
     }
 
@@ -243,6 +252,7 @@ void AppClientLinux::setupTranslations() {
 
 void AppClientLinux::openMainWindow() {
     if (!_bootstrapCompleted) {
+        _mainWindowDismissedDuringBootstrap = false;
         _mainWindowActivationPending = true;
         _systemTrayController.showMainWindow();
         qCInfo(lcAppClientLinux) << "Showing waiting screen until IPC and cache bootstrap complete";

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -126,7 +126,10 @@ void AppClientLinux::setupSignalConnections() {
                    &SentryService::updateAuthenticatedUser);
     (void) connect(&_cachePopulator, &CachePopulator::bootstrapCompleted, this, &AppClientLinux::handleBootstrapCompletion);
     (void) connect(this, &AppClientLinux::ipcConnected, this, [this] { _cachePopulator.bootstrap(); });
+    (void) connect(this, &AppClientLinux::ipcConnected, this, &AppClientLinux::refreshUpdaterState);
     (void) connect(this, &QCoreApplication::aboutToQuit, this, [] { qCInfo(lcAppClientLinux) << "Qt aboutToQuit emitted"; });
+    (void) connect(&_serverCommService, &CommService::updateStateChanged, &_systemTrayController,
+                   &SystemTrayController::handleUpdateStateChanged);
     (void) connect(&_serverCommService, &CommService::showSettings, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::showSynthesis, this, &AppClientLinux::openMainWindow);
     (void) connect(&_serverCommService, &CommService::quit, this, [] { QCoreApplication::quit(); });
@@ -171,6 +174,18 @@ void AppClientLinux::handleIpcDisconnection() {
     _appRouter.hideMainWindow();
     _appCache.clearAll();
     _parametersStore.clear();
+}
+
+void AppClientLinux::refreshUpdaterState() {
+    _serverCommService.requestUpdaterState([this](const ExitInfo &exitInfo, const UpdateState state) {
+        if (!exitInfo) {
+            qCWarning(lcAppClientLinux) << "Failed to refresh updater state | code:" << exitInfo.code()
+                                        << "| cause:" << exitInfo.cause();
+            return;
+        }
+
+        _systemTrayController.handleUpdateStateChanged(state);
+    });
 }
 
 void AppClientLinux::handleBootstrapCompletion() {

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -103,6 +103,11 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
     }
     mainWindow->setIcon(appIcon);
     _systemTrayController.setMainWindow(mainWindow);
+    (void) connect(mainWindow, &QWindow::visibleChanged, this, [this](const bool visible) {
+        if (!visible && !_bootstrapCompleted) {
+            _mainWindowActivationPending = false;
+        }
+    });
 
     qCDebug(lcAppClientLinux) << "IPC/cache/QML wiring initialized";
 }
@@ -167,11 +172,20 @@ void AppClientLinux::handleIpcDisconnection() {
 }
 
 void AppClientLinux::handleBootstrapCompletion() {
-    if (_systemTrayController.trayModeActive() || _appCache.syncContexts().empty()) {
+    _bootstrapCompleted = true;
+
+    if (_appCache.syncContexts().empty()) {
+        _mainWindowActivationPending = false;
         return;
     }
 
-    qCInfo(lcAppClientLinux) << "Opening main window after bootstrap because tray fallback mode is active";
+    if (_systemTrayController.trayModeActive() && !_mainWindowActivationPending) {
+        return;
+    }
+
+    qCInfo(lcAppClientLinux) << "Opening main window after bootstrap"
+                             << "| activation pending:" << _mainWindowActivationPending
+                             << "| tray fallback active:" << !_systemTrayController.trayModeActive();
     openMainWindow();
 }
 
@@ -228,6 +242,14 @@ void AppClientLinux::setupTranslations() {
 }
 
 void AppClientLinux::openMainWindow() {
+    if (!_bootstrapCompleted) {
+        _mainWindowActivationPending = true;
+        _systemTrayController.showMainWindow();
+        qCInfo(lcAppClientLinux) << "Showing waiting screen until IPC and cache bootstrap complete";
+        return;
+    }
+
+    _mainWindowActivationPending = false;
     if (_appCache.syncContexts().empty()) {
         _onboardingSessionManager.openOnboardingWindow();
         return;

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -106,6 +106,7 @@ class AppClientLinux : public QApplication {
         void setupIpcConnection();
         void handleIpcDisconnection();
         void handleBootstrapCompletion();
+        void refreshUpdaterState();
         void updateLoggerMinLevel() const;
         void requestQuit() const;
         void openMainWindow();

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -136,6 +136,7 @@ class AppClientLinux : public QApplication {
         QQmlApplicationEngine _qmlEngine;
         bool _bootstrapCompleted{false};
         bool _mainWindowActivationPending{false};
+        bool _mainWindowDismissedDuringBootstrap{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -134,6 +134,8 @@ class AppClientLinux : public QApplication {
         QTranslator _baseTranslator{this};
         QTranslator _localizedTranslator{this};
         QQmlApplicationEngine _qmlEngine;
+        bool _bootstrapCompleted{false};
+        bool _mainWindowActivationPending{false};
 };
 
 } // namespace KDC

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -22,6 +22,7 @@ import QtQuick
 import kDrive.UI
 import "windows/main"
 import "windows/onboarding"
+import "windows/waiting"
 
 IKShadowedWindow {
     id: mainWindow
@@ -32,6 +33,7 @@ IKShadowedWindow {
     required property var systemTrayController
 
     readonly property bool onboardingActive: onboardingSessionManager.activeSession !== null
+    readonly property bool waitingActive: !onboardingActive && !appRouter.mainWindowActive
 
     visible: false
     contentWidth: 900
@@ -39,7 +41,15 @@ IKShadowedWindow {
     minimumContentWidth: 720
     minimumContentHeight: 520
     title: onboardingActive ? onboardingSessionManager.activeSession.flowController.title : "kDrive"
-    surfaceColor: onboardingActive ? IKColors.onboardingSurfacePrimary : IKColors.surfacePrimary
+    surfaceColor: {
+        if (waitingActive) {
+            return IKColors.surfaceSecondary;
+        }
+        if (onboardingActive) {
+            return IKColors.onboardingSurfacePrimary;
+        }
+        return IKColors.surfacePrimary;
+    }
     customShadowEnabled: true
     headerOverlaysContent: onboardingActive
     windowTitleVisible: false
@@ -136,6 +146,12 @@ IKShadowedWindow {
         sourceComponent: mainWindowComponent
     }
 
+    Loader {
+        anchors.fill: parent
+        active: mainWindow.waitingActive
+        sourceComponent: waitingComponent
+    }
+
     Component {
         id: onboardingComponent
 
@@ -151,5 +167,11 @@ IKShadowedWindow {
             appRouter: mainWindow.appRouter
             mainSidebarController: mainWindow.mainSidebarController
         }
+    }
+
+    Component {
+        id: waitingComponent
+
+        WaitingView {}
     }
 }

--- a/src/gui4/linux/ui/components/IKLoadingSpinner.qml
+++ b/src/gui4/linux/ui/components/IKLoadingSpinner.qml
@@ -47,6 +47,8 @@ Item {
 
     Shape {
         anchors.fill: parent
+        preferredRendererType: Shape.CurveRenderer
+        antialiasing: true
 
         ShapePath {
             strokeColor: root.color

--- a/src/gui4/linux/ui/components/IKLoadingSpinner.qml
+++ b/src/gui4/linux/ui/components/IKLoadingSpinner.qml
@@ -1,0 +1,57 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import QtQuick.Shapes
+import kDrive.UI
+
+Item {
+    id: root
+
+    property color color: IKColors.accentPrimary
+    property real strokeWidth: 3
+    property int rotationDuration: 900
+
+    Shape {
+        anchors.fill: parent
+
+        ShapePath {
+            strokeColor: root.color
+            strokeWidth: root.strokeWidth
+            capStyle: ShapePath.RoundCap
+            fillColor: "transparent"
+
+            PathAngleArc {
+                centerX: root.width / 2
+                centerY: root.height / 2
+                radiusX: Math.max(0, (root.width - root.strokeWidth) / 2)
+                radiusY: Math.max(0, (root.height - root.strokeWidth) / 2)
+                startAngle: 0
+                sweepAngle: 270
+            }
+        }
+    }
+
+    RotationAnimator on rotation {
+        from: 0
+        to: 360
+        duration: root.rotationDuration
+        loops: Animation.Infinite
+        running: root.visible
+    }
+}

--- a/src/gui4/linux/ui/components/IKLoadingSpinner.qml
+++ b/src/gui4/linux/ui/components/IKLoadingSpinner.qml
@@ -23,9 +23,27 @@ import kDrive.UI
 Item {
     id: root
 
-    property color color: IKColors.accentPrimary
+    property color color: IKColors.accentSecondary
+    property real minimumSweepAngle: 12
+    property real maximumSweepAngle: 300
     property real strokeWidth: 3
-    property int rotationDuration: 900
+    property int cycleDuration: 2400
+    property real cycleProgress: 0
+
+    readonly property real contractionProgress: Math.max(0, root.cycleProgress * 2 - 1)
+    readonly property real sweepRange: root.maximumSweepAngle - root.minimumSweepAngle
+    readonly property real sweepAngle: {
+        const expansionProgress = Math.sin(Math.PI * root.cycleProgress);
+        return root.minimumSweepAngle + root.sweepRange * root.smoothStep(expansionProgress);
+    }
+    readonly property real startAngle: {
+        const baseRotation = root.cycleProgress * (720 - root.sweepRange);
+        return baseRotation + root.sweepRange * root.smoothStep(root.contractionProgress);
+    }
+
+    function smoothStep(value) {
+        return value * value * (3 - 2 * value);
+    }
 
     Shape {
         anchors.fill: parent
@@ -33,7 +51,7 @@ Item {
         ShapePath {
             strokeColor: root.color
             strokeWidth: root.strokeWidth
-            capStyle: ShapePath.RoundCap
+            capStyle: ShapePath.FlatCap
             fillColor: "transparent"
 
             PathAngleArc {
@@ -41,16 +59,16 @@ Item {
                 centerY: root.height / 2
                 radiusX: Math.max(0, (root.width - root.strokeWidth) / 2)
                 radiusY: Math.max(0, (root.height - root.strokeWidth) / 2)
-                startAngle: 0
-                sweepAngle: 270
+                startAngle: root.startAngle
+                sweepAngle: root.sweepAngle
             }
         }
     }
 
-    RotationAnimator on rotation {
+    NumberAnimation on cycleProgress {
         from: 0
-        to: 360
-        duration: root.rotationDuration
+        to: 1
+        duration: root.cycleDuration
         loops: Animation.Infinite
         running: root.visible
     }

--- a/src/gui4/linux/ui/tokens/IKWaiting.qml
+++ b/src/gui4/linux/ui/tokens/IKWaiting.qml
@@ -24,5 +24,5 @@ QtObject {
     readonly property real logoSize: 80
     readonly property real spinnerSize: 32
     readonly property real spinnerStrokeWidth: 3
-    readonly property int spinnerRotationDuration: 900
+    readonly property int spinnerCycleDuration: 2400
 }

--- a/src/gui4/linux/ui/tokens/IKWaiting.qml
+++ b/src/gui4/linux/ui/tokens/IKWaiting.qml
@@ -1,0 +1,28 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+pragma Singleton
+import QtQuick
+
+QtObject {
+    readonly property real contentSpacing: IKSpacing.s24
+    readonly property real logoSize: 80
+    readonly property real spinnerSize: 32
+    readonly property real spinnerStrokeWidth: 3
+    readonly property int spinnerRotationDuration: 900
+}

--- a/src/gui4/linux/ui/windows/waiting/WaitingView.qml
+++ b/src/gui4/linux/ui/windows/waiting/WaitingView.qml
@@ -1,0 +1,43 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import QtQuick
+import kDrive.UI
+
+Item {
+    Column {
+        anchors.centerIn: parent
+        spacing: IKWaiting.contentSpacing
+
+        Image {
+            width: IKWaiting.logoSize
+            height: IKWaiting.logoSize
+            source: "qrc:/assets/taskbar/logo_kdrive.svg"
+            sourceSize.width: width
+            sourceSize.height: height
+        }
+
+        IKLoadingSpinner {
+            anchors.horizontalCenter: parent.horizontalCenter
+            width: IKWaiting.spinnerSize
+            height: IKWaiting.spinnerSize
+            strokeWidth: IKWaiting.spinnerStrokeWidth
+            rotationDuration: IKWaiting.spinnerRotationDuration
+        }
+    }
+}

--- a/src/gui4/linux/ui/windows/waiting/WaitingView.qml
+++ b/src/gui4/linux/ui/windows/waiting/WaitingView.qml
@@ -17,6 +17,7 @@
  */
 
 import QtQuick
+import QtQuick.VectorImage
 import kDrive.UI
 
 Item {
@@ -24,12 +25,12 @@ Item {
         anchors.centerIn: parent
         spacing: IKWaiting.contentSpacing
 
-        Image {
+        VectorImage {
             width: IKWaiting.logoSize
             height: IKWaiting.logoSize
             source: "qrc:/assets/taskbar/logo_kdrive.svg"
-            sourceSize.width: width
-            sourceSize.height: height
+            fillMode: VectorImage.PreserveAspectFit
+            preferredRendererType: VectorImage.CurveRenderer
         }
 
         IKLoadingSpinner {

--- a/src/gui4/linux/ui/windows/waiting/WaitingView.qml
+++ b/src/gui4/linux/ui/windows/waiting/WaitingView.qml
@@ -37,7 +37,7 @@ Item {
             width: IKWaiting.spinnerSize
             height: IKWaiting.spinnerSize
             strokeWidth: IKWaiting.spinnerStrokeWidth
-            rotationDuration: IKWaiting.spinnerRotationDuration
+            cycleDuration: IKWaiting.spinnerCycleDuration
         }
     }
 }


### PR DESCRIPTION
[waiting_screen.webm](https://github.com/user-attachments/assets/25506298-1ee4-4a83-a25e-9ec8cfa627d6)

---

<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR ajoute un écran d'attente affiché lorsque la fenêtre principale est demandée avant que la connexion IPC et le bootstrap du cache ne soient terminés, évitant ainsi d'ouvrir prématurément l'onboarding ou la fenêtre principale sur un état de données incomplet.

## Changements
- Ajout du composant `IKLoadingSpinner.qml` : un spinner de chargement animé basé sur `Shape`/`PathAngleArc`, avec couleur, épaisseur de trait et durée de rotation configurables.
- Ajout de `WaitingView.qml` : l'écran d'attente affichant le logo kDrive et le spinner, centrés.
- Ajout du singleton de tokens `IKWaiting.qml` définissant l'espacement, la taille du logo et les paramètres du spinner pour cet écran.
- Intégration dans `Main.qml` : nouvelle propriété `waitingActive` (active quand l'onboarding n'est pas actif et que `appRouter.mainWindowActive` est faux), un `Loader` dédié, et une couleur de surface spécifique (`IKColors.surfaceSecondary`) pendant l'attente.
- `AppClientLinux` : ajout des indicateurs `_bootstrapCompleted` et `_mainWindowActivationPending` pour suivre l'état du bootstrap. `openMainWindow()` affiche désormais l'écran d'attente (via la fenêtre système tray) tant que le bootstrap n'est pas terminé, au lieu d'ouvrir directement l'onboarding ou la fenêtre principale. `handleBootstrapCompletion()` prend en compte l'activation en attente pour décider d'ouvrir la fenêtre principale une fois le bootstrap achevé.
- Réinitialisation de `_mainWindowActivationPending` si la fenêtre principale est masquée avant la fin du bootstrap, pour éviter une réouverture automatique non désirée.
- Mise à jour de `CMakeLists.txt` pour enregistrer les nouveaux fichiers QML (singleton `IKWaiting.qml`, composant `IKLoadingSpinner.qml`, vue `WaitingView.qml`).
- Mise à jour de `AGENTS.md` pour documenter le rôle du répertoire `ui/windows/waiting/`.

## Tests
Pour tester, il suffit de lancer le client sans lancer le serveur, puis de double-cliquer sur l'icône du systray pour afficher l'écran d'attente. Cela permet de tester la transition entre l'écran d'attente et l'onboarding / la fenêtre principale.

## Notes
Ce travail s'appuie sur les changements de `linux-v4/reduce-cognitive-complexity-of-appclient`.

</details>

---

## Summary
This PR adds a waiting screen shown when the main window is requested before the IPC connection and cache bootstrap have completed, preventing onboarding or the main window from opening prematurely on incomplete data.

## Changes
- Added `IKLoadingSpinner.qml`: an animated loading spinner built on `Shape`/`PathAngleArc`, with configurable color, stroke width, and rotation duration.
- Added `WaitingView.qml`: the waiting screen displaying the kDrive logo and the spinner, centered.
- Added the `IKWaiting.qml` token singleton defining content spacing, logo size, and spinner parameters for this screen.
- Wired the screen into `Main.qml`: a new `waitingActive` property (true when onboarding is inactive and `appRouter.mainWindowActive` is false), a dedicated `Loader`, and a distinct surface color (`IKColors.surfaceSecondary`) while waiting.
- `AppClientLinux`: introduced `_bootstrapCompleted` and `_mainWindowActivationPending` flags to track bootstrap state. `openMainWindow()` now shows the waiting screen (via the tray-mode window) until bootstrap completes, instead of opening onboarding or the main window directly. `handleBootstrapCompletion()` now accounts for the pending activation to decide whether to open the main window once bootstrap finishes.
- Reset `_mainWindowActivationPending` when the main window is hidden before bootstrap completes, avoiding an unwanted automatic reopen.
- Updated `CMakeLists.txt` to register the new QML files (the `IKWaiting.qml` singleton, the `IKLoadingSpinner.qml` component, and the `WaitingView.qml` view).
- Updated `AGENTS.md` to document the purpose of the `ui/windows/waiting/` directory.

## Testing
To test, launch the client without starting the server, then double-click the tray icon to display the waiting screen. This lets you exercise the transition between the waiting screen and onboarding / the main window.

## Notes
This work builds on top of `linux-v4/reduce-cognitive-complexity-of-appclient`.


----

Depends on #2176