### PR TITLE
ci: fix default tags (nightly) and ci output

### DIFF
--- a/.github/workflows/start-runners.yml
+++ b/.github/workflows/start-runners.yml
@@ -103,7 +103,7 @@ jobs:
               --user-data userdata-final.ps1 \
               --property "purpose=ci-runner" \
               --wait \
-              -c id -c name -c status -c addresses \
+              -c id -c name -c status  \
               "$NAME" &
             pids+=("$!")
           done

--- a/.github/workflows/start-runners.yml
+++ b/.github/workflows/start-runners.yml
@@ -89,6 +89,9 @@ jobs:
           COUNT="${{ steps.params.outputs.count }}"
           FLAVOR="${{ steps.params.outputs.flavor }}"
 
+          pids=()
+          rc=0
+
           for i in $(seq 1 "$COUNT"); do
             NAME="ci-runner-${RUN_ID}-${i}"
             echo "Launching $NAME ..."
@@ -101,8 +104,18 @@ jobs:
               --property "purpose=ci-runner" \
               --wait \
               -c id -c name -c status -c addresses \
-              "$NAME"
+              "$NAME" &
+            pids+=("$!")
           done
+
+          # Wait for every background creation and capture the first failure.
+          for pid in "${pids[@]}"; do
+            if ! wait "$pid"; then
+              rc=1
+            fi
+          done
+
+          exit "$rc"
 
       - name: Clean up rendered user-data
         if: always()

--- a/.github/workflows/start-runners.yml
+++ b/.github/workflows/start-runners.yml
@@ -10,7 +10,7 @@ on:
       labels:
         description: "Comma-separated runner labels/tags"
         required: true
-        default: "self-hosted,windows,vs2026,ci,build,test"
+        default: "self-hosted,windows,vs2026,ci,build"
       flavor:
         description: "Infomaniak flavor"
         required: false
@@ -69,7 +69,7 @@ jobs:
         id: params
         run: |
           COUNT="${{ github.event.inputs.count || '1' }}"
-          LABELS="${{ github.event.inputs.labels || 'self-hosted' }}"
+          LABELS="${{ github.event.inputs.labels || 'self-hosted,windows,vs2026,ci,build' }}"
           FLAVOR="${{ github.event.inputs.flavor || 'a16-ram32-disk80-perf1' }}"
           echo "count=$COUNT" >> "$GITHUB_OUTPUT"
           echo "labels=$LABELS" >> "$GITHUB_OUTPUT"
@@ -100,6 +100,7 @@ jobs:
               --user-data userdata-final.ps1 \
               --property "purpose=ci-runner" \
               --wait \
+              -c id -c name -c status -c addresses \
               "$NAME"
           done
 


### PR DESCRIPTION
This pull request updates the `start-runners.yml` GitHub Actions workflow to improve runner launch reliability and clarify label defaults. The main changes focus on adjusting runner label defaults and ensuring that multiple runners are launched in parallel, with proper error handling.

**Workflow improvements:**

* Changed the default runner labels in the workflow input to remove the `test` label, now defaulting to `"self-hosted,windows,vs2026,ci,build"` instead of including `test`.
* Updated the script that sets up runner parameters so that if no labels are provided, it uses the new default label set (`"self-hosted,windows,vs2026,ci,build"`).

**Runner launch and error handling enhancements:**

* Modified the runner launch loop to start each runner in the background, track their process IDs, and wait for all to finish, capturing any failures and exiting with a non-zero status if any runner fails to launch. [[1]](diffhunk://#diff-e0a546d1909fc3735abc489b40f6f2ebed50ed4cac9a16a5ee0f8bd5db149839R92-R94) [[2]](diffhunk://#diff-e0a546d1909fc3735abc489b40f6f2ebed50ed4cac9a16a5ee0f8bd5db149839L103-R119)