### PR TITLE
feat(activities): add ActivitiesController, ActivityListModel and ActivityService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -83,6 +83,7 @@ clang-format -i <file>
 - Prefer documentation for private implementation methods in the `.cpp` file rather than the header.
 - Do not introduce raw `int` in new code when a named fixed-width type fits the use case (e.g. `uint8_t`, `int32_t`, ...).
 - Do not run `clang-format` on `CMakeLists.txt` files (it can break formatting/structure unexpectedly in this project).
+- Do not introduce new Qt dependencies in server code; the server is being migrated away from Qt.
 - Keep the Linux v4 frameless header and custom shadow on native Wayland without introducing a `Qt6::GuiPrivate`
   dependency; accept the transparent shadow margin during Wayland edge snapping.
 - For any branch named `linux-v4/*`: create it from `linux-v4/main`, and compute diffs against `linux-v4/main` by

--- a/src/gui4/linux/AGENTS.md
+++ b/src/gui4/linux/AGENTS.md
@@ -35,6 +35,8 @@
   screen-specific drafts, such as proxy edition, belong to the owning UI/view model.
 - Keep per-sync runtime status and progress exclusively in `AppCache`. Consumers such as the system tray and future UI
   adapters must observe and query that shared state instead of maintaining private copies.
+- Design feature storage and presentation contracts for their intended final lifecycle. A temporarily unavailable UI or
+  action may remain inactive, but must not make the underlying model discard state needed by the completed feature.
 - In range-for loops over associative containers, prefer `std::views::keys` / `std::views::values` over structured
   bindings with an unused `_` element when only keys or only values are needed.
 - For Linux v4 model/UI checks, build only the `kdrive_qml` target unless a broader backend/server validation is
@@ -141,7 +143,7 @@
 - `app/cache/appcache.*`: graph-backed cache (`AppCache` QObject) - owns configured users/accounts/drives/syncs, the
   single volatile runtime snapshot for each sync, split sync/server errors, per-user available drives, cascade removals,
   and derived read models. Sync snapshot replacement preserves runtime data for retained sync database ids.
-- `app/cache/activitystore.*`: process-local, per-sync file-activity history. It normalizes `SyncFileItemInfo` pushes,
+- `app/cache/activitystore.*`: process-local, per-sync file-activity history. It retains server status and direction,
   updates valid operation ids in place, removes failed entries superseded by a successful or in-progress activity for the
   same node, preserves distinct anonymous operations, and bounds retention to 500 entries per synchronization. It stays
   separate from the durable `AppCache` graph and is not exposed directly to QML.
@@ -163,6 +165,12 @@
   into classic and advanced synchronization rows and exposes only the presentation data required by the selector.
 - `app/mainwindow/mainsidebarcontroller.*`: QML-facing sidebar interaction controller. It exposes `SyncSelectorModel`,
   delegates sync selection to `MainSelectionStore`, and opens the selected local sync folder through desktop services.
+- `app/mainwindow/activitylistmodel.*`: selected-sync projection joining bounded recent activities with authoritative
+  active node errors. It maps server status and direction to the QML-facing presentation enums. Active errors remain
+  visible even when their recent activity has been evicted.
+- `app/mainwindow/activitiescontroller.*`: QML-facing Activities state and action boundary. It owns filtering and title
+  presentation, including the local title-state resolver, validates local paths, and delegates asynchronous link actions
+  to `ActivityService`.
 - `app/mainwindow/homecontroller.*`: cache-backed QML adapter for the modular Home and toolbar sync controls. It
   resolves the selected sync into one central presentation state, exposes user/drive/error data, owns web-link
   construction, and delegates pause/resume to `SyncService`.
@@ -217,6 +225,8 @@
   `CachePipeline`.
 - `app/services/driveservice.*`: targeted drive use-case facade driven by `ServiceActionTracker` + `ServiceEventBus`;
   durable cache mutations stay signal-driven through `CachePipeline`.
+- `app/services/activityservice.*`: activity-row link facade. It resolves private/public URLs through `CommService`, owns
+  browser and clipboard side effects, and tracks concurrent actions without owning activity history.
 - `app/services/parametersservice.*`: targeted facade for application settings updates. It starts from the confirmed
   `ParametersStore` snapshot, sends the full `PARAMETERS_UPDATE` payload, and updates the store only after server
   confirmation.

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -39,6 +39,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/parametersstore.h
         app/mainwindow/mainsidebarcontroller.cpp
         app/mainwindow/mainsidebarcontroller.h
+        app/mainwindow/activitiescontroller.cpp
+        app/mainwindow/activitiescontroller.h
         app/mainwindow/activitylistmodel.cpp
         app/mainwindow/activitylistmodel.h
         app/mainwindow/homecontroller.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -39,6 +39,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         app/cache/parametersstore.h
         app/mainwindow/mainsidebarcontroller.cpp
         app/mainwindow/mainsidebarcontroller.h
+        app/mainwindow/activitylistmodel.cpp
+        app/mainwindow/activitylistmodel.h
         app/mainwindow/homecontroller.cpp
         app/mainwindow/homecontroller.h
         app/mainwindow/homestateresolver.cpp

--- a/src/gui4/linux/CMakeLists.txt
+++ b/src/gui4/linux/CMakeLists.txt
@@ -77,6 +77,8 @@ set(GUI_SOURCE_FILES # C++ files for the GUI application
         communicationlayer/signaldispatcher.h
         app/services/commservice.cpp
         app/services/commservice.h
+        app/services/activityservice.cpp
+        app/services/activityservice.h
         app/services/cachepopulator.cpp
         app/services/cachepopulator.h
         app/services/driveservice.cpp

--- a/src/gui4/linux/app/cache/activitystore.cpp
+++ b/src/gui4/linux/app/cache/activitystore.cpp
@@ -35,8 +35,25 @@ bool isValidOperationId(const UniqueId operationId) {
 }
 
 /** @brief Returns whether an activity is currently being synchronized. */
-bool isInProgress(const ActivityStatus status) {
-    return status == ActivityStatus::InProgress;
+bool isInProgress(const SyncFileStatus status) {
+    return status == SyncFileStatus::Syncing;
+}
+
+/** @brief Returns whether an activity ended in a state that still requires user attention. */
+bool isFailed(const SyncFileStatus status) {
+    switch (status) {
+        case SyncFileStatus::Success:
+        case SyncFileStatus::Syncing:
+            return false;
+        case SyncFileStatus::Unknown:
+        case SyncFileStatus::Error:
+        case SyncFileStatus::Conflict:
+        case SyncFileStatus::Inconsistency:
+        case SyncFileStatus::Ignored:
+        case SyncFileStatus::EnumEnd:
+            return true;
+    }
+    return true;
 }
 
 /** @brief Returns whether two activities identify the same node through a non-empty local or remote identifier. */
@@ -47,14 +64,13 @@ bool hasMatchingNodeId(const ActivityEntry &entry, const SyncFileItemInfo &item)
 }
 
 /** @brief Removes failed activities superseded by a successful or in-progress activity for the same node. */
-void removeSupersededFailures(std::vector<ActivityEntry> &entries, const SyncFileItemInfo &item, const ActivityStatus status) {
-    if (status == ActivityStatus::Failed) {
+void removeSupersededFailures(std::vector<ActivityEntry> &entries, const SyncFileItemInfo &item) {
+    if (isFailed(item.status())) {
         return;
     }
 
-    (void) std::erase_if(entries, [&item](const ActivityEntry &entry) {
-        return entry.status == ActivityStatus::Failed && hasMatchingNodeId(entry, item);
-    });
+    (void) std::erase_if(
+            entries, [&item](const ActivityEntry &entry) { return isFailed(entry.status) && hasMatchingNodeId(entry, item); });
 }
 } // namespace
 
@@ -67,15 +83,13 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
         return;
     }
 
-    const auto normalizedStatus = normalizeStatus(item.status());
-    if (!normalizedStatus.has_value()) {
+    if (item.status() == SyncFileStatus::EnumEnd) {
         qCWarning(lcActivityStore) << "Activity ignored for unsupported status | syncDbId:" << syncDbId
                                    << "/ status:" << static_cast<int32_t>(item.status());
         return;
     }
 
-    const ActivitySource source = normalizeSource(item.direction());
-    if (source == ActivitySource::Unknown) {
+    if (item.direction() == SyncDirection::Unknown || item.direction() == SyncDirection::EnumEnd) {
         qCWarning(lcActivityStore) << "Activity received with unknown source | syncDbId:" << syncDbId
                                    << "/ direction:" << static_cast<int32_t>(item.direction());
     }
@@ -88,15 +102,15 @@ void ActivityStore::ingest(const SyncDbId syncDbId, const SyncFileItemInfo &item
                 return;
             }
 
-            *entryIt = makeEntry(syncDbId, item, *normalizedStatus, source, entryIt->localId);
-            removeSupersededFailures(entries, item, *normalizedStatus);
+            *entryIt = makeEntry(syncDbId, item, entryIt->localId);
+            removeSupersededFailures(entries, item);
             emit activitiesChanged(syncDbId);
             return;
         }
     }
 
-    removeSupersededFailures(entries, item, *normalizedStatus);
-    auto entry = makeEntry(syncDbId, item, *normalizedStatus, source, _nextLocalId++);
+    removeSupersededFailures(entries, item);
+    auto entry = makeEntry(syncDbId, item, _nextLocalId++);
     entries.push_back(std::move(entry));
     enforceCapacity(entries);
     emit activitiesChanged(syncDbId);
@@ -145,57 +159,13 @@ void ActivityStore::clear() {
 }
 
 /**
- * @brief Maps a server file status to the reduced presentation status used by Activities.
- * @param status File status received from the server.
- * @return The corresponding presentation status, or std::nullopt when the value requires unsupported-status handling.
- */
-std::optional<ActivityStatus> ActivityStore::normalizeStatus(const SyncFileStatus status) {
-    switch (status) {
-        case SyncFileStatus::Success:
-            return ActivityStatus::Synchronized;
-        case SyncFileStatus::Syncing:
-            return ActivityStatus::InProgress;
-        case SyncFileStatus::Error:
-        case SyncFileStatus::Conflict:
-        case SyncFileStatus::Inconsistency:
-        case SyncFileStatus::Unknown:
-        case SyncFileStatus::Ignored:
-            return ActivityStatus::Failed;
-        case SyncFileStatus::EnumEnd:
-            return std::nullopt;
-    }
-    return std::nullopt;
-}
-
-/**
- * @brief Maps a server synchronization direction to its presentation source.
- * @param direction Direction received from the server.
- * @return The corresponding presentation source, or ActivitySource::Unknown when no source can be inferred.
- */
-ActivitySource ActivityStore::normalizeSource(const SyncDirection direction) {
-    switch (direction) {
-        case SyncDirection::Up:
-            return ActivitySource::Computer;
-        case SyncDirection::Down:
-            return ActivitySource::Web;
-        case SyncDirection::Unknown:
-        case SyncDirection::EnumEnd:
-            return ActivitySource::Unknown;
-    }
-    return ActivitySource::Unknown;
-}
-
-/**
  * @brief Builds a process-local activity entry from a server DTO.
  * @param syncDbId Database identifier of the owning synchronization.
  * @param item Activity DTO received from the server.
- * @param status Normalized presentation status.
- * @param source Normalized presentation source.
  * @param localId Stable process-local identifier assigned to the entry.
  * @return A fully populated activity entry with a fresh receive timestamp and sequence number.
  */
-ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileItemInfo &item, const ActivityStatus status,
-                                       const ActivitySource source, const GenericId localId) {
+ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileItemInfo &item, const GenericId localId) {
     ActivityEntry entry;
     entry.localId = localId;
     entry.syncDbId = syncDbId;
@@ -207,9 +177,7 @@ ActivityEntry ActivityStore::makeEntry(const SyncDbId syncDbId, const SyncFileIt
     entry.remoteNodeId = item.remoteNodeId();
     entry.direction = item.direction();
     entry.instruction = item.instruction();
-    entry.rawStatus = item.status();
-    entry.status = status;
-    entry.source = source;
+    entry.status = item.status();
     entry.size = item.size();
     entry.progress = item.progress();
     entry.receivedAtUtc = QDateTime::currentDateTimeUtc();

--- a/src/gui4/linux/app/cache/activitystore.h
+++ b/src/gui4/linux/app/cache/activitystore.h
@@ -25,26 +25,11 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
 namespace KDC {
-
-/** @brief Presentation status used by the Linux Activities UI. */
-enum class ActivityStatus : uint8_t {
-    Synchronized,
-    InProgress,
-    Failed,
-};
-
-/** @brief Origin of a synchronization activity as presented to the user. */
-enum class ActivitySource : uint8_t {
-    Unknown,
-    Computer,
-    Web,
-};
 
 /** @brief Process-local representation of one file synchronization activity. */
 struct ActivityEntry {
@@ -58,9 +43,7 @@ struct ActivityEntry {
         QString remoteNodeId;
         SyncDirection direction{SyncDirection::Unknown};
         SyncFileInstruction instruction{SyncFileInstruction::None};
-        SyncFileStatus rawStatus{SyncFileStatus::Unknown};
-        ActivityStatus status{ActivityStatus::Synchronized};
-        ActivitySource source{ActivitySource::Unknown};
+        SyncFileStatus status{SyncFileStatus::Unknown};
         int64_t size{0};
         int32_t progress{0};
         QDateTime receivedAtUtc;
@@ -70,7 +53,7 @@ struct ActivityEntry {
 /**
  * @brief Process-local, bounded history of file synchronization activities for Linux.
  *
- * The store normalizes server DTOs and retains at most maxActivitiesPerSync entries for each synchronization. It is
+ * The store retains validated server DTO data and at most maxActivitiesPerSync entries for each synchronization. It is
  * intentionally separate from AppCache's durable entity graph and must only be mutated from its QObject thread.
  */
 class ActivityStore final : public QObject {
@@ -126,10 +109,7 @@ class ActivityStore final : public QObject {
         void activitiesChanged(SyncDbId syncDbId);
 
     private:
-        [[nodiscard]] static std::optional<ActivityStatus> normalizeStatus(SyncFileStatus status);
-        [[nodiscard]] static ActivitySource normalizeSource(SyncDirection direction);
-        [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, ActivityStatus status,
-                                              ActivitySource source, GenericId localId);
+        [[nodiscard]] ActivityEntry makeEntry(SyncDbId syncDbId, const SyncFileItemInfo &item, GenericId localId);
         static void enforceCapacity(std::vector<ActivityEntry> &entries);
 
         std::unordered_map<SyncDbId, std::vector<ActivityEntry>> _activitiesBySyncDbId;

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -1,0 +1,286 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/mainwindow/activitiescontroller.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QLoggingCategory>
+#include <QUrl>
+
+#include <algorithm>
+#include <cstdint>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivitiesController, "gui.v4.activitiescontroller", QtInfoMsg)
+
+enum class ActivitiesTitleState : uint8_t {
+    Loading,
+    Offline,
+    InProgress,
+    NoActivity,
+    Idle,
+    Paused,
+};
+
+ActivitiesTitleState resolveTitleState(const bool hasSync, const bool offline, const std::optional<SyncStatus> runtimeStatus,
+                                       const bool hasActivities) {
+    if (!hasSync || !runtimeStatus.has_value()) {
+        return ActivitiesTitleState::Loading;
+    }
+
+    switch (*runtimeStatus) {
+        case SyncStatus::Undefined:
+        case SyncStatus::EnumEnd:
+            return ActivitiesTitleState::Loading;
+        case SyncStatus::Idle:
+        case SyncStatus::Paused:
+            if (offline) {
+                return ActivitiesTitleState::Offline;
+            }
+            break;
+        case SyncStatus::Starting:
+        case SyncStatus::Running:
+        case SyncStatus::PauseAsked:
+        case SyncStatus::StopAsked:
+            return ActivitiesTitleState::InProgress;
+        case SyncStatus::Stopped:
+        case SyncStatus::Error:
+            break;
+    }
+
+    if (!hasActivities) {
+        return ActivitiesTitleState::NoActivity;
+    }
+    return *runtimeStatus == SyncStatus::Idle ? ActivitiesTitleState::Idle : ActivitiesTitleState::Paused;
+}
+
+QString titleForState(const ActivitiesTitleState state) {
+    switch (state) {
+        case ActivitiesTitleState::Loading:
+            return {};
+        case ActivitiesTitleState::Offline:
+            return qtTrId("activitiesTitleOffline");
+        case ActivitiesTitleState::InProgress:
+            return qtTrId("activitiesTitleInProgress");
+        case ActivitiesTitleState::NoActivity:
+            return qtTrId("activitiesTitleNoActivity");
+        case ActivitiesTitleState::Idle:
+            return qtTrId("activitiesTitleIdle");
+        case ActivitiesTitleState::Paused:
+            return qtTrId("activitiesTitlePause");
+    }
+    return {};
+}
+
+std::optional<SyncPath> safeRelativePath(const SyncPath &path) {
+    if (path.has_root_name()) {
+        return std::nullopt;
+    }
+    SyncPath normalizedPath = path.relative_path().lexically_normal();
+    if (normalizedPath.empty() || normalizedPath == SyncPath{"."}) {
+        return std::nullopt;
+    }
+    if (std::ranges::any_of(normalizedPath, [](const SyncPath &component) { return component == SyncPath{".."}; })) {
+        return std::nullopt;
+    }
+    return normalizedPath;
+}
+
+bool isContainedIn(const SyncPath &root, const SyncPath &candidate) {
+    const SyncPath normalizedRoot = root.lexically_normal();
+    const SyncPath normalizedCandidate = candidate.lexically_normal();
+    auto candidateIt = normalizedCandidate.begin();
+    for (auto rootIt = normalizedRoot.begin(); rootIt != normalizedRoot.end(); ++rootIt, ++candidateIt) {
+        if (candidateIt == normalizedCandidate.end() || *candidateIt != *rootIt) {
+            return false;
+        }
+    }
+    return true;
+}
+
+QString activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
+} // namespace
+
+ActivitiesController::ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
+                                           MainSelectionStore &selectionStore, const NetworkStatusObserver &networkStatusObserver,
+                                           ActivityService &activityService, QObject *const parent) :
+    QObject(parent),
+    _appCache(appCache),
+    _selectionStore(selectionStore),
+    _networkStatusObserver(networkStatusObserver),
+    _activityService(activityService),
+    _model(activityStore, appCache, selectionStore, this) {
+    (void) connect(&_model, &ActivityListModel::filterChanged, this, &ActivitiesController::filterChanged);
+    (void) connect(&_model, &ActivityListModel::projectionChanged, this, &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentContextChanged, this, &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncRuntimeInfoChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncStatusChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_networkStatusObserver, &NetworkStatusObserver::offlineChanged, this,
+                   &ActivitiesController::refreshPageState);
+    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this,
+                   [this](const GenericId activityLocalId) { emit shareLinkCopied(activityRowId(activityLocalId)); });
+    (void) connect(&_activityService, &ActivityService::actionFailed, this,
+                   [this](const GenericId activityLocalId) { emit actionFailed(activityRowId(activityLocalId)); });
+    refreshPageState();
+}
+
+void ActivitiesController::setFilter(const ActivityListModel::Filter filter) {
+    _model.setFilter(filter);
+}
+
+void ActivitiesController::openLocal(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canOpenLocal) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    const auto relativePath = safeRelativePath(target->relativePath);
+    if (!context.has_value() || !relativePath.has_value()) {
+        qCWarning(lcActivitiesController) << "Local activity action rejected for invalid path | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+
+    const SyncPath rootPath = context->syncInfo.localPath().lexically_normal();
+    const QFileInfo rootInfo{Path2QStr(rootPath)};
+    const SyncPath targetPath = (rootPath / *relativePath).lexically_normal();
+    const QFileInfo targetInfo{Path2QStr(targetPath)};
+    if (!rootInfo.exists() || !rootInfo.isDir() || !targetInfo.exists()) {
+        qCWarning(lcActivitiesController) << "Local activity target is missing or outside the synchronization root"
+                                          << "| rowId:" << rowId << "| target:" << Path2QStr(targetPath);
+        emit actionFailed(rowId);
+        return;
+    }
+
+    const auto canonicalRootPath = QStr2Path(rootInfo.canonicalFilePath());
+    const auto canonicalTargetPath = QStr2Path(targetInfo.canonicalFilePath());
+    if (canonicalRootPath.empty() || canonicalTargetPath.empty() || !isContainedIn(canonicalRootPath, canonicalTargetPath)) {
+        qCWarning(lcActivitiesController) << "Local activity target resolves outside the synchronization root"
+                                          << "| rowId:" << rowId << "| target:" << Path2QStr(targetPath);
+        emit actionFailed(rowId);
+        return;
+    }
+
+    if (const SyncPath folderToOpen = targetInfo.isDir() ? canonicalTargetPath : canonicalTargetPath.parent_path();
+        folderToOpen.empty() || !QDesktopServices::openUrl(QUrl::fromLocalFile(Path2QStr(folderToOpen)))) {
+        qCWarning(lcActivitiesController) << "Desktop service failed to open local activity folder"
+                                          << "| rowId:" << rowId << "| folder:" << Path2QStr(folderToOpen);
+        emit actionFailed(rowId);
+    }
+}
+
+void ActivitiesController::openOnline(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canOpenOnline) {
+        qCWarning(lcActivitiesController) << "Online activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    if (!context.has_value()) {
+        emit actionFailed(rowId);
+        return;
+    }
+    _activityService.openOnline(target->activityLocalId, context->drive.dbId(), target->remoteNodeId);
+}
+
+void ActivitiesController::copyShareLink(const QString &rowId) {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canCopyShareLink) {
+        qCWarning(lcActivitiesController) << "Share-link activity action rejected for unavailable row | rowId:" << rowId;
+        emit actionFailed(rowId);
+        return;
+    }
+    const auto context = actionSyncContext(*target, rowId);
+    if (!context.has_value()) {
+        emit actionFailed(rowId);
+        return;
+    }
+    _activityService.copyShareLink(target->activityLocalId, context->drive.dbId(), target->remoteNodeId);
+}
+
+void ActivitiesController::requestFixErrors(const QString &rowId) const {
+    const auto target = _model.actionTarget(rowId);
+    if (!target.has_value() || !target->canFixErrors) {
+        qCInfo(lcActivitiesController) << "Activity error resolution ignored because the row has no active error"
+                                       << "| rowId:" << rowId;
+        return;
+    }
+    qCInfo(lcActivitiesController) << "Activity error resolution is not implemented yet"
+                                   << "| rowId:" << rowId << "| activeErrorCount:" << target->activeErrorDbIds.size();
+}
+
+void ActivitiesController::requestFixAllErrors() const {
+    const auto context = _selectionStore.currentSyncContext();
+    qCInfo(lcActivitiesController) << "Global activity error resolution is not implemented yet"
+                                   << "| syncDbId:" << _selectionStore.currentSyncDbId()
+                                   << "| activeErrorCount:" << (context.has_value() ? context->errors.size() : 0);
+}
+
+void ActivitiesController::refreshPageState() {
+    const bool nextHasActivities = _model.rowCount() > 0;
+    const auto context = _selectionStore.currentSyncContext();
+    const qint32 nextErrorCount = context.has_value() ? static_cast<qint32>(context->errors.size()) : 0;
+    const auto runtimeInfo = _selectionStore.currentSyncRuntimeInfo();
+    const auto runtimeStatus = runtimeInfo.has_value() ? std::make_optional(runtimeInfo->status) : std::nullopt;
+    const auto titleState =
+            resolveTitleState(context.has_value(), _networkStatusObserver.offline(), runtimeStatus, nextHasActivities);
+    const bool nextLoading = titleState == ActivitiesTitleState::Loading;
+    const QString nextTitle = titleForState(titleState);
+
+    if (_hasActivities != nextHasActivities) {
+        _hasActivities = nextHasActivities;
+        emit hasActivitiesChanged();
+    }
+    if (_errorCount != nextErrorCount) {
+        _errorCount = nextErrorCount;
+        emit errorCountChanged();
+    }
+    if (_loading != nextLoading) {
+        _loading = nextLoading;
+        emit loadingChanged();
+    }
+    if (_title != nextTitle) {
+        _title = nextTitle;
+        emit titleChanged();
+    }
+}
+
+std::optional<SyncContext> ActivitiesController::actionSyncContext(const ActivityListModel::ActionTarget &target,
+                                                                   const QString &rowId) const {
+    auto context = _appCache.syncContext(target.syncDbId);
+    if (!context.has_value() || context->syncInfo.dbId() != target.syncDbId || context->drive.dbId() <= 0) {
+        qCWarning(lcActivitiesController) << "Activity action rejected because its synchronization context disappeared"
+                                          << "| rowId:" << rowId << "| syncDbId:" << target.syncDbId;
+        return std::nullopt;
+    }
+    return context;
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.cpp
@@ -118,9 +118,6 @@ bool isContainedIn(const SyncPath &root, const SyncPath &candidate) {
     return true;
 }
 
-QString activityRowId(const GenericId localId) {
-    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
-}
 } // namespace
 
 ActivitiesController::ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
@@ -141,10 +138,12 @@ ActivitiesController::ActivitiesController(const ActivityStore &activityStore, c
                    &ActivitiesController::refreshPageState);
     (void) connect(&_networkStatusObserver, &NetworkStatusObserver::offlineChanged, this,
                    &ActivitiesController::refreshPageState);
-    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this,
-                   [this](const GenericId activityLocalId) { emit shareLinkCopied(activityRowId(activityLocalId)); });
-    (void) connect(&_activityService, &ActivityService::actionFailed, this,
-                   [this](const GenericId activityLocalId) { emit actionFailed(activityRowId(activityLocalId)); });
+    (void) connect(&_activityService, &ActivityService::shareLinkCopied, this, [this](const GenericId activityLocalId) {
+        emit shareLinkCopied(ActivityListModel::activityRowId(activityLocalId));
+    });
+    (void) connect(&_activityService, &ActivityService::actionFailed, this, [this](const GenericId activityLocalId) {
+        emit actionFailed(ActivityListModel::activityRowId(activityLocalId));
+    });
     refreshPageState();
 }
 

--- a/src/gui4/linux/app/mainwindow/activitiescontroller.h
+++ b/src/gui4/linux/app/mainwindow/activitiescontroller.h
@@ -1,0 +1,93 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+#include "app/mainwindow/activitylistmodel.h"
+#include "app/mainwindow/networkstatusobserver.h"
+#include "app/services/activityservice.h"
+
+#include <QObject>
+#include <QString>
+
+namespace KDC {
+
+/**
+ * QML-facing state and interaction controller for the Activities page.
+ *
+ * It owns the selected-sync projection, resolves page-level presentation state, validates local actions, and delegates
+ * asynchronous web actions to ActivityService. It does not own recent history or active errors.
+ */
+class ActivitiesController final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(ActivityListModel *model READ model CONSTANT)
+        Q_PROPERTY(ActivityListModel::Filter filter READ filter WRITE setFilter NOTIFY filterChanged)
+        Q_PROPERTY(QString title READ title NOTIFY titleChanged)
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+        Q_PROPERTY(bool hasActivities READ hasActivities NOTIFY hasActivitiesChanged)
+        Q_PROPERTY(qint32 errorCount READ errorCount NOTIFY errorCountChanged)
+        Q_PROPERTY(bool hasErrors READ hasErrors NOTIFY errorCountChanged)
+
+    public:
+        explicit ActivitiesController(const ActivityStore &activityStore, const AppCache &appCache,
+                                      MainSelectionStore &selectionStore, const NetworkStatusObserver &networkStatusObserver,
+                                      ActivityService &activityService, QObject *parent = nullptr);
+
+        [[nodiscard]] ActivityListModel *model() { return &_model; }
+        [[nodiscard]] ActivityListModel::Filter filter() const { return _model.filter(); }
+        void setFilter(ActivityListModel::Filter filter);
+        [[nodiscard]] const QString &title() const { return _title; }
+        [[nodiscard]] bool loading() const { return _loading; }
+        [[nodiscard]] bool hasActivities() const { return _hasActivities; }
+        [[nodiscard]] qint32 errorCount() const { return _errorCount; }
+        [[nodiscard]] bool hasErrors() const { return _errorCount > 0; }
+
+        Q_INVOKABLE void openLocal(const QString &rowId);
+        Q_INVOKABLE void openOnline(const QString &rowId);
+        Q_INVOKABLE void copyShareLink(const QString &rowId);
+        Q_INVOKABLE void requestFixErrors(const QString &rowId) const;
+        Q_INVOKABLE void requestFixAllErrors() const;
+
+    signals:
+        void filterChanged();
+        void titleChanged();
+        void loadingChanged();
+        void hasActivitiesChanged();
+        void errorCountChanged();
+        void shareLinkCopied(const QString &rowId);
+        void actionFailed(const QString &rowId);
+
+    private:
+        void refreshPageState();
+        [[nodiscard]] std::optional<SyncContext> actionSyncContext(const ActivityListModel::ActionTarget &target,
+                                                                   const QString &rowId) const;
+
+        const AppCache &_appCache;
+        MainSelectionStore &_selectionStore;
+        const NetworkStatusObserver &_networkStatusObserver;
+        ActivityService &_activityService;
+        ActivityListModel _model;
+        QString _title;
+        bool _loading{true};
+        bool _hasActivities{false};
+        qint32 _errorCount{0};
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -1,0 +1,555 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/mainwindow/activitylistmodel.h"
+
+#include "libcommon/utility/types.h"
+
+#include <QCoreApplication>
+#include <QLoggingCategory>
+#include <QLocale>
+
+#include <algorithm>
+#include <chrono>
+#include <qtimezone.h>
+#include <ranges>
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivityListModel, "gui.v4.activitylistmodel", QtInfoMsg)
+
+constexpr auto relativeTimeRefreshInterval = std::chrono::minutes{1};
+constexpr auto justNowThreshold = std::chrono::seconds{30};
+constexpr auto second = std::chrono::seconds{1};
+constexpr auto minute = std::chrono::minutes{1};
+constexpr auto hour = std::chrono::hours{1};
+constexpr auto day = std::chrono::days{1};
+constexpr auto relativeDateThreshold = std::chrono::days{4};
+
+QString activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
+
+QString errorRowId(const ErrorDbId errorDbId) {
+    return QStringLiteral("error:%1").arg(static_cast<qlonglong>(errorDbId));
+}
+
+SyncPath normalizedRelativePath(const SyncPath &path) {
+    return path.relative_path().lexically_normal();
+}
+
+SyncPath normalizedRelativePath(const QString &path) {
+    return normalizedRelativePath(QStr2Path(path));
+}
+
+QString itemName(const SyncPath &path) {
+    return Path2QStr(path.filename());
+}
+
+QString parentFolder(const SyncPath &path) {
+    const auto parent = path.parent_path();
+    return parent.empty() || parent == SyncPath{"."} ? QString{} : Path2QStr(parent);
+}
+
+QString formatSize(const NodeType nodeType, const int64_t size) {
+    if (nodeType == NodeType::Directory || size < 0) {
+        return {};
+    }
+    return QLocale().formattedDataSize(size);
+}
+
+QString formatAgo(const std::chrono::seconds elapsed, const std::chrono::seconds unit, const char *const unitTranslationId) {
+    const auto unitCount = elapsed / unit;
+    const QString duration = QStringLiteral("%1 %2").arg(unitCount).arg(qtTrId(unitTranslationId));
+    return qtTrId("labelAgo").arg(duration);
+}
+
+QString formatRelativeTime(const QDateTime &timestampUtc, const QDateTime &nowUtc = QDateTime::currentDateTimeUtc()) {
+    if (!timestampUtc.isValid()) {
+        return {};
+    }
+
+    const auto elapsed = std::chrono::seconds{std::max<qint64>(0, timestampUtc.secsTo(nowUtc))};
+    if (elapsed < justNowThreshold) {
+        return qtTrId("labelJustNow");
+    }
+
+    if (elapsed < minute) {
+        return formatAgo(elapsed, second, "labelShortSecond");
+    }
+    if (elapsed < hour) {
+        return formatAgo(elapsed, minute, "labelShortMinute");
+    }
+    if (elapsed < day) {
+        return formatAgo(elapsed, hour, "labelShortHour");
+    }
+    if (elapsed < relativeDateThreshold) {
+        return formatAgo(elapsed, day, "labelShortDay");
+    }
+    return QLocale().toString(timestampUtc.toLocalTime().date(), QLocale::ShortFormat);
+}
+
+ActivityListModel::Status toModelStatus(const SyncFileStatus status) {
+    switch (status) {
+        case SyncFileStatus::Success:
+            return ActivityListModel::Status::Synchronized;
+        case SyncFileStatus::Syncing:
+            return ActivityListModel::Status::InProgress;
+        case SyncFileStatus::Unknown:
+        case SyncFileStatus::Error:
+        case SyncFileStatus::Conflict:
+        case SyncFileStatus::Inconsistency:
+        case SyncFileStatus::Ignored:
+        case SyncFileStatus::EnumEnd:
+            return ActivityListModel::Status::Failed;
+    }
+    return ActivityListModel::Status::Failed;
+}
+
+ActivityListModel::Source toModelSource(const SyncDirection direction) {
+    switch (direction) {
+        case SyncDirection::Up:
+            return ActivityListModel::Source::Computer;
+        case SyncDirection::Down:
+            return ActivityListModel::Source::Web;
+        case SyncDirection::Unknown:
+        case SyncDirection::EnumEnd:
+            return ActivityListModel::Source::Unknown;
+    }
+    return ActivityListModel::Source::Unknown;
+}
+
+} // namespace
+
+ActivityListModel::ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
+                                     MainSelectionStore &selectionStore, QObject *const parent) :
+    QAbstractListModel(parent),
+    _activityStore(activityStore),
+    _appCache(appCache),
+    _selectionStore(selectionStore) {
+    (void) connect(&_activityStore, &ActivityStore::activitiesChanged, this, [this](const SyncDbId syncDbId) {
+        if (syncDbId == static_cast<SyncDbId>(_selectionStore.currentSyncDbId())) {
+            reconcileProjection();
+        }
+    });
+    (void) connect(&_appCache, &AppCache::syncErrorsChanged, this, &ActivityListModel::reconcileProjection);
+    (void) connect(&_selectionStore, &MainSelectionStore::currentSyncDbIdChanged, this, &ActivityListModel::resetProjection);
+
+    _relativeTimeTimer.setInterval(relativeTimeRefreshInterval);
+    (void) connect(&_relativeTimeTimer, &QTimer::timeout, this, &ActivityListModel::refreshRelativeTimes);
+    _relativeTimeTimer.start();
+    resetProjection();
+}
+
+int ActivityListModel::rowCount(const QModelIndex &parent) const {
+    return parent.isValid() ? 0 : static_cast<int>(_rows.size());
+}
+
+QVariant ActivityListModel::data(const QModelIndex &index, const int role) const {
+    if (!index.isValid() || index.row() < 0 || index.row() >= rowCount()) {
+        return {};
+    }
+
+    const auto &row = _rows[static_cast<std::size_t>(index.row())];
+    switch (role) {
+        case RowIdRole:
+            return row.rowId;
+        case NameRole:
+        case Qt::DisplayRole:
+            return row.name;
+        case FolderRole:
+            return row.folder;
+        case TimeTextRole:
+            return row.timeText;
+        case SizeTextRole:
+            return row.sizeText;
+        case NodeTypeRole:
+            return static_cast<int32_t>(row.nodeType);
+        case StatusRole:
+            return QVariant::fromValue(row.status);
+        case SourceRole:
+            return QVariant::fromValue(row.source);
+        case InstructionRole:
+            return static_cast<int32_t>(row.instruction);
+        case ProgressRole:
+            return row.progress;
+        case HasActiveErrorRole:
+            return !row.activeErrorDbIds.empty();
+        case ActiveErrorCountRole:
+            return static_cast<qint32>(row.activeErrorDbIds.size());
+        case HasOptionsRole:
+            return row.canOpenLocal || row.canOpenOnline || row.canCopyShareLink || row.canFixErrors;
+        case CanOpenLocalRole:
+            return row.canOpenLocal;
+        case CanOpenOnlineRole:
+            return row.canOpenOnline;
+        case CanCopyShareLinkRole:
+            return row.canCopyShareLink;
+        case CanFixErrorsRole:
+            return row.canFixErrors;
+        default:
+            return {};
+    }
+}
+
+QHash<int, QByteArray> ActivityListModel::roleNames() const {
+    return {
+            {RowIdRole, "rowId"},
+            {NameRole, "name"},
+            {FolderRole, "folder"},
+            {TimeTextRole, "timeText"},
+            {SizeTextRole, "sizeText"},
+            {NodeTypeRole, "nodeType"},
+            {StatusRole, "status"},
+            {SourceRole, "source"},
+            {InstructionRole, "instruction"},
+            {ProgressRole, "progress"},
+            {HasActiveErrorRole, "hasActiveError"},
+            {ActiveErrorCountRole, "activeErrorCount"},
+            {HasOptionsRole, "hasOptions"},
+            {CanOpenLocalRole, "canOpenLocal"},
+            {CanOpenOnlineRole, "canOpenOnline"},
+            {CanCopyShareLinkRole, "canCopyShareLink"},
+            {CanFixErrorsRole, "canFixErrors"},
+    };
+}
+
+void ActivityListModel::setFilter(const Filter filter) {
+    switch (filter) {
+        case Filter::MyActivityOnly:
+        case Filter::AllActivities:
+            break;
+        default:
+            qCWarning(lcActivityListModel) << "Invalid activity filter ignored | filter:" << static_cast<int32_t>(filter);
+            return;
+    }
+    if (_filter == filter) {
+        return;
+    }
+    _filter = filter;
+    emit filterChanged();
+    resetProjection();
+}
+
+std::optional<ActivityListModel::ActionTarget> ActivityListModel::actionTarget(const QString &rowId) const {
+    const auto rowIt = std::ranges::find(_rows, rowId, &Row::rowId);
+    if (rowIt == _rows.end()) {
+        return std::nullopt;
+    }
+    return ActionTarget{
+            .activityLocalId = rowIt->activityLocalId,
+            .syncDbId = rowIt->syncDbId,
+            .relativePath = rowIt->relativePath,
+            .nodeType = rowIt->nodeType,
+            .remoteNodeId = rowIt->remoteNodeId,
+            .activeErrorDbIds = rowIt->activeErrorDbIds,
+            .canOpenLocal = rowIt->canOpenLocal,
+            .canOpenOnline = rowIt->canOpenOnline,
+            .canCopyShareLink = rowIt->canCopyShareLink,
+            .canFixErrors = rowIt->canFixErrors,
+    };
+}
+
+std::vector<ActivityListModel::Row> ActivityListModel::buildProjection() const {
+    const auto syncDbId = static_cast<SyncDbId>(_selectionStore.currentSyncDbId());
+    if (syncDbId <= 0) {
+        return {};
+    }
+
+    auto rows = activityRows(syncDbId);
+    appendActiveErrors(syncDbId, _appCache.errorsForSync(syncDbId), rows);
+    finalizeProjection(rows);
+    return rows;
+}
+
+std::vector<ActivityListModel::Row> ActivityListModel::activityRows(const SyncDbId syncDbId) const {
+    std::vector<Row> rows;
+    const auto activities = _activityStore.activities(syncDbId);
+    rows.reserve(activities.size());
+    for (const auto &activity: activities) {
+        rows.push_back(makeActivityRow(syncDbId, activity));
+    }
+    return rows;
+}
+
+void ActivityListModel::appendActiveErrors(const SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows) {
+    for (const auto &error: errors) {
+        if (error.level() != ErrorLevel::Node) {
+            continue;
+        }
+        appendActiveError(syncDbId, error, rows);
+    }
+}
+
+void ActivityListModel::appendActiveError(const SyncDbId syncDbId, const Error &error, std::vector<Row> &rows) {
+    if (auto *const matchingRow = findMatchingActivity(rows, error); matchingRow != nullptr) {
+        matchingRow->activeErrorDbIds.push_back(error.dbId());
+        return;
+    }
+    rows.push_back(makeErrorRow(syncDbId, error));
+}
+
+ActivityListModel::Row ActivityListModel::makeActivityRow(const SyncDbId syncDbId, const ActivityEntry &activity) {
+    const QString currentPath =
+            activity.instruction == SyncFileInstruction::Move && !activity.newPath.isEmpty() ? activity.newPath : activity.path;
+    const SyncPath relativePath = normalizedRelativePath(currentPath);
+    const auto status = toModelStatus(activity.status);
+    const bool synchronizedWithOptions = status == Status::Synchronized && activity.instruction != SyncFileInstruction::Remove;
+
+    Row row;
+    row.rowId = activityRowId(activity.localId);
+    row.activityLocalId = activity.localId;
+    row.syncDbId = syncDbId;
+    row.name = itemName(relativePath);
+    row.folder = parentFolder(relativePath);
+    row.timeText = formatRelativeTime(activity.receivedAtUtc);
+    row.sizeText = formatSize(activity.nodeType, activity.size);
+    row.nodeType = activity.nodeType;
+    row.status = status;
+    row.source = toModelSource(activity.direction);
+    row.instruction = activity.instruction;
+    row.progress = activity.progress;
+    row.timestampUtc = activity.receivedAtUtc;
+    row.receivedSequence = activity.receivedSequence;
+    row.relativePath = relativePath;
+    row.sourcePath = normalizedRelativePath(activity.path);
+    row.destinationPath = normalizedRelativePath(activity.newPath);
+    row.localNodeId = activity.localNodeId.toStdString();
+    row.remoteNodeId = activity.remoteNodeId.toStdString();
+    row.canOpenLocal = synchronizedWithOptions && !relativePath.empty();
+    row.canOpenOnline = synchronizedWithOptions && !row.remoteNodeId.empty();
+    row.canCopyShareLink = row.canOpenOnline;
+    return row;
+}
+
+ActivityListModel::Row ActivityListModel::makeErrorRow(const SyncDbId syncDbId, const Error &error) {
+    const SyncPath relativePath =
+            normalizedRelativePath(error.destinationPath().empty() ? error.path() : error.destinationPath());
+    const QDateTime timestampUtc = error.time() > 0 ? QDateTime::fromSecsSinceEpoch(error.time(), QTimeZone::UTC) : QDateTime{};
+
+    Row row;
+    row.rowId = errorRowId(error.dbId());
+    row.syncDbId = syncDbId;
+    row.name = itemName(relativePath);
+    row.folder = parentFolder(relativePath);
+    row.timeText = formatRelativeTime(timestampUtc);
+    row.nodeType = error.nodeType();
+    row.status = Status::Failed;
+    row.timestampUtc = timestampUtc;
+    row.relativePath = relativePath;
+    row.localNodeId = error.localNodeId();
+    row.remoteNodeId = error.remoteNodeId();
+    row.activeErrorDbIds.push_back(error.dbId());
+    return row;
+}
+
+ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row> &rows, const Error &error) {
+    Row *matchingRow = nullptr;
+    int32_t bestScore = 0;
+    for (auto &row: rows) {
+        if (row.status != Status::Failed) {
+            continue;
+        }
+        if (const int32_t score = errorMatchScore(row, error);
+            score > bestScore ||
+            (score == bestScore && score > 0 && matchingRow != nullptr && row.receivedSequence > matchingRow->receivedSequence)) {
+            matchingRow = &row;
+            bestScore = score;
+        }
+    }
+    return matchingRow;
+}
+
+void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
+    for (auto &row: rows) {
+        std::ranges::sort(row.activeErrorDbIds);
+        const auto uniqueResult = std::ranges::unique(row.activeErrorDbIds);
+        const auto duplicateIt = uniqueResult.begin();
+        row.activeErrorDbIds.erase(duplicateIt, row.activeErrorDbIds.end());
+        row.canFixErrors = row.status == Status::Failed && !row.activeErrorDbIds.empty();
+    }
+
+    std::erase_if(rows, [this](const Row &row) {
+        return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
+    });
+    std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
+        const bool lhsInProgress = lhs.status == Status::InProgress;
+        const bool rhsInProgress = rhs.status == Status::InProgress;
+        if (lhsInProgress != rhsInProgress) {
+            return lhsInProgress;
+        }
+        if (lhs.timestampUtc != rhs.timestampUtc) {
+            return lhs.timestampUtc > rhs.timestampUtc;
+        }
+        if (lhs.receivedSequence != rhs.receivedSequence) {
+            return lhs.receivedSequence > rhs.receivedSequence;
+        }
+        return lhs.rowId < rhs.rowId;
+    });
+}
+
+/**
+ * Returns the strongest non-empty node identity shared by an activity row and an active node error.
+ *
+ * The comparisons mirror the server's `selectErrorByNodeInfo` lookup: local node id, remote node id, source path, then
+ * destination path. A stronger match wins when several recent failed activities could represent the same error.
+ */
+int32_t ActivityListModel::errorMatchScore(const Row &row, const Error &error) {
+    if (!row.localNodeId.empty() && row.localNodeId == error.localNodeId()) {
+        return 3;
+    }
+    if (!row.remoteNodeId.empty() && row.remoteNodeId == error.remoteNodeId()) {
+        return 2;
+    }
+    if (!error.path().empty() && row.sourcePath == normalizedRelativePath(error.path())) {
+        return 1;
+    }
+    if (!error.destinationPath().empty() && row.destinationPath == normalizedRelativePath(error.destinationPath())) {
+        return 1;
+    }
+    return 0;
+}
+
+void ActivityListModel::resetProjection() {
+    auto nextRows = buildProjection();
+    if (_rows == nextRows) {
+        return;
+    }
+    beginResetModel();
+    _rows = std::move(nextRows);
+    endResetModel();
+    emit projectionChanged();
+}
+
+void ActivityListModel::reconcileProjection() {
+    const auto nextRows = buildProjection();
+    bool changed = removeMissingRows(nextRows);
+    changed = alignRows(nextRows) || changed;
+    if (changed) {
+        emit projectionChanged();
+    }
+}
+
+bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
+    bool changed = false;
+    for (qsizetype rowIndex = static_cast<qsizetype>(_rows.size()) - 1; rowIndex >= 0; --rowIndex) {
+        const auto rowExists = std::ranges::any_of(nextRows, [this, rowIndex](const Row &row) {
+            return row.rowId == _rows[static_cast<std::size_t>(rowIndex)].rowId;
+        });
+        if (rowExists) {
+            continue;
+        }
+        beginRemoveRows({}, rowIndex, rowIndex);
+        _rows.erase(_rows.begin() + rowIndex);
+        endRemoveRows();
+        changed = true;
+    }
+    return changed;
+}
+
+bool ActivityListModel::alignRows(const std::vector<Row> &nextRows) {
+    bool changed = false;
+    for (qsizetype targetIndex = 0; targetIndex < static_cast<qsizetype>(nextRows.size()); ++targetIndex) {
+        const auto &nextRow = nextRows[static_cast<std::size_t>(targetIndex)];
+        if (targetIndex >= static_cast<qsizetype>(_rows.size())) {
+            beginInsertRows({}, targetIndex, targetIndex);
+            _rows.push_back(nextRow);
+            endInsertRows();
+            changed = true;
+            continue;
+        }
+
+        if (_rows[static_cast<std::size_t>(targetIndex)].rowId != nextRow.rowId) {
+            const auto matchingIt = std::ranges::find(_rows.begin() + targetIndex + 1, _rows.end(), nextRow.rowId, &Row::rowId);
+            if (matchingIt == _rows.end()) {
+                beginInsertRows({}, targetIndex, targetIndex);
+                _rows.insert(_rows.begin() + targetIndex, nextRow);
+                endInsertRows();
+                changed = true;
+                continue;
+            }
+
+            const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
+            beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex);
+            auto movedRow = std::move(*matchingIt);
+            _rows.erase(matchingIt);
+            _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
+            endMoveRows();
+            changed = true;
+        }
+        changed = updateRow(targetIndex, nextRow) || changed;
+    }
+    return changed;
+}
+
+bool ActivityListModel::updateRow(const qsizetype rowIndex, const Row &nextRow) {
+    auto &row = _rows[static_cast<std::size_t>(rowIndex)];
+    if (row == nextRow) {
+        return false;
+    }
+
+    QList<int> changedRoles;
+    const auto addRoleIf = [&changedRoles](const bool changed, const Role role) {
+        if (changed) {
+            changedRoles.push_back(role);
+        }
+    };
+    addRoleIf(row.name != nextRow.name, NameRole);
+    addRoleIf(row.folder != nextRow.folder, FolderRole);
+    addRoleIf(row.timeText != nextRow.timeText, TimeTextRole);
+    addRoleIf(row.sizeText != nextRow.sizeText, SizeTextRole);
+    addRoleIf(row.nodeType != nextRow.nodeType, NodeTypeRole);
+    addRoleIf(row.status != nextRow.status, StatusRole);
+    addRoleIf(row.source != nextRow.source, SourceRole);
+    addRoleIf(row.instruction != nextRow.instruction, InstructionRole);
+    addRoleIf(row.progress != nextRow.progress, ProgressRole);
+    addRoleIf(row.activeErrorDbIds.empty() != nextRow.activeErrorDbIds.empty(), HasActiveErrorRole);
+    addRoleIf(row.activeErrorDbIds.size() != nextRow.activeErrorDbIds.size(), ActiveErrorCountRole);
+    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal || row.canOpenOnline != nextRow.canOpenOnline ||
+                      row.canCopyShareLink != nextRow.canCopyShareLink || row.canFixErrors != nextRow.canFixErrors,
+              HasOptionsRole);
+    addRoleIf(row.canOpenLocal != nextRow.canOpenLocal, CanOpenLocalRole);
+    addRoleIf(row.canOpenOnline != nextRow.canOpenOnline, CanOpenOnlineRole);
+    addRoleIf(row.canCopyShareLink != nextRow.canCopyShareLink, CanCopyShareLinkRole);
+    addRoleIf(row.canFixErrors != nextRow.canFixErrors, CanFixErrorsRole);
+
+    row = nextRow;
+    if (!changedRoles.empty()) {
+        emit dataChanged(index(rowIndex, 0), index(rowIndex, 0), changedRoles);
+    }
+    return true;
+}
+
+void ActivityListModel::refreshRelativeTimes() {
+    if (_rows.empty()) {
+        return;
+    }
+    const QDateTime nowUtc = QDateTime::currentDateTimeUtc();
+    for (qsizetype rowIndex = 0; rowIndex < static_cast<qsizetype>(_rows.size()); ++rowIndex) {
+        auto &row = _rows[static_cast<std::size_t>(rowIndex)];
+        const QString nextTimeText = formatRelativeTime(row.timestampUtc, nowUtc);
+        if (row.timeText == nextTimeText) {
+            continue;
+        }
+        row.timeText = nextTimeText;
+        emit dataChanged(index(rowIndex, 0), index(rowIndex, 0), {TimeTextRole});
+    }
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.cpp
@@ -42,10 +42,6 @@ constexpr auto hour = std::chrono::hours{1};
 constexpr auto day = std::chrono::days{1};
 constexpr auto relativeDateThreshold = std::chrono::days{4};
 
-QString activityRowId(const GenericId localId) {
-    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
-}
-
 QString errorRowId(const ErrorDbId errorDbId) {
     return QStringLiteral("error:%1").arg(static_cast<qlonglong>(errorDbId));
 }
@@ -136,6 +132,10 @@ ActivityListModel::Source toModelSource(const SyncDirection direction) {
 }
 
 } // namespace
+
+QString ActivityListModel::activityRowId(const GenericId localId) {
+    return QStringLiteral("activity:%1").arg(static_cast<qlonglong>(localId));
+}
 
 ActivityListModel::ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
                                      MainSelectionStore &selectionStore, QObject *const parent) :
@@ -378,17 +378,13 @@ ActivityListModel::Row *ActivityListModel::findMatchingActivity(std::vector<Row>
 
 void ActivityListModel::finalizeProjection(std::vector<Row> &rows) const {
     for (auto &row: rows) {
-        std::ranges::sort(row.activeErrorDbIds);
-        const auto uniqueResult = std::ranges::unique(row.activeErrorDbIds);
-        const auto duplicateIt = uniqueResult.begin();
-        row.activeErrorDbIds.erase(duplicateIt, row.activeErrorDbIds.end());
         row.canFixErrors = row.status == Status::Failed && !row.activeErrorDbIds.empty();
     }
 
-    std::erase_if(rows, [this](const Row &row) {
+    (void) std::erase_if(rows, [this](const Row &row) {
         return row.activeErrorDbIds.empty() && _filter == Filter::MyActivityOnly && row.source != Source::Computer;
     });
-    std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
+    (void) std::ranges::sort(rows, [](const Row &lhs, const Row &rhs) {
         const bool lhsInProgress = lhs.status == Status::InProgress;
         const bool rhsInProgress = rhs.status == Status::InProgress;
         if (lhsInProgress != rhsInProgress) {
@@ -456,7 +452,7 @@ bool ActivityListModel::removeMissingRows(const std::vector<Row> &nextRows) {
             continue;
         }
         beginRemoveRows({}, rowIndex, rowIndex);
-        _rows.erase(_rows.begin() + rowIndex);
+        (void) _rows.erase(_rows.begin() + rowIndex);
         endRemoveRows();
         changed = true;
     }
@@ -479,17 +475,24 @@ bool ActivityListModel::alignRows(const std::vector<Row> &nextRows) {
             const auto matchingIt = std::ranges::find(_rows.begin() + targetIndex + 1, _rows.end(), nextRow.rowId, &Row::rowId);
             if (matchingIt == _rows.end()) {
                 beginInsertRows({}, targetIndex, targetIndex);
-                _rows.insert(_rows.begin() + targetIndex, nextRow);
+                (void) _rows.insert(_rows.begin() + targetIndex, nextRow);
                 endInsertRows();
                 changed = true;
                 continue;
             }
 
-            const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
-            beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex);
+            if (const qsizetype sourceIndex = std::distance(_rows.begin(), matchingIt);
+                !beginMoveRows({}, sourceIndex, sourceIndex, {}, targetIndex)) {
+                qCWarning(lcActivityListModel) << "Incremental row move rejected; resetting activity projection"
+                                               << "| sourceIndex:" << sourceIndex << "| targetIndex:" << targetIndex;
+                beginResetModel();
+                _rows = nextRows;
+                endResetModel();
+                return true;
+            }
             auto movedRow = std::move(*matchingIt);
-            _rows.erase(matchingIt);
-            _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
+            (void) _rows.erase(matchingIt);
+            (void) _rows.insert(_rows.begin() + targetIndex, std::move(movedRow));
             endMoveRows();
             changed = true;
         }

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -1,0 +1,170 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/cache/activitystore.h"
+#include "app/cache/appcache.h"
+#include "app/cache/mainselectionstore.h"
+
+#include <QAbstractListModel>
+#include <QDateTime>
+#include <QList>
+#include <QString>
+#include <QTimer>
+
+#include <cstdint>
+#include <optional>
+#include <vector>
+
+namespace KDC {
+
+/**
+ * QML-facing projection of recent activities and active node errors for the selected synchronization.
+ *
+ * ActivityStore remains the bounded recent-history owner and AppCache remains the authoritative active-error owner.
+ * This model joins both sources without moving either lifecycle into the presentation layer.
+ */
+class ActivityListModel final : public QAbstractListModel {
+        Q_OBJECT
+
+    public:
+        enum class Filter : uint8_t {
+            MyActivityOnly,
+            AllActivities,
+        };
+        Q_ENUM(Filter)
+
+        enum class Status : uint8_t {
+            Synchronized,
+            InProgress,
+            Failed,
+        };
+        Q_ENUM(Status)
+
+        enum class Source : uint8_t {
+            Unknown,
+            Computer,
+            Web,
+        };
+        Q_ENUM(Source)
+
+        enum Role {
+            RowIdRole = Qt::UserRole + 1,
+            NameRole,
+            FolderRole,
+            TimeTextRole,
+            SizeTextRole,
+            NodeTypeRole,
+            StatusRole,
+            SourceRole,
+            InstructionRole,
+            ProgressRole,
+            HasActiveErrorRole,
+            ActiveErrorCountRole,
+            HasOptionsRole,
+            CanOpenLocalRole,
+            CanOpenOnlineRole,
+            CanCopyShareLinkRole,
+            CanFixErrorsRole,
+        };
+        Q_ENUM(Role)
+
+        struct ActionTarget {
+                GenericId activityLocalId{0};
+                SyncDbId syncDbId{0};
+                SyncPath relativePath;
+                NodeType nodeType{NodeType::Unknown};
+                NodeId remoteNodeId;
+                std::vector<ErrorDbId> activeErrorDbIds;
+                bool canOpenLocal{false};
+                bool canOpenOnline{false};
+                bool canCopyShareLink{false};
+                bool canFixErrors{false};
+        };
+
+        explicit ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
+                                   MainSelectionStore &selectionStore, QObject *parent = nullptr);
+
+        [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
+        [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
+        [[nodiscard]] QHash<int, QByteArray> roleNames() const override;
+
+        [[nodiscard]] Filter filter() const { return _filter; }
+        void setFilter(Filter filter);
+        [[nodiscard]] std::optional<ActionTarget> actionTarget(const QString &rowId) const;
+
+    signals:
+        void filterChanged();
+        void projectionChanged();
+
+    private:
+        struct Row {
+                QString rowId;
+                GenericId activityLocalId{0};
+                SyncDbId syncDbId{0};
+                QString name;
+                QString folder;
+                QString timeText;
+                QString sizeText;
+                NodeType nodeType{NodeType::Unknown};
+                Status status{Status::Synchronized};
+                Source source{Source::Unknown};
+                SyncFileInstruction instruction{SyncFileInstruction::None};
+                int32_t progress{0};
+                QDateTime timestampUtc;
+                Count receivedSequence{0};
+                SyncPath relativePath;
+                SyncPath sourcePath;
+                SyncPath destinationPath;
+                NodeId localNodeId;
+                NodeId remoteNodeId;
+                std::vector<ErrorDbId> activeErrorDbIds;
+                bool canOpenLocal{false};
+                bool canOpenOnline{false};
+                bool canCopyShareLink{false};
+                bool canFixErrors{false};
+
+                friend bool operator==(const Row &lhs, const Row &rhs) = default;
+        };
+
+        [[nodiscard]] std::vector<Row> buildProjection() const;
+        [[nodiscard]] std::vector<Row> activityRows(SyncDbId syncDbId) const;
+        static void appendActiveErrors(SyncDbId syncDbId, const std::vector<Error> &errors, std::vector<Row> &rows);
+        static void appendActiveError(SyncDbId syncDbId, const Error &error, std::vector<Row> &rows);
+        [[nodiscard]] static Row makeActivityRow(SyncDbId syncDbId, const ActivityEntry &activity);
+        [[nodiscard]] static Row makeErrorRow(SyncDbId syncDbId, const Error &error);
+        [[nodiscard]] static Row *findMatchingActivity(std::vector<Row> &rows, const Error &error);
+        [[nodiscard]] static int32_t errorMatchScore(const Row &row, const Error &error);
+        void finalizeProjection(std::vector<Row> &rows) const;
+        void resetProjection();
+        void reconcileProjection();
+        [[nodiscard]] bool removeMissingRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool alignRows(const std::vector<Row> &nextRows);
+        [[nodiscard]] bool updateRow(qsizetype rowIndex, const Row &nextRow);
+        void refreshRelativeTimes();
+
+        const ActivityStore &_activityStore;
+        const AppCache &_appCache;
+        MainSelectionStore &_selectionStore;
+        std::vector<Row> _rows;
+        Filter _filter{Filter::MyActivityOnly};
+        QTimer _relativeTimeTimer;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/mainwindow/activitylistmodel.h
+++ b/src/gui4/linux/app/mainwindow/activitylistmodel.h
@@ -101,6 +101,9 @@ class ActivityListModel final : public QAbstractListModel {
         explicit ActivityListModel(const ActivityStore &activityStore, const AppCache &appCache,
                                    MainSelectionStore &selectionStore, QObject *parent = nullptr);
 
+        /** Returns the stable model row identifier for an activity. */
+        [[nodiscard]] static QString activityRowId(GenericId localId);
+
         [[nodiscard]] int rowCount(const QModelIndex &parent = QModelIndex()) const override;
         [[nodiscard]] QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
         [[nodiscard]] QHash<int, QByteArray> roleNames() const override;

--- a/src/gui4/linux/app/services/activityservice.cpp
+++ b/src/gui4/linux/app/services/activityservice.cpp
@@ -72,30 +72,13 @@ void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbI
     }
 
     const QPointer<ActivityService> guard{this};
-    _commService.requestSyncGetPrivateLinkUrl(
-            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
-                if (guard.isNull()) {
-                    return;
-                }
-                guard->endAction(actionOpenOnline, activityLocalId);
-                if (!exitInfo) {
-                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
-                    return;
-                }
-
-                const QUrl url{urlText};
-                if (!isSupportedWebUrl(url)) {
-                    qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                if (!QDesktopServices::openUrl(url)) {
-                    qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                }
-            });
+    _commService.requestSyncGetPrivateLinkUrl(driveDbId, remoteNodeId,
+                                              [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                                                  if (guard.isNull()) {
+                                                      return;
+                                                  }
+                                                  guard->handlePrivateLinkUrl(exitInfo, urlText, activityLocalId);
+                                              });
 }
 
 void ActivityService::copyShareLink(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
@@ -110,34 +93,59 @@ void ActivityService::copyShareLink(const GenericId activityLocalId, const Drive
     }
 
     const QPointer<ActivityService> guard{this};
-    _commService.requestSyncGetPublicLinkUrl(
-            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
-                if (guard.isNull()) {
-                    return;
-                }
-                guard->endAction(actionCopyShareLink, activityLocalId);
-                if (!exitInfo) {
-                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
-                    return;
-                }
+    _commService.requestSyncGetPublicLinkUrl(driveDbId, remoteNodeId,
+                                             [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                                                 if (guard.isNull()) {
+                                                     return;
+                                                 }
+                                                 guard->handlePublicLinkUrl(exitInfo, urlText, activityLocalId);
+                                             });
+}
 
-                const QUrl url{urlText};
-                if (!isSupportedWebUrl(url)) {
-                    qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                auto *const clipboard = QGuiApplication::clipboard();
-                if (clipboard == nullptr) {
-                    qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
-                                                 << "| activityLocalId:" << activityLocalId;
-                    emit guard->actionFailed(activityLocalId);
-                    return;
-                }
-                clipboard->setText(url.toString());
-                emit guard->shareLinkCopied(activityLocalId);
-            });
+void ActivityService::handlePrivateLinkUrl(const ExitInfo &exitInfo, const QString &urlText, const GenericId activityLocalId) {
+    endAction(actionOpenOnline, activityLocalId);
+    if (!exitInfo) {
+        notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
+        return;
+    }
+
+    const QUrl url{urlText};
+    if (!isSupportedWebUrl(url)) {
+        qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!QDesktopServices::openUrl(url)) {
+        qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+    }
+}
+
+void ActivityService::handlePublicLinkUrl(const ExitInfo &exitInfo, const QString &urlText, const GenericId activityLocalId) {
+    endAction(actionCopyShareLink, activityLocalId);
+    if (!exitInfo) {
+        notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
+        return;
+    }
+
+    const QUrl url{urlText};
+    if (!isSupportedWebUrl(url)) {
+        qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    auto *const clipboard = QGuiApplication::clipboard();
+    if (clipboard == nullptr) {
+        qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
+                                     << "| activityLocalId:" << activityLocalId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    clipboard->setText(url.toString());
+    emit shareLinkCopied(activityLocalId);
 }
 
 bool ActivityService::beginAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {

--- a/src/gui4/linux/app/services/activityservice.cpp
+++ b/src/gui4/linux/app/services/activityservice.cpp
@@ -1,0 +1,166 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "app/services/activityservice.h"
+
+#include <QClipboard>
+#include <QDesktopServices>
+#include <QGuiApplication>
+#include <QLoggingCategory>
+#include <QPointer>
+#include <QUrl>
+
+namespace {
+constexpr char serviceKeyActivity[] = "activity";
+constexpr char actionOpenOnline[] = "openOnline";
+constexpr char actionCopyShareLink[] = "copyShareLink";
+
+bool isSupportedWebUrl(const QUrl &url) {
+    return url.isValid() && !url.isEmpty() && !url.host().isEmpty() &&
+           (url.scheme() == QStringLiteral("https") || url.scheme() == QStringLiteral("http"));
+}
+} // namespace
+
+namespace KDC {
+
+namespace {
+Q_LOGGING_CATEGORY(lcActivityService, "gui.v4.activityservice", QtInfoMsg)
+} // namespace
+
+ActivityService::ActivityService(CommService &commService, ServiceActionTracker &serviceActionTracker,
+                                 ServiceEventBus &serviceEventBus, QObject *const parent) :
+    QObject(parent),
+    _commService(commService),
+    _serviceActionTracker(serviceActionTracker),
+    _serviceEventBus(serviceEventBus) {
+    (void) connect(&_serviceActionTracker, &ServiceActionTracker::servicePendingChanged, this,
+                   [this](const ServiceActionTracker::ServiceKey &serviceKey, const bool) {
+                       if (serviceKey == serviceKeyActivity) {
+                           emit loadingChanged();
+                       }
+                   });
+}
+
+bool ActivityService::loading() const {
+    return _serviceActionTracker.isServicePending(serviceKeyActivity);
+}
+
+void ActivityService::openOnline(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
+    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
+        qCWarning(lcActivityService) << "Online activity action rejected because its target is incomplete"
+                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!beginAction(actionOpenOnline, activityLocalId)) {
+        return;
+    }
+
+    const QPointer<ActivityService> guard{this};
+    _commService.requestSyncGetPrivateLinkUrl(
+            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                if (guard.isNull()) {
+                    return;
+                }
+                guard->endAction(actionOpenOnline, activityLocalId);
+                if (!exitInfo) {
+                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPRIVATELINKURL, activityLocalId);
+                    return;
+                }
+
+                const QUrl url{urlText};
+                if (!isSupportedWebUrl(url)) {
+                    qCWarning(lcActivityService) << "Private activity URL is empty or invalid"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                if (!QDesktopServices::openUrl(url)) {
+                    qCWarning(lcActivityService) << "Desktop service failed to open private activity URL"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                }
+            });
+}
+
+void ActivityService::copyShareLink(const GenericId activityLocalId, const DriveDbId driveDbId, const NodeId &remoteNodeId) {
+    if (activityLocalId <= 0 || driveDbId <= 0 || remoteNodeId.empty()) {
+        qCWarning(lcActivityService) << "Share-link activity action rejected because its target is incomplete"
+                                     << "| activityLocalId:" << activityLocalId << "| driveDbId:" << driveDbId;
+        emit actionFailed(activityLocalId);
+        return;
+    }
+    if (!beginAction(actionCopyShareLink, activityLocalId)) {
+        return;
+    }
+
+    const QPointer<ActivityService> guard{this};
+    _commService.requestSyncGetPublicLinkUrl(
+            driveDbId, remoteNodeId, [guard, activityLocalId](const ExitInfo &exitInfo, const QString &urlText) {
+                if (guard.isNull()) {
+                    return;
+                }
+                guard->endAction(actionCopyShareLink, activityLocalId);
+                if (!exitInfo) {
+                    guard->notifyRequestFailure(exitInfo, RequestNum::SYNC_GETPUBLICLINKURL, activityLocalId);
+                    return;
+                }
+
+                const QUrl url{urlText};
+                if (!isSupportedWebUrl(url)) {
+                    qCWarning(lcActivityService) << "Public activity URL is empty or invalid"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                auto *const clipboard = QGuiApplication::clipboard();
+                if (clipboard == nullptr) {
+                    qCWarning(lcActivityService) << "Clipboard unavailable for activity share link"
+                                                 << "| activityLocalId:" << activityLocalId;
+                    emit guard->actionFailed(activityLocalId);
+                    return;
+                }
+                clipboard->setText(url.toString());
+                emit guard->shareLinkCopied(activityLocalId);
+            });
+}
+
+bool ActivityService::beginAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {
+    if (_serviceActionTracker.isActionPending(serviceKeyActivity, actionKey, activityLocalId)) {
+        qCDebug(lcActivityService) << "Duplicate activity action ignored"
+                                   << "| action:" << actionKey << "| activityLocalId:" << activityLocalId;
+        return false;
+    }
+    _serviceActionTracker.beginAction(serviceKeyActivity, actionKey, activityLocalId);
+    return true;
+}
+
+void ActivityService::endAction(const ServiceActionTracker::ActionKey &actionKey, const GenericId activityLocalId) const {
+    _serviceActionTracker.endAction(serviceKeyActivity, actionKey, activityLocalId);
+}
+
+void ActivityService::notifyRequestFailure(const ExitInfo &exitInfo, const RequestNum requestNum,
+                                           const GenericId activityLocalId) {
+    qCWarning(lcActivityService) << "Activity service request failed"
+                                 << "| request:" << static_cast<int32_t>(requestNum) << "| code:" << exitInfo.code()
+                                 << "| cause:" << exitInfo.cause() << "| activityLocalId:" << activityLocalId;
+    _serviceEventBus.notifyGenericError(exitInfo, requestNum);
+    emit actionFailed(activityLocalId);
+}
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/activityservice.h
+++ b/src/gui4/linux/app/services/activityservice.h
@@ -1,0 +1,63 @@
+/*
+ * Infomaniak kDrive - Desktop
+ * Copyright (C) 2023-2026 Infomaniak Network SA
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#pragma once
+
+#include "app/services/commservice.h"
+#include "app/services/serviceactiontracker.h"
+#include "app/services/serviceeventbus.h"
+#include "libcommon/utility/types.h"
+
+#include <QObject>
+
+namespace KDC {
+
+/**
+ * High-level facade for asynchronous actions initiated from an activity row.
+ *
+ * It owns link resolution, browser and clipboard side effects, pending-action tracking, and backend failure reporting.
+ * Activity projection and local-path validation remain outside this service.
+ */
+class ActivityService final : public QObject {
+        Q_OBJECT
+        Q_PROPERTY(bool loading READ loading NOTIFY loadingChanged)
+
+    public:
+        explicit ActivityService(CommService &commService, ServiceActionTracker &serviceActionTracker,
+                                 ServiceEventBus &serviceEventBus, QObject *parent = nullptr);
+
+        [[nodiscard]] bool loading() const;
+        void openOnline(GenericId activityLocalId, DriveDbId driveDbId, const NodeId &remoteNodeId);
+        void copyShareLink(GenericId activityLocalId, DriveDbId driveDbId, const NodeId &remoteNodeId);
+
+    signals:
+        void loadingChanged();
+        void shareLinkCopied(GenericId activityLocalId);
+        void actionFailed(GenericId activityLocalId);
+
+    private:
+        [[nodiscard]] bool beginAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
+        void endAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
+        void notifyRequestFailure(const ExitInfo &exitInfo, RequestNum requestNum, GenericId activityLocalId);
+
+        CommService &_commService;
+        ServiceActionTracker &_serviceActionTracker;
+        ServiceEventBus &_serviceEventBus;
+};
+
+} // namespace KDC

--- a/src/gui4/linux/app/services/activityservice.h
+++ b/src/gui4/linux/app/services/activityservice.h
@@ -55,6 +55,9 @@ class ActivityService final : public QObject {
         void endAction(const ServiceActionTracker::ActionKey &actionKey, GenericId activityLocalId) const;
         void notifyRequestFailure(const ExitInfo &exitInfo, RequestNum requestNum, GenericId activityLocalId);
 
+        void handlePrivateLinkUrl(const ExitInfo &exitInfo, const QString &urlText, GenericId activityLocalId);
+        void handlePublicLinkUrl(const ExitInfo &exitInfo, const QString &urlText, GenericId activityLocalId);
+
         CommService &_commService;
         ServiceActionTracker &_serviceActionTracker;
         ServiceEventBus &_serviceEventBus;

--- a/src/gui4/linux/appclientlinux.cpp
+++ b/src/gui4/linux/appclientlinux.cpp
@@ -82,6 +82,10 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
                                                          "SyncSelectorModel is owned by MainSidebarController.");
     (void) qmlRegisterUncreatableType<HomeController>("kDrive.UI", 1, 0, "HomeController",
                                                       "HomeController is owned by AppClientLinux.");
+    (void) qmlRegisterUncreatableType<ActivityListModel>("kDrive.UI", 1, 0, "ActivityListModel",
+                                                         "ActivityListModel is owned by ActivitiesController.");
+    (void) qmlRegisterUncreatableType<ActivitiesController>("kDrive.UI", 1, 0, "ActivitiesController",
+                                                            "ActivitiesController is owned by AppClientLinux.");
     (void) qmlRegisterUncreatableMetaObject(AppConstants::WebDrive::staticMetaObject, "kDrive.UI", 1, 0, "WebDrive",
                                             QStringLiteral("WebDrive only exposes enums."));
     _qmlEngine.setOutputWarningsToStandardError(false);
@@ -94,6 +98,7 @@ void AppClientLinux::setupQmlEngine(const QIcon &appIcon) {
             {QStringLiteral("appRouter"), QVariant::fromValue<QObject *>(&_appRouter)},
             {QStringLiteral("mainSidebarController"), QVariant::fromValue<QObject *>(&_mainSidebarController)},
             {QStringLiteral("homeController"), QVariant::fromValue<QObject *>(&_homeController)},
+            {QStringLiteral("activitiesController"), QVariant::fromValue<QObject *>(&_activitiesController)},
             {QStringLiteral("onboardingSessionManager"), QVariant::fromValue<QObject *>(&_onboardingSessionManager)},
             {QStringLiteral("systemTrayController"), QVariant::fromValue<QObject *>(&_systemTrayController)},
     });

--- a/src/gui4/linux/appclientlinux.h
+++ b/src/gui4/linux/appclientlinux.h
@@ -23,6 +23,7 @@
 #include "app/cache/cachepipeline.h"
 #include "app/cache/mainselectionstore.h"
 #include "app/cache/parametersstore.h"
+#include "app/mainwindow/activitiescontroller.h"
 #include "app/mainwindow/homecontroller.h"
 #include "app/mainwindow/mainsidebarcontroller.h"
 #include "app/mainwindow/networkstatusobserver.h"
@@ -30,6 +31,7 @@
 #include "app/onboarding/onboardingsessionmanager.h"
 #include "app/services/cachepopulator.h"
 #include "app/services/commservice.h"
+#include "app/services/activityservice.h"
 #include "app/services/driveservice.h"
 #include "app/services/parametersservice.h"
 #include "app/services/sentryservice.h"
@@ -59,7 +61,7 @@ Q_DECLARE_LOGGING_CATEGORY(lcAppClientLinux)
  * - IPC transport, server-signal dispatch, and the typed communication facade.
  * - AppCache, ActivityStore, ParametersStore, their live push pipeline, and the two-branch bootstrap population.
  * - Application services, action tracking, transient service events, and Sentry coordination.
- * - Main selection, navigation, sidebar, Home, and the ephemeral onboarding-session manager.
+ * - Main selection, navigation, sidebar, Home, Activities, and the ephemeral onboarding-session manager.
  * - Linux system tray, network observation, frameless-window integration, translations, and the QML runtime.
  *
  * Construction configures logging, translations, application identity, the system tray, signal connections, and the QML
@@ -127,6 +129,7 @@ class AppClientLinux : public QApplication {
         AppRouter _appRouter{this};
         ServiceActionTracker _serviceActionTracker{this};
         ServiceEventBus _serviceEventBus{this};
+        ActivityService _activityService{_serverCommService, _serviceActionTracker, _serviceEventBus, this};
         SentryService _sentryService{_parametersService, _appCache, _parametersStore, this};
         CachePopulator _cachePopulator{_serverCommService, _appCache, _parametersStore, this};
         UserService _userService{_serverCommService, _appCache, _serviceActionTracker, _serviceEventBus, this};
@@ -139,6 +142,8 @@ class AppClientLinux : public QApplication {
         NetworkStatusObserver _networkStatusObserver{this};
         HomeController _homeController{
                 _appCache, _mainSelectionStore, _syncService, _appRouter, _systemTrayController, _networkStatusObserver, this};
+        ActivitiesController _activitiesController{_activityStore,         _appCache,        _mainSelectionStore,
+                                                   _networkStatusObserver, _activityService, this};
         QTranslator _baseTranslator{this};
         QTranslator _localizedTranslator{this};
         QQmlApplicationEngine _qmlEngine;

--- a/src/gui4/linux/ui/Main.qml
+++ b/src/gui4/linux/ui/Main.qml
@@ -28,6 +28,7 @@ IKShadowedWindow {
     id: mainWindow
 
     required property var appRouter
+    required property var activitiesController
     required property var homeController
     required property var mainSidebarController
     required property var onboardingSessionManager


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
Cette PR construit la couche de présentation et d'actions de la page Activities pour Linux v4 : un modèle de liste QML qui joint l'historique récent (`ActivityStore`) et les erreurs actives (`AppCache`), un contrôleur qui pilote le titre, le filtre et les actions de la page, et un service qui exécute les actions asynchrones liées au web (ouverture en ligne, copie de lien de partage). `ActivityStore` est également simplifié pour ne plus dupliquer la normalisation de statut/direction, désormais du ressort de la couche de présentation.

## Changements
- Ajout de `ActivityService` (`app/services/activityservice.*`) : façade pour les actions "ouvrir en ligne" et "copier le lien de partage" d'une ligne d'activité. Résout les URLs privées/publiques via `CommService`, gère les effets de bord navigateur/presse-papiers, suit les actions concurrentes via `ServiceActionTracker` et remonte les échecs via `ServiceEventBus`.
- Ajout de `ActivityListModel` (`app/mainwindow/activitylistmodel.*`) : `QAbstractListModel` exposé à QML qui projette, pour la synchronisation sélectionnée, les activités récentes bornées (`ActivityStore`) et les erreurs de nœud actives autoritatives (`AppCache`), en les fusionnant lorsqu'elles correspondent à la même opération. Les erreurs actives restent visibles même après éviction de l'activité correspondante. Le modèle mappe le statut/direction serveur vers des énumérations de présentation (`Status`, `Source`), calcule les temps relatifs ("il y a 2 minutes") rafraîchis périodiquement, et détermine par ligne les actions disponibles (ouverture locale/en ligne, copie de lien, correction d'erreur).
- Ajout de `ActivitiesController` (`app/mainwindow/activitiescontroller.*`) : frontière QML pour l'état et les actions de la page Activities. Résout le titre de la page selon un état dérivé (chargement, hors-ligne, en cours, aucune activité, inactif, en pause), gère le filtre (mes activités / toutes), valide les chemins locaux (résolution canonique, confinement dans la racine de synchronisation) avant d'ouvrir un fichier localement, et délègue les actions web à `ActivityService`.
- Simplification de `ActivityStore::ingest` et suppression des énumérations `ActivityStatus`/`ActivitySource` et de leurs fonctions de normalisation associées : le store conserve désormais directement `SyncFileStatus`/`SyncDirection` bruts et valide seulement leur validité, laissant la normalisation vers des états de présentation à `ActivityListModel`.
- Enregistrement de `ActivityListModel` et `ActivitiesController` comme types QML non instanciables, exposition de `_activitiesController` en contexte QML, et câblage de `ActivityService`/`ActivitiesController` dans `AppClientLinux`.
- Mise à jour de `AGENTS.md` (racine et `src/gui4/linux/`) : nouvelle règle interdisant les nouvelles dépendances Qt dans le code serveur, règle sur la conception du stockage/présentation pour leur cycle de vie final, et documentation des nouveaux composants `activitylistmodel.*`, `activitiescontroller.*` et `activityservice.*`.

## Notes
Les actions "corriger les erreurs" (`requestFixErrors` / `requestFixAllErrors`) sont présentes dans `ActivitiesController` mais ne sont pas encore implémentées ; elles se contentent actuellement de journaliser l'appel.

</details>

---

## Summary
This PR builds the presentation and action layer for the Linux v4 Activities page: a QML list model that joins recent history (`ActivityStore`) with active errors (`AppCache`), a controller that drives the page title, filter, and actions, and a service that executes asynchronous web-related actions (open online, copy share link). `ActivityStore` is also simplified so it no longer duplicates status/direction normalization, which now belongs to the presentation layer.

## Changes
- Added `ActivityService` (`app/services/activityservice.*`): facade for the "open online" and "copy share link" actions of an activity row. Resolves private/public URLs through `CommService`, handles browser/clipboard side effects, tracks concurrent actions via `ServiceActionTracker`, and reports failures through `ServiceEventBus`.
- Added `ActivityListModel` (`app/mainwindow/activitylistmodel.*`): a QML-exposed `QAbstractListModel` that projects, for the selected synchronization, bounded recent activities (`ActivityStore`) and authoritative active node errors (`AppCache`), merging them when they match the same operation. Active errors remain visible even after their corresponding activity has been evicted. The model maps server status/direction to presentation enums (`Status`, `Source`), computes periodically refreshed relative timestamps ("2 minutes ago"), and derives per-row available actions (open locally/online, copy link, fix error).
- Added `ActivitiesController` (`app/mainwindow/activitiescontroller.*`): QML-facing boundary for Activities page state and actions. Resolves the page title from a derived state (loading, offline, in progress, no activity, idle, paused), owns the filter (my activity only / all activities), validates local paths (canonical resolution, containment within the sync root) before opening a file locally, and delegates web actions to `ActivityService`.
- Simplified `ActivityStore::ingest` and removed the `ActivityStatus`/`ActivitySource` enums and their normalization helpers: the store now keeps raw `SyncFileStatus`/`SyncDirection` directly and only validates them, leaving normalization to presentation states to `ActivityListModel`.
- Registered `ActivityListModel` and `ActivitiesController` as uncreatable QML types, exposed `_activitiesController` in the QML context, and wired `ActivityService`/`ActivitiesController` into `AppClientLinux`.
- Updated `AGENTS.md` (root and `src/gui4/linux/`): added a rule forbidding new Qt dependencies in server code, a rule about designing storage/presentation for their final lifecycle, and documentation for the new `activitylistmodel.*`, `activitiescontroller.*`, and `activityservice.*` components.

## Notes
The "fix errors" actions (`requestFixErrors` / `requestFixAllErrors`) are present on `ActivitiesController` but not yet implemented; they currently only log the call.

---

PR 2 on 3 about this view

<img width="1992" height="1392" alt="image" src="https://github.com/user-attachments/assets/def35f50-59b9-40a2-af4a-ac85667ae5f6" />

---

Depends on #2261