### PR TITLE
fix: enforce strict TLS certificate verification

### DIFF
--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -25,6 +25,7 @@ set(libcommonserver_SRCS
     # Utility
     utility/utility.h utility/utility.cpp
     utility/selfsignedcert.h utility/selfsignedcert.cpp
+    utility/truststorehelper.h
     utility/stateholder.h
     utility/jsonparserutility.h
     # Db
@@ -58,11 +59,15 @@ if(APPLE)
 
     list(APPEND libcommonserver_SRCS utility/utility_mac.cpp utility/utility_mac.mm)
     set_property(SOURCE utility/utility_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
+    list(APPEND libcommonserver_SRCS utility/truststorehelper_mac.mm)
+    set_property(SOURCE utility/truststorehelper_mac.mm APPEND_STRING PROPERTY COMPILE_FLAGS "-fobjc-arc")
 elseif(WIN32)
     list(APPEND libcommonserver_SRCS io/iohelper_win.h io/iohelper_win.cpp utility/utility_win.cpp)
     list(APPEND libcommonserver_SRCS utility/digitalsignaturechecker_win.h utility/digitalsignaturechecker_win.cpp)
+    list(APPEND libcommonserver_SRCS utility/truststorehelper_win.cpp)
 else()
     list(APPEND libcommonserver_SRCS io/iohelper_linux.cpp utility/utility_linux.cpp)
+    list(APPEND libcommonserver_SRCS utility/truststorehelper_linux.cpp)
 endif()
 
 # Target
@@ -149,9 +154,11 @@ elseif(APPLE)
     find_library(FOUNDATION_LIBRARY NAMES Foundation)
     find_library(CORESERVICES_LIBRARY NAMES CoreServices)
     find_library(APPKIT_LIBRARY NAMES AppKit)
+    find_library(SECURITY_LIBRARY NAMES Security)
 
     target_link_libraries(${libcommonserver_NAME}
         ${FOUNDATION_LIBRARY}
         ${CORESERVICES_LIBRARY}
-        ${APPKIT_LIBRARY})
+        ${APPKIT_LIBRARY}
+        ${SECURITY_LIBRARY})
 endif()

--- a/src/libcommonserver/utility/truststorehelper.h
+++ b/src/libcommonserver/utility/truststorehelper.h
@@ -1,0 +1,41 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommonserver/commonserverlib.h"
+
+#include <openssl/ssl.h>
+
+namespace KDC {
+
+/// Loads the platform-native CA trust store into the OpenSSL SSL_CTX used by Poco.
+///
+/// On macOS and Windows the bundled OpenSSL build does not ship a CA bundle and
+/// `loadDefaultCAs=true` only checks paths compiled into the OpenSSL binary
+/// (e.g. `/usr/local/ssl/cert.pem` on macOS), which do not exist on end-user
+/// machines.  This helper extracts the native trust store (macOS keychain /
+/// Windows certificate store / Linux ca-certificates) and feeds it into the
+/// SSL_CTX so that peer verification actually works.
+struct COMMONSERVER_EXPORT TrustStoreHelper {
+        /// Load platform-native root CAs into the given SSL_CTX.
+        /// Returns true on success, false on error.
+        static bool loadSystemCAs(SSL_CTX *ctx);
+};
+
+} // namespace KDC

--- a/src/libcommonserver/utility/truststorehelper_linux.cpp
+++ b/src/libcommonserver/utility/truststorehelper_linux.cpp
@@ -1,0 +1,48 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "truststorehelper.h"
+
+#include "log/log.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include <openssl/ssl.h>
+
+namespace KDC {
+
+bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
+    if (!ctx) {
+        LOG_WARN(Log::instance()->getLogger(), "SSL_CTX is null");
+        return false;
+    }
+
+    // The Conan Center OpenSSL on Linux is compiled with OPENSSLDIR="/etc/ssl",
+    // so SSL_CTX_set_default_verify_paths() already knows where to find the system CA
+    // bundle (/etc/ssl/certs/ and /etc/ssl/cert.pem). This is equivalent to
+    // loadDefaultCAs=true in the Poco Context constructor.
+    if (SSL_CTX_set_default_verify_paths(ctx) != 1) {
+        LOG_WARN(Log::instance()->getLogger(), "Failed to load system default CA paths");
+        return false;
+    }
+
+    LOG_DEBUG(Log::instance()->getLogger(), "Loaded system CA certificates via OpenSSL default verify paths");
+    return true;
+}
+
+} // namespace KDC

--- a/src/libcommonserver/utility/truststorehelper_mac.mm
+++ b/src/libcommonserver/utility/truststorehelper_mac.mm
@@ -27,6 +27,8 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
+#include <cstdint>
+
 #include <Security/Security.h>
 #include <Security/SecCertificate.h>
 #include <Security/SecTrust.h>
@@ -87,7 +89,7 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
                                         "(OpenSSL default paths fallback is unreliable on this platform)");
         // This line is only useful so we have a default path for the context
         // We still return false because we failed to load any CA and verification would very likely fail
-        SSL_CTX_set_default_verify_paths(ctx);
+        (void) SSL_CTX_set_default_verify_paths(ctx);
         return false;
     }
 
@@ -101,8 +103,8 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
         SSL_CTX_set_cert_store(ctx, store);
     }
 
-    int addedCount = 0;
-    int failedCount = 0;
+    int32_t addedCount = 0;
+    int32_t failedCount = 0;
     for (const auto &der: derCerts) {
         const unsigned char *data = der.data();
         X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));

--- a/src/libcommonserver/utility/truststorehelper_mac.mm
+++ b/src/libcommonserver/utility/truststorehelper_mac.mm
@@ -20,6 +20,8 @@
 
 #include "log/log.h"
 
+#include "libcommon/log/sentry/handler.h"
+
 #include <log4cplus/loggingmacros.h>
 
 #include <openssl/x509.h>
@@ -50,7 +52,7 @@ std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
 
     CFIndex count = CFArrayGetCount(anchors);
     for (CFIndex i = 0; i < count; i++) {
-        SecCertificateRef certRef = (SecCertificateRef)CFArrayGetValueAtIndex(anchors, i);
+        SecCertificateRef certRef = (SecCertificateRef) CFArrayGetValueAtIndex(anchors, i);
         if (!certRef) continue;
 
         CFDataRef certData = SecCertificateCopyData(certRef);
@@ -80,7 +82,13 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
     if (derCerts.empty()) {
         LOG_WARN(Log::instance()->getLogger(),
                  "Failed to extract system root CAs from keychain, falling back to OpenSSL default paths");
-        return SSL_CTX_set_default_verify_paths(ctx) == 1;
+        sentry::Handler::captureMessage(sentry::Level::Error, "TrustStoreHelper::loadSystemCAs",
+                                        "Failed to extract root CAs from macOS keychain "
+                                        "(OpenSSL default paths fallback is unreliable on this platform)");
+        // This line is only useful so we have a default path for the context
+        // We still return false because we failed to load any CA and verification would very likely fail
+        SSL_CTX_set_default_verify_paths(ctx);
+        return false;
     }
 
     X509_STORE *store = SSL_CTX_get_cert_store(ctx);
@@ -93,18 +101,45 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
         SSL_CTX_set_cert_store(ctx, store);
     }
 
+    int addedCount = 0;
+    int failedCount = 0;
     for (const auto &der: derCerts) {
         const unsigned char *data = der.data();
         X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));
-        if (cert) {
-            if (X509_STORE_add_cert(store, cert) != 1) {
-                LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
-            }
-            X509_free(cert);
+        if (!cert) {
+            failedCount++;
+            continue;
         }
+        if (X509_STORE_add_cert(store, cert) != 1) {
+            failedCount++;
+            LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
+        } else {
+            addedCount++;
+        }
+        X509_free(cert);
     }
 
-    LOG_INFO(Log::instance()->getLogger(), "Loaded CA certificates from macOS keychain");
+    if (addedCount == 0) {
+        LOG_ERROR(Log::instance()->getLogger(), "Failed to add any CA certificate from macOS keychain ("
+                                                        << derCerts.size() << " extracted, " << failedCount << " failed)");
+        sentry::Handler::captureMessage(sentry::Level::Error, "TrustStoreHelper::loadSystemCAs",
+                                        "Failed to add any CA certificate from macOS keychain (" +
+                                                std::to_string(derCerts.size()) + " extracted, 0 added)");
+        return false;
+    }
+
+    if (failedCount > 0) {
+        LOG_WARN(Log::instance()->getLogger(), "Loaded CA certificates from macOS keychain with partial failures ("
+                                                       << addedCount << " added, " << failedCount << " failed of "
+                                                       << derCerts.size() << ")");
+        sentry::Handler::captureMessage(sentry::Level::Warning, "TrustStoreHelper::loadSystemCAs",
+                                        "Partial CA load from macOS keychain (" + std::to_string(addedCount) + " added, " +
+                                                std::to_string(failedCount) + " failed of " + std::to_string(derCerts.size()) +
+                                                ")");
+    } else {
+        LOG_INFO(Log::instance()->getLogger(), "Loaded " << addedCount << " CA certificates from macOS keychain");
+    }
+
     return true;
 }
 

--- a/src/libcommonserver/utility/truststorehelper_mac.mm
+++ b/src/libcommonserver/utility/truststorehelper_mac.mm
@@ -1,0 +1,111 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "truststorehelper.h"
+
+#include "log/log.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+
+#include <Security/Security.h>
+#include <Security/SecCertificate.h>
+#include <Security/SecTrust.h>
+#include <CoreFoundation/CoreFoundation.h>
+
+#include <vector>
+
+namespace KDC {
+
+namespace {
+
+// Extract DER-encoded certificates from the macOS system root trust store
+// using the public SecTrustCopyAnchorCertificates API.
+std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
+    std::vector<std::vector<unsigned char>> certs;
+
+    CFArrayRef anchors = nullptr;
+    OSStatus status = SecTrustCopyAnchorCertificates(&anchors);
+    if (status != errSecSuccess || !anchors) {
+        LOG_WARN(Log::instance()->getLogger(), "SecTrustCopyAnchorCertificates failed (OSStatus=" << status << ")");
+        return {};
+    }
+
+    CFIndex count = CFArrayGetCount(anchors);
+    for (CFIndex i = 0; i < count; i++) {
+        SecCertificateRef certRef = static_cast<SecCertificateRef>(CFArrayGetValueAtIndex(anchors, i));
+        if (!certRef) continue;
+
+        CFDataRef certData = SecCertificateCopyData(certRef);
+        if (!certData) continue;
+
+        const UInt8 *dataPtr = CFDataGetBytePtr(certData);
+        CFIndex dataLen = CFDataGetLength(certData);
+        if (dataPtr && dataLen > 0) {
+            certs.emplace_back(dataPtr, dataPtr + dataLen);
+        }
+        CFRelease(certData);
+    }
+
+    CFRelease(anchors);
+    return certs;
+}
+
+} // namespace
+
+bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
+    if (!ctx) {
+        LOG_WARN(Log::instance()->getLogger(), "SSL_CTX is null");
+        return false;
+    }
+
+    auto derCerts = extractSystemRootCAs();
+    if (derCerts.empty()) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "Failed to extract system root CAs from keychain, falling back to OpenSSL default paths");
+        return SSL_CTX_set_default_verify_paths(ctx) == 1;
+    }
+
+    X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+    if (!store) {
+        store = X509_STORE_new();
+        if (!store) {
+            LOG_WARN(Log::instance()->getLogger(), "Failed to create X509_STORE");
+            return false;
+        }
+        SSL_CTX_set_cert_store(ctx, store);
+    }
+
+    for (const auto &der: derCerts) {
+        const unsigned char *data = der.data();
+        X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));
+        if (cert) {
+            if (X509_STORE_add_cert(store, cert) != 1) {
+                LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
+            }
+            X509_free(cert);
+        }
+    }
+
+    LOG_INFO(Log::instance()->getLogger(), "Loaded CA certificates from macOS keychain");
+    return true;
+}
+
+} // namespace KDC

--- a/src/libcommonserver/utility/truststorehelper_mac.mm
+++ b/src/libcommonserver/utility/truststorehelper_mac.mm
@@ -50,7 +50,7 @@ std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
 
     CFIndex count = CFArrayGetCount(anchors);
     for (CFIndex i = 0; i < count; i++) {
-        SecCertificateRef certRef = static_cast<SecCertificateRef>(CFArrayGetValueAtIndex(anchors, i));
+        SecCertificateRef certRef = (SecCertificateRef)CFArrayGetValueAtIndex(anchors, i);
         if (!certRef) continue;
 
         CFDataRef certData = SecCertificateCopyData(certRef);

--- a/src/libcommonserver/utility/truststorehelper_win.cpp
+++ b/src/libcommonserver/utility/truststorehelper_win.cpp
@@ -1,0 +1,98 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "truststorehelper.h"
+
+#include "log/log.h"
+
+#include <log4cplus/loggingmacros.h>
+
+#include <openssl/x509.h>
+#include <openssl/pem.h>
+
+#include <windows.h>
+#include <wincrypt.h>
+
+#include <vector>
+
+namespace KDC {
+
+namespace {
+
+// Extract DER-encoded certificates from the Windows "ROOT" system certificate store.
+std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
+    std::vector<std::vector<unsigned char>> certs;
+
+    HCERTSTORE hStore = CertOpenSystemStore(nullptr, L"ROOT");
+    if (!hStore) {
+        LOG_WARN(Log::instance()->getLogger(), "CertOpenSystemStore(ROOT) failed (error=" << GetLastError() << ")");
+        return {};
+    }
+
+    PCCERT_CONTEXT pCertCtx = nullptr;
+    while ((pCertCtx = CertEnumCertificatesInStore(hStore, pCertCtx)) != nullptr) {
+        if (pCertCtx->pbCertEncoded && pCertCtx->cbCertEncoded > 0) {
+            certs.emplace_back(pCertCtx->pbCertEncoded, pCertCtx->pbCertEncoded + pCertCtx->cbCertEncoded);
+        }
+    }
+
+    CertCloseStore(hStore, 0);
+    return certs;
+}
+
+} // namespace
+
+bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
+    if (!ctx) {
+        LOG_WARN(Log::instance()->getLogger(), "SSL_CTX is null");
+        return false;
+    }
+
+    auto derCerts = extractSystemRootCAs();
+    if (derCerts.empty()) {
+        LOG_WARN(Log::instance()->getLogger(),
+                 "Failed to extract system root CAs from Windows certificate store, falling back to OpenSSL default paths");
+        return SSL_CTX_set_default_verify_paths(ctx) == 1;
+    }
+
+    X509_STORE *store = SSL_CTX_get_cert_store(ctx);
+    if (!store) {
+        store = X509_STORE_new();
+        if (!store) {
+            LOG_WARN(Log::instance()->getLogger(), "Failed to create X509_STORE");
+            return false;
+        }
+        SSL_CTX_set_cert_store(ctx, store);
+    }
+
+    for (const auto &der: derCerts) {
+        const unsigned char *data = der.data();
+        X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));
+        if (cert) {
+            if (X509_STORE_add_cert(store, cert) != 1) {
+                LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
+            }
+            X509_free(cert);
+        }
+    }
+
+    LOG_INFO(Log::instance()->getLogger(), "Loaded CA certificates from Windows certificate store");
+    return true;
+}
+
+} // namespace KDC

--- a/src/libcommonserver/utility/truststorehelper_win.cpp
+++ b/src/libcommonserver/utility/truststorehelper_win.cpp
@@ -27,6 +27,8 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
+#include <cstdint>
+
 #include <Windows.h>
 #include <wincrypt.h>
 
@@ -74,7 +76,7 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
                                         "(OpenSSL default paths fallback is unreliable on this platform)");
         // This line is only useful so we have a default path for the context
         // We still return false because we failed to load any CA and verification would very likely fail
-        SSL_CTX_set_default_verify_paths(ctx);
+        (void) SSL_CTX_set_default_verify_paths(ctx);
         return false;
     }
 
@@ -88,8 +90,8 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
         SSL_CTX_set_cert_store(ctx, store);
     }
 
-    int addedCount = 0;
-    int failedCount = 0;
+    int32_t addedCount = 0;
+    int32_t failedCount = 0;
     for (const auto &der: derCerts) {
         const unsigned char *data = der.data();
         X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));

--- a/src/libcommonserver/utility/truststorehelper_win.cpp
+++ b/src/libcommonserver/utility/truststorehelper_win.cpp
@@ -25,7 +25,7 @@
 #include <openssl/x509.h>
 #include <openssl/pem.h>
 
-#include <windows.h>
+#include <Windows.h>
 #include <wincrypt.h>
 
 #include <vector>
@@ -47,11 +47,11 @@ std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
     PCCERT_CONTEXT pCertCtx = nullptr;
     while ((pCertCtx = CertEnumCertificatesInStore(hStore, pCertCtx)) != nullptr) {
         if (pCertCtx->pbCertEncoded && pCertCtx->cbCertEncoded > 0) {
-            certs.emplace_back(pCertCtx->pbCertEncoded, pCertCtx->pbCertEncoded + pCertCtx->cbCertEncoded);
+            (void) certs.emplace_back(pCertCtx->pbCertEncoded, pCertCtx->pbCertEncoded + pCertCtx->cbCertEncoded);
         }
     }
 
-    CertCloseStore(hStore, 0);
+    (void) CertCloseStore(hStore, 0);
     return certs;
 }
 

--- a/src/libcommonserver/utility/truststorehelper_win.cpp
+++ b/src/libcommonserver/utility/truststorehelper_win.cpp
@@ -38,7 +38,7 @@ namespace {
 std::vector<std::vector<unsigned char>> extractSystemRootCAs() {
     std::vector<std::vector<unsigned char>> certs;
 
-    HCERTSTORE hStore = CertOpenSystemStore(nullptr, L"ROOT");
+    HCERTSTORE hStore = CertOpenSystemStore(0, L"ROOT");
     if (!hStore) {
         LOG_WARN(Log::instance()->getLogger(), "CertOpenSystemStore(ROOT) failed (error=" << GetLastError() << ")");
         return {};

--- a/src/libcommonserver/utility/truststorehelper_win.cpp
+++ b/src/libcommonserver/utility/truststorehelper_win.cpp
@@ -20,6 +20,8 @@
 
 #include "log/log.h"
 
+#include "libcommon/log/sentry/handler.h"
+
 #include <log4cplus/loggingmacros.h>
 
 #include <openssl/x509.h>
@@ -67,7 +69,13 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
     if (derCerts.empty()) {
         LOG_WARN(Log::instance()->getLogger(),
                  "Failed to extract system root CAs from Windows certificate store, falling back to OpenSSL default paths");
-        return SSL_CTX_set_default_verify_paths(ctx) == 1;
+        sentry::Handler::captureMessage(sentry::Level::Error, "TrustStoreHelper::loadSystemCAs",
+                                        "Failed to extract root CAs from Windows certificate store "
+                                        "(OpenSSL default paths fallback is unreliable on this platform)");
+        // This line is only useful so we have a default path for the context
+        // We still return false because we failed to load any CA and verification would very likely fail
+        SSL_CTX_set_default_verify_paths(ctx);
+        return false;
     }
 
     X509_STORE *store = SSL_CTX_get_cert_store(ctx);
@@ -80,18 +88,45 @@ bool TrustStoreHelper::loadSystemCAs(SSL_CTX *ctx) {
         SSL_CTX_set_cert_store(ctx, store);
     }
 
+    int addedCount = 0;
+    int failedCount = 0;
     for (const auto &der: derCerts) {
         const unsigned char *data = der.data();
         X509 *cert = d2i_X509(nullptr, &data, static_cast<long>(der.size()));
-        if (cert) {
-            if (X509_STORE_add_cert(store, cert) != 1) {
-                LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
-            }
-            X509_free(cert);
+        if (!cert) {
+            failedCount++;
+            continue;
         }
+        if (X509_STORE_add_cert(store, cert) != 1) {
+            failedCount++;
+            LOG_DEBUG(Log::instance()->getLogger(), "Skipped a certificate that X509_STORE_add_cert rejected");
+        } else {
+            addedCount++;
+        }
+        X509_free(cert);
     }
 
-    LOG_INFO(Log::instance()->getLogger(), "Loaded CA certificates from Windows certificate store");
+    if (addedCount == 0) {
+        LOG_ERROR(Log::instance()->getLogger(), "Failed to add any CA certificate from Windows certificate store ("
+                                                        << derCerts.size() << " extracted, " << failedCount << " failed)");
+        sentry::Handler::captureMessage(sentry::Level::Error, "TrustStoreHelper::loadSystemCAs",
+                                        "Failed to add any CA certificate from Windows certificate store (" +
+                                                std::to_string(derCerts.size()) + " extracted, 0 added)");
+        return false;
+    }
+
+    if (failedCount > 0) {
+        LOG_WARN(Log::instance()->getLogger(), "Loaded CA certificates from Windows certificate store with partial failures ("
+                                                       << addedCount << " added, " << failedCount << " failed of "
+                                                       << derCerts.size() << ")");
+        sentry::Handler::captureMessage(sentry::Level::Warning, "TrustStoreHelper::loadSystemCAs",
+                                        "Partial CA load from Windows certificate store (" + std::to_string(addedCount) +
+                                                " added, " + std::to_string(failedCount) + " failed of " +
+                                                std::to_string(derCerts.size()) + ")");
+    } else {
+        LOG_INFO(Log::instance()->getLogger(), "Loaded " << addedCount << " CA certificates from Windows certificate store");
+    }
+
     return true;
 }
 

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -24,6 +24,7 @@
 #include "libcommon/utility/utility.h"
 #include "libcommonserver/utility/utility.h"
 #include "libcommonserver/utility/jsonparserutility.h"
+#include "libcommonserver/utility/truststorehelper.h"
 #include "utility/timerutility.h"
 
 #include <log4cplus/loggingmacros.h>
@@ -33,10 +34,8 @@
 #include <Poco/DOM/DOMParser.h>
 #include <Poco/DOM/AutoPtr.h>
 #include <Poco/SharedPtr.h>
-#include <Poco/InflatingStream.h>
 #include <Poco/Error.h>
 
-#include <iostream> // std::ios, std::istream, std::cout, std::cerr
 #include <atomic>
 #include <functional>
 #include <thread>
@@ -64,9 +63,18 @@ AbstractNetworkJob::AbstractNetworkJob() :
     if (!_context) {
         for (int trials = 1; trials <= std::min(_trials, MAX_TRIALS); trials++) {
             try {
+                // VERIFY_STRICT enables peer certificate verification.
+                // loadDefaultCAs is false because the bundled OpenSSL build does not ship a CA
+                // bundle; instead we load the platform-native trust store below.
                 _context = new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "", "", "",
-                                                  Poco::Net::Context::VERIFY_STRICT, 9, true);
+                                                  Poco::Net::Context::VERIFY_STRICT, 9, false);
                 _context->requireMinimumProtocol(Poco::Net::Context::PROTO_TLSV1_2);
+
+                // Load the platform-native trust store (macOS keychain / Windows cert store /
+                // Linux ca-certificates) into the underlying OpenSSL SSL_CTX.
+                if (!TrustStoreHelper::loadSystemCAs(_context->sslContext())) {
+                    LOG_WARN(_logger, "Failed to load system CAs — peer verification may fail");
+                }
             } catch (Poco::Exception const &e) {
                 if (trials < _trials) {
                     LOG_INFO(_logger, "Error in Poco::Net::Context constructor: " << errorText(e) << ", retrying...");

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -72,9 +72,10 @@ AbstractNetworkJob::AbstractNetworkJob() :
 
                 // Load the platform-native trust store (macOS keychain / Windows cert store /
                 // Linux ca-certificates) into the underlying OpenSSL SSL_CTX.
-                if (!TrustStoreHelper::loadSystemCAs(_context->sslContext())) {
-                    LOG_WARN(_logger, "Failed to load system CAs — peer verification may fail");
+                if (TrustStoreHelper::loadSystemCAs(_context->sslContext())) {
+                    break;
                 }
+                LOG_ERROR(_logger, "Failed to load system CAs, peer verification may fail");
             } catch (Poco::Exception const &e) {
                 if (trials < _trials) {
                     LOG_INFO(_logger, "Error in Poco::Net::Context constructor: " << errorText(e) << ", retrying...");

--- a/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
+++ b/src/libsyncengine/jobs/network/abstractnetworkjob.cpp
@@ -64,8 +64,8 @@ AbstractNetworkJob::AbstractNetworkJob() :
     if (!_context) {
         for (int trials = 1; trials <= std::min(_trials, MAX_TRIALS); trials++) {
             try {
-                _context =
-                        new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE);
+                _context = new Poco::Net::Context(Poco::Net::Context::TLS_CLIENT_USE, "", "", "",
+                                                  Poco::Net::Context::VERIFY_STRICT, 9, true);
                 _context->requireMinimumProtocol(Poco::Net::Context::PROTO_TLSV1_2);
             } catch (Poco::Exception const &e) {
                 if (trials < _trials) {


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR active la vérification stricte des certificats TLS pour toutes les connexions réseau et introduit un `TrustStoreHelper` multiplateforme qui charge le magasin de certificats racine natif du système (trousseau macOS, magasin de certificats Windows, ca-certificates Linux) dans le contexte OpenSSL sous-jacent.

## Changements
- Ajout de `TrustStoreHelper` dans `src/libcommonserver/utility/` avec des implémentations spécifiques à chaque plateforme (`truststorehelper_mac.mm`, `truststorehelper_win.cpp`, `truststorehelper_linux.cpp`)
- Modification du contexte Poco dans `AbstractNetworkJob` pour passer de `VERIFY_NONE` à `VERIFY_STRICT` avec `loadDefaultCAs=false`, et chargement des autorités de certification système via `TrustStoreHelper::loadSystemCAs`
- Sur macOS, extraction des certificats racines depuis le trousseau via `SecTrustCopyAnchorCertificates` et ajout au `X509_STORE` d'OpenSSL
- Sur Windows, énumération du magasin de certificats « ROOT » via `CertOpenSystemStore` / `CertEnumCertificatesInStore`
- Sur Linux, utilisation de `SSL_CTX_set_default_verify_paths` car le paquet OpenSSL de Conan Center est compilé avec `OPENSSLDIR=/etc/ssl`
- Mise à jour de `CMakeLists.txt` pour inclure les nouveaux fichiers sources et lier le framework `Security` sur macOS
- Suppression des inclusions inutilisées `Poco/InflatingStream.h` et `<iostream>` dans `abstractnetworkjob.cpp`

## Détails techniques
Le build OpenSSL fourni par Conan sur macOS et Windows n'embarque pas de bundle de certificats. L'option `loadDefaultCAs=true` de Poco ne vérifie que les chemins compilés dans le binaire OpenSSL (par exemple `/usr/local/ssl/cert.pem` sur macOS), qui n'existent pas sur les machines des utilisateurs finaux. En conséquence, la vérification des certificats pairs ne fonctionnait pas réellement. Cette PR charge explicitement le magasin de confiance natif de chaque plateforme dans le `SSL_CTX` afin que la vérification stricte puisse aboutir.

</details>

---

## Summary
This PR enables strict TLS certificate verification for all network connections and introduces a cross-platform `TrustStoreHelper` that loads the platform-native root certificate store (macOS keychain, Windows certificate store, Linux ca-certificates) into the underlying OpenSSL context.

## Changes
- Added `TrustStoreHelper` in `src/libcommonserver/utility/` with platform-specific implementations (`truststorehelper_mac.mm`, `truststorehelper_win.cpp`, `truststorehelper_linux.cpp`)
- Changed the Poco context in `AbstractNetworkJob` from `VERIFY_NONE` to `VERIFY_STRICT` with `loadDefaultCAs=false`, and loads system CAs via `TrustStoreHelper::loadSystemCAs`
- On macOS, extracts root certificates from the keychain via `SecTrustCopyAnchorCertificates` and adds them to the OpenSSL `X509_STORE`
- On Windows, enumerates the "ROOT" certificate store via `CertOpenSystemStore` / `CertEnumCertificatesInStore`
- On Linux, uses `SSL_CTX_set_default_verify_paths` since the Conan Center OpenSSL is compiled with `OPENSSLDIR=/etc/ssl`
- Updated `CMakeLists.txt` to include the new source files and link the `Security` framework on macOS
- Removed unused `Poco/InflatingStream.h` and `<iostream>` includes from `abstractnetworkjob.cpp`

## Technical Details
The Conan-provided OpenSSL build on macOS and Windows does not ship a CA bundle. Poco's `loadDefaultCAs=true` only checks paths compiled into the OpenSSL binary (e.g. `/usr/local/ssl/cert.pem` on macOS), which do not exist on end-user machines. As a result, peer certificate verification was not actually working. This PR explicitly loads each platform's native trust store into the `SSL_CTX` so that strict verification can succeed.
