### PR TITLE
fix(folder-tree-item-widget): Do not update blacklist paths if the synchronization DB identifier associated to the widget is not known yet

### DIFF
--- a/src/gui/foldertreeitemwidget.cpp
+++ b/src/gui/foldertreeitemwidget.cpp
@@ -158,7 +158,8 @@ void FolderTreeItemWidget::loadSubFolders() {
 ExitCode FolderTreeItemWidget::updateBlacklistSet() {
     _newlyBlackListedItems.clear();
 
-    if (!_syncDbId) return ExitCode::Ok;
+    if (!_syncDbId)
+        return ExitCode::Ok; // `_syncDbId` can be 0 for a non-LiteSync `FolderTreeItemWidget` that is not fully initialized yet.
 
     bool userConnected = false;
     if (const auto userInfoIt = _gui->userInfoMap().find(_userDbId); userInfoIt != _gui->userInfoMap().end()) {
@@ -176,6 +177,8 @@ ExitCode FolderTreeItemWidget::updateBlacklistSet() {
 }
 
 void FolderTreeItemWidget::updateBlacklistPathMap() {
+    if (!_syncDbId) return; // `_syncDbId` can be 0 for a non-LiteSync `FolderTreeItemWidget` that is not fully initialized.
+
     for (const QString &nodeId: _oldBlackList) {
         QString path;
         if (const auto exitCode = GuiRequests::getNodePath(_syncDbId, nodeId, path); exitCode != ExitCode::Ok) {


### PR DESCRIPTION
This PR prevents spurious errors from happening during the creation of a non-_LiteSync_ synchronization. 
The errors are caused by a synchronization database identifier improperly set with `0` when the `AppServer` executes a request of type `NODE_PATH`. Although these errors seem harmless, they are reported in the logs and can cause confusion.
