### PR TITLE
fix: Bring all windows to foreground on click of toolbar button

### DIFF
--- a/src/gui4/macOS/kDrive/AppDelegate.swift
+++ b/src/gui4/macOS/kDrive/AppDelegate.swift
@@ -103,6 +103,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     @objc func bringAllWindowsToFront() {
+        openMainWindow()
         if #available(macOS 14.0, *) {
             NSApp.activate()
         } else {

--- a/src/gui4/macOS/kDrive/AppDelegate.swift
+++ b/src/gui4/macOS/kDrive/AppDelegate.swift
@@ -117,7 +117,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         if let preferencesWindow, preferencesWindow.window?.isVisible == true {
-            preferencesWindow.window?.orderFrontRegardless()
+            preferencesWindow.window?.makeKeyAndOrderFront(nil)
         }
     }
 

--- a/src/gui4/macOS/kDrive/AppDelegate.swift
+++ b/src/gui4/macOS/kDrive/AppDelegate.swift
@@ -102,6 +102,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainWindow.window?.makeFirstResponder(nil)
     }
 
+    @objc func bringAllWindowsToFront() {
+        if #available(macOS 14.0, *) {
+            NSApp.activate()
+        } else {
+            NSApp.activate(ignoringOtherApps: true)
+        }
+
+        if mainWindow.window?.isVisible == true {
+            mainWindow.window?.orderFrontRegardless()
+            mainWindow.window?.makeKey()
+            mainWindow.window?.makeFirstResponder(nil)
+        }
+
+        if let preferencesWindow, preferencesWindow.window?.isVisible == true {
+            preferencesWindow.window?.orderFrontRegardless()
+        }
+    }
+
     @objc func openPreferencesWindow() {
         @InjectService var matomo: MatomoUtils
         matomo.track(eventWithCategory: .navBar, name: "openSettings")

--- a/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/PreferencesWindowController.swift
+++ b/src/gui4/macOS/kDrive/UI/Controllers/PreferencesWindow/PreferencesWindowController.swift
@@ -39,7 +39,7 @@ final class PreferencesWindowController: NSWindowController {
         window.maxSize = NSSize(width: 1000, height: 1000)
         window.isReleasedWhenClosed = true
 
-        window.collectionBehavior.insert(.fullScreenNone)
+        window.collectionBehavior = [.managed, .moveToActiveSpace, .fullScreenNone]
 
         preferencesViewController = PreferencesSplitViewController()
         window.contentView = preferencesViewController.view

--- a/src/gui4/macOS/kDrive/Utils/StatusBarManager.swift
+++ b/src/gui4/macOS/kDrive/Utils/StatusBarManager.swift
@@ -167,7 +167,7 @@ final class StatusBarManager {
 
         switch event.type {
         case .leftMouseUp:
-            (NSApp.delegate as? AppDelegate)?.openMainWindow()
+            (NSApp.delegate as? AppDelegate)?.bringAllWindowsToFront()
         case .rightMouseUp:
             presentMenu()
         default:


### PR DESCRIPTION
Also works for mac users using the "spaces" feature.