### PR TITLE
fix(server): cherry-pick TLS review fixes onto Windows client PR

### DIFF
--- a/src/libcommon/comm.h
+++ b/src/libcommon/comm.h
@@ -20,6 +20,8 @@
 #include <string>
 //keychain key for tls certificate
 inline constexpr char certKeychainKey[] = "kdrive_ipc_tls_cert";
+// Name for tls certification
+inline constexpr char localHostName[] = "kDrive-localhost";
 
 #define COMM_SHORT_TIMEOUT 1000
 #define COMM_AVERAGE_TIMEOUT 10000

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -46,6 +46,12 @@
 
 namespace KDC {
 
+namespace keychainConstant {
+// this define constant used for the key chain in the gui and server
+static const std::string package("com.infomaniak.drive");
+static const std::string service("desktopclient");
+} // namespace keychainConstant
+
 namespace fsType {
 static const std::string NTFS = "NTFS";
 static const std::string APFS = "APFS";

--- a/src/libcommon/utility/utility.h
+++ b/src/libcommon/utility/utility.h
@@ -48,8 +48,8 @@ namespace KDC {
 
 namespace keychainConstant {
 // this define constant used for the key chain in the gui and server
-static const std::string package("com.infomaniak.drive");
-static const std::string service("desktopclient");
+inline const std::string package("com.infomaniak.drive");
+inline const std::string service("desktopclient");
 } // namespace keychainConstant
 
 namespace fsType {

--- a/src/libcommonserver/CMakeLists.txt
+++ b/src/libcommonserver/CMakeLists.txt
@@ -6,7 +6,7 @@ endif()
 
 find_package(Qt6 REQUIRED Core)
 find_package(SQLite3 3.53.0 REQUIRED)
-find_package(Poco 1.13.3 REQUIRED Foundation Net JSON Util)
+find_package(Poco 1.13.3 REQUIRED Foundation Net Crypto JSON Util)
 find_package(OpenSSL 3.1.0 REQUIRED SSL Crypto)
 find_package(xxHash 0.8.2 REQUIRED)
 
@@ -135,7 +135,7 @@ endif()
 target_link_libraries(${libcommonserver_NAME}
     ${libcommon_NAME}
     SQLite::SQLite3
-    Poco::Foundation Poco::Net Poco::JSON Poco::Util
+    Poco::Foundation Poco::Net Poco::Crypto Poco::JSON Poco::Util
     OpenSSL::SSL OpenSSL::Crypto
     xxHash::xxhash)
 

--- a/src/libcommonserver/keychainmanager/keychainstorage.cpp
+++ b/src/libcommonserver/keychainmanager/keychainstorage.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "keychainstorage.h"
+
+#include "libcommon/utility/utility.h"
 #include "keychain/keychain.h"
 #include "log/log.h"
 
@@ -24,12 +26,10 @@
 
 namespace KDC {
 
-static const std::string package("com.infomaniak.drive");
-static const std::string service("desktopclient");
 
 bool KeyChainStorage::writePassword(const std::string &keychainKey, const std::string &rawData) {
     keychain::Error error{};
-    keychain::setPassword(package, service, keychainKey, rawData, error);
+    keychain::setPassword(keychainConstant::package, keychainConstant::service, keychainKey, rawData, error);
     if (error) {
         LOG_DEBUG(KDC::Log::instance()->getLogger(),
                   "Failed to save authentication info to keychain: " << error.code << " - " << error.message);
@@ -43,7 +43,7 @@ bool KeyChainStorage::writePassword(const std::string &keychainKey, const std::s
 
 bool KeyChainStorage::readPassword(const std::string &keychainKey, std::string &data, bool &found) {
     keychain::Error error{};
-    data = keychain::getPassword(package, service, keychainKey, error);
+    data = keychain::getPassword(keychainConstant::package, keychainConstant::service, keychainKey, error);
     if (error.type == keychain::ErrorType::NotFound) {
         LOG_DEBUG(KDC::Log::instance()->getLogger(),
                   "Could not find data in keychain for key " << keychainKey << ": " << error.code << " - " << error.message);
@@ -61,7 +61,7 @@ bool KeyChainStorage::readPassword(const std::string &keychainKey, std::string &
 
 bool KeyChainStorage::deletePassword(const std::string &keychainKey) {
     keychain::Error error{};
-    keychain::deletePassword(package, service, keychainKey, error);
+    keychain::deletePassword(keychainConstant::package, keychainConstant::service, keychainKey, error);
     if (error) {
         LOG_DEBUG(KDC::Log::instance()->getLogger(),
                   "Failed to delete authentication info from keychain: " << error.code << " - " << error.message);

--- a/src/libcommonserver/utility/selfsignedcert.cpp
+++ b/src/libcommonserver/utility/selfsignedcert.cpp
@@ -27,6 +27,7 @@
 #include <Poco/Crypto/X509Certificate.h>
 
 #include <openssl/x509.h>
+#include <openssl/x509v3.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 
@@ -53,6 +54,25 @@ const char *sslError() {
     return err ? ERR_error_string(err, nullptr) : "no OpenSSL error";
 }
 
+bool addExtension(X509 *const x509, const int nid, const char *const value) {
+    X509V3_CTX ctx;
+    X509V3_set_ctx_nodb(&ctx);
+    X509V3_set_ctx(&ctx, x509, x509, nullptr, nullptr, 0); // issuer == subject (self-signed)
+
+    X509_EXTENSION *const ext = X509V3_EXT_conf_nid(nullptr, &ctx, nid, value);
+    if (!ext) {
+        LOG_ERROR(Log::instance()->getLogger(), "X509V3_EXT_conf_nid failed for nid " << nid << ": " << sslError());
+        return false;
+    }
+    const int rc = X509_add_ext(x509, ext, -1);
+    X509_EXTENSION_free(ext);
+    if (rc != 1) {
+        LOG_ERROR(Log::instance()->getLogger(), "X509_add_ext failed for nid " << nid << ": " << sslError());
+        return false;
+    }
+    return true;
+}
+
 bool fillCertificateFields(X509 *const x509) {
     if (X509_set_version(x509, 2) != 1) {
         LOG_ERROR(Log::instance()->getLogger(), "X509_set_version failed: " << sslError());
@@ -72,7 +92,7 @@ bool fillCertificateFields(X509 *const x509) {
     }
 
     X509_NAME *const name = X509_get_subject_name(x509);
-    if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const uint8_t *>("kDrive-localhost"), -1, -1, 0) !=
+    if (X509_NAME_add_entry_by_txt(name, "CN", MBSTRING_ASC, reinterpret_cast<const unsigned char *>(localHostName), -1, -1, 0) !=
         1) {
         LOG_ERROR(Log::instance()->getLogger(), "X509_NAME_add_entry_by_txt failed: " << sslError());
         return false;
@@ -81,6 +101,17 @@ bool fillCertificateFields(X509 *const x509) {
         LOG_ERROR(Log::instance()->getLogger(), "X509_set_issuer_name failed: " << sslError());
         return false;
     }
+
+    // v3 extensions. Must be added after the subject/issuer name is set (the SAN and
+    // basicConstraints config draw on the X509V3 context) and before X509_sign, since
+    // signing freezes the certificate and anything added afterwards is not covered by
+    // the signature.
+    if (!addExtension(x509, NID_basic_constraints, "critical,CA:FALSE")) return false;
+    if (!addExtension(x509, NID_key_usage, "critical,digitalSignature,keyEncipherment")) return false;
+    if (!addExtension(x509, NID_ext_key_usage, "serverAuth")) return false;
+    const std::string san = std::string("IP:127.0.0.1,IP:0:0:0:0:0:0:0:1,DNS:") + localHostName;
+    if (!addExtension(x509, NID_subject_alt_name, san.c_str())) return false;
+
     return true;
 }
 

--- a/src/libcommonserver/utility/selfsignedcert.cpp
+++ b/src/libcommonserver/utility/selfsignedcert.cpp
@@ -54,7 +54,7 @@ const char *sslError() {
     return err ? ERR_error_string(err, nullptr) : "no OpenSSL error";
 }
 
-bool addExtension(X509 *const x509, const int nid, const char *const value) {
+bool addExtension(X509 *const x509, const int32_t nid, const char *const value) {
     X509V3_CTX ctx;
     X509V3_set_ctx_nodb(&ctx);
     X509V3_set_ctx(&ctx, x509, x509, nullptr, nullptr, 0); // issuer == subject (self-signed)
@@ -64,7 +64,7 @@ bool addExtension(X509 *const x509, const int nid, const char *const value) {
         LOG_ERROR(Log::instance()->getLogger(), "X509V3_EXT_conf_nid failed for nid " << nid << ": " << sslError());
         return false;
     }
-    const int rc = X509_add_ext(x509, ext, -1);
+    const int32_t rc = X509_add_ext(x509, ext, -1);
     X509_EXTENSION_free(ext);
     if (rc != 1) {
         LOG_ERROR(Log::instance()->getLogger(), "X509_add_ext failed for nid " << nid << ": " << sslError());

--- a/src/server/AGENTS.md
+++ b/src/server/AGENTS.md
@@ -66,8 +66,8 @@ rg -n "vfs|Vfs|VFS" src/server/ -g "*.h" -l
 
 ## Common Gotchas
 
-- macOS uses **XPC** exclusively for GUI IPC; Windows/Linux use TCP sockets. They are separate implementations — changes
-  to IPC logic may need to be applied to both `xpccommserver_mac.mm` and `socketcommserver.cpp`.
+- macOS uses **XPC** exclusively for GUI IPC; Windows/Linux use TLS over TCP sockets. They are separate implementations —
+  changes to IPC logic may need to be applied to both `xpccommserver_mac.mm` and `socketcommserver.cpp`.
 - The server process starts before the GUI; never assume GUI is alive when handling server-side events.
 - VFS mode (LiteSync) changes the file representation on disk; IO operations in VFS mode must go through the VFS plugin
   API, not direct `std::filesystem` calls.

--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
 endif()
 
 find_package(Qt6 REQUIRED COMPONENTS Network Svg)
-find_package(Poco 1.13.3 REQUIRED XML Net NetSSL)
+find_package(Poco 1.13.3 REQUIRED XML Net NetSSL Crypto)
 find_package(sentry REQUIRED)
 
 set(CMAKE_AUTOMOC TRUE)
@@ -339,6 +339,9 @@ target_link_libraries(updater
 
 target_link_libraries(${APPLICATION_EXECUTABLE}
     Qt6::Svg
+    Poco::Net
+    Poco::NetSSL
+    Poco::Crypto
     sentry::sentry
     updater)
 

--- a/src/server/comm/abstractcommchannel.h
+++ b/src/server/comm/abstractcommchannel.h
@@ -42,6 +42,15 @@ class AbstractCommChannel : public std::enable_shared_from_this<AbstractCommChan
         virtual CommString readMessage() = 0;
         virtual uint64_t bytesAvailable() const = 0;
 
+        //! Returns true if the channel has data ready to be read.
+        /*!
+          For most channels this is equivalent to \c bytesAvailable() > 0. TLS-based channels override
+          it because poll() can report the descriptor readable while SSL_read() has no decrypted
+          application data to hand back yet (incomplete TLS record or TLS control message).
+          \return true if a subsequent readData() call may return data.
+        */
+        virtual bool isReadable() const { return bytesAvailable() > 0; }
+
         //! Gets an unique identifier for the object.
         /*!
           \return the object ptr casted to string.

--- a/src/server/comm/extcommserver.cpp
+++ b/src/server/comm/extcommserver.cpp
@@ -61,7 +61,7 @@ CommString ExtCommChannel::readMessage() {
 }
 
 bool ExtCommChannel::canReadMessage() {
-    while (bytesAvailable() > 0) {
+    while (isReadable()) {
         CommChar data[1024];
         if (uint64_t charRead = readData(data, 1024); charRead > 0) {
             _readBuffer.append(data, charRead);

--- a/src/server/comm/guicommserver.cpp
+++ b/src/server/comm/guicommserver.cpp
@@ -94,9 +94,9 @@ bool GuiCommChannel::containsCompleteMessage(const CommString &message, size_t &
 }
 
 void GuiCommChannel::fetchDataToBuffer() {
-    while (bytesAvailable() > 0) {
+    while (isReadable()) {
         CommChar data[1024];
-        if (uint64_t charRead = readData(data, (std::min) (bytesAvailable(), static_cast<uint64_t>(1024))); charRead > 0) {
+        if (uint64_t charRead = readData(data, 1024); charRead > 0) {
             const std::scoped_lock lock(_readBufferMutex);
             _readBuffer.append(data, charRead);
         } else {

--- a/src/server/comm/securecontextsingleton.cpp
+++ b/src/server/comm/securecontextsingleton.cpp
@@ -19,6 +19,7 @@
 #include "securecontextsingleton.h"
 
 #include "libcommonserver/utility/selfsignedcert.h"
+#include "libcommonserver/log/log.h"
 
 #include <Poco/Net/Context.h>
 #include <Poco/Crypto/X509Certificate.h>
@@ -27,7 +28,6 @@
 
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
-#include <openssl/rsa.h>
 
 #include <sstream>
 

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -27,9 +27,9 @@ namespace KDC {
 constexpr char host[] = "127.0.0.1";
 // Bound the TLS handshake after accept so a peer that connects but never sends a
 // ClientHello can't block the accept loop forever.
-constexpr int handshakeTimeoutSec = 5;
+constexpr int32_t handshakeTimeoutSec = 5;
 // Channel-lifetime receive timeout: SSL_read() must never park on _socketMutex forever.
-constexpr int channelReceiveTimeoutSec = 30;
+constexpr int32_t channelReceiveTimeoutSec = 30;
 
 SocketCommChannel::SocketCommChannel(const Poco::Net::StreamSocket &socket) :
     AbstractCommChannel(),

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -159,7 +159,7 @@ void SocketCommChannel::callbackHandler() {
 
 uint64_t SocketCommChannel::bytesAvailable() const {
     try {
-        int32_t avail = 0;
+        int avail = 0;
         {
             std::lock_guard lock(_socketMutex);
             avail = _socket.available();

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -112,17 +112,19 @@ uint64_t SocketCommChannel::writeData(const CommChar *data, uint64_t len) {
         written = _socket.sendBytes(data, static_cast<int>(len) * commCharSize);
     } catch (Poco::Exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::sendBytes: " << ex.displayText());
-        _isClosing = true;
-        lostConnectionCbk();
-        close();
+        if (!_isClosing.exchange(true)) {
+            lostConnectionCbk();
+            close();
+        }
         return 0;
     }
 
     if (written < 0) {
         LOG_ERROR(Log::instance()->getLogger(), "Socket connection error on sendBytes");
-        _isClosing = true;
-        lostConnectionCbk();
-        close();
+        if (!_isClosing.exchange(true)) {
+            lostConnectionCbk();
+            close();
+        }
         return 0;
     }
 

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -132,7 +132,7 @@ uint64_t SocketCommChannel::writeData(const CommChar *data, uint64_t len) {
 void SocketCommChannel::callbackHandler() {
     while (!_isClosing) {
         try {
-            if (bytesAvailable() == 0 &&
+            if (!isReadable() &&
                 !_socket.poll(Poco::Timespan(1, 0), Poco::Net::Socket::SELECT_READ | Poco::Net::Socket::SELECT_ERROR)) {
                 continue;
             }
@@ -157,19 +157,26 @@ uint64_t SocketCommChannel::bytesAvailable() const {
             std::lock_guard lock(_socketMutex);
             avail = _socket.available();
         }
-        if (avail > 0) return static_cast<uint64_t>(avail);
-        // For TLS sockets, available() may return 0 even when encrypted data is pending.
-        // Fall back to poll() to detect readability.
-        {
-            std::lock_guard lock(_socketMutex);
-            if (_socket.poll(Poco::Timespan(0, 0), Poco::Net::Socket::SELECT_READ)) {
-                return 1; // Data is likely available to be read
-            }
-        }
-        return 0;
+        if (avail < 0) return 0;
+        return static_cast<uint64_t>(avail);
     } catch (Poco::Exception &ex) {
         LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::available: " << ex.displayText());
-        return static_cast<uint64_t>(0);
+        return 0;
+    }
+}
+
+bool SocketCommChannel::isReadable() const {
+    if (bytesAvailable() > 0) return true;
+    // For TLS sockets, available() may return 0 even when encrypted data is pending.
+    // Fall back to poll() to detect readability: an incomplete TLS record or a TLS control
+    // message makes poll() report the descriptor readable while SSL_read() has nothing to
+    // hand back yet. bytesAvailable() must stay exact (it is also used as a read size),
+    // so readability is reported separately here.
+    try {
+        return _socket.poll(Poco::Timespan(0, 0), Poco::Net::Socket::SELECT_READ);
+    } catch (Poco::Exception &ex) {
+        LOG_ERROR(Log::instance()->getLogger(), "Exception in StreamSocket::poll: " << ex.displayText());
+        return false;
     }
 }
 

--- a/src/server/comm/socketcommserver.cpp
+++ b/src/server/comm/socketcommserver.cpp
@@ -25,6 +25,11 @@
 namespace KDC {
 
 constexpr char host[] = "127.0.0.1";
+// Bound the TLS handshake after accept so a peer that connects but never sends a
+// ClientHello can't block the accept loop forever.
+constexpr int handshakeTimeoutSec = 5;
+// Channel-lifetime receive timeout: SSL_read() must never park on _socketMutex forever.
+constexpr int channelReceiveTimeoutSec = 30;
 
 SocketCommChannel::SocketCommChannel(const Poco::Net::StreamSocket &socket) :
     AbstractCommChannel(),
@@ -338,8 +343,8 @@ void SocketCommServer::execute() {
         // Bound the handshake: without a timeout, a local process that opens a TCP connection and
         // never sends a ClientHello blocks this accept loop forever and no GUI can connect again.
         const Poco::Timespan sndTimeout = socket.getSendTimeout();
-        socket.setReceiveTimeout(Poco::Timespan(5, 0));
-        socket.setSendTimeout(Poco::Timespan(5, 0));
+        socket.setReceiveTimeout(Poco::Timespan(handshakeTimeoutSec, 0));
+        socket.setSendTimeout(Poco::Timespan(handshakeTimeoutSec, 0));
 
         // Eagerly complete the TLS handshake so that encrypted data on the wire
         // is already decrypted when the callback thread polls for it later.
@@ -363,7 +368,7 @@ void SocketCommServer::execute() {
 
         // Keep a bounded receive timeout for the channel's lifetime: SSL_read() must never park on
         // _socketMutex forever (see the comment on readData).
-        secureSocket.setReceiveTimeout(Poco::Timespan(30, 0));
+        secureSocket.setReceiveTimeout(Poco::Timespan(channelReceiveTimeoutSec, 0));
         secureSocket.setSendTimeout(sndTimeout);
 
         const auto channel = makeCommChannel(secureSocket);

--- a/src/server/comm/socketcommserver.h
+++ b/src/server/comm/socketcommserver.h
@@ -40,6 +40,7 @@ class SocketCommChannel : public AbstractCommChannel {
         void startCallbackThread();
 
         uint64_t bytesAvailable() const override;
+        bool isReadable() const override;
         void close() override;
 
         bool joinCallbackThread() noexcept;

--- a/test/server/CMakeLists.txt
+++ b/test/server/CMakeLists.txt
@@ -5,7 +5,7 @@ else()
 endif()
 
 find_package(Qt6 REQUIRED COMPONENTS Network Svg)
-find_package(Poco 1.13.3 REQUIRED XML Net NetSSL)
+find_package(Poco 1.13.3 REQUIRED XML Net NetSSL Crypto)
 
 set(CMAKE_AUTOMOC ON)
 

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -79,7 +79,8 @@ void TestSocketComm::testServerListen() {
 
     // Wait for the server to receive the message
     remainWait = 100; // wait max 1 second
-    while (!serverSidechannel->isReadable() && remainWait-- > 0) {
+    while (!serverSidechannel->isReadable() && remainWait > 0) {
+        --remainWait;
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->isReadable());
@@ -205,7 +206,8 @@ void TestSocketComm::testChannelReadAndWriteData() {
         clientSideChannel->sendMessage(msg);
         // Wait for the server to receive the message
         int remainWait = 100; // wait max 1 second
-        while (!serverSidechannel->isReadable() && remainWait-- > 0) {
+        while (!serverSidechannel->isReadable() && remainWait > 0) {
+            --remainWait;
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
         CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->isReadable());
@@ -225,7 +227,8 @@ void TestSocketComm::testChannelReadAndWriteData() {
 
     // Wait for the server to receive the message
     remainWait = 100; // wait max 1 second
-    while (!serverSidechannel->isReadable() && remainWait-- > 0) {
+    while (!serverSidechannel->isReadable() && remainWait > 0) {
+        --remainWait;
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
     CPPUNIT_ASSERT_MESSAGE("Server did not receive the long message in time", serverSidechannel->isReadable());

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -124,7 +124,7 @@ void TestSocketComm::testServerCallbacks() {
     clientSideChannel->close();
 
     // Force a read on the server side channel to detect the peer close and
-    // trigger lostConnectionCbk() — required because available() can no longer
+    // trigger lostConnectionCbk(), required because available() can no longer
     // be used as a proxy for EOF with TLS sockets.
     (void) serverSidechannel->readMessage();
 

--- a/test/server/comm/testsocketcomm.cpp
+++ b/test/server/comm/testsocketcomm.cpp
@@ -79,10 +79,10 @@ void TestSocketComm::testServerListen() {
 
     // Wait for the server to receive the message
     remainWait = 100; // wait max 1 second
-    while (serverSidechannel->bytesAvailable() == 0 && remainWait-- > 0) {
+    while (!serverSidechannel->isReadable() && remainWait-- > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->bytesAvailable() > 0);
+    CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->isReadable());
 
     // Read the message on the server side
     auto message = serverSidechannel->readMessage();
@@ -205,10 +205,10 @@ void TestSocketComm::testChannelReadAndWriteData() {
         clientSideChannel->sendMessage(msg);
         // Wait for the server to receive the message
         int remainWait = 100; // wait max 1 second
-        while (serverSidechannel->bytesAvailable() == 0 && remainWait-- > 0) {
+        while (!serverSidechannel->isReadable() && remainWait-- > 0) {
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
         }
-        CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->bytesAvailable() > 0);
+        CPPUNIT_ASSERT_MESSAGE("Server did not receive the message in time", serverSidechannel->isReadable());
         // Read the message on the server side
         auto message = serverSidechannel->readMessage();
         CPPUNIT_ASSERT(message.starts_with(msg)); // The mock readMessage always return a 1024 CommChar string.
@@ -225,10 +225,10 @@ void TestSocketComm::testChannelReadAndWriteData() {
 
     // Wait for the server to receive the message
     remainWait = 100; // wait max 1 second
-    while (serverSidechannel->bytesAvailable() == 0 && remainWait-- > 0) {
+    while (!serverSidechannel->isReadable() && remainWait-- > 0) {
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
     }
-    CPPUNIT_ASSERT_MESSAGE("Server did not receive the long message in time", serverSidechannel->bytesAvailable() > 0);
+    CPPUNIT_ASSERT_MESSAGE("Server did not receive the long message in time", serverSidechannel->isReadable());
 
     // Read the message on the server side
     CommChar data[101];

--- a/test/server/test.cpp
+++ b/test/server/test.cpp
@@ -19,7 +19,9 @@
 #include "testincludes.h"
 
 #if defined(KD_WINDOWS)
+extern "C" {
 #include <openssl/applink.c>
+}
 #endif
 
 #if defined(KD_MACOS)


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR cherry-pick les modifications côté serveur demandées lors de la revue du PR Linux v4 (#2211) et les ajoute par-dessus le PR client Windows (#2234). Les deux PR clients (Windows et Linux) bénéficient ainsi des mêmes améliorations TLS côté serveur.

## Changements
- Ajout d'extensions X.509 v3 aux certificats auto-signés : `basicConstraints` (CA:FALSE), `keyUsage` (digitalSignature, keyEncipherment), `extKeyUsage` (serverAuth) et `subjectAltName` (IPv4/IPv6 localhost + nom DNS)
- Nouvelle méthode virtuelle `isReadable()` sur `AbstractCommChannel` pour distinguer la lisibilité TLS de la disponibilité d'octets ; `bytesAvailable()` reste exact (utilisé comme taille de lecture), tandis que `isReadable()` utilise `poll()` comme repli pour les sockets TLS
- Protection contre les appels multiples à `lostConnectionCbk()` via `_isClosing.exchange(true)` dans les chemins d'erreur de `writeData`
- Extraction des constantes de timeout TLS (`handshakeTimeoutSec = 5`, `channelReceiveTimeoutSec = 30`)
- Refactorisation des constantes keychain (`package`, `service`) dans un namespace partagé `keychainConstant` dans `utility.h`
- Ajout de la dépendance `Poco::Crypto` aux CMakeLists de `libcommonserver` et `server`
- Encapsulation de `openssl/applink.c` dans un bloc `extern "C"` pour la compatibilité Windows
- Extraction de la constante `localHostName` ("kDrive-localhost") dans `comm.h`
- Mise à jour de la documentation `AGENTS.md` pour refléter l'utilisation de TLS sur les sockets TCP

## Détails techniques
Cette PR est la 4e d'une série de PR TLS :
1. #2202 (`fix/tls-secure-server-socket`) - TLS côté serveur (base)
2. #2234 (`fix/winui/incorporate-tls`) - Client Windows (par-dessus #2202)
3. #2211 (`linux-v4/incorporate-tls`) - Client Linux v4 (par-dessus #2202)

La revue du PR Linux v4 a demandé des modifications qui touchent le code côté serveur. Ces commits sont cherry-pickés ici par-dessus le PR client Windows afin que les deux branches clients restent synchronisées.

La distinction `isReadable()` vs `bytesAvailable()` est nécessaire car `SSL_read()` peut ne retourner aucune donnée déchiffrée même quand `poll()` indique le descripteur lisible (enregistrement TLS incomplet ou message de contrôle TLS).

</details>

---

## Summary
This PR cherry-picks the server-side changes requested during the review of the Linux v4 TLS PR (#2211) and stacks them on top of the Windows client PR (#2234). Both client PRs (Windows and Linux) now share the same server-side TLS improvements.

## Changes
- Added X.509 v3 extensions to self-signed certificates: `basicConstraints` (CA:FALSE), `keyUsage` (digitalSignature, keyEncipherment), `extKeyUsage` (serverAuth), and `subjectAltName` (localhost IPv4/IPv6 + DNS name)
- New virtual `isReadable()` method on `AbstractCommChannel` to separate TLS readability from byte availability; `bytesAvailable()` stays exact (used as read size), while `isReadable()` falls back to `poll()` for TLS sockets where `available()` may return 0 despite pending encrypted data
- Guarded against multiple `lostConnectionCbk()` calls via `_isClosing.exchange(true)` in `writeData` error paths
- Extracted TLS timeout constants (`handshakeTimeoutSec = 5`, `channelReceiveTimeoutSec = 30`)
- Refactored keychain constants (`package`, `service`) into a shared `keychainConstant` namespace in `utility.h`
- Added `Poco::Crypto` dependency to `libcommonserver` and `server` CMakeLists
- Wrapped `openssl/applink.c` in `extern "C"` block for Windows compatibility
- Extracted `localHostName` constant ("kDrive-localhost") into `comm.h`
- Updated `AGENTS.md` documentation to reflect TLS over TCP sockets

## Technical Details
This PR is the 4th in a series of TLS PRs:
1. #2202 (`fix/tls-secure-server-socket`) - Server-side TLS (base)
2. #2234 (`fix/winui/incorporate-tls`) - Windows client (on top of #2202)
3. #2211 (`linux-v4/incorporate-tls`) - Linux v4 client (on top of #2202)

The Linux v4 review requested modifications that touch server-side code. These commits are cherry-picked here on top of the Windows client PR so both client branches stay in sync.

The `isReadable()` vs `bytesAvailable()` distinction is needed because `SSL_read()` may return no decrypted application data even when `poll()` reports the descriptor readable (incomplete TLS record or TLS control message). `bytesAvailable()` must stay exact since it is also used as a read size, so readability is reported separately.
