### PR TITLE
fix(sqlitedb): prevent deletion of a locked database during consistency check

### DIFF
--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -57,7 +57,7 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
         return false;
     }
 
-    auto checkResult = checkDb();
+    const auto checkResult = checkDb();
     if (checkResult != CheckDbResult::Ok) {
         if (checkResult == CheckDbResult::Locked) {
             // The database is locked by another connection. This is transient and does not

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -421,7 +421,7 @@ SqliteDb::CheckDbResult SqliteDb::checkDb() {
     bool hasData;
     if (!queryNext(PRAGMA_QUICK_CHECK_ID, hasData) || !hasData) {
         // Same as above: a lock during step is transient, the db must not be removed.
-        const int stepErrId = _queries.at(PRAGMA_QUICK_CHECK_ID)._query->errorId();
+        const int32_t stepErrId = _queries.at(PRAGMA_QUICK_CHECK_ID)._query->errorId();
         if (stepErrId == SQLITE_BUSY || stepErrId == SQLITE_LOCKED) {
             LOG_WARN(_logger, "Database is locked during consistency check step: " << PRAGMA_QUICK_CHECK_ID);
             queryFree(PRAGMA_QUICK_CHECK_ID);

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -57,35 +57,32 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
         return false;
     }
 
-    const auto checkResult = checkDb();
-    if (checkResult != CheckDbResult::Ok) {
-        if (checkResult == CheckDbResult::Locked) {
-            // The database is locked by another connection. This is transient and does not
-            // indicate corruption: preserve the file so the caller can retry later.
-            LOGW_WARN(_logger, L"Database is locked, aborting open (db not removed): " << Path2WStr(dbPath));
+    const auto handleLockedDb = [this, &dbPath]() -> bool {
+        LOGW_WARN(_logger, L"Database is locked, aborting open (db not removed): " << Path2WStr(dbPath));
+        close();
+        return false;
+    };
+
+    const auto handleCantPrepare = [this, &dbPath]() -> bool {
+        // When disk space is low, preparing may fail even though the db is fine.
+        // Typically CANTOPEN or IOERR.
+        if (const int64_t freeSpace = Utility::getFreeDiskSpace(dbPath); freeSpace != -1 && freeSpace < 1000000) {
+            LOG_WARN(_logger, "Can't prepare consistency check and disk space is low: " << freeSpace);
             close();
-            return false;
+            return true;
         }
 
-        if (checkResult == CheckDbResult::CantPrepare) {
-            // When disk space is low, preparing may fail even though the db is fine.
-            // Typically CANTOPEN or IOERR.
-            int64_t freeSpace = Utility::getFreeDiskSpace(dbPath);
-            if (freeSpace != -1 && freeSpace < 1000000) {
-                LOG_WARN(_logger, "Can't prepare consistency check and disk space is low: " << freeSpace);
-                close();
-                return false;
-            }
-
-            // Even when there's enough disk space, it might very well be that the
-            // file is on a read-only filesystem and can't be opened because of that.
-            if (_errId == SQLITE_CANTOPEN) {
-                LOG_WARN(_logger, "Can't open db to prepare consistency check, aborting");
-                close();
-                return false;
-            }
+        // Even when there's enough disk space, it might very well be that the
+        // file is on a read-only filesystem and can't be opened because of that.
+        if (_errId == SQLITE_CANTOPEN) {
+            LOG_WARN(_logger, "Can't open db to prepare consistency check, aborting");
+            close();
+            return true;
         }
+        return false;
+    };
 
+    const auto removeAndReopen = [this, &dbPath]() -> bool {
         LOGW_FATAL(_logger, L"Consistency check failed, removing broken db " << Path2WStr(dbPath));
         close();
         if (auto ioError = IoError::Unknown; !IoHelper::deleteItem(dbPath, ioError)) {
@@ -93,11 +90,27 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
             close();
             return false;
         }
-
         return openHelper(dbPath, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
-    }
+    };
 
-    return true;
+    switch (checkDb()) {
+        case CheckDbResult::Ok:
+            return true;
+        case CheckDbResult::Locked:
+            return handleLockedDb();
+        case CheckDbResult::CantPrepare:
+            if (handleCantPrepare()) return false;
+            return removeAndReopen();
+        case CheckDbResult::NotOk: // error never returned by checkDb yet
+            LOGW_WARN(_logger, L"Database is not ok " << Path2WStr(dbPath));
+            close();
+            return removeAndReopen();
+        case CheckDbResult::CantExec: // error never returned by checkDb yet
+            LOGW_WARN(_logger, L"Database can't exec " << Path2WStr(dbPath));
+            close();
+            return false;
+    }
+    return false;
 }
 
 bool SqliteDb::openReadOnly(const std::filesystem::path &dbPath) {
@@ -406,10 +419,12 @@ bool SqliteDb::openHelper(const std::filesystem::path &dbPath, int sqliteFlags) 
 
 SqliteDb::CheckDbResult SqliteDb::checkDb() {
     // quick_check can fail with a disk IO error when diskspace is low
+    auto isDbLocked = [](const int32_t errId) { return errId == SQLITE_BUSY || errId == SQLITE_LOCKED; };
+
     LOG_IF_FAIL(queryCreate(PRAGMA_QUICK_CHECK_ID));
     if (!queryPrepare(PRAGMA_QUICK_CHECK_ID, PRAGMA_QUICK_CHECK, true, _errId, _error)) {
         // A persistent lock is not a sign of corruption — abort without deleting the db.
-        if (_errId == SQLITE_BUSY || _errId == SQLITE_LOCKED) {
+        if (isDbLocked(_errId)) {
             LOG_WARN(_logger, "Database is locked, consistency check aborted: " << PRAGMA_QUICK_CHECK_ID);
             queryFree(PRAGMA_QUICK_CHECK_ID);
             return CheckDbResult::Locked;
@@ -422,7 +437,7 @@ SqliteDb::CheckDbResult SqliteDb::checkDb() {
     if (!queryNext(PRAGMA_QUICK_CHECK_ID, hasData) || !hasData) {
         // Same as above: a lock during step is transient, the db must not be removed.
         const int32_t stepErrId = _queries.at(PRAGMA_QUICK_CHECK_ID)._query->errorId();
-        if (stepErrId == SQLITE_BUSY || stepErrId == SQLITE_LOCKED) {
+        if (isDbLocked(stepErrId)) {
             LOG_WARN(_logger, "Database is locked during consistency check step: " << PRAGMA_QUICK_CHECK_ID);
             queryFree(PRAGMA_QUICK_CHECK_ID);
             return CheckDbResult::Locked;

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -102,7 +102,7 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
             return handleLockedDb();
         case CheckDbResult::CantPrepare:
             return handleCantPrepare();
-        case CheckDbResult::NotOk: // error never returned by checkDb yet
+        case CheckDbResult::NotOk:
         {
             LOGW_WARN(_logger, L"Database is not ok " << Path2WStr(dbPath));
             close();

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -59,6 +59,14 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
 
     auto checkResult = checkDb();
     if (checkResult != CheckDbResult::Ok) {
+        if (checkResult == CheckDbResult::Locked) {
+            // The database is locked by another connection. This is transient and does not
+            // indicate corruption: preserve the file so the caller can retry later.
+            LOGW_WARN(_logger, L"Database is locked, aborting open (db not removed): " << Path2WStr(dbPath));
+            close();
+            return false;
+        }
+
         if (checkResult == CheckDbResult::CantPrepare) {
             // When disk space is low, preparing may fail even though the db is fine.
             // Typically CANTOPEN or IOERR.
@@ -400,12 +408,25 @@ SqliteDb::CheckDbResult SqliteDb::checkDb() {
     // quick_check can fail with a disk IO error when diskspace is low
     LOG_IF_FAIL(queryCreate(PRAGMA_QUICK_CHECK_ID));
     if (!queryPrepare(PRAGMA_QUICK_CHECK_ID, PRAGMA_QUICK_CHECK, true, _errId, _error)) {
+        // A persistent lock is not a sign of corruption — abort without deleting the db.
+        if (_errId == SQLITE_BUSY || _errId == SQLITE_LOCKED) {
+            LOG_WARN(_logger, "Database is locked, consistency check aborted: " << PRAGMA_QUICK_CHECK_ID);
+            queryFree(PRAGMA_QUICK_CHECK_ID);
+            return CheckDbResult::Locked;
+        }
         LOG_WARN(_logger, "Error preparing query: " << PRAGMA_QUICK_CHECK_ID);
         queryFree(PRAGMA_QUICK_CHECK_ID);
         return CheckDbResult::CantPrepare;
     }
     bool hasData;
     if (!queryNext(PRAGMA_QUICK_CHECK_ID, hasData) || !hasData) {
+        // Same as above: a lock during step is transient, the db must not be removed.
+        const int stepErrId = _queries.at(PRAGMA_QUICK_CHECK_ID)._query->errorId();
+        if (stepErrId == SQLITE_BUSY || stepErrId == SQLITE_LOCKED) {
+            LOG_WARN(_logger, "Database is locked during consistency check step: " << PRAGMA_QUICK_CHECK_ID);
+            queryFree(PRAGMA_QUICK_CHECK_ID);
+            return CheckDbResult::Locked;
+        }
         LOG_WARN(_logger, "Error getting query result: " << PRAGMA_QUICK_CHECK_ID);
         queryFree(PRAGMA_QUICK_CHECK_ID);
         return CheckDbResult::NotOk;

--- a/src/libcommonserver/db/sqlitedb.cpp
+++ b/src/libcommonserver/db/sqlitedb.cpp
@@ -57,31 +57,6 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
         return false;
     }
 
-    const auto handleLockedDb = [this, &dbPath]() -> bool {
-        LOGW_WARN(_logger, L"Database is locked, aborting open (db not removed): " << Path2WStr(dbPath));
-        close();
-        return false;
-    };
-
-    const auto handleCantPrepare = [this, &dbPath]() -> bool {
-        // When disk space is low, preparing may fail even though the db is fine.
-        // Typically CANTOPEN or IOERR.
-        if (const int64_t freeSpace = Utility::getFreeDiskSpace(dbPath); freeSpace != -1 && freeSpace < 1000000) {
-            LOG_WARN(_logger, "Can't prepare consistency check and disk space is low: " << freeSpace);
-            close();
-            return true;
-        }
-
-        // Even when there's enough disk space, it might very well be that the
-        // file is on a read-only filesystem and can't be opened because of that.
-        if (_errId == SQLITE_CANTOPEN) {
-            LOG_WARN(_logger, "Can't open db to prepare consistency check, aborting");
-            close();
-            return true;
-        }
-        return false;
-    };
-
     const auto removeAndReopen = [this, &dbPath]() -> bool {
         LOGW_FATAL(_logger, L"Consistency check failed, removing broken db " << Path2WStr(dbPath));
         close();
@@ -93,22 +68,52 @@ bool SqliteDb::openOrCreateReadWrite(const std::filesystem::path &dbPath) {
         return openHelper(dbPath, SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE);
     };
 
+
+    const auto handleLockedDb = [this, &dbPath]() -> bool {
+        LOGW_WARN(_logger, L"Database is locked, aborting open (db not removed): " << Path2WStr(dbPath));
+        close();
+        return false;
+    };
+
+    const auto handleCantPrepare = [this, &dbPath, removeAndReopen]() -> bool {
+        // When disk space is low, preparing may fail even though the db is fine.
+        // Typically CANTOPEN or IOERR.
+        if (const int64_t freeSpace = Utility::getFreeDiskSpace(dbPath); freeSpace != -1 && freeSpace < 1000000) {
+            LOG_WARN(_logger, "Can't prepare consistency check and disk space is low: " << freeSpace);
+            close();
+            return false;
+        }
+
+        // Even when there's enough disk space, it might very well be that the
+        // file is on a read-only filesystem and can't be opened because of that.
+        if (_errId == SQLITE_CANTOPEN) {
+            LOG_WARN(_logger, "Can't open db to prepare consistency check, aborting");
+            close();
+            return false;
+        }
+        return removeAndReopen(); // we assume the db is corrupted and delete the db
+    };
+
+
     switch (checkDb()) {
         case CheckDbResult::Ok:
             return true;
         case CheckDbResult::Locked:
             return handleLockedDb();
         case CheckDbResult::CantPrepare:
-            if (handleCantPrepare()) return false;
-            return removeAndReopen();
+            return handleCantPrepare();
         case CheckDbResult::NotOk: // error never returned by checkDb yet
+        {
             LOGW_WARN(_logger, L"Database is not ok " << Path2WStr(dbPath));
             close();
-            return removeAndReopen();
+            return removeAndReopen(); // we assume the db is corrupted and delete the db
+        }
         case CheckDbResult::CantExec: // error never returned by checkDb yet
+        {
             LOGW_WARN(_logger, L"Database can't exec " << Path2WStr(dbPath));
             close();
             return false;
+        }
     }
     return false;
 }

--- a/src/libcommonserver/db/sqlitedb.h
+++ b/src/libcommonserver/db/sqlitedb.h
@@ -74,6 +74,7 @@ class SqliteDb {
             CantPrepare,
             CantExec,
             NotOk,
+            Locked,
         };
 
         struct QueryInfo {


### PR DESCRIPTION
<details>
<summary>:information_source: Description en français</summary>

## Résumé
La vérification de cohérence de la base de données (`PRAGMA quick_check`) pouvait échouer avec `SQLITE_BUSY` ou `SQLITE_LOCKED` lorsqu'un autre processus détenait un verrou sur le fichier. Cet échec était traité comme une corruption et entraînait la suppression immédiate du fichier `.db`, provoquant une perte de données.

## Changements
- Ajout de la valeur `Locked` à l'énumération `CheckDbResult` dans `sqlitedb.h`.
- Détection de `SQLITE_BUSY` / `SQLITE_LOCKED` dans `checkDb()`, à la fois sur le chemin de préparation (`queryPrepare`) et sur le chemin d'exécution (`queryNext`), et retour du nouveau résultat `Locked` au lieu de `CantPrepare` / `NotOk`.
- Ajout d'une branche `Locked` dans `openOrCreateReadWrite()` qui ferme proprement la connexion et retourne `false` sans supprimer le fichier, permettant à l'appelant de réessayer plus tard.

## Détails techniques
Le code existant distinguait déjà `CantPrepare` (échec de préparation, avec des chemins gracieux pour les cas de disque plein et `SQLITE_CANTOPEN`) des autres erreurs qui déclenchaient systématiquement un `LOGW_FATAL` suivi de la suppression du fichier. Une base verrouillée tombait dans ce dernier chemin car le verrou était indissociable d'une corruption réelle. La nouvelle valeur `Locked` court-circuite la suppression avant le bloc `CantPrepare` existant. L'identifiant d'erreur de l'étape (`queryNext`) est lu via `_queries.at(id)._query->errorId()`, la requête étant toujours présente dans la map à ce stade.

</details>

---

## Summary
The database consistency check (`PRAGMA quick_check`) could fail with `SQLITE_BUSY` or `SQLITE_LOCKED` when another process held a lock on the file. This failure was treated as corruption and triggered immediate deletion of the `.db` file, causing data loss.

## Changes
- Added `Locked` value to the `CheckDbResult` enum in `sqlitedb.h`.
- Detect `SQLITE_BUSY` / `SQLITE_LOCKED` in `checkDb()` on both the prepare path (`queryPrepare`) and the step path (`queryNext`), returning the new `Locked` result instead of `CantPrepare` / `NotOk`.
- Added a `Locked` branch in `openOrCreateReadWrite()` that cleanly closes the connection and returns `false` without deleting the file, letting the caller retry later.

## Technical Details
The existing code already distinguished `CantPrepare` (prepare failure, with graceful paths for low-disk-space and `SQLITE_CANTOPEN`) from other errors which unconditionally triggered `LOGW_FATAL` followed by file deletion. A locked database fell into the deletion path because a lock was indistinguishable from actual corruption. The new `Locked` result short-circuits deletion before the existing `CantPrepare` block. The step-path error id is read via `_queries.at(id)._query->errorId()`, since the query is still in the map at that point before `queryFree` is called.
