### PR TITLE
feat(gui4-linux): add ActivityStore for file activity tracking

### DIFF
--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -70,6 +70,10 @@
 - Render the future main-toolbar Search action as a standalone 36 px circular icon-only button, without a text label,
   and center its 16 px magnifier with 10 px between the SVG and each horizontal edge. Reuse the Support button component
   so both outer circles remain identical.
+- For Activities status presentation, mirror the Windows fallback: `Unknown`, `Error`, `Conflict`, `Inconsistency`, and
+  `Ignored` are all visible error activities; only `Success` and `Syncing` use non-error presentations.
+- Automated tests for the current Activities milestone are deferred. Do not add an Activities-specific test target or
+  files under `test/gui4/linux/` until the user explicitly reopens that scope.
 - Main-sidebar selection changes only the row background; it must not recolor the icon or increase the label weight.
 - Keep shared color primitives aligned with the macOS design-token assets; notably, `NeutralBlue200` is `#DCE3F0` and
   `NeutralBlue600` is `#1F242E`.
@@ -137,8 +141,14 @@
 - `app/cache/appcache.*`: graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs, the
   single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
-- `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache` push signals.
-    - Routes entity and sync-runtime pushes after population; drops earlier mutations and logs the invariant violation.
+- `app/cache/activitystore.*`: process-local, per-sync file-activity history. It normalizes `SyncFileItemInfo` pushes,
+  updates valid operation ids in place, preserves distinct anonymous operations, and bounds retention to 500 entries per
+  synchronization. It stays separate from the durable `AppCache` graph and is not exposed directly to QML.
+- `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache/ActivityStore` push signals.
+    - Routes entity and sync-runtime pushes after population; drops earlier entity mutations and logs the invariant
+      violation.
+    - Buffers a bounded number of file activities during initial population, replays them once parent synchronizations
+      exist, and prunes activity history when the configured synchronization set changes.
 - `app/cache/cachetypes.h`: cache read models and onboarding keys (`SyncContext`, `DriveContext`,
   `SyncRuntimeInfo`, `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
     - Configured-drive state uses the unified `libcommon/data/drive.h` `Drive` model; do not reintroduce the removed

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -142,8 +142,9 @@
   single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
 - `app/cache/activitystore.*`: process-local, per-sync file-activity history. It normalizes `SyncFileItemInfo` pushes,
-  updates valid operation ids in place, preserves distinct anonymous operations, and bounds retention to 500 entries per
-  synchronization. It stays separate from the durable `AppCache` graph and is not exposed directly to QML.
+  updates valid operation ids in place, removes failed entries superseded by a successful or in-progress activity for the
+  same node, preserves distinct anonymous operations, and bounds retention to 500 entries per synchronization. It stays
+  separate from the durable `AppCache` graph and is not exposed directly to QML.
 - `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache/ActivityStore` push signals.
     - Routes entity, sync-runtime, and file-activity pushes after population; drops and logs earlier pushes as invariant
       violations.

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -50,8 +50,8 @@
   hexadecimal or RGBA values.
 - Do not run `qmlformat --normalize` on structured token files: it reorders QML members independently of the intended
   T1/T2/T3 hierarchy and detaches section comments from their tokens.
-- Render the main-sidebar synchronization selector with the bare drive glyph tinted by the drive color; do not place
-  the glyph on a colored tile.
+- Render the main-sidebar synchronization selector with the bare drive glyph tinted by the drive color; do not place the
+  glyph on a colored tile.
 - Render advanced synchronizations with the outline `ui/assets/main/folder.svg` tinted by the owning drive color;
   reserve the bare drive glyph for classic root synchronizations.
 - In the main-sidebar Figma variants, "no synchronization" means no advanced synchronization. The drive row is the
@@ -88,8 +88,8 @@
   window shell.
 - When ending an onboarding session, unpublish it so QML unloads the onboarding `Loader`, then destroy it with
   `deleteLater()`. Invalidate session-scoped asynchronous results before allowing a new session to consume them.
-- Keep `AppClientLinux` as an application composition root. Move multi-step feature workflows such as onboarding login into
-  dedicated coordinators instead of accumulating workflow lambdas in `AppClientLinux`.
+- Keep `AppClientLinux` as an application composition root. Move multi-step feature workflows such as onboarding login
+  into dedicated coordinators instead of accumulating workflow lambdas in `AppClientLinux`.
 - `Qt.labs.lottieqt` renders Lottie JSON assets, not `.lottie` zip containers.
 - For Qt 6.11+ onboarding Lottie assets, prefer generated QML from `lottietoqml` over PNG spritesheets when the
   generated output builds and visually matches the source animation.
@@ -145,10 +145,9 @@
   updates valid operation ids in place, preserves distinct anonymous operations, and bounds retention to 500 entries per
   synchronization. It stays separate from the durable `AppCache` graph and is not exposed directly to QML.
 - `app/cache/cachepipeline.*`: unique bridge for `CommService -> AppCache/ActivityStore` push signals.
-    - Routes entity and sync-runtime pushes after population; drops earlier entity mutations and logs the invariant
-      violation.
-    - Buffers a bounded number of file activities during initial population, replays them once parent synchronizations
-      exist, and prunes activity history when the configured synchronization set changes.
+    - Routes entity, sync-runtime, and file-activity pushes after population; drops and logs earlier pushes as invariant
+      violations.
+    - Prunes activity history when the configured synchronization set changes.
 - `app/cache/cachetypes.h`: cache read models and onboarding keys (`SyncContext`, `DriveContext`,
   `SyncRuntimeInfo`, `AvailableDriveContext`, `AvailableDriveKey`, `PendingSyncConfig`).
     - Configured-drive state uses the unified `libcommon/data/drive.h` `Drive` model; do not reintroduce the removed
@@ -177,13 +176,13 @@
   next activation.
 - `app/cache/onboardingstate.*`: session-owned onboarding selected user, selected available-drive keys, and pending sync
   configs.
-- `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`).
-  It is populated during the bootstrap sequence next to the product graph snapshot, but remains separate from `AppCache`
+- `app/cache/parametersstore.*`: process-wide cache for server-owned application parameters (`ParametersInfo`). It is
+  populated during the bootstrap sequence next to the product graph snapshot, but remains separate from `AppCache`
   because the server is still the persistence source of truth for application settings. It stores only the last
   server-confirmed snapshot; update workflows publish a new value only after `PARAMETERS_UPDATE` succeeds.
 - `app/onboarding/availabledrivesmodel.*`: QML adapter for onboarding drive selection. It derives rows from
-  `AppCache::availableDriveContexts(selectedUserDbId)` and stores row selection through `OnboardingState`. It must not own
-  screen-level loading, user, or navigation state.
+  `AppCache::availableDriveContexts(selectedUserDbId)` and stores row selection through `OnboardingState`. It must not
+  own screen-level loading, user, or navigation state.
 - `app/onboarding/driveselectioncontroller.*`: QML-facing screen controller for user presentation, loading/error state,
   counts, retry, and navigation actions. It owns the session's `AvailableDrivesModel`.
 - `app/onboarding/onboardingentrydecision.*`: pure post-bootstrap decision from `AppCache` to Inactive, Login, or
@@ -191,21 +190,21 @@
   lowest database id, preserving the stable ordering returned by `AppCache::users()`.
 - `app/onboarding/onboardingsession.*`: ephemeral owner of onboarding state, flow, login workflow, and drive-selection
   controller/model.
-- `app/onboarding/onboardingsessionmanager.*`: process-long nullable-session owner and the only onboarding object exposed
-  at the root QML boundary. It creates a session after cache bootstrap and unpublishes it before deferred destruction. It
-  accepts activation requests while onboarding is required and rejects them with an explanatory log when no onboarding
-  route is displayable. On successful onboarding completion, `AppClientLinux` opens the main window route.
+- `app/onboarding/onboardingsessionmanager.*`: process-long nullable-session owner and the only onboarding object
+  exposed at the root QML boundary. It creates a session after cache bootstrap and unpublishes it before deferred
+  destruction. It accepts activation requests while onboarding is required and rejects them with an explanatory log when
+  no onboarding route is displayable. On successful onboarding completion, `AppClientLinux` opens the main window route.
 - `app/onboarding/onboardingflowcontroller.*`: QML-facing onboarding flow controller aligned with the macOS flow
   (`login -> drive selection -> synchronization -> ready`, with macOS permission steps omitted on Linux). It owns simple
   onboarding UI actions such as opening account signup and drive-offer URLs, plus synchronization/ready presentation
   state; OAuth launch, `LOGIN_REQUESTTOKEN`, available-drive loading, and sync creation stay outside QML-facing flow
   state.
-- `app/onboarding/onboardinglogincoordinator.*`: login workflow coordinator for onboarding. It wires the flow controller,
-  OAuth service, comm service, user service, app cache, and onboarding state so `AppClientLinux` does not accumulate
-  login-specific workflow logic.
-- `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It derives
-  collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only failed and
-  not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a failed `SYNC_ADD`.
+- `app/onboarding/onboardinglogincoordinator.*`: login workflow coordinator for onboarding. It wires the flow
+  controller, OAuth service, comm service, user service, app cache, and onboarding state so `AppClientLinux` does not
+  accumulate login-specific workflow logic.
+- `app/onboarding/onboardingsynccreationcoordinator.*`: automatic end-of-onboarding sync creation coordinator. It
+  derives collision-free local folders, creates selected-drive syncs sequentially at the remote root, preserves only
+  failed and not-yet-attempted work for retry, and reconciles the parent-first cache snapshot after a failed `SYNC_ADD`.
 - `app/onboarding/oauthloginservice.*`: Linux v4 OAuth browser-launch service. It owns PKCE/state generation, idempotent
   browser relaunch during an active authorization, callback validation, and emits the authorization code to app wiring.
   Do not expose OAuth details to QML.
@@ -246,9 +245,10 @@
       diffuse shadow. It publishes `_GTK_FRAME_EXTENTS` on X11/XWayland so those window managers align the visible
       surface rather than the transparent shadow during snapping and maximization. Native Wayland intentionally uses
       public Qt APIs only and therefore snaps the complete native window, including its transparent shadow margin.
-    - `ui/windows/onboarding/animations/`: versioned generated QML animation components produced from Lottie JSON payloads.
-      Do not edit these files manually. They are excluded from `qmllint`; validation belongs to the generator and the
-      QML compilation step.
+    - `ui/windows/onboarding/animations/`: versioned generated QML animation components produced from Lottie JSON
+      payloads. Do not edit these files manually. They are excluded from `qmllint`; validation belongs to the generator
+      and the QML compilation step.
+
 ### Regenerate Onboarding Lottie QML
 
 Run `lottietoqml` from the Qt/Conan package that provides `qtlottie`. The loader source JSON is supplied locally and is
@@ -354,8 +354,8 @@ cmake --build build-linux/build/build/Debug --target kDrive kDrive_client kdrive
 - Request methods should parse `Poco::DynamicStruct` into typed DTOs before exposing data upward.
 - Generic UI-facing request failures from high-level services should be emitted through `ServiceEventBus` so UI can
   subscribe once (`genericErrorOccurred()`).
-- Sentry captures in Linux v4 should go through `SentryService`; capture helpers must tolerate Sentry being uninitialized
-  because consent can disable the native SDK.
+- Sentry captures in Linux v4 should go through `SentryService`; capture helpers must tolerate Sentry being
+  uninitialized because consent can disable the native SDK.
 - Action-level and per-service loading state should come from `ServiceActionTracker`
   (`isActionPending(...)`, `isServicePending(...)`).
 - Use shared `msgParam*` keys and enums from `libcommon`; avoid ad-hoc string keys.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -22,6 +22,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/appconstants.h
         app/applicationidentity.cpp
         app/applicationidentity.h
+        app/cache/activitystore.cpp
+        app/cache/activitystore.h
         app/cache/appcache.cpp
         app/cache/appcache.h
         app/cache/appcachegraph.cpp

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -68,11 +68,9 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
     }
 
     auto entry = makeEntry(syncDbId, item, *normalizedStatus, source, _nextLocalId++);
-    const GenericId insertedLocalId = entry.localId;
     entries.push_back(std::move(entry));
-    if (enforceCapacity(syncDbId, insertedLocalId, entries)) {
-        emit activitiesChanged(syncDbId);
-    }
+    enforceCapacity(entries);
+    emit activitiesChanged(syncDbId);
 }
 
 std::vector<ActivityEntry> ActivityStore::activities(const SyncDbId syncDbId) const {
@@ -228,47 +226,17 @@ ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileIt
 /**
  * @brief Trims a synchronization's activity collection to ActivityStore::maxActivitiesPerSync entries.
  *
- * Eviction preserves active work whenever possible. While the collection exceeds its limit, the oldest entry that is no
- * longer in progress is removed first, using ActivityEntry::receivedSequence as the stable age discriminator. If every
- * retained entry is still in progress, the oldest one is removed instead and the exceptional condition is logged.
+ * While the collection exceeds its limit, the activity with the oldest ActivityEntry::receivedSequence is removed,
+ * regardless of its status. The entry inserted immediately before this call has the newest sequence and is therefore
+ * always retained. This guarantees that a new error remains visible even when every retained activity is in progress.
  *
- * The newly inserted entry can itself be selected for eviction. This happens, for example, when 500 in-progress entries
- * are already retained and the new entry is the only completed candidate. Returning whether that entry survived lets
- * the caller avoid emitting activitiesChanged() when insertion followed by eviction leaves the observable collection
- * unchanged.
- *
- * @param syncDbId Database identifier used to contextualize capacity warnings.
- * @param insertedLocalId Process-local identifier of the entry inserted immediately before this call.
  * @param entries Mutable activity collection to trim.
- * @return true if the newly inserted entry remains in the collection; false if capacity enforcement evicted it.
  */
-bool ActivityStore::enforceCapacity(const SyncDbId syncDbId, const GenericId insertedLocalId,
-                                    std::vector<ActivityEntry> &entries) {
-    bool insertedEntryRetained = true;
+void ActivityStore::enforceCapacity(std::vector<ActivityEntry> &entries) {
     while (entries.size() > ActivityStore::maxActivitiesPerSync) {
-        auto oldestCompletedIt = entries.end();
-        for (auto entryIt = entries.begin(); entryIt != entries.end(); ++entryIt) {
-            if (isInProgress(entryIt->status)) {
-                continue;
-            }
-            if (oldestCompletedIt == entries.end() || entryIt->receivedSequence < oldestCompletedIt->receivedSequence) {
-                oldestCompletedIt = entryIt;
-            }
-        }
-
-        if (oldestCompletedIt != entries.end()) {
-            insertedEntryRetained = insertedEntryRetained && oldestCompletedIt->localId != insertedLocalId;
-            entries.erase(oldestCompletedIt);
-            continue;
-        }
-
         const auto oldestIt = std::ranges::min_element(entries, {}, &ActivityEntry::receivedSequence);
-        qCWarning(lcActivityStore) << "Activity capacity reached with only in-progress operations; evicting oldest"
-                                   << "| syncDbId:" << syncDbId << "/ capacity:" << maxActivitiesPerSync;
-        insertedEntryRetained = insertedEntryRetained && oldestIt->localId != insertedLocalId;
         entries.erase(oldestIt);
     }
-    return insertedEntryRetained;
 }
 
 } // namespace KDC

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -38,6 +38,24 @@ bool isValidOperationId(const UniqueId operationId) {
 bool isInProgress(const ActivityStatus status) {
     return status == ActivityStatus::InProgress;
 }
+
+/** @brief Returns whether two activities identify the same node through a non-empty local or remote identifier. */
+bool hasMatchingNodeId(const ActivityEntry &entry, const SyncFileItemInfo &item) {
+    const bool sameLocalNode = !item.localNodeId().isEmpty() && item.localNodeId() == entry.localNodeId;
+    const bool sameRemoteNode = !item.remoteNodeId().isEmpty() && item.remoteNodeId() == entry.remoteNodeId;
+    return sameLocalNode || sameRemoteNode;
+}
+
+/** @brief Removes failed activities superseded by a successful or in-progress activity for the same node. */
+void removeSupersededFailures(std::vector<ActivityEntry> &entries, const SyncFileItemInfo &item, const ActivityStatus status) {
+    if (status == ActivityStatus::Failed) {
+        return;
+    }
+
+    (void) std::erase_if(entries, [&item](const ActivityEntry &entry) {
+        return entry.status == ActivityStatus::Failed && hasMatchingNodeId(entry, item);
+    });
+}
 } // namespace
 
 ActivityStore::ActivityStore(QObject *const parent) :
@@ -63,10 +81,21 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
     }
 
     auto &entries = _activitiesBySyncDbId[syncDbId];
-    if (updateExistingOperation(syncDbId, entries, item, *normalizedStatus, source)) {
-        return;
+    if (isValidOperationId(item.operationId())) {
+        if (const auto entryIt = std::ranges::find(entries, item.operationId(), &ActivityEntry::operationId);
+            entryIt != entries.end()) {
+            if (!isInProgress(entryIt->status)) {
+                return;
+            }
+
+            *entryIt = makeEntry(syncDbId, item, *normalizedStatus, source, entryIt->localId);
+            removeSupersededFailures(entries, item, *normalizedStatus);
+            emit activitiesChanged(syncDbId);
+            return;
+        }
     }
 
+    removeSupersededFailures(entries, item, *normalizedStatus);
     auto entry = makeEntry(syncDbId, item, *normalizedStatus, source, _nextLocalId++);
     entries.push_back(std::move(entry));
     enforceCapacity(entries);
@@ -154,41 +183,6 @@ ActivitySource ActivityStore::normalizeSource(const SyncDirection direction) {
             return ActivitySource::Unknown;
     }
     return ActivitySource::Unknown;
-}
-
-/**
- * @brief Updates an existing operation or absorbs a late event for an operation that is no longer in progress.
- *
- * Invalid and unknown operation identifiers return false so the caller can insert a distinct activity. An in-progress
- * entry is replaced while preserving its local identifier. Entries that are no longer in progress absorb duplicate or
- * regressive events without emitting a change.
- *
- * @param syncDbId Database identifier of the owning synchronization.
- * @param entries Mutable activity collection for that synchronization.
- * @param item Latest activity DTO received for the operation.
- * @param status Normalized presentation status.
- * @param source Normalized presentation source.
- * @return true when the operation identifier was already present, whether updated or deliberately ignored; false when a
- * new entry must be inserted.
- */
-bool ActivityStore::updateExistingOperation(const SyncDbId syncDbId, std::vector<ActivityEntry> &entries,
-                                            const SyncFileItemInfo &item, const ActivityStatus status,
-                                            const ActivitySource source) {
-    if (!isValidOperationId(item.operationId())) {
-        return false;
-    }
-
-    const auto entryIt = std::ranges::find(entries, item.operationId(), &ActivityEntry::operationId);
-    if (entryIt == entries.end()) {
-        return false;
-    }
-    if (!isInProgress(entryIt->status)) {
-        return true;
-    }
-
-    *entryIt = makeEntry(syncDbId, item, status, source, entryIt->localId);
-    emit activitiesChanged(syncDbId);
-    return true;
 }
 
 /**

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -1,0 +1,274 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "activitystore.h"
+
+#include <QLoggingCategory>
+
+#include <algorithm>
+#include <ranges>
+#include <utility>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivityStore, "gui.v4.activitystore", QtInfoMsg)
+
+/** @brief Returns whether an operation identifier can safely be used for deduplication. */
+bool isValidOperationId(const UniqueId operationId) {
+    return operationId > 0;
+}
+
+/** @brief Returns whether an activity is currently being synchronized. */
+bool isInProgress(const ActivityStatus status) {
+    return status == ActivityStatus::InProgress;
+}
+} // namespace
+
+ActivityStore::ActivityStore(QObject *const parent) :
+    QObject(parent) {}
+
+void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item) {
+    if (syncDbId <= 0) {
+        qCWarning(lcActivityStore) << "Activity ignored for invalid synchronization | syncDbId:" << syncDbId;
+        return;
+    }
+
+    const auto normalizedStatus = normalizeStatus(item.status());
+    if (!normalizedStatus.has_value()) {
+        qCWarning(lcActivityStore) << "Activity ignored for unsupported status | syncDbId:" << syncDbId
+                                   << "/ status:" << static_cast<int32_t>(item.status());
+        return;
+    }
+
+    const ActivitySource source = normalizeSource(item.direction());
+    if (source == ActivitySource::Unknown) {
+        qCWarning(lcActivityStore) << "Activity received with unknown source | syncDbId:" << syncDbId
+                                   << "/ direction:" << static_cast<int32_t>(item.direction());
+    }
+
+    auto &entries = _activitiesBySyncDbId[syncDbId];
+    if (updateExistingOperation(syncDbId, entries, item, *normalizedStatus, source)) {
+        return;
+    }
+
+    auto entry = makeEntry(syncDbId, item, *normalizedStatus, source, _nextLocalId++);
+    const GenericId insertedLocalId = entry.localId;
+    entries.push_back(std::move(entry));
+    if (enforceCapacity(syncDbId, insertedLocalId, entries)) {
+        emit activitiesChanged(syncDbId);
+    }
+}
+
+std::vector<ActivityEntry> ActivityStore::activities(const SyncDbId syncDbId) const {
+    const auto syncIt = _activitiesBySyncDbId.find(syncDbId);
+    return syncIt == _activitiesBySyncDbId.end() ? std::vector<ActivityEntry>{} : syncIt->second;
+}
+
+void ActivityStore::removeSync(const SyncDbId syncDbId) {
+    if (_activitiesBySyncDbId.erase(syncDbId) == 0) {
+        return;
+    }
+    emit activitiesChanged(syncDbId);
+}
+
+void ActivityStore::retainSyncs(const std::unordered_set<SyncDbId> &syncDbIds) {
+    std::vector<SyncDbId> removedSyncDbIds;
+    for (auto syncIt = _activitiesBySyncDbId.begin(); syncIt != _activitiesBySyncDbId.end();) {
+        if (syncDbIds.contains(syncIt->first)) {
+            ++syncIt;
+            continue;
+        }
+
+        removedSyncDbIds.push_back(syncIt->first);
+        syncIt = _activitiesBySyncDbId.erase(syncIt);
+    }
+
+    for (const SyncDbId syncDbId: removedSyncDbIds) {
+        emit activitiesChanged(syncDbId);
+    }
+}
+
+void ActivityStore::clear() {
+    std::vector<SyncDbId> removedSyncDbIds;
+    removedSyncDbIds.reserve(_activitiesBySyncDbId.size());
+    for (const SyncDbId syncDbId: _activitiesBySyncDbId | std::views::keys) {
+        removedSyncDbIds.push_back(syncDbId);
+    }
+    _activitiesBySyncDbId.clear();
+
+    for (const SyncDbId syncDbId: removedSyncDbIds) {
+        emit activitiesChanged(syncDbId);
+    }
+}
+
+/**
+ * @brief Maps a server file status to the reduced presentation status used by Activities.
+ * @param status File status received from the server.
+ * @return The corresponding presentation status, or std::nullopt when the value requires unsupported-status handling.
+ */
+std::optional<ActivityStatus> ActivityStore::normalizeStatus(const SyncFileStatus status) {
+    switch (status) {
+        case SyncFileStatus::Success:
+            return ActivityStatus::Synchronized;
+        case SyncFileStatus::Syncing:
+            return ActivityStatus::InProgress;
+        case SyncFileStatus::Error:
+        case SyncFileStatus::Conflict:
+        case SyncFileStatus::Inconsistency:
+        case SyncFileStatus::Unknown:
+        case SyncFileStatus::Ignored:
+            return ActivityStatus::Failed;
+        case SyncFileStatus::EnumEnd:
+            return std::nullopt;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Maps a server synchronization direction to its presentation source.
+ * @param direction Direction received from the server.
+ * @return The corresponding presentation source, or ActivitySource::Unknown when no source can be inferred.
+ */
+ActivitySource ActivityStore::normalizeSource(const SyncDirection direction) {
+    switch (direction) {
+        case SyncDirection::Up:
+            return ActivitySource::Computer;
+        case SyncDirection::Down:
+            return ActivitySource::Web;
+        case SyncDirection::Unknown:
+        case SyncDirection::EnumEnd:
+            return ActivitySource::Unknown;
+    }
+    return ActivitySource::Unknown;
+}
+
+/**
+ * @brief Updates an existing operation or absorbs a late event for an operation that is no longer in progress.
+ *
+ * Invalid and unknown operation identifiers return false so the caller can insert a distinct activity. An in-progress
+ * entry is replaced while preserving its local identifier. Entries that are no longer in progress absorb duplicate or
+ * regressive events without emitting a change.
+ *
+ * @param syncDbId Database identifier of the owning synchronization.
+ * @param entries Mutable activity collection for that synchronization.
+ * @param item Latest activity DTO received for the operation.
+ * @param status Normalized presentation status.
+ * @param source Normalized presentation source.
+ * @return true when the operation identifier was already present, whether updated or deliberately ignored; false when a
+ * new entry must be inserted.
+ */
+bool ActivityStore::updateExistingOperation(const SyncDbId syncDbId, std::vector<ActivityEntry> &entries,
+                                            const SyncFileItemInfo &item, const ActivityStatus status,
+                                            const ActivitySource source) {
+    if (!isValidOperationId(item.operationId())) {
+        return false;
+    }
+
+    const auto entryIt = std::ranges::find(entries, item.operationId(), &ActivityEntry::operationId);
+    if (entryIt == entries.end()) {
+        return false;
+    }
+    if (!isInProgress(entryIt->status)) {
+        return true;
+    }
+
+    *entryIt = makeEntry(syncDbId, item, status, source, entryIt->localId);
+    emit activitiesChanged(syncDbId);
+    return true;
+}
+
+/**
+ * @brief Builds a process-local activity entry from a server DTO.
+ * @param syncDbId Database identifier of the owning synchronization.
+ * @param item Activity DTO received from the server.
+ * @param status Normalized presentation status.
+ * @param source Normalized presentation source.
+ * @param localId Stable process-local identifier assigned to the entry.
+ * @return A fully populated activity entry with a fresh receive timestamp and sequence number.
+ */
+ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileItemInfo &item, const ActivityStatus status,
+                                       const ActivitySource source, const GenericId localId) {
+    ActivityEntry entry;
+    entry.localId = localId;
+    entry.syncDbId = syncDbId;
+    entry.operationId = item.operationId();
+    entry.nodeType = item.type();
+    entry.path = item.path();
+    entry.newPath = item.newPath();
+    entry.localNodeId = item.localNodeId();
+    entry.remoteNodeId = item.remoteNodeId();
+    entry.direction = item.direction();
+    entry.instruction = item.instruction();
+    entry.rawStatus = item.status();
+    entry.status = status;
+    entry.source = source;
+    entry.size = item.size();
+    entry.progress = item.progress();
+    entry.receivedAtUtc = QDateTime::currentDateTimeUtc();
+    entry.receivedSequence = _nextReceivedSequence++;
+    return entry;
+}
+
+/**
+ * @brief Trims a synchronization's activity collection to ActivityStore::maxActivitiesPerSync entries.
+ *
+ * Eviction preserves active work whenever possible. While the collection exceeds its limit, the oldest entry that is no
+ * longer in progress is removed first, using ActivityEntry::receivedSequence as the stable age discriminator. If every
+ * retained entry is still in progress, the oldest one is removed instead and the exceptional condition is logged.
+ *
+ * The newly inserted entry can itself be selected for eviction. This happens, for example, when 500 in-progress entries
+ * are already retained and the new entry is the only completed candidate. Returning whether that entry survived lets
+ * the caller avoid emitting activitiesChanged() when insertion followed by eviction leaves the observable collection
+ * unchanged.
+ *
+ * @param syncDbId Database identifier used to contextualize capacity warnings.
+ * @param insertedLocalId Process-local identifier of the entry inserted immediately before this call.
+ * @param entries Mutable activity collection to trim.
+ * @return true if the newly inserted entry remains in the collection; false if capacity enforcement evicted it.
+ */
+bool ActivityStore::enforceCapacity(const SyncDbId syncDbId, const GenericId insertedLocalId,
+                                    std::vector<ActivityEntry> &entries) {
+    bool insertedEntryRetained = true;
+    while (entries.size() > ActivityStore::maxActivitiesPerSync) {
+        auto oldestCompletedIt = entries.end();
+        for (auto entryIt = entries.begin(); entryIt != entries.end(); ++entryIt) {
+            if (isInProgress(entryIt->status)) {
+                continue;
+            }
+            if (oldestCompletedIt == entries.end() || entryIt->receivedSequence < oldestCompletedIt->receivedSequence) {
+                oldestCompletedIt = entryIt;
+            }
+        }
+
+        if (oldestCompletedIt != entries.end()) {
+            insertedEntryRetained = insertedEntryRetained && oldestCompletedIt->localId != insertedLocalId;
+            entries.erase(oldestCompletedIt);
+            continue;
+        }
+
+        const auto oldestIt = std::ranges::min_element(entries, {}, &ActivityEntry::receivedSequence);
+        qCWarning(lcActivityStore) << "Activity capacity reached with only in-progress operations; evicting oldest"
+                                   << "| syncDbId:" << syncDbId << "/ capacity:" << maxActivitiesPerSync;
+        insertedEntryRetained = insertedEntryRetained && oldestIt->localId != insertedLocalId;
+        entries.erase(oldestIt);
+    }
+    return insertedEntryRetained;
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -235,7 +235,7 @@ ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileIt
 void ActivityStore::enforceCapacity(std::vector<ActivityEntry> &entries) {
     while (entries.size() > ActivityStore::maxActivitiesPerSync) {
         const auto oldestIt = std::ranges::min_element(entries, {}, &ActivityEntry::receivedSequence);
-        entries.erase(oldestIt);
+        (void) entries.erase(oldestIt);
     }
 }
 

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -129,8 +129,7 @@ class ActivityStore final : public QObject {
                                                    const SyncFileItemInfo &item, ActivityStatus status, ActivitySource source);
         [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, ActivityStatus status,
                                               ActivitySource source, GenericId localId);
-        [[nodiscard]] static bool enforceCapacity(SyncDbId syncDbId, GenericId insertedLocalId,
-                                                  std::vector<ActivityEntry> &entries);
+        static void enforceCapacity(std::vector<ActivityEntry> &entries);
 
         std::unordered_map<SyncDbId, std::vector<ActivityEntry>> _activitiesBySyncDbId;
         GenericId _nextLocalId{1};

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -88,6 +88,9 @@ class ActivityStore final : public QObject {
 
         /**
          * @brief Inserts a new server activity or updates the matching in-progress operation.
+         *
+         * Successful and in-progress activities remove superseded failed entries that share a non-empty local or remote
+         * node identifier.
          * @param syncDbId Database identifier of the owning synchronization.
          * @param item Activity DTO received from the server.
          */
@@ -125,8 +128,6 @@ class ActivityStore final : public QObject {
     private:
         [[nodiscard]] static std::optional<ActivityStatus> normalizeStatus(SyncFileStatus status);
         [[nodiscard]] static ActivitySource normalizeSource(SyncDirection direction);
-        [[nodiscard]] bool updateExistingOperation(SyncDbId syncDbId, std::vector<ActivityEntry> &entries,
-                                                   const SyncFileItemInfo &item, ActivityStatus status, ActivitySource source);
         [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, ActivityStatus status,
                                               ActivitySource source, GenericId localId);
         static void enforceCapacity(std::vector<ActivityEntry> &entries);

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -1,0 +1,140 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "libcommon/info/syncfileiteminfo.h"
+
+#include <QDateTime>
+#include <QObject>
+
+#include <cstddef>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace KDC {
+
+/** @brief Presentation status used by the Linux Activities UI. */
+enum class ActivityStatus : uint8_t {
+    Synchronized,
+    InProgress,
+    Failed,
+};
+
+/** @brief Origin of a synchronization activity as presented to the user. */
+enum class ActivitySource : uint8_t {
+    Unknown,
+    Computer,
+    Web,
+};
+
+/** @brief Process-local representation of one file synchronization activity. */
+struct ActivityEntry {
+        GenericId localId{0};
+        SyncDbId syncDbId{0};
+        UniqueId operationId{0};
+        NodeType nodeType{NodeType::Unknown};
+        QString path;
+        QString newPath;
+        QString localNodeId;
+        QString remoteNodeId;
+        SyncDirection direction{SyncDirection::Unknown};
+        SyncFileInstruction instruction{SyncFileInstruction::None};
+        SyncFileStatus rawStatus{SyncFileStatus::Unknown};
+        ActivityStatus status{ActivityStatus::Synchronized};
+        ActivitySource source{ActivitySource::Unknown};
+        int64_t size{0};
+        int32_t progress{0};
+        QDateTime receivedAtUtc;
+        Count receivedSequence{0};
+};
+
+/**
+ * @brief Process-local, bounded history of file synchronization activities for Linux.
+ *
+ * The store normalizes server DTOs and retains at most maxActivitiesPerSync entries for each synchronization. It is
+ * intentionally separate from AppCache's durable entity graph and must only be mutated from its QObject thread.
+ */
+class ActivityStore final : public QObject {
+        Q_OBJECT
+
+    public:
+        /** @brief Maximum number of retained activities for each synchronization. */
+        static constexpr std::size_t maxActivitiesPerSync = 500;
+
+        /**
+         * @brief Creates an empty activity store.
+         * @param parent Optional QObject owner.
+         */
+        explicit ActivityStore(QObject *parent = nullptr);
+
+        /**
+         * @brief Inserts a new server activity or updates the matching in-progress operation.
+         * @param syncDbId Database identifier of the owning synchronization.
+         * @param item Activity DTO received from the server.
+         */
+        void ingest(SyncDbId syncDbId, const SyncFileItemInfo &item);
+
+        /**
+         * @brief Returns the retained activities for one synchronization.
+         * @param syncDbId Database identifier of the synchronization to query.
+         * @return A snapshot copy of the retained activities, or an empty vector when the synchronization has none.
+         */
+        [[nodiscard]] std::vector<ActivityEntry> activities(SyncDbId syncDbId) const;
+
+        /**
+         * @brief Removes every retained activity owned by one synchronization.
+         * @param syncDbId Database identifier of the synchronization to remove.
+         */
+        void removeSync(SyncDbId syncDbId);
+
+        /**
+         * @brief Removes activities whose owning synchronization is absent from the supplied set.
+         * @param syncDbIds Database identifiers of all synchronizations that must be retained.
+         */
+        void retainSyncs(const std::unordered_set<SyncDbId> &syncDbIds);
+
+        /** @brief Removes every retained activity from the store. */
+        void clear();
+
+    signals:
+        /**
+         * @brief Notifies consumers that one synchronization's activity snapshot changed.
+         * @param syncDbId Database identifier of the changed synchronization.
+         */
+        void activitiesChanged(SyncDbId syncDbId);
+
+    private:
+        [[nodiscard]] static std::optional<ActivityStatus> normalizeStatus(SyncFileStatus status);
+        [[nodiscard]] static ActivitySource normalizeSource(SyncDirection direction);
+        [[nodiscard]] bool updateExistingOperation(SyncDbId syncDbId, std::vector<ActivityEntry> &entries,
+                                                   const SyncFileItemInfo &item, ActivityStatus status, ActivitySource source);
+        [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, ActivityStatus status,
+                                              ActivitySource source, GenericId localId);
+        [[nodiscard]] static bool enforceCapacity(SyncDbId syncDbId, GenericId insertedLocalId,
+                                                  std::vector<ActivityEntry> &entries);
+
+        std::unordered_map<SyncDbId, std::vector<ActivityEntry>> _activitiesBySyncDbId;
+        GenericId _nextLocalId{1};
+        Count _nextReceivedSequence{1};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -21,6 +21,8 @@
 #include <QLoggingCategory>
 
 #include <tuple>
+#include <unordered_set>
+#include <utility>
 
 namespace KDC {
 
@@ -57,10 +59,11 @@ constexpr auto directCacheConnections =
                         makeCacheConnection("errorRemoved", &CommService::errorRemoved, &AppCache::removeError));
 } // namespace
 
-CachePipeline::CachePipeline(CommService &commService, AppCache &appCache, QObject *const parent) :
+CachePipeline::CachePipeline(CommService &commService, AppCache &appCache, ActivityStore &activityStore, QObject *const parent) :
     QObject(parent),
     _commService(commService),
-    _appCache(appCache) {
+    _appCache(appCache),
+    _activityStore(activityStore) {
     connectDropPipeline();
 }
 
@@ -73,6 +76,8 @@ void CachePipeline::connectDropPipeline() {
                  ...);
             },
             directCacheConnections);
+    _prePopulationConnections.push_back(
+            connect(&_commService, &CommService::itemCompleted, this, &CachePipeline::bufferActivity));
 }
 
 void CachePipeline::connectLivePipeline() {
@@ -81,6 +86,8 @@ void CachePipeline::connectLivePipeline() {
                 ((void) connect(&_commService, connection.signal, &_appCache, connection.slot, Qt::UniqueConnection), ...);
             },
             directCacheConnections);
+    (void) connect(&_commService, &CommService::itemCompleted, this, &CachePipeline::routeActivity, Qt::UniqueConnection);
+    (void) connect(&_appCache, &AppCache::syncsChanged, this, &CachePipeline::reconcileActivities, Qt::UniqueConnection);
 }
 
 void CachePipeline::markPopulated() {
@@ -94,7 +101,43 @@ void CachePipeline::markPopulated() {
     }
     _prePopulationConnections.clear();
     connectLivePipeline();
+
+    const std::size_t pendingActivityCount = _pendingActivities.size();
+    while (!_pendingActivities.empty()) {
+        const auto [syncDbId, syncFileItemInfo] = std::move(_pendingActivities.front());
+        _pendingActivities.pop_front();
+        routeActivity(syncDbId, syncFileItemInfo);
+    }
+
     qCInfo(lcCachePipeline) << "Cache population completed; live cache push mutations enabled";
+}
+
+void CachePipeline::bufferActivity(const SyncDbId syncDbId, const SyncFileItemInfo &item) {
+    if (_pendingActivities.size() == maxPendingActivities) {
+        qCWarning(lcCachePipeline) << "Pre-population activity buffer full; dropping oldest activity"
+                                   << "| capacity:" << maxPendingActivities;
+        _pendingActivities.pop_front();
+    }
+    _pendingActivities.push_back(PendingActivity{.syncDbId = syncDbId, .item = item});
+}
+
+void CachePipeline::routeActivity(const SyncDbId syncDbId, const SyncFileItemInfo &item) const {
+    if (!_appCache.sync(syncDbId).has_value()) {
+        qCWarning(lcCachePipeline) << "Activity dropped for unknown synchronization | syncDbId:" << syncDbId
+                                   << "/ operationId:" << item.operationId();
+        return;
+    }
+    _activityStore.ingest(syncDbId, item);
+}
+
+void CachePipeline::reconcileActivities() const {
+    const auto syncs = _appCache.syncs();
+    std::unordered_set<SyncDbId> retainedSyncDbIds;
+    retainedSyncDbIds.reserve(syncs.size());
+    for (const auto &sync: syncs) {
+        retainedSyncDbIds.insert(sync.dbId());
+    }
+    _activityStore.retainSyncs(retainedSyncDbIds);
 }
 
 void CachePipeline::logDroppedPush(const char *const signalName) {

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -102,7 +102,6 @@ void CachePipeline::markPopulated() {
     _prePopulationConnections.clear();
     connectLivePipeline();
 
-    const std::size_t pendingActivityCount = _pendingActivities.size();
     while (!_pendingActivities.empty()) {
         const auto [syncDbId, syncFileItemInfo] = std::move(_pendingActivities.front());
         _pendingActivities.pop_front();

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -22,7 +22,6 @@
 
 #include <tuple>
 #include <unordered_set>
-#include <utility>
 
 namespace KDC {
 
@@ -77,7 +76,7 @@ void CachePipeline::connectDropPipeline() {
             },
             directCacheConnections);
     _prePopulationConnections.push_back(
-            connect(&_commService, &CommService::itemCompleted, this, &CachePipeline::bufferActivity));
+            connect(&_commService, &CommService::itemCompleted, this, [](const auto &...) { logDroppedPush("itemCompleted"); }));
 }
 
 void CachePipeline::connectLivePipeline() {
@@ -102,22 +101,7 @@ void CachePipeline::markPopulated() {
     _prePopulationConnections.clear();
     connectLivePipeline();
 
-    while (!_pendingActivities.empty()) {
-        const auto [syncDbId, syncFileItemInfo] = std::move(_pendingActivities.front());
-        _pendingActivities.pop_front();
-        routeActivity(syncDbId, syncFileItemInfo);
-    }
-
     qCInfo(lcCachePipeline) << "Cache population completed; live cache push mutations enabled";
-}
-
-void CachePipeline::bufferActivity(const SyncDbId syncDbId, const SyncFileItemInfo &item) {
-    if (_pendingActivities.size() == maxPendingActivities) {
-        qCWarning(lcCachePipeline) << "Pre-population activity buffer full; dropping oldest activity"
-                                   << "| capacity:" << maxPendingActivities;
-        _pendingActivities.pop_front();
-    }
-    _pendingActivities.push_back(PendingActivity{.syncDbId = syncDbId, .item = item});
 }
 
 void CachePipeline::routeActivity(const SyncDbId syncDbId, const SyncFileItemInfo &item) const {

--- a/src/gui4/linux/app/cache/cachepipeline.cpp
+++ b/src/gui4/linux/app/cache/cachepipeline.cpp
@@ -118,7 +118,7 @@ void CachePipeline::reconcileActivities() const {
     std::unordered_set<SyncDbId> retainedSyncDbIds;
     retainedSyncDbIds.reserve(syncs.size());
     for (const auto &sync: syncs) {
-        retainedSyncDbIds.insert(sync.dbId());
+        (void) retainedSyncDbIds.insert(sync.dbId());
     }
     _activityStore.retainSyncs(retainedSyncDbIds);
 }

--- a/src/gui4/linux/app/cache/cachepipeline.h
+++ b/src/gui4/linux/app/cache/cachepipeline.h
@@ -18,18 +18,21 @@
 
 #pragma once
 
+#include "app/cache/activitystore.h"
 #include "app/cache/appcache.h"
 #include "app/services/commservice.h"
 
 #include <QMetaObject>
 #include <QObject>
 
+#include <cstddef>
+#include <deque>
 #include <vector>
 
 namespace KDC {
 
 /**
- * Owns all server-push signal connections from CommService to AppCache.
+ * Owns all server-push signal connections from CommService to Linux v4 cache stores.
  *
  * This is the single bridge for push-driven cache mutation in the Linux v4 services layer.
  *
@@ -37,26 +40,41 @@ namespace KDC {
  * mutations cannot race with CachePopulator's initial full-snapshot replacements. Once markPopulated() is called after
  * CachePopulator::bootstrapCompleted(), those temporary drop connections are removed and the live pipeline is installed.
  *
- * Push signals are connected directly to matching AppCache mutation slots in live mode. The class owns only the signal
- * wiring; AppCache remains the cache authority, and CachePopulator remains responsible for initial snapshot loading.
+ * Entity push signals are connected directly to matching AppCache mutation slots in live mode. File activity signals are
+ * buffered during population, then replayed into ActivityStore after their parent synchronizations exist. The class owns
+ * only the signal wiring; AppCache and ActivityStore remain their respective cache authorities, and CachePopulator remains
+ * responsible for initial snapshot loading.
  */
 class CachePipeline : public QObject {
         Q_OBJECT
 
     public:
-        explicit CachePipeline(CommService &commService, AppCache &appCache, QObject *parent = nullptr);
+        explicit CachePipeline(CommService &commService, AppCache &appCache, ActivityStore &activityStore,
+                               QObject *parent = nullptr);
 
     public slots:
         void markPopulated();
 
     private:
+        struct PendingActivity {
+                SyncDbId syncDbId{0};
+                SyncFileItemInfo item;
+        };
+
+        static constexpr std::size_t maxPendingActivities = 5000;
+
         void connectDropPipeline();
         void connectLivePipeline();
+        void bufferActivity(SyncDbId syncDbId, const SyncFileItemInfo &item);
+        void routeActivity(SyncDbId syncDbId, const SyncFileItemInfo &item) const;
+        void reconcileActivities() const;
         static void logDroppedPush(const char *signalName);
 
         CommService &_commService;
         AppCache &_appCache;
+        ActivityStore &_activityStore;
         std::vector<QMetaObject::Connection> _prePopulationConnections;
+        std::deque<PendingActivity> _pendingActivities;
         bool _populated{false};
 };
 

--- a/src/gui4/linux/app/cache/cachepipeline.h
+++ b/src/gui4/linux/app/cache/cachepipeline.h
@@ -25,8 +25,6 @@
 #include <QMetaObject>
 #include <QObject>
 
-#include <cstddef>
-#include <deque>
 #include <vector>
 
 namespace KDC {
@@ -41,7 +39,7 @@ namespace KDC {
  * CachePopulator::bootstrapCompleted(), those temporary drop connections are removed and the live pipeline is installed.
  *
  * Entity push signals are connected directly to matching AppCache mutation slots in live mode. File activity signals are
- * buffered during population, then replayed into ActivityStore after their parent synchronizations exist. The class owns
+ * also dropped during population: receiving one in that phase violates the server/client startup contract. The class owns
  * only the signal wiring; AppCache and ActivityStore remain their respective cache authorities, and CachePopulator remains
  * responsible for initial snapshot loading.
  */
@@ -56,16 +54,8 @@ class CachePipeline : public QObject {
         void markPopulated();
 
     private:
-        struct PendingActivity {
-                SyncDbId syncDbId{0};
-                SyncFileItemInfo item;
-        };
-
-        static constexpr std::size_t maxPendingActivities = 5000;
-
         void connectDropPipeline();
         void connectLivePipeline();
-        void bufferActivity(SyncDbId syncDbId, const SyncFileItemInfo &item);
         void routeActivity(SyncDbId syncDbId, const SyncFileItemInfo &item) const;
         void reconcileActivities() const;
         static void logDroppedPush(const char *signalName);
@@ -74,7 +64,6 @@ class CachePipeline : public QObject {
         AppCache &_appCache;
         ActivityStore &_activityStore;
         std::vector<QMetaObject::Connection> _prePopulationConnections;
-        std::deque<PendingActivity> _pendingActivities;
         bool _populated{false};
 };
 

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "app/cache/appcache.h"
+#include "app/cache/activitystore.h"
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
 #include "app/cache/parametersstore.h"
@@ -52,20 +53,17 @@ namespace KDC {
 Q_DECLARE_LOGGING_CATEGORY(lcAppClientLinux)
 
 /**
- * Top-level application object for the Linux GUI client.
+ * @brief Composition root for the Linux GUI client.
  *
- * Owns the IPC client and cross-service infrastructure objects:
- * - SignalDispatcher: routes server push messages to typed handlers.
- * - CommService: typed request/signal facade over IPC.
- * - CachePipeline: unique bridge from CommService push signals to AppCache.
- * - CachePopulator: sequential initial snapshot loader for the graph-backed cache.
- * - MainSidebarController: configured-sync presentation and main-sidebar actions.
- * - ServiceActionTracker: durable UI-facing pending-action state.
- * - ServiceEventBus: transient cross-service events (errors, notifications, ...).
- * - WindowDecorationController: platform-specific input regions for frameless windows.
+ * Owns and wires the process-long application layers:
+ * - IPC transport, server-signal dispatch, and the typed communication facade.
+ * - AppCache, ActivityStore, ParametersStore, their live push pipeline, and the two-branch bootstrap population.
+ * - Application services, action tracking, transient service events, and Sentry coordination.
+ * - Main selection, navigation, sidebar, Home, and the ephemeral onboarding-session manager.
+ * - Linux system tray, network observation, frameless-window integration, translations, and the QML runtime.
  *
- * On construction, sets up logging,
- * wires IPC signals to the dispatcher, initializes the system tray, and initiates the connection to the server.
+ * Construction configures logging, translations, application identity, the system tray, signal connections, and the QML
+ * engine before initiating the IPC connection to the server.
  */
 class AppClientLinux : public QApplication {
         Q_OBJECT
@@ -120,8 +118,9 @@ class AppClientLinux : public QApplication {
         SignalDispatcher _signalDispatcher{this};
         CommService _serverCommService{_ipcClient, _signalDispatcher, this};
         AppCache _appCache{this};
+        ActivityStore _activityStore{this};
         ParametersStore _parametersStore{this};
-        CachePipeline _cachePipeline{_serverCommService, _appCache, this};
+        CachePipeline _cachePipeline{_serverCommService, _appCache, _activityStore, this};
         MainSelectionStore _mainSelectionStore{_appCache, this};
         MainSidebarController _mainSidebarController{_appCache, _mainSelectionStore, this};
         ParametersService _parametersService{_serverCommService, _parametersStore, this};


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR introduit `ActivityStore`, un nouveau cache process-local et borné qui conserve l'historique des activités de synchronisation de fichiers pour le client Linux v4, et le connecte au pipeline de push existant (`CachePipeline`) sans perturber le flux `CommService -> AppCache` déjà en place.

## Changements
- Ajoute `app/cache/activitystore.{h,cpp}` : un `QObject` qui normalise les DTO `SyncFileItemInfo` reçus du serveur en `ActivityEntry` (statut réduit `Synchronized`/`InProgress`/`Failed`, source `Computer`/`Web`/`Unknown`), met à jour en place les opérations en cours identifiées par `operationId`, absorbe silencieusement les événements tardifs ou régressifs sur des opérations déjà terminées, et borne la rétention à 500 entrées par synchronisation (`maxActivitiesPerSync`) avec une politique d'éviction qui privilégie la préservation du travail en cours.
- Étend `CachePipeline` pour router les activités de fichiers vers `ActivityStore` : bufferise les activités reçues via `itemCompleted` pendant la phase de pré-population (jusqu'à 5000 entrées, avec purge de la plus ancienne en cas de dépassement), les rejoue une fois `markPopulated()` appelée, ignore les activités dont la synchronisation parente n'existe pas encore dans `AppCache`, et réconcilie l'historique (`retainSyncs`) à chaque changement de l'ensemble des synchronisations configurées via `AppCache::syncsChanged`.
- Instancie `ActivityStore` dans `AppClientLinux` et l'injecte dans `CachePipeline`, qui prend désormais trois dépendances (`CommService`, `AppCache`, `ActivityStore`) au lieu de deux.
- Met à jour `src/gui4/linux/AGENTS.md` : documente la nouvelle classe `ActivityStore` et le rôle étendu de `CachePipeline`, précise le mapping des statuts d'activité (`Unknown`/`Error`/`Conflict`/`Inconsistency`/`Ignored` sont tous des activités d'erreur visibles, calqué sur le comportement Windows), et note que les tests automatisés dédiés aux Activities sont volontairement différés pour ce jalon.
- Ajoute les nouveaux fichiers source à `CMakeLists.txt`.

## Détails techniques
`ActivityStore` reste volontairement séparé du graphe durable `AppCache` et n'est pas exposé directement au QML. Les événements pré-population sont mis en tampon plutôt que traités immédiatement afin d'éviter les courses avec le remplacement initial du snapshot complet par `CachePopulator`, cohérent avec le pattern déjà utilisé pour les entités.

## Notes
Aucun test automatisé n'est ajouté pour `ActivityStore` dans cette PR ; cela est explicitement documenté comme différé dans `AGENTS.md` jusqu'à ce que le périmètre soit rouvert.

</details>

---

## Summary
This PR introduces `ActivityStore`, a new bounded, process-local cache that retains file synchronization activity history for the Linux v4 client, and wires it into the existing push pipeline (`CachePipeline`) without disrupting the already established `CommService -> AppCache` flow.

## Changes
- Adds `app/cache/activitystore.{h,cpp}`: a `QObject` that normalizes server `SyncFileItemInfo` DTOs into `ActivityEntry` records (reduced status `Synchronized`/`InProgress`/`Failed`, source `Computer`/`Web`/`Unknown`), updates in-progress operations in place by `operationId`, silently absorbs late or regressive events for operations that already completed, and caps retention at 500 entries per synchronization (`maxActivitiesPerSync`) with an eviction policy that favors preserving in-progress work.
- Extends `CachePipeline` to route file activities into `ActivityStore`: buffers activities received via `itemCompleted` during pre-population (up to 5000 entries, dropping the oldest on overflow), replays them once `markPopulated()` is called, drops activities whose parent synchronization does not yet exist in `AppCache`, and reconciles retained history (`retainSyncs`) whenever the configured synchronization set changes via `AppCache::syncsChanged`.
- Instantiates `ActivityStore` in `AppClientLinux` and injects it into `CachePipeline`, which now takes three dependencies (`CommService`, `AppCache`, `ActivityStore`) instead of two.
- Updates `src/gui4/linux/AGENTS.md`: documents the new `ActivityStore` class and `CachePipeline`'s expanded role, clarifies the activity status mapping (`Unknown`/`Error`/`Conflict`/`Inconsistency`/`Ignored` are all visible error activities, mirroring Windows), and notes that dedicated Activities test coverage is intentionally deferred for this milestone.
- Adds the new source files to `CMakeLists.txt`.

## Technical Details
`ActivityStore` is deliberately kept separate from `AppCache`'s durable entity graph and is not exposed directly to QML. Pre-population events are buffered rather than processed immediately to avoid races with `CachePopulator`'s initial full-snapshot replacement, consistent with the existing pattern used for entities.

## Notes
No automated tests are added for `ActivityStore` in this PR; this is explicitly documented as deferred in `AGENTS.md` until the scope is reopened.

-----

PR 1 on 3 about this view

<img width="1992" height="1392" alt="image" src="https://github.com/user-attachments/assets/def35f50-59b9-40a2-af4a-ac85667ae5f6" />

-----

Depends on #2248 