### PR TITLE
feat(server): add a macOS job to check Full Disk Access permissions

### DIFF
--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -125,6 +125,7 @@ enum class RequestNum {
     UTILITY_SEND_APP_START_TRACE, // Sent by the Client process as soon the UI is visible for the user.
 #if defined(KD_MACOS)
     UTILITY_INSTALL_MAC_LITESYNC_EXT,
+    UTILITY_CHECK_MACOS_PERMISSIONS, // Ask the Server process for the state of the authorizations required by Lite Sync.
 #endif
     UPDATER_CHANGE_CHANNEL,
     UPDATER_VERSION_INFO,
@@ -277,6 +278,8 @@ inline std::string toString(RequestNum e) {
 #if defined(KD_MACOS)
         case RequestNum::UTILITY_INSTALL_MAC_LITESYNC_EXT:
             return "UTILITY_INSTALL_MAC_LITESYNC_EXT";
+        case RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS:
+            return "UTILITY_CHECK_MACOS_PERMISSIONS";
 #endif
         case RequestNum::UPDATER_VERSION_INFO:
             return "UPDATER_VERSION_INFO";

--- a/src/libcommon/utility/utility.cpp
+++ b/src/libcommon/utility/utility.cpp
@@ -1263,6 +1263,16 @@ bool CommonUtility::isLiteSyncExtFullDiskAccessAuthOk(std::string &errorDescr) {
     return false;
 }
 
+bool CommonUtility::isFullDiskAccessAuthOk() {
+    // Listing this directory is only permitted to processes that have been granted the Full Disk Access authorization.
+    static const SyncPath tccDirPath = "/Library/Application Support/com.apple.TCC";
+
+    std::error_code ec;
+    (void) std::filesystem::directory_iterator(tccDirPath, ec);
+
+    return !ec;
+}
+
 #endif
 
 QString CommonUtility::truncateLongLogMessage(const QString &message) {

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -172,6 +172,11 @@ struct COMMON_EXPORT CommonUtility {
         static const std::string liteSyncExtBundleId();
         static bool isLiteSyncExtEnabled();
         static bool isLiteSyncExtFullDiskAccessAuthOk(std::string &errorDescr);
+        /**
+         * @brief Check whether the calling process has been granted the Full Disk Access authorization.
+         * @return True if the process has Full Disk Access; otherwise, false.
+         */
+        static bool isFullDiskAccessAuthOk();
 #endif
         static std::string envVarValue(const std::string &name);
         static std::string envVarValue(const std::string &name, bool &isSet);

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -172,6 +172,7 @@ if(APPLE)
     list(APPEND server_SRCS comm/guijobs/exclappsetlistjob.h comm/guijobs/exclappsetlistjob.cpp)
     list(APPEND server_SRCS comm/guijobs/exclappgetfetchingapplistjob.h comm/guijobs/exclappgetfetchingapplistjob.cpp)
     list(APPEND server_SRCS comm/guijobs/utilityinstallmaclitesyncextjob.h comm/guijobs/utilityinstallmaclitesyncextjob.cpp)
+    list(APPEND server_SRCS comm/guijobs/utilitycheckmacospermissionsjob.h comm/guijobs/utilitycheckmacospermissionsjob.cpp)
 
     set_property(SOURCE comm/abstractcommserver_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
     set_property(SOURCE comm/xpccommserver_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")

--- a/src/server/comm/guijobs/guijobfactory.cpp
+++ b/src/server/comm/guijobs/guijobfactory.cpp
@@ -82,6 +82,7 @@
 #include "utilitysendappstarttracejob.h"
 #if defined(KD_MACOS)
 #include "utilityinstallmaclitesyncextjob.h"
+#include "utilitycheckmacospermissionsjob.h"
 #endif
 
 #include "updaterversioninfojob.h"
@@ -156,6 +157,7 @@ GuiJobFactory::GuiJobFactory() {
                 {RequestNum::UTILITY_SEND_APP_START_TRACE, makeShared<UtilitySendAppStartTraceJob>},
 #if defined(KD_MACOS)
                 {RequestNum::UTILITY_INSTALL_MAC_LITESYNC_EXT, makeShared<UtilityInstallMacLiteSyncExtJob>},
+                {RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS, makeShared<UtilityCheckMacOsPermissionsJob>},
 #endif
                 {RequestNum::UPDATER_VERSION_INFO, makeShared<UpdaterVersionInfoJob>},
                 {RequestNum::UPDATER_STATE, makeShared<UpdaterStateJob>},

--- a/src/server/comm/guijobs/utilitycheckmacospermissionsjob.cpp
+++ b/src/server/comm/guijobs/utilitycheckmacospermissionsjob.cpp
@@ -1,0 +1,66 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "utilitycheckmacospermissionsjob.h"
+
+#include "libcommon/comm.h"
+#include "libcommon/utility/utility.h"
+#include "libcommonserver/log/log.h"
+
+// Output parameters keys
+static const auto outParamsFullDiskAccess = "fullDiskAccess";
+static const auto outParamsLiteSyncExtEnabled = "liteSyncExtEnabled";
+static const auto outParamsLiteSyncExtFullDiskAccess = "liteSyncExtFullDiskAccess";
+
+namespace KDC {
+
+UtilityCheckMacOsPermissionsJob::UtilityCheckMacOsPermissionsJob(std::shared_ptr<CommManager> commManager, int requestId,
+                                                                 const Poco::DynamicStruct &inParams,
+                                                                 std::shared_ptr<AbstractCommChannel> channel) :
+    AbstractGuiJob(commManager, requestId, inParams, channel) {
+    _requestNum = RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS;
+}
+
+ExitInfo UtilityCheckMacOsPermissionsJob::serializeOutputParms() {
+    writeParamValue(outParamsFullDiskAccess, _fullDiskAccess);
+    writeParamValue(outParamsLiteSyncExtEnabled, _liteSyncExtEnabled);
+    writeParamValue(outParamsLiteSyncExtFullDiskAccess, _liteSyncExtFullDiskAccess);
+
+    return ExitCode::Ok;
+}
+
+ExitInfo UtilityCheckMacOsPermissionsJob::process() {
+    _fullDiskAccess = CommonUtility::isFullDiskAccessAuthOk();
+    if (!_fullDiskAccess) {
+        // The state of the Lite Sync extension authorization is read from the TCC database, which is itself unreadable without
+        // the Full Disk Access authorization.
+        LOG_WARN(_logger, "The Server process has not been granted the Full Disk Access authorization");
+    }
+
+    _liteSyncExtEnabled = CommonUtility::isLiteSyncExtEnabled();
+
+    std::string liteSyncExtErrorDescr;
+    _liteSyncExtFullDiskAccess = CommonUtility::isLiteSyncExtFullDiskAccessAuthOk(liteSyncExtErrorDescr);
+    if (!_liteSyncExtFullDiskAccess && !liteSyncExtErrorDescr.empty()) {
+        LOG_WARN(_logger, "Error in CommonUtility::isLiteSyncExtFullDiskAccessAuthOk: " << liteSyncExtErrorDescr);
+    }
+
+    return ExitCode::Ok;
+}
+
+} // namespace KDC

--- a/src/server/comm/guijobs/utilitycheckmacospermissionsjob.h
+++ b/src/server/comm/guijobs/utilitycheckmacospermissionsjob.h
@@ -1,0 +1,49 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "server/comm/guijobs/abstractguijob.h"
+
+namespace KDC {
+
+//! Report the state of the macOS authorizations required by Lite Sync.
+/*!
+  Those authorizations cannot be reliably checked from the Client process: reading the TCC database requires the reading process
+  itself to have been granted the Full Disk Access authorization, which the Client process does not need. Only the Server process
+  can answer.
+*/
+class UtilityCheckMacOsPermissionsJob : public AbstractGuiJob {
+    public:
+        UtilityCheckMacOsPermissionsJob(std::shared_ptr<CommManager> commManager, int requestId,
+                                        const Poco::DynamicStruct &inParams, std::shared_ptr<AbstractCommChannel> channel);
+
+    private:
+        // Output parameters
+        bool _fullDiskAccess{false}; //!< The Server process has been granted the Full Disk Access authorization.
+        bool _liteSyncExtEnabled{false}; //!< The Lite Sync extension is installed and enabled.
+        bool _liteSyncExtFullDiskAccess{false}; //!< The Lite Sync extension has been granted the Full Disk Access authorization.
+
+        ExitInfo deserializeInputParms() override { return ExitCode::Ok; };
+        ExitInfo serializeOutputParms() override;
+        ExitInfo process() override;
+
+        friend class TestGuiCommChannel;
+};
+
+} // namespace KDC

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -146,6 +146,7 @@ if(APPLE)
     list(APPEND server_SRCS ${server_srcs_path}/comm/guijobs/exclappsetlistjob.h ${server_srcs_path}/comm/guijobs/exclappsetlistjob.cpp)
     list(APPEND server_SRCS ${server_srcs_path}/comm/guijobs/exclappgetfetchingapplistjob.h ${server_srcs_path}/comm/guijobs/exclappgetfetchingapplistjob.cpp)
     list(APPEND server_SRCS ${server_srcs_path}/comm/guijobs/utilityinstallmaclitesyncextjob.h ${server_srcs_path}/comm/guijobs/utilityinstallmaclitesyncextjob.cpp)
+    list(APPEND server_SRCS ${server_srcs_path}/comm/guijobs/utilitycheckmacospermissionsjob.h ${server_srcs_path}/comm/guijobs/utilitycheckmacospermissionsjob.cpp)
 
     set_property(SOURCE ${server_srcs_path}/comm/abstractcommserver_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
     set_property(SOURCE ${server_srcs_path}/comm/xpccommserver_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")

--- a/test/server/comm/guicommchannel/testguicommchannel.h
+++ b/test/server/comm/guicommchannel/testguicommchannel.h
@@ -111,6 +111,9 @@ class TestGuiCommChannel : public CppUnit::TestFixture, public TestBase {
         CPPUNIT_TEST(testSignalUtilityQuitJob);
         CPPUNIT_TEST(testUtilityCheckCommStatusJob);
         CPPUNIT_TEST(testUtilityHasSystemLaunchOnStartupJob);
+#if defined(KD_MACOS)
+        CPPUNIT_TEST(testUtilityCheckMacOsPermissionsJob);
+#endif
         CPPUNIT_TEST(testUtilityQuitJob);
         CPPUNIT_TEST(testUtilitySendAppStartTraceJob);
         CPPUNIT_TEST(testUtilityGetAppStateJob);
@@ -194,6 +197,9 @@ class TestGuiCommChannel : public CppUnit::TestFixture, public TestBase {
         void testUtilityActivateLoadInfoJob();
         void testUtilityCheckCommStatusJob();
         void testUtilityHasSystemLaunchOnStartupJob();
+#if defined(KD_MACOS)
+        void testUtilityCheckMacOsPermissionsJob();
+#endif
         void testUtilityQuitJob();
         void testUtilitySendAppStartTraceJob();
         void testUtilityGetAppStateJob();

--- a/test/server/comm/guicommchannel/testutility.cpp
+++ b/test/server/comm/guicommchannel/testutility.cpp
@@ -31,6 +31,7 @@
 #include "comm/guijobs/utilitysendappstarttracejob.h"
 #if defined(KD_MACOS)
 #include "comm/guijobs/utilityinstallmaclitesyncextjob.h"
+#include "comm/guijobs/utilitycheckmacospermissionsjob.h"
 #endif
 
 #include "testguicommchannel.h"
@@ -255,6 +256,44 @@ void TestGuiCommChannel::testUtilityHasSystemLaunchOnStartupJob() {
     testGenericJob(queryStr, answerStr, cbkAnswerStr, processFct);
 #endif
 }
+
+#if defined(KD_MACOS)
+void TestGuiCommChannel::testUtilityCheckMacOsPermissionsJob() {
+    const auto query = createSimpleQuery(RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS);
+    const auto queryStr = stringifyQueryObj(query);
+
+    // Answer
+    Poco::JSON::Object answerObj;
+    (void) answerObj.set("cause", 0);
+    (void) answerObj.set("code", 0);
+    (void) answerObj.set("id", 1);
+
+    Poco::JSON::Object paramsObj;
+    (void) paramsObj.set("fullDiskAccess", true);
+    (void) paramsObj.set("liteSyncExtEnabled", true);
+    (void) paramsObj.set("liteSyncExtFullDiskAccess", false);
+    (void) answerObj.set("params", paramsObj);
+
+    Poco::JSON::Object answerObjWithNumAndType = answerObj;
+    (void) answerObjWithNumAndType.set("num", toInt(RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS));
+    (void) answerObjWithNumAndType.set("type", toInt(GuiJobType::Query));
+
+    // Job expected answers
+    const auto answerStr = stringifyAnswerObj(answerObjWithNumAndType);
+
+    auto processFct = [](std::shared_ptr<AbstractGuiJob> job) {
+        auto utilityCheckMacOsPermissionsJob = std::dynamic_pointer_cast<UtilityCheckMacOsPermissionsJob>(job);
+        CPPUNIT_ASSERT(utilityCheckMacOsPermissionsJob);
+
+        utilityCheckMacOsPermissionsJob->_fullDiskAccess = true;
+        utilityCheckMacOsPermissionsJob->_liteSyncExtEnabled = true;
+        utilityCheckMacOsPermissionsJob->_liteSyncExtFullDiskAccess = false;
+    };
+
+    const auto cbkAnswerStr = stringifyCbkAnswerObj(answerObj);
+    testGenericJob(queryStr, answerStr, cbkAnswerStr, processFct);
+}
+#endif
 
 void TestGuiCommChannel::testUtilitySetAppStateJob() {
     // Query


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Sur macOS v4, l'interface graphique vérifie aujourd'hui elle-même le Full Disk Access (FDA), alors que c'est le process Serveur (et l'extension Lite Sync) qui en a réellement besoin. Cette PR ajoute côté serveur un job IPC macOS qui expose l'état réel de ces autorisations, afin que le client puisse s'appuyer dessus au lieu de tester le FDA sur lui-même.

## Changements
- Ajout de `RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS` dans `src/libcommon/comm.h`, placé juste après `UTILITY_INSTALL_MAC_LITESYNC_EXT` dans le bloc d'enum spécifique macOS afin de ne décaler aucune valeur existante (compatibilité avec le client Windows C# qui duplique cet enum).
- Ajout du helper `CommonUtility::isFullDiskAccessAuthOk()` dans `src/libcommon/utility/utility.cpp` / `.h`, qui manquait jusqu'ici : il vérifie le FDA du process courant en tentant de lister le dossier protégé `/Library/Application Support/com.apple.TCC`.
- Nouveau job serveur `UtilityCheckMacOsPermissionsJob` (`src/server/comm/guijobs/utilitycheckmacospermissionsjob.h/.cpp`), enregistré dans `GuiJobFactory` et dans `CMakeLists.txt`. Il renvoie trois booléens :
  - `fullDiskAccess` : le process Serveur a le FDA.
  - `liteSyncExtEnabled` : l'extension Lite Sync est installée et activée.
  - `liteSyncExtFullDiskAccess` : le FDA a été accordé à l'extension Lite Sync.
- Job compilé uniquement sur macOS (`#if defined(KD_MACOS)`).

## Détails techniques
L'état FDA de l'extension Lite Sync se lit dans la base TCC (`/Library/Application Support/com.apple.TCC/TCC.db`), et cette lecture exige que le process lecteur ait lui-même le FDA. Le process UI ne l'a pas nécessairement, d'où l'existant `FullDiskChecker` (`src/gui4/macOS/kDriveCore/Utils/MacOSPermissionHandler.swift`) qui bloquait à tort l'étape « permissions » de l'onboarding en testant le FDA depuis le mauvais process. Seul le Serveur peut répondre de façon fiable, d'où ce nouveau job IPC.

Limite importante : quand `fullDiskAccess` vaut `false`, `liteSyncExtFullDiskAccess` vaudra forcément `false` également, sans que ce soit une information fiable (la base TCC est alors illisible). Le client devra traiter ce cas à part. En revanche, `liteSyncExtEnabled` reste fiable dans tous les cas, car il passe par `systemextensionsctl`.

## Tests
Ajout de `testUtilityCheckMacOsPermissionsJob` dans `test/server/comm/guicommchannel/testutility.cpp` (et enregistrement dans `testguicommchannel.h`), qui valide la sérialisation/désérialisation IPC du job. La compilation et l'exécution des tests n'ont pas pu être vérifiées localement (pas d'environnement de build disponible dans ce dépôt).

## Notes
Le branchement côté UI est volontairement hors périmètre de cette PR : le remplacement de `FullDiskChecker` par un appel à ce nouveau job côté Swift (macOS v4), ainsi que l'éventuelle mise à jour de la GUI Qt legacy, restent à faire dans un travail de suivi.

</details>

---

## Summary
On macOS v4, the UI currently checks Full Disk Access (FDA) on itself, even though only the Server process (and the Lite Sync extension) actually need it. This PR adds a server-side macOS IPC job that reports the real state of these authorizations, so the client can rely on it instead of testing FDA on itself.

## Changes
- Added `RequestNum::UTILITY_CHECK_MACOS_PERMISSIONS` in `src/libcommon/comm.h`, placed right after `UTILITY_INSTALL_MAC_LITESYNC_EXT` in the existing macOS-only enum block so no existing enum value shifts (important for compatibility with the Windows C# client, which duplicates this enum).
- Added the missing `CommonUtility::isFullDiskAccessAuthOk()` helper in `src/libcommon/utility/utility.cpp` / `.h`, which checks the current process's FDA by attempting to list the protected `/Library/Application Support/com.apple.TCC` directory.
- New server job `UtilityCheckMacOsPermissionsJob` (`src/server/comm/guijobs/utilitycheckmacospermissionsjob.h/.cpp`), registered in `GuiJobFactory` and in `CMakeLists.txt`. It returns three booleans:
  - `fullDiskAccess`: whether the Server process itself has FDA.
  - `liteSyncExtEnabled`: whether the Lite Sync extension is installed and enabled.
  - `liteSyncExtFullDiskAccess`: whether FDA has been granted to the Lite Sync extension.
- The job is compiled for macOS only (`#if defined(KD_MACOS)`).

## Technical Details
The Lite Sync extension's FDA state is read from the TCC database (`/Library/Application Support/com.apple.TCC/TCC.db`), and reading it requires the reading process itself to have FDA. The UI process may not have it, which is why the existing `FullDiskChecker` (`src/gui4/macOS/kDriveCore/Utils/MacOSPermissionHandler.swift`) was incorrectly blocking the onboarding "permissions" step by checking FDA from the wrong process. Only the Server can answer reliably, hence this new IPC job.

Important limitation: when `fullDiskAccess` is `false`, `liteSyncExtFullDiskAccess` will necessarily also be `false`, without this being reliable information (the TCC database is unreadable in that case). The client will need to handle this case separately. `liteSyncExtEnabled`, however, remains reliable in all cases since it goes through `systemextensionsctl`.

## Testing
Added `testUtilityCheckMacOsPermissionsJob` in `test/server/comm/guicommchannel/testutility.cpp` (registered in `testguicommchannel.h`), which validates the job's IPC serialization/deserialization. Building and running the tests could not be verified locally (no build environment available in this repository).

## Notes
Wiring this up on the UI side is intentionally out of scope for this PR: replacing `FullDiskChecker` with a call to this new job on the Swift side (macOS v4), as well as any update to the legacy Qt GUI, are left as follow-up work.