### PR TITLE
fix(legacy gui): Always paint the synthesis popover background

### DIFF
--- a/src/gui/synthesispopover.cpp
+++ b/src/gui/synthesispopover.cpp
@@ -200,8 +200,12 @@ void SynthesisPopover::paintEvent(QPaintEvent *event) {
 
     QScreen *screen = QGuiApplication::screenAt(_sysTrayIconRect.center());
     if (!screen) {
-        qCDebug(lcSynthesisPopover) << "No Screen found";
-        return;
+        // The window is translucent: leaving this method without painting would leave its background fully transparent.
+        // The systray icon geometry is unreliable on Linux, so fall back to the screen of the window instead: at worst the
+        // arrow pointing to the systray icon is misplaced, but the background is always painted.
+        qCDebug(lcSynthesisPopover) << "No screen found at the systray icon position, falling back to the window screen";
+        screen = QWidget::screen();
+        if (!screen) return;
     }
 
     QRect screenRect = screen->availableGeometry();

--- a/src/gui/synthesispopover.cpp
+++ b/src/gui/synthesispopover.cpp
@@ -200,16 +200,12 @@ void SynthesisPopover::paintEvent(QPaintEvent *event) {
 
     QScreen *screen = QGuiApplication::screenAt(_sysTrayIconRect.center());
     if (!screen) {
-        // The window is translucent: leaving this method without painting would leave its background fully transparent.
-        // The systray icon geometry is unreliable on Linux, so fall back to the screen of the window instead: at worst the
-        // arrow pointing to the systray icon is misplaced, but the background is always painted.
         qCDebug(lcSynthesisPopover) << "No screen found at the systray icon position, falling back to the window screen";
         screen = QWidget::screen();
         if (!screen) return;
     }
 
     QRect screenRect = screen->availableGeometry();
-
     KDC::GuiUtility::systrayPosition position = KDC::GuiUtility::getSystrayPosition(screen);
 
     bool trianglePositionLeft = false;


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Sur Linux, l'en-tête du panneau ouvert depuis l'icône du systray peut s'afficher totalement transparent et inutilisable.

Fixes #1079

## Changements
- `src/gui/synthesispopover.cpp` : dans `paintEvent()`, quand `QGuiApplication::screenAt(_sysTrayIconRect.center())` ne trouve aucun écran, on retombe sur `QWidget::screen()` au lieu de sortir sans rien peindre.

## Détails techniques
`SynthesisPopover` est une fenêtre sans cadre et translucide : son fond, ses coins arrondis et la flèche pointant vers l'icône du systray sont dessinés à la main dans `paintEvent()`, et tout ce que cette méthode ne peint pas reste réellement transparent. Or elle sortait sans rien peindre lorsqu'aucun écran ne correspondait à la position de l'icône du systray.

Ce cas ne se produit que sur Linux, où cette position n'est pas fiable : `_tray->geometry()` est invalide avec StatusNotifierItem (KDE, GNOME), d'où le repli sur `QCursor::pos()` dans `ClientGui::showSynthesisDialog()`, lui-même inexploitable sous Wayland tant que le pointeur n'est pas entré dans une surface de l'application. Sur macOS et Windows `screenAt()` réussit toujours : le bloc modifié y reste inatteignable, aucun changement de comportement.

Au pire, avec ce correctif, la flèche pointant vers l'icône du systray est mal placée ; le fond, lui, est toujours peint.

</details>

---

## Summary
Fixes #1079: on Linux, the popover header opened from the systray icon could render fully transparent and unusable.

## Changes
- `src/gui/synthesispopover.cpp`: in `paintEvent()`, when `QGuiApplication::screenAt(_sysTrayIconRect.center())` resolves no screen, fall back to `QWidget::screen()` instead of returning without painting anything.

## Technical Details
`SynthesisPopover` is a frameless, translucent window: its background, rounded corners and the arrow pointing at the systray icon are hand-drawn in `paintEvent()`, and anything this method does not paint stays genuinely transparent. It used to return without painting whenever no screen matched the systray icon position.

This only happens on Linux, where that position is unreliable: `_tray->geometry()` is invalid with StatusNotifierItem (KDE, GNOME), hence the fallback to `QCursor::pos()` in `ClientGui::showSynthesisDialog()`, itself unusable under Wayland until the pointer has entered an application surface. On macOS and Windows `screenAt()` always succeeds, so the modified block remains unreachable there and no behavior changes.

Worst case with this fix, the arrow pointing at the systray icon is misplaced; the background is always painted.