### PR TITLE
fix(app-server): Avoid a scenario of massive file deletion on Windows

### DIFF
--- a/src/libcommon/data/sync.cpp
+++ b/src/libcommon/data/sync.cpp
@@ -87,7 +87,7 @@ Sync::Sync(SyncDbId dbId, DriveDbId driveDbId, const std::filesystem::path &loca
            const std::filesystem::path &targetPath, const NodeId &targetNodeId, bool paused, bool supportVfs,
            VirtualFileMode virtualFileMode, bool notificationsDisabled, const std::filesystem::path &dbPath,
            bool hasFullyCompleted, const std::string &navigationPaneClsid, const std::string &listingCursor,
-           int64_t listingCursorTimestamp) :
+           int64_t listingCursorTimestamp, bool toDelete) :
     BaseSync(dbId, driveDbId, localPath, targetPath, targetNodeId, supportVfs, virtualFileMode, navigationPaneClsid),
     _localNodeId(localNodeId),
     _paused(paused),
@@ -95,6 +95,7 @@ Sync::Sync(SyncDbId dbId, DriveDbId driveDbId, const std::filesystem::path &loca
     _dbPath(dbPath),
     _hasFullyCompleted(hasFullyCompleted),
     _listingCursor(listingCursor),
-    _listingCursorTimestamp(listingCursorTimestamp) {}
+    _listingCursorTimestamp(listingCursorTimestamp),
+    _toDelete(toDelete) {}
 
 } // namespace KDC

--- a/src/libcommon/data/sync.h
+++ b/src/libcommon/data/sync.h
@@ -131,7 +131,7 @@ class Sync : public BaseSync {
              bool supportVfs = false, VirtualFileMode virtualFileMode = VirtualFileMode::Off, bool notificationsDisabled = false,
              const std::filesystem::path &dbPath = std::filesystem::path(), bool hasFullyCompleted = false,
              const std::string &navigationPaneClsid = std::string(), const std::string &listingCursor = std::string(),
-             int64_t listingCursorTimestamp = 0);
+             int64_t listingCursorTimestamp = 0, bool toDelete = false);
 
         [[nodiscard]] const NodeId &localNodeId() const { return _localNodeId; }
         void setLocalNodeId(const NodeId &localNodeId) { _localNodeId = localNodeId; }
@@ -155,6 +155,8 @@ class Sync : public BaseSync {
             listingCursor = _listingCursor;
             timestamp = _listingCursorTimestamp;
         }
+        [[nodiscard]] bool toDelete() const { return _toDelete; }
+        void setToDelete(const bool toDelete) { _toDelete = toDelete; }
 
     private:
         NodeId _localNodeId;
@@ -164,6 +166,7 @@ class Sync : public BaseSync {
         bool _hasFullyCompleted{false};
         std::string _listingCursor;
         int64_t _listingCursorTimestamp{0};
+        bool _toDelete{false};
 };
 
 } // namespace KDC

--- a/src/libcommon/utility/cstypes.h
+++ b/src/libcommon/utility/cstypes.h
@@ -167,6 +167,7 @@ enum class ExitCause {
     MissingReplyData,
     BlackListPropagationError,
     FileSystemNotSupported,
+    SyncDeletionFailed,
     EnumEnd
 };
 

--- a/src/libcommon/utility/types.cpp
+++ b/src/libcommon/utility/types.cpp
@@ -243,6 +243,8 @@ std::string toString(const ExitCause e) {
             return "BlackListPropagationError";
         case ExitCause::FileSystemNotSupported:
             return "FileSystemNotSupported";
+        case ExitCause::SyncDeletionFailed:
+            return "SyncDeletionFailed";
         default:
             return noConversionStr;
     }

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -2474,7 +2474,7 @@ void ParmsDb::fillSyncWithQueryResult(Sync &sync, const char *requestId) {
     LOG_IF_FAIL(queryInt64Value(requestId, 14, int64Result));
     sync.setListingCursor(strResult, int64Result);
 
-    int toDeleteResult{0};
+    int32_t toDeleteResult{0};
     LOG_IF_FAIL(queryIntValue(requestId, 15, toDeleteResult));
     sync.setToDelete(static_cast<bool>(toDeleteResult));
 }
@@ -2628,7 +2628,7 @@ bool ParmsDb::selectAllSyncs(const DriveDbId driveDbId, std::vector<Sync> &syncL
         LOG_IF_FAIL(queryStringValue(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 12, listingCursor));
         int64_t listingCursorTimestamp;
         LOG_IF_FAIL(queryInt64Value(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 13, listingCursorTimestamp));
-        int toDelete = 0;
+        int32_t toDelete = 0;
         LOG_IF_FAIL(queryIntValue(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 14, toDelete));
 
         syncList.push_back(Sync(id, driveDbId, SyncPath(localPath), localNodeId, SyncPath(targetPath), targetNodeId,

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -303,6 +303,11 @@
     "UPDATE sync SET hasFullyCompleted=?1 "   \
     "WHERE dbId=?2;"
 
+#define UPDATE_SYNC_TODELETE_REQUEST_ID "update_sync_todelete"
+#define UPDATE_SYNC_TODELETE_REQUEST \
+    "UPDATE sync SET toDelete=?1 "   \
+    "WHERE dbId=?2;"
+
 #define DELETE_SYNC_REQUEST_ID "delete_sync"
 #define DELETE_SYNC_REQUEST \
     "DELETE FROM sync "     \
@@ -1053,6 +1058,7 @@ bool ParmsDb::prepare() {
     if (!createAndPrepareRequest(UPDATE_SYNC_REQUEST_ID, UPDATE_SYNC_REQUEST)) return false;
     if (!createAndPrepareRequest(UPDATE_SYNC_PAUSED_REQUEST_ID, UPDATE_SYNC_PAUSED_REQUEST)) return false;
     if (!createAndPrepareRequest(UPDATE_SYNC_HASFULLYCOMPLETED_REQUEST_ID, UPDATE_SYNC_HASFULLYCOMPLETED_REQUEST)) return false;
+    if (!createAndPrepareRequest(UPDATE_SYNC_TODELETE_REQUEST_ID, UPDATE_SYNC_TODELETE_REQUEST)) return false;
     if (!createAndPrepareRequest(DELETE_SYNC_REQUEST_ID, DELETE_SYNC_REQUEST)) return false;
     if (!createAndPrepareRequest(SELECT_SYNC_REQUEST_ID, SELECT_SYNC_REQUEST)) return false;
     if (!createAndPrepareRequest(SELECT_SYNC_BY_PATH_REQUEST_ID, SELECT_SYNC_BY_PATH_REQUEST)) return false;
@@ -2361,6 +2367,29 @@ bool ParmsDb::setSyncHasFullyCompleted(const SyncDbId dbId, bool value, bool &fo
         found = true;
     } else {
         LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_HASFULLYCOMPLETED_REQUEST_ID << " - num rows affected != 1");
+        found = false;
+    }
+
+    return true;
+}
+
+bool ParmsDb::setSyncToDelete(const SyncDbId dbId, bool value, bool &found) {
+    const std::scoped_lock lock(_mutex);
+
+    int errId;
+    std::string error;
+
+    LOG_IF_FAIL(queryResetAndClearBindings(UPDATE_SYNC_TODELETE_REQUEST_ID));
+    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_TODELETE_REQUEST_ID, 1, value));
+    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_TODELETE_REQUEST_ID, 2, dbId));
+    if (!queryExec(UPDATE_SYNC_TODELETE_REQUEST_ID, errId, error)) {
+        LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_TODELETE_REQUEST_ID);
+        return false;
+    }
+    if (numRowsAffected() == 1) {
+        found = true;
+    } else {
+        LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_TODELETE_REQUEST_ID << " - num rows affected != 1");
         found = false;
     }
 

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -274,6 +274,7 @@
     "navigationPaneClsid TEXT,"                                                              \
     "listingCursor TEXT,"                                                                    \
     "listingCursorTimestamp INTEGER,"                                                        \
+    "toDelete INTEGER,"                                                                      \
     "FOREIGN KEY (driveDbId) REFERENCES drive(dbId) ON DELETE CASCADE ON UPDATE NO ACTION) " \
     "WITHOUT ROWID;"
 
@@ -281,16 +282,16 @@
 #define INSERT_SYNC_REQUEST                                                                                             \
     "INSERT INTO sync (dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, " \
     "virtualFileMode, "                                                                                                 \
-    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp) "            \
-    "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15);"
+    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp, toDelete) "  \
+    "VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16);"
 
 #define UPDATE_SYNC_REQUEST_ID "update_sync"
 #define UPDATE_SYNC_REQUEST                                                                                                \
     "UPDATE sync SET driveDbId=?1, localPath=?2, localNodeId = ?3, targetPath=?4, targetNodeId=?5, dbPath=?6, paused=?7, " \
     "supportVfs=?8, "                                                                                                      \
     "virtualFileMode=?9, notificationsDisabled=?10, hasFullyCompleted=?11, navigationPaneClsid=?12, listingCursor=?13, "   \
-    "listingCursorTimestamp=?14 "                                                                                          \
-    "WHERE dbId=?15;"
+    "listingCursorTimestamp=?14, toDelete=?15 "                                                                            \
+    "WHERE dbId=?16;"
 
 #define UPDATE_SYNC_PAUSED_REQUEST_ID "update_sync_paused"
 #define UPDATE_SYNC_PAUSED_REQUEST \
@@ -308,29 +309,29 @@
     "WHERE dbId=?1;"
 
 #define SELECT_SYNC_REQUEST_ID "select_sync"
-#define SELECT_SYNC_REQUEST                                                                                                   \
-    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, " \
-    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp FROM sync "         \
+#define SELECT_SYNC_REQUEST                                                                                                     \
+    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, "   \
+    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp, toDelete FROM sync " \
     "WHERE dbId=?1;"
 
 #define SELECT_SYNC_BY_PATH_REQUEST_ID "select_sync_by_path"
-#define SELECT_SYNC_BY_PATH_REQUEST                                                                                           \
-    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, " \
-    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp FROM sync "         \
+#define SELECT_SYNC_BY_PATH_REQUEST                                                                                             \
+    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, "   \
+    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp, toDelete FROM sync " \
     "WHERE dbPath=?1;"
 
 
 #define SELECT_ALL_SYNCS_REQUEST_ID "select_syncs"
-#define SELECT_ALL_SYNCS_REQUEST                                                                                              \
-    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, " \
-    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp FROM sync "         \
+#define SELECT_ALL_SYNCS_REQUEST                                                                                                \
+    "SELECT dbId, driveDbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, "   \
+    "notificationsDisabled, hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp, toDelete FROM sync " \
     "ORDER BY dbId;"
 
 #define SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID "select_syncs_by_drive"
 #define SELECT_ALL_SYNCS_BY_DRIVE_REQUEST                                                                          \
     "SELECT dbId, localPath, localNodeId, targetPath, targetNodeId, dbPath, paused, supportVfs, virtualFileMode, " \
     "notificationsDisabled, "                                                                                      \
-    "hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp FROM sync "                     \
+    "hasFullyCompleted, navigationPaneClsid, listingCursor, listingCursorTimestamp, toDelete FROM sync "           \
     "WHERE driveDbId=?1 "                                                                                          \
     "ORDER BY dbId;"
 
@@ -1171,6 +1172,9 @@ bool ParmsDb::upgradeTables() {
     // Sync table
     tableName = "sync";
     if (!addTextColumnIfMissing(tableName, "localNodeId")) {
+        return false;
+    }
+    if (!addIntegerColumnIfMissing(tableName, "toDelete")) {
         return false;
     }
 
@@ -2264,6 +2268,7 @@ bool ParmsDb::insertSync(const Sync &sync) {
     LOG_IF_FAIL(queryBindValue(requestId, 13, sync.navigationPaneClsid()));
     LOG_IF_FAIL(queryBindValue(requestId, 14, listingCursor));
     LOG_IF_FAIL(queryBindValue(requestId, 15, listingCursorTimestamp));
+    LOG_IF_FAIL(queryBindValue(requestId, 16, static_cast<int>(sync.toDelete())));
 
     int errId = -1;
     std::string error;
@@ -2300,7 +2305,8 @@ bool ParmsDb::updateSync(const Sync &sync, bool &found) {
     LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 12, sync.navigationPaneClsid()));
     LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 13, listingCursor));
     LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 14, listingCursorTimestamp));
-    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 15, sync.dbId()));
+    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 15, static_cast<int>(sync.toDelete())));
+    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_REQUEST_ID, 16, sync.dbId()));
     if (!queryExec(UPDATE_SYNC_REQUEST_ID, errId, error)) {
         LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_REQUEST_ID);
         return false;
@@ -2436,6 +2442,10 @@ void ParmsDb::fillSyncWithQueryResult(Sync &sync, const char *requestId) {
     int64_t int64Result{0};
     LOG_IF_FAIL(queryInt64Value(requestId, 14, int64Result));
     sync.setListingCursor(strResult, int64Result);
+
+    int toDeleteResult{0};
+    LOG_IF_FAIL(queryIntValue(requestId, 15, toDeleteResult));
+    sync.setToDelete(static_cast<bool>(toDeleteResult));
 }
 
 bool ParmsDb::selectSync(const SyncPath &syncDbPath, Sync &sync, bool &found) {
@@ -2528,12 +2538,14 @@ bool ParmsDb::selectAllSyncs(std::vector<Sync> &syncList) {
         LOG_IF_FAIL(queryStringValue(SELECT_ALL_SYNCS_REQUEST_ID, 13, listingCursor));
         int64_t listingCursorTimestamp;
         LOG_IF_FAIL(queryInt64Value(SELECT_ALL_SYNCS_REQUEST_ID, 14, listingCursorTimestamp));
+        int32_t toDelete = 0;
+        LOG_IF_FAIL(queryIntValue(SELECT_ALL_SYNCS_REQUEST_ID, 15, toDelete));
 
         syncList.push_back(Sync(id, driveDbId, SyncPath(localPath), localNodeId, SyncPath(targetPath), targetNodeId,
                                 static_cast<bool>(paused), static_cast<bool>(supportVfs),
                                 static_cast<VirtualFileMode>(virtualFileMode), static_cast<bool>(notificationsDisabled),
                                 SyncPath(dbPath), static_cast<bool>(hasFullyCompleted), navigationPaneClsid, listingCursor,
-                                listingCursorTimestamp));
+                                listingCursorTimestamp, static_cast<bool>(toDelete)));
     }
     LOG_IF_FAIL(queryResetAndClearBindings(SELECT_ALL_SYNCS_REQUEST_ID));
 
@@ -2585,12 +2597,14 @@ bool ParmsDb::selectAllSyncs(const DriveDbId driveDbId, std::vector<Sync> &syncL
         LOG_IF_FAIL(queryStringValue(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 12, listingCursor));
         int64_t listingCursorTimestamp;
         LOG_IF_FAIL(queryInt64Value(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 13, listingCursorTimestamp));
+        int toDelete = 0;
+        LOG_IF_FAIL(queryIntValue(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID, 14, toDelete));
 
         syncList.push_back(Sync(id, driveDbId, SyncPath(localPath), localNodeId, SyncPath(targetPath), targetNodeId,
                                 static_cast<bool>(paused), static_cast<bool>(supportVfs),
                                 static_cast<VirtualFileMode>(virtualFileMode), static_cast<bool>(notificationsDisabled),
                                 SyncPath(dbPath), static_cast<bool>(hasFullyCompleted), navigationPaneClsid, listingCursor,
-                                listingCursorTimestamp));
+                                listingCursorTimestamp, static_cast<bool>(toDelete)));
     }
     LOG_IF_FAIL(queryResetAndClearBindings(SELECT_ALL_SYNCS_BY_DRIVE_REQUEST_ID));
 

--- a/src/libparms/db/parmsdb.cpp
+++ b/src/libparms/db/parmsdb.cpp
@@ -2376,20 +2376,22 @@ bool ParmsDb::setSyncHasFullyCompleted(const SyncDbId dbId, bool value, bool &fo
 bool ParmsDb::setSyncToDelete(const SyncDbId dbId, bool value, bool &found) {
     const std::scoped_lock lock(_mutex);
 
-    int errId;
+    int errId = -1;
     std::string error;
 
-    LOG_IF_FAIL(queryResetAndClearBindings(UPDATE_SYNC_TODELETE_REQUEST_ID));
-    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_TODELETE_REQUEST_ID, 1, value));
-    LOG_IF_FAIL(queryBindValue(UPDATE_SYNC_TODELETE_REQUEST_ID, 2, dbId));
-    if (!queryExec(UPDATE_SYNC_TODELETE_REQUEST_ID, errId, error)) {
-        LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_TODELETE_REQUEST_ID);
+    const auto requestId = UPDATE_SYNC_TODELETE_REQUEST_ID;
+
+    LOG_IF_FAIL(queryResetAndClearBindings(requestId));
+    LOG_IF_FAIL(queryBindValue(requestId, 1, value));
+    LOG_IF_FAIL(queryBindValue(requestId, 2, dbId));
+    if (!queryExec(requestId, errId, error)) {
+        LOG_WARN(_logger, "Error running query: " << requestId);
         return false;
     }
     if (numRowsAffected() == 1) {
         found = true;
     } else {
-        LOG_WARN(_logger, "Error running query: " << UPDATE_SYNC_TODELETE_REQUEST_ID << " - num rows affected != 1");
+        LOG_WARN(_logger, "Error running query: " << requestId << " - num rows affected != 1");
         found = false;
     }
 

--- a/src/libparms/db/parmsdb.h
+++ b/src/libparms/db/parmsdb.h
@@ -92,6 +92,7 @@ class PARMS_EXPORT ParmsDb : public Db {
         bool updateSync(const Sync &sync, bool &found);
         bool setSyncPaused(SyncDbId dbId, bool value, bool &found);
         bool setSyncHasFullyCompleted(SyncDbId dbId, bool value, bool &found);
+        bool setSyncToDelete(SyncDbId dbId, bool value, bool &found);
         bool deleteSync(SyncDbId dbId, bool &found);
         bool selectSync(SyncDbId dbId, Sync &sync, bool &found);
         bool selectSync(const SyncPath &syncDbPath, Sync &sync, bool &found);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -3373,7 +3373,7 @@ ExitInfo AppServer::startSyncs(User &user, const std::unordered_set<SyncDbId> to
                     LOG_WARN(_logger, "Error in checkIfSyncIsValid for syncDbId=" << sync.dbId() << " : " << exitInfo);
                     addError(Error(sync.dbId(), ERR_ID, exitInfo));
 
-                    if (exitInfo.cause() == ExitCause::SyncDeletionFailed) deleteSync(sync.dbId());
+                    if (exitInfo.cause() == ExitCause::SyncDeletionFailed) deleteSyncAsBackgroundTask(sync.dbId());
 
                     continue;
                 }

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2935,11 +2935,11 @@ ExitCode AppServer::migrateConfiguration(bool &proxyNotSupported) {
 
     MigrationParams mp = MigrationParams();
     std::vector<std::pair<migrateptr, std::string>> migrateArr = {
-            {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
-            {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
-            {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
+        {&MigrationParams::migrateGeneralParams, "migrateGeneralParams"},
+        {&MigrationParams::migrateAccountsParams, "migrateAccountsParams"},
+        {&MigrationParams::migrateTemplateExclusion, "migrateFileExclusion"},
 #if defined(KD_MACOS)
-            {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
+        {&MigrationParams::migrateAppExclusion, "migrateAppExclusion"},
 #endif
     };
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -653,6 +653,15 @@ void AppServer::quitLater(const int32_t delayMs) {
 // This task can be long and block the GUI
 void AppServer::stopSyncTask(const SyncDbId syncDbId,
                              const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
+    if (behavior == SyncPal::DbBehaviorAfterStop::Remove) {
+        // Mark the sync for deletion in the parameters DB.
+        if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
+            LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
+        } else if (!found) {
+            LOG_WARN(_logger, "Sync not found in DB for syncDbId=" << syncDbId);
+        }
+    }
+
     // Stop sync and remove it from syncPalMap
     if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);
@@ -4073,6 +4082,13 @@ ExitInfo AppServer::updateAllUsersInfo(const UpdateFollowUpAction action) {
 
 ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool start, const std::chrono::seconds &startDelay,
                                 bool resumedByUser, bool firstInit) {
+    if (sync.toDelete()) {
+        LOG_WARN(_logger, "Synchronization with syncDbId="
+                                  << sync.dbId()
+                                  << " should have been deleted, but is still present in the database. It will be ignored.");
+        return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
+    }
+
     const std::scoped_lock lock(syncPalMapMutex);
     auto syncPalMapIt = syncPalMap.find(sync.dbId());
     if (syncPalMapIt == syncPalMap.end()) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -653,15 +653,6 @@ void AppServer::quitLater(const int32_t delayMs) {
 // This task can be long and block the GUI
 void AppServer::stopSyncTask(const SyncDbId syncDbId,
                              const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
-    if (behavior == SyncPal::DbBehaviorAfterStop::Remove) {
-        // Mark the sync for deletion in the parameters DB.
-        if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
-            LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
-        } else if (!found) {
-            LOG_WARN(_logger, "Sync not found in DB for syncDbId=" << syncDbId);
-        }
-    }
-
     // Stop sync and remove it from syncPalMap
     if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);
@@ -4082,13 +4073,6 @@ ExitInfo AppServer::updateAllUsersInfo(const UpdateFollowUpAction action) {
 
 ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool start, const std::chrono::seconds &startDelay,
                                 bool resumedByUser, bool firstInit) {
-    if (sync.toDelete()) {
-        LOG_WARN(_logger, "Synchronization with syncDbId="
-                                  << sync.dbId()
-                                  << " should have been deleted, but is still present in the database. It will be ignored.");
-        return ExitCode::SystemError;
-    }
-
     const std::scoped_lock lock(syncPalMapMutex);
     auto syncPalMapIt = syncPalMap.find(sync.dbId());
     if (syncPalMapIt == syncPalMap.end()) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -2653,6 +2653,7 @@ ExitInfo AppServer::checkIfSyncIsValid(const BaseSync &sync) {
     // Check for nested syncs
     for (const auto &sync_: syncList) {
         if (sync_.dbId() == sync.dbId()) {
+            if (sync_.toDelete()) return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
             continue;
         }
         if (CommonUtility::isSubDir(sync.localPath(), sync_.localPath()) ||
@@ -2661,10 +2662,6 @@ ExitInfo AppServer::checkIfSyncIsValid(const BaseSync &sync) {
                                                            << L"; (2) dbId=" << sync_.dbId() << L", "
                                                            << Utility::formatSyncPath(sync_.localPath()));
             return {ExitCode::InvalidSync, ExitCause::SyncDirNestingError};
-        }
-
-        if (sync_.toDelete()) {
-            return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
         }
     }
 
@@ -3268,12 +3265,6 @@ std::string liteSyncActivationLogMessage(const bool enabled, const SyncDbId sync
 
 // This function will pause the synchronization in case of errors.
 ExitInfo AppServer::tryCreateAndStartVfs(const Sync &sync, bool &startPostponed) noexcept {
-    if (sync.toDelete()) {
-        LOG_INFO(_logger,
-                 "Sync with dbId=" << sync.dbId() << " is marked for deletion, skipping VFS creation. The sync will be ignored.");
-        return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
-    }
-
     startPostponed = false;
     const std::string liteSyncMsg = liteSyncActivationLogMessage(sync.virtualFileMode() != VirtualFileMode::Off, sync.dbId());
     LOG_INFO(_logger, liteSyncMsg);
@@ -4097,13 +4088,6 @@ ExitInfo AppServer::updateAllUsersInfo(const UpdateFollowUpAction action) {
 
 ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool start, const std::chrono::seconds &startDelay,
                                 bool resumedByUser, bool firstInit) {
-    if (sync.toDelete()) {
-        LOG_WARN(_logger, "Synchronization with syncDbId="
-                                  << sync.dbId()
-                                  << " should have been deleted, but is still present in the database. It will be ignored.");
-        return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
-    }
-
     const std::scoped_lock lock(syncPalMapMutex);
     auto syncPalMapIt = syncPalMap.find(sync.dbId());
     if (syncPalMapIt == syncPalMap.end()) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -653,6 +653,11 @@ void AppServer::quitLater(const int32_t delayMs) {
 // This task can be long and block the GUI
 void AppServer::stopSyncTask(const SyncDbId syncDbId,
                              const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
+    // Mark the sync for deletion in the parameters DB
+    if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found) || !found) {
+        LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
+    }
+
     // Stop sync and remove it from syncPalMap
     if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -657,19 +657,20 @@ void AppServer::stopSyncTask(const SyncDbId syncDbId,
         // Mark the sync for deletion in the parameters DB.
         if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
             LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
-#if defined(KD_WINDOWS)
-            LOG_FATAL(_logger, "Quitting to avoid risks of unwanted deletion.");
-            AppServer::quit();
-#endif
+            addError(Error(syncDbId, ERR_ID, ExitCode::DbError, ExitCause::Unknown));
+
+            return; // We cannot continue if we cannot mark the sync for deletion in the DB as stopVfs (on Windows only) could
+                    // delete dehydrated placeholders whereas the sync is still in the DB.
         } else if (!found) {
             LOG_WARN(_logger, "Sync not found in DB for syncDbId=" << syncDbId);
         }
     }
 
-
     // Stop sync and remove it from syncPalMap
     if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
         LOG_WARN(_logger, "Error in stopSyncPal for syncDbId=" << syncDbId << " : " << exitInfo);
+
+        return;
     }
 
     // Stop Vfs
@@ -808,6 +809,19 @@ void AppServer::deleteSync(const SyncDbId syncDbId) {
                                    // May even cause a crash if both sendDriveRemoved and sendSyncRemoved are processed
                                    // concurrently on the GUI side.
     }
+}
+
+void AppServer::deleteSyncAsBackgroundTask(const SyncDbId syncDbId) {
+    QTimer::singleShot(100, [this, syncDbId]() {
+        AppServer::stopSyncTask(syncDbId,
+                                SyncPal::DbBehaviorAfterStop::Remove); // This task can be long, hence blocking, on Windows.
+
+        // Delete sync from DB
+        deleteSync(syncDbId);
+#if defined(KD_MACOS)
+        Utility::restartFinderExtension();
+#endif
+    });
 }
 
 void AppServer::logExtendedLogActivationMessage(const bool isExtendedLogEnabled) noexcept {
@@ -1740,16 +1754,7 @@ void AppServer::onRequestReceived(int id, RequestNum num, const QByteArray &para
             ArgsWriter(params).write(tmpSyncDbId);
 
             const auto syncDbId = static_cast<SyncDbId>(tmpSyncDbId);
-            QTimer::singleShot(100, [this, syncDbId]() {
-                AppServer::stopSyncTask(
-                        syncDbId, SyncPal::DbBehaviorAfterStop::Remove); // This task can be long, hence blocking, on Windows.
-
-                // Delete sync from DB
-                deleteSync(syncDbId);
-#if defined(KD_MACOS)
-                Utility::restartFinderExtension();
-#endif
-            });
+            deleteSyncAsBackgroundTask(syncDbId);
 
             break;
         }
@@ -3367,6 +3372,9 @@ ExitInfo AppServer::startSyncs(User &user, const std::unordered_set<SyncDbId> to
                 if (const auto exitInfo = checkIfSyncIsValid(sync); !exitInfo) {
                     LOG_WARN(_logger, "Error in checkIfSyncIsValid for syncDbId=" << sync.dbId() << " : " << exitInfo);
                     addError(Error(sync.dbId(), ERR_ID, exitInfo));
+
+                    if (exitInfo.cause() == ExitCause::SyncDeletionFailed) deleteSync(sync.dbId());
+
                     continue;
                 }
 

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -653,9 +653,13 @@ void AppServer::quitLater(const int32_t delayMs) {
 // This task can be long and block the GUI
 void AppServer::stopSyncTask(const SyncDbId syncDbId,
                              const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
-    // Mark the sync for deletion in the parameters DB
-    if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found) || !found) {
-        LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
+    if (behavior == SyncPal::DbBehaviorAfterStop::Remove) {
+        // Mark the sync for deletion in the parameters DB
+        if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
+            LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
+        } else if (!found) {
+            LOG_WARN(_logger, "Sync not found in DB for syncDbId=" << syncDbId);
+        }
     }
 
     // Stop sync and remove it from syncPalMap
@@ -4078,6 +4082,13 @@ ExitInfo AppServer::updateAllUsersInfo(const UpdateFollowUpAction action) {
 
 ExitInfo AppServer::initSyncPal(const Sync &sync, const NodeSet &blackList, bool start, const std::chrono::seconds &startDelay,
                                 bool resumedByUser, bool firstInit) {
+    if (sync.toDelete()) {
+        LOG_WARN(_logger, "Synchronization with syncDbId="
+                                  << sync.dbId()
+                                  << " should have been deleted, but is still present in the database. It will be ignored.");
+        return ExitCode::SystemError;
+    }
+
     const std::scoped_lock lock(syncPalMapMutex);
     auto syncPalMapIt = syncPalMap.find(sync.dbId());
     if (syncPalMapIt == syncPalMap.end()) {

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -657,10 +657,15 @@ void AppServer::stopSyncTask(const SyncDbId syncDbId,
         // Mark the sync for deletion in the parameters DB.
         if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
             LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
+#if defined(KD_WINDOWS)
+            LOG_FATAL(_logger, "Quitting to avoid risks of unwanted deletion.");
+            AppServer::quit();
+#endif
         } else if (!found) {
             LOG_WARN(_logger, "Sync not found in DB for syncDbId=" << syncDbId);
         }
     }
+
 
     // Stop sync and remove it from syncPalMap
     if (const auto exitInfo = stopSyncPal(syncDbId, SyncPal::PauseCaller::Sync, behavior); !exitInfo) {
@@ -2657,6 +2662,10 @@ ExitInfo AppServer::checkIfSyncIsValid(const BaseSync &sync) {
                                                            << Utility::formatSyncPath(sync_.localPath()));
             return {ExitCode::InvalidSync, ExitCause::SyncDirNestingError};
         }
+
+        if (sync_.toDelete()) {
+            return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
+        }
     }
 
     return ExitCode::Ok;
@@ -3259,6 +3268,12 @@ std::string liteSyncActivationLogMessage(const bool enabled, const SyncDbId sync
 
 // This function will pause the synchronization in case of errors.
 ExitInfo AppServer::tryCreateAndStartVfs(const Sync &sync, bool &startPostponed) noexcept {
+    if (sync.toDelete()) {
+        LOG_INFO(_logger,
+                 "Sync with dbId=" << sync.dbId() << " is marked for deletion, skipping VFS creation. The sync will be ignored.");
+        return {ExitCode::SystemError, ExitCause::SyncDeletionFailed};
+    }
+
     startPostponed = false;
     const std::string liteSyncMsg = liteSyncActivationLogMessage(sync.virtualFileMode() != VirtualFileMode::Off, sync.dbId());
     LOG_INFO(_logger, liteSyncMsg);

--- a/src/server/appserver.cpp
+++ b/src/server/appserver.cpp
@@ -654,7 +654,7 @@ void AppServer::quitLater(const int32_t delayMs) {
 void AppServer::stopSyncTask(const SyncDbId syncDbId,
                              const SyncPal::DbBehaviorAfterStop behavior /*= SyncPal::DbBehaviorAfterStop::Keep*/) {
     if (behavior == SyncPal::DbBehaviorAfterStop::Remove) {
-        // Mark the sync for deletion in the parameters DB
+        // Mark the sync for deletion in the parameters DB.
         if (bool found = false; !ParmsDb::instance()->setSyncToDelete(syncDbId, true, found)) {
             LOG_WARN(_logger, "Error in setSyncToDelete for syncDbId=" << syncDbId);
         } else if (!found) {

--- a/src/server/appserver.h
+++ b/src/server/appserver.h
@@ -163,6 +163,7 @@ class AppServer : public SharedTools::QtSingleApplication {
         void updateSentryUser();
         void deleteDrive(DriveDbId driveDbId);
         void deleteSync(SyncDbId syncDbId);
+        void deleteSyncAsBackgroundTask(SyncDbId syncDbId);
         ExitCode clearErrors(SyncDbId syncDbId, bool autoResolved = false);
         // Check if the synchronization `sync` is registered in the sync database and
         // if the `sync` folder does not contain any other sync subfolder.

--- a/test/libparms/db/testparmsdb.cpp
+++ b/test/libparms/db/testparmsdb.cpp
@@ -290,6 +290,7 @@ void TestParmsDb::testSync() {
         sync2.setLocalPath("/Users/xxxxxx/Movies");
         sync2.setPaused(true);
         sync2.setNotificationsDisabled(true);
+        sync2.setToDelete(true);
         bool syncIsFound = false;
         CPPUNIT_ASSERT(ParmsDb::instance()->updateSync(sync2, syncIsFound) && syncIsFound);
     }
@@ -302,6 +303,7 @@ void TestParmsDb::testSync() {
         CPPUNIT_ASSERT(sync.localPath() == sync2.localPath());
         CPPUNIT_ASSERT(sync.paused() == sync2.paused());
         CPPUNIT_ASSERT(sync.notificationsDisabled() == sync2.notificationsDisabled());
+        CPPUNIT_ASSERT(sync.toDelete() == sync2.toDelete());
     }
     // Find sync by DB path
     {
@@ -311,6 +313,7 @@ void TestParmsDb::testSync() {
         CPPUNIT_ASSERT(sync.localPath() == sync2.localPath());
         CPPUNIT_ASSERT(sync.paused() == sync2.paused());
         CPPUNIT_ASSERT(sync.notificationsDisabled() == sync2.notificationsDisabled());
+        CPPUNIT_ASSERT(sync.toDelete() == sync2.toDelete());
     }
     // Select all syncs
     {
@@ -321,6 +324,8 @@ void TestParmsDb::testSync() {
         CPPUNIT_ASSERT(syncList[0].localPath() == sync1.localPath());
         CPPUNIT_ASSERT(syncList[0].paused() == sync1.paused());
         CPPUNIT_ASSERT(syncList[0].notificationsDisabled() == sync1.notificationsDisabled());
+        CPPUNIT_ASSERT(syncList[0].toDelete() == sync1.toDelete());
+        CPPUNIT_ASSERT(syncList[1].toDelete() == sync2.toDelete());
     }
     // Delete sync
     {


### PR DESCRIPTION
These changes add a new column `toDelete` in the `sync` table of `ParmDb` to mark the synchronizations for which the deletion has been requested by the user. If some synchronization deletion fails, `AppServer` will not try to restart such a synchronization, avoiding thus any risk of propagating the deletion of dehydrated placeholders that might have happened during the deletion attempt. (The deletion of dehydrated placeholders is triggered when stopping the VFS on Windows).