### PR TITLE
feat(home): add HomeController and network status observer

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -134,12 +134,19 @@
   prefers a classic root synchronization, then any synchronization.
     - Emits `currentContextChanged()` as a coarse invalidation signal when the selected ids stay unchanged but the
       underlying cache graph changes.
-    - Exposes selected-sync runtime through its dedicated accessor and signal so progress ticks do not rebuild the
-      configured graph context.
+    - Exposes selected-sync runtime through its dedicated accessor and signals, including a status-only notification so
+      progress ticks do not invalidate presentation that only depends on the synchronization status.
 - `app/mainwindow/syncselectormodel.*`: QML adapter for the synchronization selector. It flattens each configured drive
   into classic and advanced synchronization rows and exposes only the presentation data required by the selector.
 - `app/mainwindow/mainsidebarcontroller.*`: QML-facing sidebar interaction controller. It exposes `SyncSelectorModel`,
   delegates sync selection to `MainSelectionStore`, and opens the selected local sync folder through desktop services.
+- `app/mainwindow/homecontroller.*`: cache-backed adapter for Home presentation and synchronization controls. It resolves
+  the selected synchronization into one central state, exposes user, drive, and error data, and delegates pause/resume to
+  `SyncService`.
+- `app/mainwindow/homestateresolver.*`: pure status matrix used by `HomeController`. Structured sync errors remain an
+  independent Home banner instead of replacing the central state.
+- `app/mainwindow/networkstatusobserver.*`: process-long `QNetworkInformation` adapter. Only explicit disconnected
+  reachability is treated as offline; unavailable or unknown backends preserve the cache-derived state.
 - `app/navigation/approuter.*`: minimal main-window router. It owns only `mainWindowActive` and the selected main tab;
   it must not read `AppCache`, call backend services, or decide whether onboarding is required.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -37,6 +37,12 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/parametersstore.h
         app/mainwindow/mainsidebarcontroller.cpp
         app/mainwindow/mainsidebarcontroller.h
+        app/mainwindow/homecontroller.cpp
+        app/mainwindow/homecontroller.h
+        app/mainwindow/homestateresolver.cpp
+        app/mainwindow/homestateresolver.h
+        app/mainwindow/networkstatusobserver.cpp
+        app/mainwindow/networkstatusobserver.h
         app/mainwindow/syncselectormodel.cpp
         app/mainwindow/syncselectormodel.h
         app/navigation/approuter.cpp

--- a/src/gui4/linux/app/cache/mainselectionstore.cpp
+++ b/src/gui4/linux/app/cache/mainselectionstore.cpp
@@ -37,6 +37,11 @@ MainSelectionStore::MainSelectionStore(AppCache &cache, QObject *const parent) :
             emit currentSyncRuntimeInfoChanged();
         }
     });
+    (void) connect(&_cache, &AppCache::syncStatusChanged, this, [this](const SyncDbId syncDbId) {
+        if (syncDbId == _currentSyncDbId) {
+            emit currentSyncStatusChanged();
+        }
+    });
 }
 
 qint64 MainSelectionStore::currentSyncDbId() const {

--- a/src/gui4/linux/app/cache/mainselectionstore.h
+++ b/src/gui4/linux/app/cache/mainselectionstore.h
@@ -58,6 +58,7 @@ class MainSelectionStore : public QObject {
         void currentSyncDbIdChanged();
         void currentContextChanged();
         void currentSyncRuntimeInfoChanged();
+        void currentSyncStatusChanged();
 
     private:
         void handleCacheGraphChanged();

--- a/src/gui4/linux/app/mainwindow/homecontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/homecontroller.cpp
@@ -61,6 +61,10 @@ HomeController::HomeController(AppCache &appCache, MainSelectionStore &mainSelec
 }
 
 HomeController::HomeStatus HomeController::status() const {
+    if (syncActionPending()) {
+        return HomeStatus::Loading;
+    }
+
     const auto context = _mainSelectionStore.currentSyncContext();
     return resolveHomeStatus(context.has_value(), _networkStatusObserver.offline(), currentRuntimeStatus());
 }

--- a/src/gui4/linux/app/mainwindow/homecontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/homecontroller.cpp
@@ -1,0 +1,224 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "homecontroller.h"
+
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+#include "app/mainwindow/homestateresolver.h"
+#include "app/mainwindow/networkstatusobserver.h"
+#include "app/navigation/approuter.h"
+#include "app/services/syncservice.h"
+#include "app/systraycontroller.h"
+
+#include <QLoggingCategory>
+
+#include <algorithm>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcHomeController, "gui.v4.homecontroller", QtInfoMsg)
+
+HomeController::HomeStatus toHomeStatus(const ResolvedHomeStatus status) {
+    switch (status) {
+        case ResolvedHomeStatus::Loading:
+            return HomeController::HomeStatus::Loading;
+        case ResolvedHomeStatus::UpToDate:
+            return HomeController::HomeStatus::UpToDate;
+        case ResolvedHomeStatus::Syncing:
+            return HomeController::HomeStatus::Syncing;
+        case ResolvedHomeStatus::Paused:
+            return HomeController::HomeStatus::Paused;
+        case ResolvedHomeStatus::Offline:
+            return HomeController::HomeStatus::Offline;
+        case ResolvedHomeStatus::SetupRequired:
+            return HomeController::HomeStatus::SetupRequired;
+    }
+    return HomeController::HomeStatus::Loading;
+}
+
+} // namespace
+
+HomeController::HomeController(AppCache &appCache, MainSelectionStore &mainSelectionStore, SyncService &syncService,
+                               AppRouter &appRouter, SystemTrayController &systemTrayController,
+                               NetworkStatusObserver &networkStatusObserver, QObject *const parent) :
+    QObject(parent),
+    _appCache(appCache),
+    _mainSelectionStore(mainSelectionStore),
+    _syncService(syncService),
+    _appRouter(appRouter),
+    _systemTrayController(systemTrayController),
+    _networkStatusObserver(networkStatusObserver) {
+    (void) connect(&_mainSelectionStore, &MainSelectionStore::currentContextChanged, this, &HomeController::homeChanged);
+    (void) connect(&_mainSelectionStore, &MainSelectionStore::currentSyncStatusChanged, this, &HomeController::homeChanged);
+    (void) connect(&_appCache, &AppCache::usersChanged, this, &HomeController::homeChanged);
+    (void) connect(&_appCache, &AppCache::syncsChanged, this, &HomeController::homeChanged);
+    (void) connect(&_appCache, &AppCache::syncErrorsChanged, this, &HomeController::homeChanged);
+    (void) connect(&_syncService, &SyncService::syncActionPendingChanged, this, [this](const qint64 syncDbId) {
+        if (syncDbId == currentSyncDbId()) {
+            emit homeChanged();
+        }
+    });
+    (void) connect(&_systemTrayController, &SystemTrayController::trayModeActiveChanged, this, &HomeController::homeChanged);
+    (void) connect(&_networkStatusObserver, &NetworkStatusObserver::offlineChanged, this, &HomeController::homeChanged);
+}
+
+HomeController::HomeStatus HomeController::status() const {
+    const auto context = _mainSelectionStore.currentSyncContext();
+    const auto resolvedStatus = resolveHomeStatus(context.has_value(), _networkStatusObserver.offline(), currentRuntimeStatus());
+    return toHomeStatus(resolvedStatus);
+}
+
+HomeController::PrimaryAction HomeController::primaryAction() const {
+    switch (status()) {
+        case HomeStatus::UpToDate:
+            if (errorCount() > 0) {
+                return PrimaryAction::ShowActivities;
+            }
+            return _systemTrayController.trayModeActive() ? PrimaryAction::HideWindow : PrimaryAction::None;
+        case HomeStatus::Syncing:
+            return PrimaryAction::ShowActivities;
+        case HomeStatus::Paused:
+            return syncControlState() == SyncControlState::Resume ? PrimaryAction::ResumeSync : PrimaryAction::None;
+        case HomeStatus::SetupRequired:
+            return hasConnectedUser() ? PrimaryAction::ConfigureSync : PrimaryAction::SignIn;
+        case HomeStatus::Loading:
+        case HomeStatus::Offline:
+            return PrimaryAction::None;
+    }
+    return PrimaryAction::None;
+}
+
+HomeController::SyncControlState HomeController::syncControlState() const {
+    if (!hasCurrentDrive() || _networkStatusObserver.offline()) {
+        return SyncControlState::Disabled;
+    }
+    if (syncActionPending()) {
+        return SyncControlState::Pending;
+    }
+
+    const auto runtimeStatus = currentRuntimeStatus();
+    if (!runtimeStatus.has_value()) {
+        return SyncControlState::Disabled;
+    }
+
+    switch (*runtimeStatus) {
+        case SyncStatus::Running:
+        case SyncStatus::Idle:
+            return SyncControlState::Pause;
+        case SyncStatus::Paused:
+        case SyncStatus::Stopped:
+        case SyncStatus::Error:
+            return SyncControlState::Resume;
+        case SyncStatus::Starting:
+        case SyncStatus::PauseAsked:
+        case SyncStatus::StopAsked:
+            return SyncControlState::Pending;
+        case SyncStatus::Undefined:
+        case SyncStatus::EnumEnd:
+            return SyncControlState::Disabled;
+    }
+    return SyncControlState::Disabled;
+}
+
+QString HomeController::firstName() const {
+    const auto context = _mainSelectionStore.currentSyncContext();
+    return context.has_value() ? QString::fromStdString(context->userDisplayInfo.firstName()) : QString{};
+}
+
+QString HomeController::driveName() const {
+    const auto context = _mainSelectionStore.currentSyncContext();
+    return context.has_value() ? QString::fromStdString(context->drive.name()) : QString{};
+}
+
+QString HomeController::avatarSource() const {
+    const auto context = _mainSelectionStore.currentSyncContext();
+    return context.has_value() ? context->userDisplayInfo.avatarSource() : QString{};
+}
+
+int32_t HomeController::errorCount() const {
+    const auto context = _mainSelectionStore.currentSyncContext();
+    return context.has_value() ? static_cast<int32_t>(context->errors.size()) : 0;
+}
+
+bool HomeController::hasCurrentDrive() const {
+    return _mainSelectionStore.currentSyncContext().has_value();
+}
+
+bool HomeController::hasConnectedUser() const {
+    const auto users = _appCache.users();
+    return std::ranges::any_of(users, [](const User &user) { return user.connected(); });
+}
+
+void HomeController::triggerPrimaryAction() {
+    switch (primaryAction()) {
+        case PrimaryAction::HideWindow:
+            _systemTrayController.hideMainWindow();
+            return;
+        case PrimaryAction::ShowActivities:
+            _appRouter.showActivities();
+            return;
+        case PrimaryAction::ResumeSync:
+            toggleSync();
+            return;
+        case PrimaryAction::SignIn:
+        case PrimaryAction::ConfigureSync:
+            emit setupRequested();
+            return;
+        case PrimaryAction::None:
+            return;
+    }
+}
+
+void HomeController::toggleSync() {
+    const auto syncDbId = currentSyncDbId();
+    if (syncDbId == 0) {
+        qCWarning(lcHomeController) << "Sync control ignored: no synchronization is selected";
+        return;
+    }
+
+    switch (syncControlState()) {
+        case SyncControlState::Pause:
+            _syncService.stopSync(syncDbId);
+            return;
+        case SyncControlState::Resume:
+            _syncService.startSync(syncDbId);
+            return;
+        case SyncControlState::Disabled:
+        case SyncControlState::Pending:
+            qCDebug(lcHomeController) << "Sync control ignored in current presentation state | syncDbId:" << syncDbId;
+            return;
+    }
+}
+
+std::optional<SyncStatus> HomeController::currentRuntimeStatus() const {
+    const auto runtimeInfo = _mainSelectionStore.currentSyncRuntimeInfo();
+    return runtimeInfo.has_value() ? std::make_optional(runtimeInfo->status) : std::nullopt;
+}
+
+qint64 HomeController::currentSyncDbId() const {
+    return _mainSelectionStore.currentSyncDbId();
+}
+
+bool HomeController::syncActionPending() const {
+    const auto syncDbId = currentSyncDbId();
+    return syncDbId != 0 && (_syncService.isStartSyncPending(syncDbId) || _syncService.isStopSyncPending(syncDbId));
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/homecontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/homecontroller.cpp
@@ -155,7 +155,7 @@ void HomeController::triggerPrimaryAction() {
             _appRouter.showActivities();
             return;
         case PrimaryAction::ResumeSync:
-            toggleSync();
+            _syncService.startSync(currentSyncDbId());
             return;
         case PrimaryAction::SignIn:
         case PrimaryAction::ConfigureSync:

--- a/src/gui4/linux/app/mainwindow/homecontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/homecontroller.cpp
@@ -34,25 +34,6 @@ namespace KDC {
 
 namespace {
 Q_LOGGING_CATEGORY(lcHomeController, "gui.v4.homecontroller", QtInfoMsg)
-
-HomeController::HomeStatus toHomeStatus(const ResolvedHomeStatus status) {
-    switch (status) {
-        case ResolvedHomeStatus::Loading:
-            return HomeController::HomeStatus::Loading;
-        case ResolvedHomeStatus::UpToDate:
-            return HomeController::HomeStatus::UpToDate;
-        case ResolvedHomeStatus::Syncing:
-            return HomeController::HomeStatus::Syncing;
-        case ResolvedHomeStatus::Paused:
-            return HomeController::HomeStatus::Paused;
-        case ResolvedHomeStatus::Offline:
-            return HomeController::HomeStatus::Offline;
-        case ResolvedHomeStatus::SetupRequired:
-            return HomeController::HomeStatus::SetupRequired;
-    }
-    return HomeController::HomeStatus::Loading;
-}
-
 } // namespace
 
 HomeController::HomeController(AppCache &appCache, MainSelectionStore &mainSelectionStore, SyncService &syncService,
@@ -81,8 +62,7 @@ HomeController::HomeController(AppCache &appCache, MainSelectionStore &mainSelec
 
 HomeController::HomeStatus HomeController::status() const {
     const auto context = _mainSelectionStore.currentSyncContext();
-    const auto resolvedStatus = resolveHomeStatus(context.has_value(), _networkStatusObserver.offline(), currentRuntimeStatus());
-    return toHomeStatus(resolvedStatus);
+    return resolveHomeStatus(context.has_value(), _networkStatusObserver.offline(), currentRuntimeStatus());
 }
 
 HomeController::PrimaryAction HomeController::primaryAction() const {

--- a/src/gui4/linux/app/mainwindow/homecontroller.h
+++ b/src/gui4/linux/app/mainwindow/homecontroller.h
@@ -1,0 +1,119 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/cstypes.h"
+
+#include <QObject>
+#include <QString>
+
+#include <cstdint>
+#include <optional>
+
+namespace KDC {
+
+class AppCache;
+class AppRouter;
+class MainSelectionStore;
+class NetworkStatusObserver;
+class SyncService;
+class SystemTrayController;
+
+/**
+ * Cache-backed QML adapter for the Linux v4 Home and its toolbar controls.
+ *
+ * The controller centralizes presentation-state resolution and synchronization actions. QML remains a modular rendering layer
+ * and does not call backend services directly.
+ */
+class HomeController final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(HomeStatus status READ status NOTIFY homeChanged)
+        Q_PROPERTY(PrimaryAction primaryAction READ primaryAction NOTIFY homeChanged)
+        Q_PROPERTY(SyncControlState syncControlState READ syncControlState NOTIFY homeChanged)
+        Q_PROPERTY(QString firstName READ firstName NOTIFY homeChanged)
+        Q_PROPERTY(QString driveName READ driveName NOTIFY homeChanged)
+        Q_PROPERTY(QString avatarSource READ avatarSource NOTIFY homeChanged)
+        Q_PROPERTY(int32_t errorCount READ errorCount NOTIFY homeChanged)
+        Q_PROPERTY(bool hasCurrentDrive READ hasCurrentDrive NOTIFY homeChanged)
+        Q_PROPERTY(bool hasConnectedUser READ hasConnectedUser NOTIFY homeChanged)
+
+    public:
+        enum class HomeStatus : uint8_t {
+            Loading = 0,
+            UpToDate,
+            Syncing,
+            Paused,
+            Offline,
+            SetupRequired,
+        };
+        Q_ENUM(HomeStatus)
+
+        enum class PrimaryAction : uint8_t {
+            None = 0,
+            HideWindow,
+            ShowActivities,
+            ResumeSync,
+            SignIn,
+            ConfigureSync,
+        };
+        Q_ENUM(PrimaryAction)
+
+        enum class SyncControlState : uint8_t {
+            Disabled = 0,
+            Pending,
+            Pause,
+            Resume,
+        };
+        Q_ENUM(SyncControlState)
+
+        explicit HomeController(AppCache &appCache, MainSelectionStore &mainSelectionStore, SyncService &syncService,
+                                AppRouter &appRouter, SystemTrayController &systemTrayController,
+                                NetworkStatusObserver &networkStatusObserver, QObject *parent = nullptr);
+
+        [[nodiscard]] HomeStatus status() const;
+        [[nodiscard]] PrimaryAction primaryAction() const;
+        [[nodiscard]] SyncControlState syncControlState() const;
+        [[nodiscard]] QString firstName() const;
+        [[nodiscard]] QString driveName() const;
+        [[nodiscard]] QString avatarSource() const;
+        [[nodiscard]] int32_t errorCount() const;
+        [[nodiscard]] bool hasCurrentDrive() const;
+        [[nodiscard]] bool hasConnectedUser() const;
+
+        Q_INVOKABLE void triggerPrimaryAction();
+        Q_INVOKABLE void toggleSync();
+
+    signals:
+        void homeChanged();
+        void setupRequested();
+
+    private:
+        [[nodiscard]] std::optional<SyncStatus> currentRuntimeStatus() const;
+        [[nodiscard]] qint64 currentSyncDbId() const;
+        [[nodiscard]] bool syncActionPending() const;
+
+        AppCache &_appCache;
+        MainSelectionStore &_mainSelectionStore;
+        SyncService &_syncService;
+        AppRouter &_appRouter;
+        SystemTrayController &_systemTrayController;
+        NetworkStatusObserver &_networkStatusObserver;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/homestateresolver.cpp
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.cpp
@@ -1,0 +1,50 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "homestateresolver.h"
+
+namespace KDC {
+
+ResolvedHomeStatus resolveHomeStatus(const bool hasSync, const bool offline, const std::optional<SyncStatus> runtimeStatus) {
+    if (!hasSync) {
+        return ResolvedHomeStatus::SetupRequired;
+    }
+    if (!runtimeStatus.has_value()) {
+        return ResolvedHomeStatus::Loading;
+    }
+
+    switch (*runtimeStatus) {
+        case SyncStatus::Starting:
+        case SyncStatus::Running:
+        case SyncStatus::PauseAsked:
+        case SyncStatus::StopAsked:
+            return ResolvedHomeStatus::Syncing;
+        case SyncStatus::Idle:
+            return ResolvedHomeStatus::UpToDate;
+        case SyncStatus::Paused:
+        case SyncStatus::Stopped:
+        case SyncStatus::Error:
+            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::Paused;
+        case SyncStatus::Undefined:
+        case SyncStatus::EnumEnd:
+            return ResolvedHomeStatus::Loading;
+    }
+    return ResolvedHomeStatus::Loading;
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/homestateresolver.cpp
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.cpp
@@ -31,10 +31,7 @@ HomeStatus resolveHomeStatus(const bool hasSync, const bool offline, const std::
     }
 
     switch (*runtimeStatus) {
-        case SyncStatus::Starting:
         case SyncStatus::Running:
-        case SyncStatus::PauseAsked:
-        case SyncStatus::StopAsked:
             return HomeStatus::Syncing;
         case SyncStatus::Idle:
             return offline ? HomeStatus::Offline : HomeStatus::UpToDate;
@@ -43,6 +40,9 @@ HomeStatus resolveHomeStatus(const bool hasSync, const bool offline, const std::
         case SyncStatus::Stopped:
         case SyncStatus::Error:
             return HomeStatus::Paused;
+        case SyncStatus::Starting:
+        case SyncStatus::PauseAsked:
+        case SyncStatus::StopAsked:
         case SyncStatus::Undefined:
         case SyncStatus::EnumEnd:
             return HomeStatus::Loading;

--- a/src/gui4/linux/app/mainwindow/homestateresolver.cpp
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.cpp
@@ -20,12 +20,14 @@
 
 namespace KDC {
 
-ResolvedHomeStatus resolveHomeStatus(const bool hasSync, const bool offline, const std::optional<SyncStatus> runtimeStatus) {
+using HomeStatus = HomeController::HomeStatus;
+
+HomeStatus resolveHomeStatus(const bool hasSync, const bool offline, const std::optional<SyncStatus> runtimeStatus) {
     if (!hasSync) {
-        return ResolvedHomeStatus::SetupRequired;
+        return HomeStatus::SetupRequired;
     }
     if (!runtimeStatus.has_value()) {
-        return ResolvedHomeStatus::Loading;
+        return HomeStatus::Loading;
     }
 
     switch (*runtimeStatus) {
@@ -33,19 +35,19 @@ ResolvedHomeStatus resolveHomeStatus(const bool hasSync, const bool offline, con
         case SyncStatus::Running:
         case SyncStatus::PauseAsked:
         case SyncStatus::StopAsked:
-            return ResolvedHomeStatus::Syncing;
+            return HomeStatus::Syncing;
         case SyncStatus::Idle:
-            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::UpToDate;
+            return offline ? HomeStatus::Offline : HomeStatus::UpToDate;
         case SyncStatus::Paused:
-            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::Paused;
+            return offline ? HomeStatus::Offline : HomeStatus::Paused;
         case SyncStatus::Stopped:
         case SyncStatus::Error:
-            return ResolvedHomeStatus::Paused;
+            return HomeStatus::Paused;
         case SyncStatus::Undefined:
         case SyncStatus::EnumEnd:
-            return ResolvedHomeStatus::Loading;
+            return HomeStatus::Loading;
     }
-    return ResolvedHomeStatus::Loading;
+    return HomeStatus::Loading;
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/mainwindow/homestateresolver.cpp
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.cpp
@@ -35,11 +35,12 @@ ResolvedHomeStatus resolveHomeStatus(const bool hasSync, const bool offline, con
         case SyncStatus::StopAsked:
             return ResolvedHomeStatus::Syncing;
         case SyncStatus::Idle:
-            return ResolvedHomeStatus::UpToDate;
+            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::UpToDate;
         case SyncStatus::Paused:
+            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::Paused;
         case SyncStatus::Stopped:
         case SyncStatus::Error:
-            return offline ? ResolvedHomeStatus::Offline : ResolvedHomeStatus::Paused;
+            return ResolvedHomeStatus::Paused;
         case SyncStatus::Undefined:
         case SyncStatus::EnumEnd:
             return ResolvedHomeStatus::Loading;

--- a/src/gui4/linux/app/mainwindow/homestateresolver.h
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.h
@@ -1,0 +1,44 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/utility/cstypes.h"
+
+#include <cstdint>
+#include <optional>
+
+namespace KDC {
+
+enum class ResolvedHomeStatus : uint8_t {
+    Loading = 0,
+    UpToDate,
+    Syncing,
+    Paused,
+    Offline,
+    SetupRequired,
+};
+
+/**
+ * Resolves the mutually exclusive central Home status from connectivity and synchronization runtime state.
+ *
+ * Structured synchronization errors are intentionally excluded because Home renders them independently in its error banner.
+ */
+[[nodiscard]] ResolvedHomeStatus resolveHomeStatus(bool hasSync, bool offline, std::optional<SyncStatus> runtimeStatus);
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/homestateresolver.h
+++ b/src/gui4/linux/app/mainwindow/homestateresolver.h
@@ -18,27 +18,18 @@
 
 #pragma once
 
+#include "app/mainwindow/homecontroller.h"
 #include "libcommon/utility/cstypes.h"
 
-#include <cstdint>
 #include <optional>
 
 namespace KDC {
-
-enum class ResolvedHomeStatus : uint8_t {
-    Loading = 0,
-    UpToDate,
-    Syncing,
-    Paused,
-    Offline,
-    SetupRequired,
-};
 
 /**
  * Resolves the mutually exclusive central Home status from connectivity and synchronization runtime state.
  *
  * Structured synchronization errors are intentionally excluded because Home renders them independently in its error banner.
  */
-[[nodiscard]] ResolvedHomeStatus resolveHomeStatus(bool hasSync, bool offline, std::optional<SyncStatus> runtimeStatus);
+[[nodiscard]] HomeController::HomeStatus resolveHomeStatus(bool hasSync, bool offline, std::optional<SyncStatus> runtimeStatus);
 
 } // namespace KDC

--- a/src/gui4/linux/app/mainwindow/networkstatusobserver.cpp
+++ b/src/gui4/linux/app/mainwindow/networkstatusobserver.cpp
@@ -1,0 +1,83 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "networkstatusobserver.h"
+
+#include <QLoggingCategory>
+#include <QNetworkInformation>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcNetworkStatusObserver, "gui.v4.networkstatus", QtInfoMsg)
+
+bool isOfflineReachability(const QNetworkInformation::Reachability reachability) {
+    switch (reachability) {
+        case QNetworkInformation::Reachability::Disconnected:
+            return true;
+        case QNetworkInformation::Reachability::Unknown:
+        case QNetworkInformation::Reachability::Local:
+        case QNetworkInformation::Reachability::Site:
+        case QNetworkInformation::Reachability::Online:
+            return false;
+    }
+    return false;
+}
+} // namespace
+
+NetworkStatusObserver::NetworkStatusObserver(QObject *const parent) :
+    QObject(parent) {
+    // If Flatpak, this class requires either D-Bus access to org.freedesktop.NetworkManager or the Qt GLib backend using the
+    // NetworkMonitor portal.
+    if (!QNetworkInformation::loadDefaultBackend()) {
+        qCWarning(lcNetworkStatusObserver) << "No Qt network information backend available; offline detection disabled";
+        return;
+    }
+
+    const auto *const networkInformation = QNetworkInformation::instance();
+    if (networkInformation == nullptr) {
+        qCWarning(lcNetworkStatusObserver) << "Qt network information backend loaded without an instance";
+        return;
+    }
+
+    qCInfo(lcNetworkStatusObserver) << "Network status backend loaded | backend:" << networkInformation->backendName()
+                                    << "/ available backends:" << QNetworkInformation::availableBackends();
+    (void) connect(networkInformation, &QNetworkInformation::reachabilityChanged, this,
+                   &NetworkStatusObserver::updateReachability);
+    updateReachability();
+}
+
+void NetworkStatusObserver::updateReachability() {
+    const auto *const networkInformation = QNetworkInformation::instance();
+    if (networkInformation == nullptr) {
+        return;
+    }
+
+    const auto reachability = networkInformation->reachability();
+    const bool offline = isOfflineReachability(reachability);
+    qCInfo(lcNetworkStatusObserver) << "Network reachability evaluated | backend:" << networkInformation->backendName()
+                                    << "/ reachability:" << reachability << "/ offline:" << offline;
+    if (_offline == offline) {
+        return;
+    }
+
+    _offline = offline;
+    emit offlineChanged();
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/networkstatusobserver.h
+++ b/src/gui4/linux/app/mainwindow/networkstatusobserver.h
@@ -1,0 +1,49 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include <QObject>
+
+namespace KDC {
+
+/**
+ * Process-long network reachability adapter for the Linux v4 presentation layer.
+ *
+ * Only explicit disconnected reachability is considered offline. Other reachability levels deliberately preserve the
+ * cache-derived synchronization state so an inconclusive connectivity probe does not block otherwise usable controls.
+ */
+class NetworkStatusObserver final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool offline READ offline NOTIFY offlineChanged)
+
+    public:
+        explicit NetworkStatusObserver(QObject *parent = nullptr);
+
+        [[nodiscard]] bool offline() const { return _offline; }
+
+    signals:
+        void offlineChanged();
+
+    private:
+        void updateReachability();
+
+        bool _offline{false};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/syncservice.cpp
+++ b/src/gui4/linux/app/services/syncservice.cpp
@@ -49,6 +49,13 @@ SyncService::SyncService(CommService &commService, ServiceActionTracker &service
                            emit loadingChanged();
                        }
                    });
+    (void) connect(&_serviceActionTracker, &ServiceActionTracker::actionPendingChanged, this,
+                   [this](const ServiceActionTracker::ServiceKey &serviceKey, const ServiceActionTracker::ActionKey &actionKey,
+                          const ServiceActionTracker::ScopeId scopeId, const bool) {
+                       if (serviceKey == serviceKeySync && (actionKey == actionStartSync || actionKey == actionStopSync)) {
+                           emit syncActionPendingChanged(scopeId);
+                       }
+                   });
 }
 
 bool SyncService::loading() const {

--- a/src/gui4/linux/app/services/syncservice.h
+++ b/src/gui4/linux/app/services/syncservice.h
@@ -67,6 +67,7 @@ class SyncService : public QObject {
 
     signals:
         void loadingChanged();
+        void syncActionPendingChanged(qint64 syncDbId);
         void syncStatusReceived(qint64 syncDbId, int32_t status);
         void suggestedPathReceived(const QString &goodPath, const QString &warningMessage);
         void pathValidationReceived(bool isValid);

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -22,7 +22,9 @@
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
 #include "app/cache/parametersstore.h"
+#include "app/mainwindow/homecontroller.h"
 #include "app/mainwindow/mainsidebarcontroller.h"
+#include "app/mainwindow/networkstatusobserver.h"
 #include "app/navigation/approuter.h"
 #include "app/onboarding/onboardingsessionmanager.h"
 #include "app/services/cachepopulator.h"
@@ -132,6 +134,9 @@ class AppClientLinux : public QApplication {
         SyncService _syncService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         WindowDecorationController _windowDecorationController{this};
         SystemTrayController _systemTrayController{this};
+        NetworkStatusObserver _networkStatusObserver{this};
+        HomeController _homeController{
+                _appCache, _mainSelectionStore, _syncService, _appRouter, _systemTrayController, _networkStatusObserver, this};
         QTranslator _baseTranslator{this};
         QTranslator _localizedTranslator{this};
         QQmlApplicationEngine _qmlEngine;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
La vue Home de la GUI Linux v4 n'avait pas encore de composant central pour résoudre son état de présentation (chargement, à jour, synchronisation, en pause, hors ligne, configuration requise) ni pour piloter l'action principale et le contrôle pause/reprise de la synchronisation. Cette PR introduit `HomeController`, un résolveur d'état pur associé, et un observateur de connectivité réseau, puis les câble dans le client d'application.

## Changements
- Ajout de `app/mainwindow/homestateresolver.*` : fonction pure `resolveHomeStatus()` qui dérive un `ResolvedHomeStatus` unique (Loading, UpToDate, Syncing, Paused, Offline, SetupRequired) à partir de la présence d'une synchronisation, de l'état de connectivité et du statut runtime de la synchronisation. Les erreurs de synchronisation structurées restent volontairement gérées par la bannière d'erreur dédiée de Home plutôt que par cet état central.
- Ajout de `app/mainwindow/networkstatusobserver.*` (`NetworkStatusObserver`) : adaptateur `QNetworkInformation` de durée de vie processus qui n'expose `offline` que sur une accessibilité explicitement déconnectée, afin qu'une sonde de connectivité non concluante ne bloque pas des contrôles par ailleurs utilisables.
- Ajout de `app/mainwindow/homecontroller.*` (`HomeController`) : adaptateur QML orienté cache qui expose `status`, `primaryAction`, `syncControlState`, ainsi que les informations utilisateur, drive et erreurs, et qui délègue la mise en pause/reprise de la synchronisation à `SyncService`.
- `MainSelectionStore` émet désormais `currentSyncStatusChanged()`, un signal dédié au statut de la synchronisation sélectionnée, pour que les tics de progression n'invalident plus une présentation qui ne dépend que du statut.
- `SyncService` émet désormais `syncActionPendingChanged(syncDbId)` lorsqu'une action de démarrage/arrêt de synchronisation devient en attente ou se termine, ce que `HomeController` utilise pour exposer un état "Pending" pendant les actions en cours.
- `NetworkStatusObserver` et `HomeController` sont instanciés dans `AppClientLinux` et enregistrés dans `src/gui4/linux/CMakeLists.txt`.
- Documentation des trois nouveaux composants et de l'évolution de `MainSelectionStore` dans `src/gui4/linux/AGENTS.md`.

## Détails techniques
- `resolveHomeStatus()` est une fonction libre sans dépendance Qt, ce qui la rend directement testable indépendamment de `HomeController`.
- `HomeController::primaryAction()` et `syncControlState()` sont dérivés de `status()` et du statut runtime, sans état interne supplémentaire ; toute la logique de présentation reste donc recalculée à la demande à partir du cache et des services.
- `HomeController` se réabonne à `currentSyncStatusChanged()`, `syncActionPendingChanged()` et `NetworkStatusObserver::offlineChanged()` pour réémettre un unique signal `homeChanged()`, conservant ainsi le modèle de propriétés Q_PROPERTY/NOTIFY existant du reste de la GUI v4.
- Sous Flatpak, `NetworkStatusObserver` nécessite un accès D-Bus à `org.freedesktop.NetworkManager` ou le backend Qt GLib via le portail NetworkMonitor ; en l'absence de backend disponible, la détection hors ligne est simplement désactivée (log d'avertissement) plutôt que de faire échouer le démarrage.

## Notes
- `HomeController` n'est pas encore consommé par une vue QML dans cette PR ; l'intégration côté interface reste à faire dans un suivi.

</details>

---

## Summary
The Linux v4 Home view had no central component to resolve its presentation state (loading, up to date, syncing, paused, offline, setup required) or to drive the primary action and the sync pause/resume control. This PR introduces `HomeController`, an associated pure status resolver, and a network connectivity observer, then wires them into the application client.

## Changes
- Added `app/mainwindow/homestateresolver.*`: a pure `resolveHomeStatus()` function that derives a single `ResolvedHomeStatus` (Loading, UpToDate, Syncing, Paused, Offline, SetupRequired) from whether a sync exists, connectivity state, and the sync's runtime status. Structured sync errors are deliberately kept out of this central state and remain handled by Home's own error banner.
- Added `app/mainwindow/networkstatusobserver.*` (`NetworkStatusObserver`): a process-long `QNetworkInformation` adapter that only exposes `offline` for explicitly disconnected reachability, so an inconclusive connectivity probe does not block otherwise usable controls.
- Added `app/mainwindow/homecontroller.*` (`HomeController`): a cache-backed QML adapter exposing `status`, `primaryAction`, `syncControlState`, plus user, drive, and error data, and delegating sync pause/resume to `SyncService`.
- `MainSelectionStore` now emits `currentSyncStatusChanged()`, a status-only signal for the selected sync, so progress ticks no longer invalidate presentation that only depends on the status.
- `SyncService` now emits `syncActionPendingChanged(syncDbId)` when a start/stop sync action becomes pending or completes, which `HomeController` uses to expose a "Pending" control state while an action is in flight.
- `NetworkStatusObserver` and `HomeController` are instantiated in `AppClientLinux` and registered in `src/gui4/linux/CMakeLists.txt`.
- Documented the three new components and the `MainSelectionStore` change in `src/gui4/linux/AGENTS.md`.

## Technical Details
- `resolveHomeStatus()` is a free function with no Qt dependency, making it directly testable independently of `HomeController`.
- `HomeController::primaryAction()` and `syncControlState()` are derived from `status()` and the runtime status with no extra internal state, so all presentation logic stays recomputed on demand from the cache and services.
- `HomeController` re-subscribes to `currentSyncStatusChanged()`, `syncActionPendingChanged()`, and `NetworkStatusObserver::offlineChanged()` to re-emit a single `homeChanged()` signal, keeping the existing Q_PROPERTY/NOTIFY pattern used across the rest of the v4 GUI.
- Under Flatpak, `NetworkStatusObserver` requires either D-Bus access to `org.freedesktop.NetworkManager` or the Qt GLib backend via the NetworkMonitor portal; when no backend is available, offline detection is simply disabled (with a warning log) rather than failing startup.

## Notes
- `HomeController` is not yet consumed by a QML view in this PR; wiring it into the UI is left as follow-up work.